### PR TITLE
ci: mirror mention workflow tool fix to default branch

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(npx jest:*),Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"
+            --allowedTools "Bash(git:*),Bash(gh:*),Bash(npm ci),Bash(npm install:*),Bash(npm run compile),Bash(npm test),Bash(npx jest:*)"
             --max-turns 30


### PR DESCRIPTION
Mirror of #51. The mention workflow runs from the default branch, so this fix must land here to take effect.