### PR TITLE
ci: allow git and gh commands in the mention workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(npx jest:*),Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"
+            --allowedTools "Bash(git:*),Bash(gh:*),Bash(npm ci),Bash(npm install:*),Bash(npm run compile),Bash(npm test),Bash(npx jest:*)"
             --max-turns 30


### PR DESCRIPTION
A branch-update request via @claude on PR #47 was blocked because the mention workflow's --allowedTools had no git commands and only scoped gh subcommands. Grants Bash(git:*), Bash(gh:*), and Bash(npm install:*) so mention-driven tasks can fetch, merge, push, and manage PRs. Trigger safety is unchanged: the workflow only fires on @claude mentions from users with write access. Mirror PR to main follows.