### PR TITLE
fix: lifecycle and wiring fixes (shared handler, assets watcher, timers, regex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Cached results are validated against the filesystem before use, with automatic fallback to a full scan when the cache is stale
   - The search near the current file runs first again, so the nearest module is preferred over project-wide matches
 - **Optimize Imports Reliability**: with auto-import enabled (the default), "Optimize Imports" could momentarily strip every import, report success, and leave the file unorganized while the imports reappeared a moment later. The command now organizes imports in a single step and never leaves the file without them; behavior no longer depends on the auto-import debounce delay
+- **Auto-Import Asset Class Names**: automatic imports now exclude asset class names from the import path, matching the quick-fix behavior. Previously the automatic path could import `using { A.B.ClassName }` where the quick fix correctly used `using { A.B }`
+- **Asset Changes Detected Promptly**: adding or renaming assets in UEFN is now picked up as soon as the assets digest regenerates, instead of after a delay. The file watcher for the out-of-workspace assets digest was not firing
+- **Ambiguous Module Detection**: when a module is defined in several files, path conversion no longer drops valid locations depending on the order files are scanned
+- **Snooze Timer**: repeatedly starting snooze from the command palette no longer leaves extra countdown timers running, and an active snooze is cleaned up when the extension is disabled or reloaded
 
 ### Changed
 

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,7 +1,9 @@
 const workspace = {
     getConfiguration: jest.fn().mockReturnValue({
         get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+        update: jest.fn().mockResolvedValue(undefined),
     }),
+    onDidChangeConfiguration: jest.fn().mockReturnValue({ dispose: jest.fn() }),
 };
 
 const window = {
@@ -11,6 +13,21 @@ const window = {
         clear: jest.fn(),
         dispose: jest.fn(),
     }),
+    createStatusBarItem: jest.fn().mockImplementation(() => ({
+        text: "",
+        tooltip: "",
+        command: "",
+        name: "",
+        color: undefined,
+        backgroundColor: undefined,
+        show: jest.fn(),
+        hide: jest.fn(),
+        dispose: jest.fn(),
+    })),
+    showInformationMessage: jest.fn(),
+    showWarningMessage: jest.fn(),
+    showErrorMessage: jest.fn(),
+    setStatusBarMessage: jest.fn(),
 };
 
 const DiagnosticSeverity = {
@@ -20,4 +37,15 @@ const DiagnosticSeverity = {
     Hint: 3,
 };
 
-export { workspace, window, DiagnosticSeverity };
+const StatusBarAlignment = {
+    Left: 1,
+    Right: 2,
+};
+
+const ConfigurationTarget = {
+    Global: 1,
+    Workspace: 2,
+    WorkspaceFolder: 3,
+};
+
+export { workspace, window, DiagnosticSeverity, StatusBarAlignment, ConfigurationTarget };

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -10,8 +10,13 @@ export class DiagnosticsHandler {
     private pendingTimers: Map<string, NodeJS.Timeout> = new Map();
     private delayMs: number = 1000;
 
-    constructor(private outputChannel: vscode.OutputChannel) {
-        this.importHandler = new ImportHandler(outputChannel);
+    constructor(
+        private outputChannel: vscode.OutputChannel,
+        importHandler: ImportHandler,
+    ) {
+        // Use the shared, fully-wired ImportHandler so the auto-import path has
+        // the same asset-class detection and precompiled digests as quick fixes.
+        this.importHandler = importHandler;
         logger.debug("DiagnosticsHandler", `Initialized with ${this.delayMs}ms delay`);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Create handlers and providers
     const importHandler = new ImportHandler(outputChannel, assetsDigestParser, context);
-    const diagnosticsHandler = new DiagnosticsHandler(outputChannel);
+    const diagnosticsHandler = new DiagnosticsHandler(outputChannel, importHandler);
     const statusBarHandler = new StatusBarHandler(outputChannel);
     const importPathConverter = new ImportPathConverter(outputChannel, projectPathCache);
     const importCodeLensProvider = new ImportCodeLensProvider(outputChannel);
@@ -124,8 +124,9 @@ export function activate(context: vscode.ExtensionContext) {
         ),
     );
 
-    // Register status bar item
-    context.subscriptions.push(statusBarHandler.getStatusBarItem());
+    // Register the status bar handler for disposal (clears the snooze timer
+    // and disposes the status bar item on deactivation).
+    context.subscriptions.push(statusBarHandler);
 
     // Configuration change listener for debounce delay
     context.subscriptions.push(

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -70,6 +70,17 @@ export class ImportPathConverter {
         return location === "/" || location === "" ? `${projectVersePath}/${modulePath}` : `${projectVersePath}${location}/${modulePath}`;
     }
 
+    /**
+     * Builds a regex matching an explicit `Name := module:` declaration for the
+     * given module name. Non-global on purpose: this pattern is reused with
+     * `.test()` across many files, and a global flag would carry `lastIndex`
+     * between calls and skip valid definitions depending on file order.
+     */
+    static buildModuleDefinitionRegex(moduleName: string): RegExp {
+        const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        return new RegExp(`\\b${escaped}(?:'[^']*')?\\s*(?:<\\s*(?:public|private|internal|protected)\\s*>)?\\s*:=\\s*module\\s*[:>]`, "m");
+    }
+
     /** Extracts the path string from an import statement */
     private extractPathFromImport(importStatement: string): string {
         const curlyMatch = importStatement.match(/using\s*\{\s*([^}]+)\s*\}/);
@@ -232,8 +243,7 @@ export class ImportPathConverter {
         if (workspaceIsContent) searchPattern = "**/*.verse";
 
         const verseFiles = await vscode.workspace.findFiles(searchPattern, null, 100);
-        const escapedModuleName = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const modulePattern = new RegExp(`\\b${escapedModuleName}(?:'[^']*')?\\s*(?:<\\s*(?:public|private|internal|protected)\\s*>)?\\s*:=\\s*module\\s*[:>]`, "gm");
+        const modulePattern = ImportPathConverter.buildModuleDefinitionRegex(moduleName);
 
         for (const file of verseFiles) {
             const content = await vscode.workspace.fs.readFile(file).then(

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -19,3 +19,41 @@ describe("ImportPathConverter.buildFullVersePath", () => {
         expect(ImportPathConverter.buildFullVersePath(projectVersePath, "/UI/Shared", "HUD/Textures")).toBe("/mygame@fortnite.com/mygame/UI/Shared/HUD/Textures");
     });
 });
+
+describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
+    it("matches a module declaration with and without a visibility specifier", () => {
+        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
+        expect(re.test("Inventory := module:")).toBe(true);
+        expect(re.test("Inventory<public> := module:")).toBe(true);
+        expect(re.test("Inventory := module>")).toBe(true);
+    });
+
+    it("does not match a different module or a non-module declaration", () => {
+        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
+        expect(re.test("MyInventory := module:")).toBe(false);
+        expect(re.test("Inventory := class:")).toBe(false);
+        expect(re.test("InventoryItem := module:")).toBe(false);
+    });
+
+    it("is not global, so repeated .test() calls are order-independent", () => {
+        // A global regex would retain lastIndex between calls and could skip a
+        // match in a later string depending on where the previous match ended.
+        const re = ImportPathConverter.buildModuleDefinitionRegex("Foo");
+        expect(re.flags).not.toContain("g");
+
+        const withLateMatch = "some preamble text here\n\n\nFoo := module:";
+        const withEarlyMatch = "Foo := module:";
+
+        // Call against a string whose match is far into the text, then against a
+        // string whose match is at the very start. Both must return true.
+        expect(re.test(withLateMatch)).toBe(true);
+        expect(re.test(withEarlyMatch)).toBe(true);
+        expect(re.test(withLateMatch)).toBe(true);
+    });
+
+    it("escapes regex metacharacters in the module name", () => {
+        const re = ImportPathConverter.buildModuleDefinitionRegex("a.b");
+        expect(re.test("a.b := module:")).toBe(true);
+        expect(re.test("axb := module:")).toBe(false);
+    });
+});

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -159,10 +159,11 @@ export class AssetsDigestParser {
 
         // Watch for Assets.digest.verse in the VerseProject folder
         const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
-        const watchPattern = path.join(localAppData, "UnrealEditorFortnite", "Saved", "VerseProject", "**", "Assets.digest.verse");
-
-        // Use a glob pattern for the watcher
-        const watcher = vscode.workspace.createFileSystemWatcher(watchPattern);
+        // The digest lives outside the workspace. A plain string glob is only
+        // honored inside workspace folders, so watch the external VerseProject
+        // directory recursively via a RelativePattern anchored to its Uri.
+        const verseProjectDir = path.join(localAppData, "UnrealEditorFortnite", "Saved", "VerseProject");
+        const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(vscode.Uri.file(verseProjectDir), "**/Assets.digest.verse"));
 
         const handleChange = (uri: vscode.Uri) => {
             logger.debug("AssetsDigestParser", `Assets.digest.verse changed: ${uri.fsPath}`);

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -183,6 +183,10 @@ export class ProjectPathCache {
         });
         disposables.push(projectWatcher);
 
+        // Clear any pending debounced update on teardown so it cannot run
+        // against a disposed extension context after deactivation.
+        disposables.push({ dispose: () => this.clear() });
+
         logger.debug("ProjectPathCache", "File watchers set up");
 
         return vscode.Disposable.from(...disposables);

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -44,10 +44,6 @@ export class StatusBarHandler {
         });
     }
 
-    getStatusBarItem(): vscode.StatusBarItem {
-        return this.statusBarItem;
-    }
-
     updateDisplay(): void {
         if (this.snoozeEndTime !== null) {
             // Snooze is active - show text with countdown
@@ -424,6 +420,10 @@ export class StatusBarHandler {
 
     startSnooze(minutes: number): void {
         logger.debug("StatusBarHandler", `Starting snooze for ${minutes} minutes`);
+
+        // Clear any existing snooze first so re-invoking (e.g. the command
+        // palette while already snoozed) cannot orphan a running interval.
+        this.clearSnoozeState();
 
         // Set snooze end time
         this.snoozeEndTime = Date.now() + minutes * MS_PER_MINUTE;

--- a/src/ui/__tests__/StatusBarHandler.test.ts
+++ b/src/ui/__tests__/StatusBarHandler.test.ts
@@ -1,0 +1,60 @@
+import { StatusBarHandler } from "../StatusBarHandler";
+import * as vscode from "vscode";
+
+describe("StatusBarHandler snooze timer lifecycle", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    function makeHandler(): StatusBarHandler {
+        const outputChannel = vscode.window.createOutputChannel("test");
+        return new StatusBarHandler(outputChannel);
+    }
+
+    it("runs exactly one interval while snoozed", () => {
+        const handler = makeHandler();
+        expect(jest.getTimerCount()).toBe(0);
+
+        handler.startSnooze(5);
+        expect(jest.getTimerCount()).toBe(1);
+    });
+
+    it("does not leak an interval when snooze is started again while active", () => {
+        const clearSpy = jest.spyOn(global, "clearInterval");
+        const handler = makeHandler();
+
+        handler.startSnooze(5);
+        clearSpy.mockClear();
+
+        // Re-invoke while already snoozed (reachable via the command palette).
+        handler.startSnooze(5);
+
+        // The prior interval must have been cleared, leaving exactly one.
+        expect(clearSpy).toHaveBeenCalledTimes(1);
+        expect(jest.getTimerCount()).toBe(1);
+    });
+
+    it("clears the interval on cancel", () => {
+        const handler = makeHandler();
+        handler.startSnooze(5);
+        expect(jest.getTimerCount()).toBe(1);
+
+        handler.cancelSnooze();
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it("clears the interval on dispose", () => {
+        const handler = makeHandler();
+        handler.startSnooze(5);
+        expect(jest.getTimerCount()).toBe(1);
+
+        handler.dispose();
+        expect(jest.getTimerCount()).toBe(0);
+    });
+});


### PR DESCRIPTION
Closes #43

Four confirmed lifecycle/wiring defects from the 0.7 review, one hygiene pass.

## Fixes

1. **Auto-import used a partially-wired ImportHandler.** `DiagnosticsHandler` constructed `new ImportHandler(outputChannel)` without the `AssetsDigestParser` or extension context, so auto-import regressed the 0.6.2 asset-class fix (`using { A.B.ClassName }` instead of `using { A.B }`) while the quick fix stayed correct. It now receives the shared, fully-wired instance from `extension.ts`.

2. **The assets-digest watcher never fired.** It watched an absolute out-of-workspace path with a plain string glob, which VS Code only honors inside workspace folders. Now uses `RelativePattern(Uri.file(verseProjectDir), "**/Assets.digest.verse")`, so newly added/renamed assets are picked up when the digest regenerates (previously stale up to the 5-minute TTL).

3. **Timer lifecycle.** `startSnooze` now clears any existing snooze first (the command palette could re-invoke it while snoozed and orphan an interval); `StatusBarHandler` is registered in `context.subscriptions` so its snooze interval is cleared on deactivation (and its now-dead `getStatusBarItem` accessor is removed); the project path cache clears its pending debounce timer on teardown.

4. **Stateful module regex.** `searchExplicitModuleDefinitions` reused one global (`/g`) regex with `.test()` across files, so the retained `lastIndex` skipped valid module definitions depending on scan order. Extracted a non-global `buildModuleDefinitionRegex`.

## Tests

- `buildModuleDefinitionRegex`: matching with/without visibility, non-matches, metacharacter escaping, and an order-independence test that a global regex would fail.
- Snooze lifecycle (fake timers): exactly one interval while snoozed, no leak on re-entry, cleared on cancel and on dispose. Required expanding the shared `vscode` mock (status bar item, config update, `onDidChangeConfiguration`, alignment/target enums).

Watcher firing and disposal-on-deactivate are verified by manual smoke test (no VS Code runtime in jest).

## Verification

- `npm run format:check`, `npm run compile`: clean
- `npm test`: 5 suites, 46 tests (8 new)

This is the last code blocker for 0.7.0; #44 (changelog finalization) is all that remains.
