### PR TITLE
Add feature to import custom missing usings

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ New features:
 - Better code organization and maintainability
 - Added automatic `<public>` attribute handling for internal modules
 
+### 0.3.1
+
+New features:
+
+- Support custom missing usings (namespaces)
+
 ## Contributing
 
 Feel free to submit issues and pull requests on our GitHub repository.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "verse-auto-imports",
   "displayName": "Verse Auto Imports",
   "description": "Automatically adds missing using statements in Verse files",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/handlers/importHandler.ts
+++ b/src/handlers/importHandler.ts
@@ -23,16 +23,27 @@ export class ImportHandler {
     
     extractImportStatement(errorMessage: string): string | null {
         log(this.outputChannel, `Extracting import statement from error: ${errorMessage}`);
-        const match = errorMessage.match(/Did you forget to specify (using \{ \/[^}]+ \})\?/);
         
+        // Pattern 1: Existing pattern
+        let match = errorMessage.match(/Did you forget to specify (using \{ \/[^}]+ \})\?/);
         if (match) {
             log(this.outputChannel, `Found import statement: ${match[1]}`);
             return match[1];
         }
         
+        // Pattern 2: New pattern for custom using, e.g. "Did you mean `Utils.Format`?"
+        match = errorMessage.match(/Did you mean `([^`]+)\.[^`]+`\?/);
+        if (match) {
+            const namespace = match[1];
+            const importStatement = `using { ${namespace} }`;
+            log(this.outputChannel, `Inferred import statement: ${importStatement}`);
+            return importStatement;
+        }
+        
         log(this.outputChannel, 'No import statement found in error message');
         return null;
     }
+    
 
     async addImportsToDocument(editor: vscode.TextEditor, importStatements: string[]) {
         log(this.outputChannel, `Adding ${importStatements.length} import statements to document`);


### PR DESCRIPTION
Do the same, like origin version, but for custom namespaces (folders)