### PR TITLE
fix: make prettier line-ending-agnostic for cross-platform

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
     "tabWidth": 4,
-    "printWidth": 200
+    "printWidth": 200,
+    "endOfLine": "auto"
 }


### PR DESCRIPTION
Follow-up to #54. Prettier's default `endOfLine: "lf"` made `npm run format:check` fail on Windows working trees (git checks some files out as CRLF) even though CI on Linux passed. `endOfLine: "auto"` accepts each file's existing line endings, so the check is consistent everywhere without forcing line-ending changes.

Verified: `npm run format:check` now passes locally (was 19 files failing) and `npm run compile` is clean. One-line config change only.