### PR TITLE
fix: make Optimize Imports deterministic and atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Module names are matched exactly: unrelated identifiers like `MyUtils` no longer match `Utils`, and class or struct names are never offered as module locations
   - Cached results are validated against the filesystem before use, with automatic fallback to a full scan when the cache is stale
   - The search near the current file runs first again, so the nearest module is preferred over project-wide matches
+- **Optimize Imports Reliability**: with auto-import enabled (the default), "Optimize Imports" could momentarily strip every import, report success, and leave the file unorganized while the imports reappeared a moment later. The command now organizes imports in a single step and never leaves the file without them; behavior no longer depends on the auto-import debounce delay
 
 ### Changed
 

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -35,8 +35,6 @@ export class CommandsHandler {
     // Named constants for timing delays
     private static readonly STATUS_MESSAGE_DURATION_MS = 3000;
     private static readonly SNOOZE_DURATION_MINUTES = 5;
-    private static readonly DIAGNOSTICS_REFRESH_DELAY_MS = 200;
-    private static readonly AUTO_IMPORT_WAIT_DELAY_MS = 500;
 
     constructor(private readonly deps: CommandsDependencies) {}
 
@@ -95,10 +93,7 @@ export class CommandsHandler {
      */
     async addSingleImport(document: vscode.TextDocument, importStatement: string): Promise<void> {
         await this.deps.importHandler.addImportsToDocument(document, [importStatement]);
-        vscode.window.setStatusBarMessage(
-            `Added import: ${importStatement}`,
-            CommandsHandler.STATUS_MESSAGE_DURATION_MS
-        );
+        vscode.window.setStatusBarMessage(`Added import: ${importStatement}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
     }
 
     /**
@@ -122,60 +117,19 @@ export class CommandsHandler {
 
         try {
             const document = editor.document;
-            const config = vscode.workspace.getConfiguration("verseAutoImports");
-            const autoImportEnabled = config.get<boolean>("general.autoImport", true);
-            const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
 
-            logger.debug("CommandsHandler", `Auto-import: ${autoImportEnabled}, Preferred syntax: ${preferDotSyntax ? "dot" : "curly"}`);
-
-            // Step 1: Remove all imports from the document
-            logger.debug("CommandsHandler", "Step 1: Removing all imports");
-            await this.deps.importHandler.removeAllImports(document);
-
-            // Step 2: Save the document to trigger diagnostics refresh
-            logger.debug("CommandsHandler", "Step 2: Saving document to trigger diagnostics");
-            await document.save();
-
-            // Step 3: Wait for diagnostics to update
-            logger.debug("CommandsHandler", "Step 3: Waiting for diagnostics to update");
-            await this.delay(CommandsHandler.DIAGNOSTICS_REFRESH_DELAY_MS);
-
-            // Step 4: Get diagnostics for the document
+            // Anything the compiler currently reports as a missing import gets
+            // added during the rebuild. No waiting: the command does not race
+            // the auto-import debounce, it computes the result itself.
             const diagnostics = vscode.languages.getDiagnostics(document.uri);
-            logger.debug("CommandsHandler", `Found ${diagnostics.length} diagnostics`);
+            const missingImportPaths = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
+            logger.debug("CommandsHandler", `Found ${missingImportPaths.length} missing import(s) in current diagnostics`);
 
-            if (autoImportEnabled) {
-                // Step 5a: Auto-import is ON - wait for it to handle missing imports
-                logger.debug("CommandsHandler", "Step 5a: Auto-import is enabled, waiting for automatic imports");
-                await this.delay(CommandsHandler.AUTO_IMPORT_WAIT_DELAY_MS);
-            } else {
-                // Step 5b: Auto-import is OFF - manually add missing imports
-                logger.debug("CommandsHandler", "Step 5b: Auto-import is disabled, manually processing diagnostics");
+            // Rebuild the import block in one atomic edit: existing imports plus
+            // missing ones, deduplicated, grouped, sorted, and written in the
+            // preferred syntax. The document is never left import-less.
+            await this.deps.importHandler.organizeImports(document, missingImportPaths);
 
-                const missingImportPaths = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
-
-                if (missingImportPaths.length > 0) {
-                    logger.debug("CommandsHandler", `Found ${missingImportPaths.length} missing imports to add`);
-
-                    const importStatements = missingImportPaths.map((path) => {
-                        const statement = preferDotSyntax ? `using. ${path}` : `using { ${path} }`;
-                        logger.trace("CommandsHandler", `Formatting import: ${statement}`);
-                        return statement;
-                    });
-
-                    await this.deps.importHandler.addImportsToDocument(document, importStatements);
-                }
-            }
-
-            // Step 6: Convert scattered imports to preferred syntax (common to both paths)
-            logger.debug("CommandsHandler", "Step 6: Converting scattered imports to preferred syntax");
-            await this.deps.importHandler.convertScatteredImportsToPreferredSyntax(document);
-
-            // Step 7: Ensure proper spacing after imports (common to both paths)
-            logger.debug("CommandsHandler", "Step 7: Ensuring proper spacing after imports");
-            await this.deps.importHandler.ensureEmptyLinesAfterImports(document);
-
-            // Save the document again to ensure all changes are persisted
             await document.save();
 
             logger.info("CommandsHandler", "Successfully optimized imports");
@@ -255,11 +209,7 @@ export class CommandsHandler {
         try {
             const uri = await logger.exportDebugLogs();
             if (uri) {
-                const action = await vscode.window.showInformationMessage(
-                    `Debug logs exported to ${uri.fsPath}`,
-                    "Open File",
-                    "Open Folder"
-                );
+                const action = await vscode.window.showInformationMessage(`Debug logs exported to ${uri.fsPath}`, "Open File", "Open Folder");
                 if (action === "Open File") {
                     await vscode.commands.executeCommand("vscode.open", uri);
                 } else if (action === "Open Folder") {
@@ -267,9 +217,7 @@ export class CommandsHandler {
                 }
             }
         } catch (error) {
-            vscode.window.showErrorMessage(
-                `Failed to export debug logs: ${error instanceof Error ? error.message : String(error)}`
-            );
+            vscode.window.showErrorMessage(`Failed to export debug logs: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 
@@ -296,7 +244,7 @@ export class CommandsHandler {
             },
             async () => {
                 await this.deps.projectPathCache!.rebuildCache();
-            }
+            },
         );
 
         const stats = this.deps.projectPathCache.getStats();
@@ -484,16 +432,5 @@ export class CommandsHandler {
 
         vscode.window.showInformationMessage(`Using relative paths for ${convertedCount} import${convertedCount !== 1 ? "s" : ""}.`);
         this.finalizeConversion(documentUri);
-    }
-
-    //==========================================================================
-    // Private Utilities
-    //==========================================================================
-
-    /**
-     * Promise-based delay helper.
-     */
-    private delay(ms: number): Promise<void> {
-        return new Promise((resolve) => setTimeout(resolve, ms));
     }
 }

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -9,38 +9,25 @@ interface ImportBlock {
     imports: string[];
 }
 
-/** Represents a single line edit for syntax conversion. */
-interface LineEdit {
-    line: number;
-    oldText: string;
-    newText: string;
-}
-
 /**
  * Handles all document modifications for imports.
  */
 export class ImportDocumentEditor {
     private readonly formatter: ImportFormatter;
 
-    constructor(private outputChannel: vscode.OutputChannel, formatter: ImportFormatter) {
+    constructor(
+        private outputChannel: vscode.OutputChannel,
+        formatter: ImportFormatter,
+    ) {
         this.formatter = formatter;
     }
 
     /**
      * Creates an edit to replace an import block with combined and formatted imports.
      */
-    private createBlockReplacementEdit(
-        edit: vscode.WorkspaceEdit,
-        document: vscode.TextDocument,
-        block: ImportBlock,
-        newPaths: string[],
-        preferDotSyntax: boolean,
-        sortAlphabetically: boolean
-    ): void {
+    private createBlockReplacementEdit(edit: vscode.WorkspaceEdit, document: vscode.TextDocument, block: ImportBlock, newPaths: string[], preferDotSyntax: boolean, sortAlphabetically: boolean): void {
         // Get existing paths in this block for combined sorting
-        const existingBlockPaths = block.imports
-            .map((imp) => this.formatter.extractPathFromImport(imp))
-            .filter((p): p is string => p !== null);
+        const existingBlockPaths = block.imports.map((imp) => this.formatter.extractPathFromImport(imp)).filter((p): p is string => p !== null);
 
         const combinedPaths = [...existingBlockPaths, ...newPaths];
         if (sortAlphabetically) {
@@ -48,16 +35,10 @@ export class ImportDocumentEditor {
         }
 
         // Format all imports for this block
-        const formattedImports = combinedPaths.map((path) =>
-            this.formatter.formatImportStatement(path, preferDotSyntax)
-        );
+        const formattedImports = combinedPaths.map((path) => this.formatter.formatImportStatement(path, preferDotSyntax));
 
         // Replace the entire block
-        edit.replace(
-            document.uri,
-            new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)),
-            formattedImports.join("\n") + "\n"
-        );
+        edit.replace(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)), formattedImports.join("\n") + "\n");
     }
 
     /**
@@ -201,26 +182,12 @@ export class ImportDocumentEditor {
 
                 // Add digest imports to digest block
                 if (newDigestPaths.length > 0 && digestBlockIndex >= 0) {
-                    this.createBlockReplacementEdit(
-                        edit,
-                        document,
-                        importBlocks[digestBlockIndex],
-                        newDigestPaths,
-                        preferDotSyntax,
-                        sortAlphabetically
-                    );
+                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], newDigestPaths, preferDotSyntax, sortAlphabetically);
                 }
 
                 // Add local imports to local block
                 if (newLocalPaths.length > 0 && localBlockIndex >= 0) {
-                    this.createBlockReplacementEdit(
-                        edit,
-                        document,
-                        importBlocks[localBlockIndex],
-                        newLocalPaths,
-                        preferDotSyntax,
-                        sortAlphabetically
-                    );
+                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], newLocalPaths, preferDotSyntax, sortAlphabetically);
                 }
 
                 // Handle imports that don't have a matching block
@@ -305,75 +272,119 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * Removes all import statements from the document.
-     * Handles all three Verse import formats:
-     * - using { /path }
-     * - using. /path
-     * - using:
-     *     /path
+     * Computes the document text with every module import consolidated into
+     * one organized block at the top: existing imports plus additional paths,
+     * deduplicated, grouped, sorted, and formatted per the given options.
+     * Handles all three Verse import styles, including the indented pair
+     * (`using:` plus the indented path on the next line). Local-scope `using`
+     * statements are left where they are. Returns null when the document has
+     * no module imports and no additional paths (nothing to organize).
      */
-    async removeAllImports(document: vscode.TextDocument): Promise<boolean> {
-        logger.info("ImportDocumentEditor", "Removing all imports from document");
-
-        const text = document.getText();
+    buildOrganizedContent(
+        text: string,
+        additionalPaths: string[],
+        options: {
+            preferDotSyntax: boolean;
+            sortAlphabetically: boolean;
+            importGrouping: string;
+        },
+    ): string | null {
         const lines = text.split("\n");
-        const resultLines: string[] = [];
+        const paths: string[] = [];
+        const body: string[] = [];
         let i = 0;
-        let removedCount = 0;
 
         while (i < lines.length) {
             const line = lines[i];
-            const trimmedLine = line.trim();
-
-            // Check for single-line imports (curly or dot syntax) — skip local-scope using
+            const trimmed = line.trim();
             const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
-            if (ImportFormatter.isModuleImport(trimmedLine, nextLine) && (trimmedLine.match(/^using\s*\{[^}]+\}/) || trimmedLine.match(/^using\.\s+.+/))) {
-                logger.trace("ImportDocumentEditor", `Removing single-line import at line ${i + 1}: ${trimmedLine}`);
-                removedCount++;
-                i++;
-                continue;
-            }
 
-            // Check for multi-line import start (indented style)
-            if (ImportFormatter.isModuleImport(trimmedLine, nextLine) && trimmedLine.match(/^using\s*:\s*$/)) {
-                logger.trace("ImportDocumentEditor", `Found multi-line import start at line ${i + 1}`);
-                removedCount++;
-                i++;
-
-                // Skip the next indented path line
-                if (i < lines.length) {
-                    const nextLine = lines[i];
-                    // Check if next line is indented (has leading whitespace)
-                    if (nextLine.match(/^\s+.+/)) {
-                        logger.trace("ImportDocumentEditor", `Removing indented path at line ${i + 1}: ${nextLine.trim()}`);
-                        i++;
+            if (ImportFormatter.isModuleImport(trimmed, nextLine)) {
+                // Indented style: the path lives on the next line; consume both.
+                if (/^using\s*:\s*$/.test(trimmed)) {
+                    if (nextLine !== undefined && /^\s+\S/.test(nextLine)) {
+                        paths.push(nextLine.trim());
+                        i += 2;
+                        continue;
                     }
+                    i += 1;
+                    continue;
                 }
+
+                const path = this.formatter.extractPathFromImport(trimmed);
+                if (path) {
+                    paths.push(path);
+                }
+                i += 1;
                 continue;
             }
 
-            // Keep non-import lines
-            resultLines.push(line);
-            i++;
+            body.push(line);
+            i += 1;
         }
 
-        if (removedCount === 0) {
-            logger.debug("ImportDocumentEditor", "No imports found to remove");
+        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0);
+        if (paths.length === 0 && extraPaths.length === 0) {
+            return null;
+        }
+
+        const uniquePaths = Array.from(new Set([...paths, ...extraPaths]));
+        const formatted = this.formatter.groupAndFormatImports(uniquePaths, options.preferDotSyntax, options.sortAlphabetically, options.importGrouping);
+
+        // Drop blank lines the removed imports left at the top; the gap after
+        // the block is normalized by ensureEmptyLinesAfterImports afterwards.
+        let firstContent = 0;
+        while (firstContent < body.length && body[firstContent].trim() === "") {
+            firstContent++;
+        }
+        const remainingBody = body.slice(firstContent);
+
+        if (remainingBody.length === 0) {
+            return formatted.join("\n") + "\n";
+        }
+
+        return [...formatted, "", ...remainingBody].join("\n");
+    }
+
+    /**
+     * Rebuilds the document's import block in a single atomic edit: existing
+     * imports plus the given additional paths, deduplicated, grouped, sorted,
+     * and written in the preferred syntax at the top of the file. Unlike
+     * addImportsToDocument this reorganizes even when nothing new is added.
+     */
+    async organizeImports(document: vscode.TextDocument, additionalPaths: string[]): Promise<boolean> {
+        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
+        const sortAlphabetically = config.get<boolean>("behavior.sortImportsAlphabetically", true);
+        const importGrouping = config.get<string>("behavior.importGrouping", "none");
+
+        const text = document.getText();
+        const organized = this.buildOrganizedContent(text, additionalPaths, {
+            preferDotSyntax,
+            sortAlphabetically,
+            importGrouping,
+        });
+
+        if (organized === null || organized === text) {
+            logger.debug("ImportDocumentEditor", "No import changes needed by organize");
             return true;
         }
 
-        // Apply the edit to replace entire document
         const edit = new vscode.WorkspaceEdit();
         const fullRange = new vscode.Range(new vscode.Position(0, 0), document.lineAt(document.lineCount - 1).range.end);
-
-        edit.replace(document.uri, fullRange, resultLines.join("\n"));
+        edit.replace(document.uri, fullRange, organized);
 
         try {
             const success = await vscode.workspace.applyEdit(edit);
-            logger.debug("ImportDocumentEditor", `Removed ${removedCount} import statements. Success: ${success}`);
+            logger.info("ImportDocumentEditor", success ? "Organized imports in document" : "Failed to organize imports");
+
+            if (success) {
+                await this.ensureEmptyLinesAfterImports(document);
+            }
+
             return success;
         } catch (error) {
-            logger.error("ImportDocumentEditor", `Error removing imports: ${error}`, error);
+            logger.error("ImportDocumentEditor", `Error organizing imports: ${error}`, error);
             return false;
         }
     }
@@ -472,124 +483,6 @@ export class ImportDocumentEditor {
             return success;
         } catch (error) {
             logger.error("ImportDocumentEditor", `Error adjusting spacing: ${error}`, error);
-            return false;
-        }
-    }
-
-    /**
-     * Converts all import statements in the document to the preferred syntax.
-     * This includes imports that are not at the top of the file (e.g., inside namespaces).
-     */
-    async convertScatteredImportsToPreferredSyntax(document: vscode.TextDocument): Promise<boolean> {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
-        const preferredSyntax = config.get<string>("behavior.importSyntax", "curly");
-        const preferDotSyntax = preferredSyntax === "dot";
-
-        logger.info("ImportDocumentEditor", `Converting all imports to ${preferredSyntax} syntax`);
-
-        const text = document.getText();
-        const lines = text.split("\n");
-        const edits: LineEdit[] = [];
-
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            const trimmedLine = line.trim();
-
-            // Skip local-scope using statements (e.g., using{Variable})
-            const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
-            if (trimmedLine.startsWith("using") && !ImportFormatter.isModuleImport(trimmedLine, nextLine)) {
-                continue;
-            }
-
-            // Check for single-line curly syntax
-            const curlyMatch = trimmedLine.match(/^(using\s*\{\s*)([^}]+)(\s*\})/);
-            if (curlyMatch) {
-                const path = curlyMatch[2].trim();
-                const currentIsDot = false;
-
-                if (currentIsDot !== preferDotSyntax) {
-                    const newStatement = this.formatter.formatImportStatement(path, preferDotSyntax);
-                    // Preserve indentation
-                    const leadingWhitespace = line.match(/^\s*/)?.[0] || "";
-                    edits.push({
-                        line: i,
-                        oldText: line,
-                        newText: leadingWhitespace + newStatement,
-                    });
-                    logger.trace("ImportDocumentEditor", `Converting line ${i + 1} from curly to ${preferredSyntax}`);
-                }
-                continue;
-            }
-
-            // Check for single-line dot syntax
-            const dotMatch = trimmedLine.match(/^(using\.\s*)(.+)/);
-            if (dotMatch) {
-                const path = dotMatch[2].trim();
-                const currentIsDot = true;
-
-                if (currentIsDot !== preferDotSyntax) {
-                    const newStatement = this.formatter.formatImportStatement(path, preferDotSyntax);
-                    // Preserve indentation
-                    const leadingWhitespace = line.match(/^\s*/)?.[0] || "";
-                    edits.push({
-                        line: i,
-                        oldText: line,
-                        newText: leadingWhitespace + newStatement,
-                    });
-                    logger.trace("ImportDocumentEditor", `Converting line ${i + 1} from dot to ${preferredSyntax}`);
-                }
-                continue;
-            }
-
-            // Check for multi-line import (always convert to preferred single-line format)
-            if (trimmedLine.match(/^using\s*:\s*$/)) {
-                // Look for the next indented path line
-                if (i + 1 < lines.length) {
-                    const nextLine = lines[i + 1];
-                    const pathMatch = nextLine.match(/^\s+(.+)/);
-                    if (pathMatch) {
-                        const importPath = pathMatch[1].trim();
-                        const newStatement = this.formatter.formatImportStatement(importPath, preferDotSyntax);
-                        // Preserve indentation of the original 'using:' line
-                        const leadingWhitespace = line.match(/^\s*/)?.[0] || "";
-
-                        // Replace the 'using:' line with the converted single-line import
-                        edits.push({
-                            line: i,
-                            oldText: line,
-                            newText: leadingWhitespace + newStatement,
-                        });
-                        // Mark the indented path line for removal (replace with empty)
-                        edits.push({
-                            line: i + 1,
-                            oldText: nextLine,
-                            newText: "",
-                        });
-                        logger.trace("ImportDocumentEditor", `Converting multi-line import at lines ${i + 1}-${i + 2} to ${preferredSyntax}`);
-                        i++; // Skip the next line since we've handled it
-                    }
-                }
-            }
-        }
-
-        if (edits.length === 0) {
-            logger.debug("ImportDocumentEditor", "No imports need syntax conversion");
-            return true;
-        }
-
-        // Apply all edits
-        const edit = new vscode.WorkspaceEdit();
-        for (const e of edits) {
-            const range = new vscode.Range(new vscode.Position(e.line, 0), new vscode.Position(e.line, lines[e.line].length));
-            edit.replace(document.uri, range, e.newText);
-        }
-
-        try {
-            const success = await vscode.workspace.applyEdit(edit);
-            logger.debug("ImportDocumentEditor", `Converted ${edits.length} import statements. Success: ${success}`);
-            return success;
-        } catch (error) {
-            logger.error("ImportDocumentEditor", `Error converting imports: ${error}`, error);
             return false;
         }
     }

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -17,15 +17,10 @@ export class ImportHandler {
     constructor(
         private outputChannel: vscode.OutputChannel,
         assetsDigestParser?: AssetsDigestParser,
-        extensionContext?: vscode.ExtensionContext
+        extensionContext?: vscode.ExtensionContext,
     ) {
         this.formatter = new ImportFormatter();
-        this.suggestionExtractor = new ImportSuggestionExtractor(
-            outputChannel,
-            this.formatter,
-            assetsDigestParser,
-            extensionContext
-        );
+        this.suggestionExtractor = new ImportSuggestionExtractor(outputChannel, this.formatter, assetsDigestParser, extensionContext);
         this.documentEditor = new ImportDocumentEditor(outputChannel, this.formatter);
     }
 
@@ -51,10 +46,12 @@ export class ImportHandler {
     }
 
     /**
-     * Removes all import statements from the document.
+     * Rebuilds the document's import block in one atomic edit: existing
+     * imports plus the given additional paths, deduplicated, grouped,
+     * sorted, and formatted per settings.
      */
-    async removeAllImports(document: vscode.TextDocument): Promise<boolean> {
-        return this.documentEditor.removeAllImports(document);
+    async organizeImports(document: vscode.TextDocument, additionalPaths: string[]): Promise<boolean> {
+        return this.documentEditor.organizeImports(document, additionalPaths);
     }
 
     /**
@@ -69,12 +66,5 @@ export class ImportHandler {
      */
     async ensureEmptyLinesAfterImports(document: vscode.TextDocument): Promise<boolean> {
         return this.documentEditor.ensureEmptyLinesAfterImports(document);
-    }
-
-    /**
-     * Converts all import statements in the document to the preferred syntax.
-     */
-    async convertScatteredImportsToPreferredSyntax(document: vscode.TextDocument): Promise<boolean> {
-        return this.documentEditor.convertScatteredImportsToPreferredSyntax(document);
     }
 }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1,0 +1,118 @@
+import { ImportDocumentEditor } from "../ImportDocumentEditor";
+import { ImportFormatter } from "../ImportFormatter";
+import * as vscode from "vscode";
+
+describe("ImportDocumentEditor.buildOrganizedContent", () => {
+  let editor: ImportDocumentEditor;
+
+  const curlyNoSort = {
+    preferDotSyntax: false,
+    sortAlphabetically: false,
+    importGrouping: "none",
+  };
+  const curlySorted = { ...curlyNoSort, sortAlphabetically: true };
+
+  beforeEach(() => {
+    const outputChannel = vscode.window.createOutputChannel("test");
+    editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
+  });
+
+  it("returns null when there are no imports and nothing to add", () => {
+    expect(
+      editor.buildOrganizedContent("foo := 1\nbar := 2", [], curlyNoSort),
+    ).toBeNull();
+  });
+
+  it("consolidates existing imports at the top with one blank line before code", () => {
+    const input = "using { /A }\nusing { /B }\ncode()";
+    expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(
+      "using { /A }\nusing { /B }\n\ncode()",
+    );
+  });
+
+  it("deduplicates repeated imports", () => {
+    const input = "using { /A }\nusing { /A }\ncode()";
+    expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(
+      "using { /A }\n\ncode()",
+    );
+  });
+
+  it("sorts alphabetically when enabled", () => {
+    const input = "using { /Zebra }\nusing { /Apple }\ncode()";
+    expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(
+      "using { /Apple }\nusing { /Zebra }\n\ncode()",
+    );
+  });
+
+  it("preserves original order when sorting is disabled", () => {
+    const input = "using { /Zebra }\nusing { /Apple }\ncode()";
+    expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(
+      "using { /Zebra }\nusing { /Apple }\n\ncode()",
+    );
+  });
+
+  it("writes the preferred dot syntax", () => {
+    const input = "using { /A }\ncode()";
+    expect(
+      editor.buildOrganizedContent(input, [], {
+        ...curlyNoSort,
+        preferDotSyntax: true,
+      }),
+    ).toBe("using. /A\n\ncode()");
+  });
+
+  it("normalizes the indented using: pair into a single-line import", () => {
+    const input = "using:\n    /A\ncode()";
+    expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(
+      "using { /A }\n\ncode()",
+    );
+  });
+
+  it("hoists an import scattered below code up into the block", () => {
+    const input = "code_before()\nusing { /A }\ncode_after()";
+    expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(
+      "using { /A }\n\ncode_before()\ncode_after()",
+    );
+  });
+
+  it("merges additional paths with existing imports, deduped and sorted", () => {
+    const input = "using { /Existing }\ncode()";
+    expect(
+      editor.buildOrganizedContent(input, ["/Added", "/Existing"], curlySorted),
+    ).toBe("using { /Added }\nusing { /Existing }\n\ncode()");
+  });
+
+  it("adds imports to a document that had none", () => {
+    expect(editor.buildOrganizedContent("code()", ["/New"], curlyNoSort)).toBe(
+      "using { /New }\n\ncode()",
+    );
+  });
+
+  it("leaves local-scope using statements in the body", () => {
+    const input = "using { /A }\nusing { LocalVar }\ncode()";
+    expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(
+      "using { /A }\n\nusing { LocalVar }\ncode()",
+    );
+  });
+
+  it("collapses extra blank lines left by removed top imports", () => {
+    const input = "using { /A }\n\n\ncode()";
+    expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(
+      "using { /A }\n\ncode()",
+    );
+  });
+
+  it("returns only the import block when the file is nothing but imports", () => {
+    const input = "using { /B }\nusing { /A }";
+    expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(
+      "using { /A }\nusing { /B }\n",
+    );
+  });
+
+  it("ignores blank additional paths", () => {
+    const input = "using { /A }\ncode()";
+    expect(editor.buildOrganizedContent(input, ["", "   "], curlyNoSort)).toBe(
+      "using { /A }\n\ncode()",
+    );
+  });
+});


### PR DESCRIPTION
Closes #42

## What this fixes

With auto-import enabled (the default), "Optimize Imports" was deterministically broken: it removed every import, waited a hardcoded 700ms that cannot cover the 3000ms auto-import debounce (which its own edits kept resetting), ran its normalization steps on an import-less document, saved that document, and showed "Imports optimized successfully". The imports reappeared seconds later via the debounced auto-import, without the syntax-conversion and spacing the command promised, and the file was left modified after the command reported done.

## How

- New `ImportDocumentEditor.buildOrganizedContent(text, additionalPaths, options)` (pure, no VS Code) computes the final document: every module import consolidated at the top, plus the additional paths, deduplicated, grouped, sorted, and written in the preferred syntax, with the indented `using:` pair collapsed to single-line and local-scope `using` left in place.
- New `organizeImports` applies that in a single atomic `WorkspaceEdit` (one undo step), then normalizes spacing.
- `optimizeImports` now just reads current diagnostics, extracts missing paths, and calls `organizeImports`. No sleep, no branch on the auto-import setting, no dependence on the debounce delay. The document is never left without its imports.
- Removed the now-dead `removeAllImports` and `convertScatteredImportsToPreferredSyntax` (its behavior is subsumed by the hoisting + syntax pass) and the unused `LineEdit` type, along with the two timing constants.

## Behavior notes

- Optimize is deterministic and identical whether auto-import is on or off, at any debounce setting.
- Imports added are those in the compiler's current diagnostics at invocation; this matches the prior intent (the old off-branch did the same) without the race.

## Out of scope (per PRD #42)

Timer disposal and the shared-ImportHandler wiring are #43; formatting rules themselves are unchanged.

## Verification

- `npm run compile`: clean
- `npm test`: 4 suites, 38 tests (14 new for `buildOrganizedContent`: dedup, sort on/off, curly/dot syntax, indented pair, hoisting scattered imports, local-scope preservation, blank-line collapse, no-op)

## Note for reviewer

Diff is 4-space to match the bulk of `src/`. There is a separate, pre-existing issue where the local formatter reindents edited files (it put a few `src/` files on 2-space in #47); raising that separately as a repo-wide decision.
