### PR TITLE
ci: workflow hardening from GitHub Actions docs review

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report a problem with the extension
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: e.g. saved a file with an unknown identifier and the wrong using statement was added
+    validations:
+      required: true
+
+  - type: input
+    id: extension-version
+    attributes:
+      label: Extension version
+      description: Extensions panel -> Verse Auto Imports -> version number
+      placeholder: e.g. 0.6.4
+    validations:
+      required: true
+
+  - type: input
+    id: vscode-version
+    attributes:
+      label: VS Code version
+      description: Help -> About
+      placeholder: e.g. 1.101.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: compiler-error
+    attributes:
+      label: Verse compiler error text
+      description: If the problem involves an error message, paste the exact compiler diagnostic from the Problems panel.
+      render: text
+
+  - type: textarea
+    id: sample-code
+    attributes:
+      label: Sample Verse code
+      description: A minimal snippet that reproduces the problem.
+      render: text
+
+  - type: textarea
+    id: settings
+    attributes:
+      label: Relevant settings
+      description: Any verseAutoImports.* settings you changed from their defaults.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that the extension makes hard or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you use today, or other ways this could be solved.

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: triage-${{ github.event.issue.number }}
+
 jobs:
   triage:
     # Issues that mention @claude are handled by claude.yml instead
@@ -49,4 +52,6 @@ jobs:
             - Follow the conventions in CLAUDE.md (no emojis, short factual comments).
             - Post at most two comments total; prefer one.
             - Never close the issue. Never assign anyone.
-          claude_args: '--allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh label list:*),Bash(gh search:*),Read,Grep,Glob"'
+          claude_args: |
+            --allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh label list:*),Bash(gh search:*),Read,Grep,Glob"
+            --max-turns 15

--- a/.github/workflows/claude-maintenance.yml
+++ b/.github/workflows/claude-maintenance.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 9 * * 1" # Mondays 09:00 UTC
   workflow_dispatch:
 
+# Never run two sweeps at once (cron + manual dispatch)
+concurrency:
+  group: maintenance
+
 jobs:
   maintenance:
     runs-on: ubuntu-latest
@@ -66,4 +70,6 @@ jobs:
 
             Rules: no emojis; do not modify any code or open PRs from this run;
             do not close or edit other issues.
-          claude_args: '--allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(git log:*),Bash(git describe:*),Bash(git diff:*),Bash(gh issue:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh label:*),Bash(gh api:*),Read,Grep,Glob"'
+          claude_args: |
+            --allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(git log:*),Bash(git describe:*),Bash(git diff:*),Bash(gh issue:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh label:*),Bash(gh api:*),Read,Grep,Glob"
+            --max-turns 25

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,14 +4,21 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
+# A newer review request on the same PR supersedes a running one
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   gate:
     # Decide whether this PR warrants an automatic Claude review:
-    # community PRs always; Dependabot PRs only for major version bumps.
-    # The maintainer's own PRs are reviewed on demand via an @claude comment.
+    # community PRs get a code review; Dependabot PRs only get a
+    # breaking-change review for major version bumps. The maintainer's
+    # own PRs are reviewed on demand via an @claude comment.
     runs-on: ubuntu-latest
     outputs:
       review: ${{ steps.decide.outputs.review }}
+      kind: ${{ steps.decide.outputs.kind }}
     steps:
       - name: Fetch Dependabot metadata
         if: github.actor == 'dependabot[bot]'
@@ -30,6 +37,7 @@ jobs:
           if [ "$ACTOR" = "dependabot[bot]" ]; then
             if [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then
               echo "review=true" >> "$GITHUB_OUTPUT"
+              echo "kind=dependency" >> "$GITHUB_OUTPUT"
             else
               echo "review=false" >> "$GITHUB_OUTPUT"
             fi
@@ -37,6 +45,7 @@ jobs:
             echo "review=false" >> "$GITHUB_OUTPUT"
           else
             echo "review=true" >> "$GITHUB_OUTPUT"
+            echo "kind=code" >> "$GITHUB_OUTPUT"
           fi
 
   review:
@@ -62,29 +71,41 @@ jobs:
           node-version: "20"
           cache: "npm"
 
-      - name: Review PR
+      # Community code changes: official code-review skill, posts inline
+      # comments on the diff.
+      - name: Review code changes
+        if: needs.gate.outputs.kind == 'code'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          claude_args: "--max-turns 20"
+
+      # Dependabot major bumps: the diff is just manifests, so a code review
+      # is useless. Analyze the dependency's breaking changes instead.
+      - name: Review major dependency bump
+        if: needs.gate.outputs.kind == 'dependency'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           prompt: |
-            Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+            PR #${{ github.event.pull_request.number }} in ${{ github.repository }}
+            bumps a dependency by a major version. Assess whether it is safe to
+            merge for this repository (a VS Code extension, see CLAUDE.md).
 
-            This repository is a VS Code extension for the Verse language (UEFN).
-            Read CLAUDE.md first for architecture and conventions, then review the
-            diff for:
-            - Correctness bugs, especially in compiler-error pattern matching
-              (ImportSuggestionExtractor) and document editing (ImportDocumentEditor)
-            - Violations of the architecture (bypassing the ImportHandler facade,
-              services called from the wrong layer)
-            - Missing CHANGELOG entry for user-facing changes
-            - Missing or broken tests (run `npm ci && npm run compile && npm test`
-              to verify)
-            - For dependency major bumps: scan the changelog/release notes of the
-              dependency for breaking changes that affect this codebase and say
-              explicitly whether the bump is safe to merge
-
-            Post the review as a single sticky comment: a short verdict first
-            (safe to merge / needs changes), then only the findings that matter.
-            No emojis. Do not approve or request changes formally; comment only.
-          claude_args: '--allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Read,Grep,Glob"'
+            1. Identify the package and the old/new versions from the PR diff.
+            2. Read the package's changelog or release notes for breaking
+               changes between those versions.
+            3. Search this codebase for usage affected by those breaking
+               changes.
+            4. Verify empirically: apply the bump locally with npm install,
+               then run npm run compile and npm test, and report the results.
+            5. Post a single sticky comment: verdict first (safe to merge /
+               needs changes / do not merge), then only the findings that
+               matter. No emojis. Do not approve or request changes formally.
+          claude_args: |
+            --allowedTools "Bash(npm ci),Bash(npm install:*),Bash(npm run compile),Bash(npm test),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),WebFetch,WebSearch,Read,Grep,Glob"
+            --max-turns 20

--- a/.github/workflows/claude-release-prep.yml
+++ b/.github/workflows/claude-release-prep.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
 
+# Never prepare two releases at once
+concurrency:
+  group: release-prep
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -67,4 +71,6 @@ jobs:
 
             Rules: no emojis, no AI attribution in commits, conventional commit
             prefixes only.
-          claude_args: '--allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(npm install --package-lock-only),Bash(git:*),Bash(gh pr:*),Bash(gh api:*),Read,Write,Edit,Grep,Glob"'
+          claude_args: |
+            --allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(npm install --package-lock-only),Bash(git:*),Bash(gh pr:*),Bash(gh api:*),Read,Write,Edit,Grep,Glob"
+            --max-turns 30

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   issues:
     types: [opened, assigned]
 
+# Queue runs per issue/PR so two quick mentions never push conflicting commits
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+
 jobs:
   claude:
     if: |
@@ -41,4 +45,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(npx jest:*),Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"'
+          claude_args: |
+            --allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(npx jest:*),Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"
+            --max-turns 30


### PR DESCRIPTION
Improvements from auditing our setup against https://code.claude.com/docs/en/github-actions:

- Concurrency groups: duplicate @claude mentions on the same issue/PR now queue instead of running in parallel (which could push conflicting commits); maintenance and release-prep runs can no longer overlap.
- Explicit --max-turns per workflow (mention/release-prep 30, review 20, maintenance 25, triage 15). The action default is 10, which could cut off implementation tasks mid-run.
- Community PR reviews now use the official code-review plugin (inline diff comments) instead of a hand-written prompt. Dependabot major bumps keep a tailored breaking-change analysis, now with web access to read the dependency's release notes plus an empirical compile/test check.
- Issue form templates collect extension version, VS Code version, compiler error text, and a sample snippet up front, so triage does not have to ask.

A mirror PR registers the same workflow changes on main (comment/schedule/dispatch triggers only read the default branch).