### PR TITLE
ci: add module labels and path-based PR labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,69 @@
+# Path-based module/area labels for pull requests (actions/labeler).
+# Keep in sync with the label mapping in claude-issue-triage.yml.
+
+"module: imports":
+  - changed-files:
+      - all-globs-to-any-file:
+          - "src/imports/**"
+          - "!src/imports/ImportPathConverter.ts"
+          - "!src/imports/ImportCodeLensProvider.ts"
+          - "!src/imports/__tests__/ImportPathConverter*"
+          - "!src/imports/__tests__/ImportCodeLensProvider*"
+
+"module: path-conversion":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/imports/ImportPathConverter.ts"
+          - "src/imports/ImportCodeLensProvider.ts"
+          - "src/imports/__tests__/ImportPathConverter*"
+          - "src/imports/__tests__/ImportCodeLensProvider*"
+
+"module: diagnostics":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/diagnostics/**"
+
+"module: digest":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/services/DigestParser.ts"
+          - "src/services/AssetsDigestParser.ts"
+          - "src/services/PrecompiledDigestLoader.ts"
+          - "src/services/moduleLocationLookup.ts"
+          - "src/services/__tests__/DigestParser*"
+          - "src/services/__tests__/AssetsDigestParser*"
+          - "src/services/__tests__/PrecompiledDigestLoader*"
+          - "src/services/__tests__/moduleLocationLookup*"
+          - "src/data/**"
+          - "src/scripts/**"
+          - "src/utils/*.digest.verse"
+
+"module: project-detection":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/project/**"
+          - "src/services/ProjectPath*.ts"
+          - "src/services/__tests__/ProjectPath*"
+          - "src/types/projectCache.ts"
+
+"module: config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/types/configuration.ts"
+
+"module: ui":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/ui/**"
+          - "src/commands/**"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - "docs/**"

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -39,11 +39,28 @@ jobs:
                "enhancement", "question", or "documentation". Check available
                labels first with `gh label list` and use the closest match;
                do not create new labels.
-            4. For bugs: check whether the report includes the extension version,
+            4. Apply exactly one module/area label identifying the part of the
+               extension involved:
+               - "module: imports" - wrong/missing/duplicated using statement,
+                 quick fix content, import formatting or placement
+               - "module: diagnostics" - when auto-import triggers (e.g. fires
+                 mid-typing), debounce, compiler error processing
+               - "module: digest" - digest lookup, Assets.digest.verse parsing,
+                 unknown identifier resolution from API data
+               - "module: project-detection" - .uefnproject not found, wrong
+                 project name or Verse path
+               - "module: path-conversion" - the path conversion CodeLens
+               - "module: config" - settings behavior, defaults, migration
+               - "module: ui" - status bar, commands, quick fix menu appearance
+               - "area: ci" - workflows, releases, repo automation
+               - "area: docs" - README, wiki, changelog
+               If the area is genuinely unclear from the report, skip this label
+               rather than guessing.
+            5. For bugs: check whether the report includes the extension version,
                VS Code version, and a sample Verse snippet or compiler error text.
                If any of these are missing, post one polite comment asking for the
                specific missing items.
-            5. If the report includes a Verse compiler error message, inspect
+            6. If the report includes a Verse compiler error message, inspect
                src/imports/ImportSuggestionExtractor.ts and note in a comment which
                extraction pattern is involved (or that none matches), to speed up
                the eventual fix.

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,23 @@
+name: Label PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: label-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v5
+        with:
+          # Never remove labels added manually or by other automation
+          sync-labels: false


### PR DESCRIPTION
## Summary

Adds a module/area label taxonomy so every issue and PR is classified by the part of the extension it touches, and wires it into the existing automation.

- 9 new labels created directly on the repo: `module: imports`, `module: diagnostics`, `module: digest`, `module: project-detection`, `module: path-conversion`, `module: config`, `module: ui`, `area: ci`, `area: docs`
- `.github/labeler.yml` + `label-pr.yml`: deterministic path-based PR labeling via actions/labeler on `pull_request_target` (`sync-labels: false`, so manual labels are never removed)
- `claude-issue-triage.yml`: the triage prompt now applies exactly one module/area label per issue, with an explicit symptom-to-label mapping; it skips the label when the area is unclear rather than guessing

Targets `main` because `issues` and `pull_request_target` triggers only run workflow definitions from the default branch; routing through `develop` would leave the automation inert until the next release. All changes are `.github/**` only.

## After merge

Merge `main` back into `develop` to keep the branches in sync. That sync PR doubles as the live test of the labeler (it should receive `area: ci`).

## Verification

- `npm run compile` passes. No test script exists on `main` (jest lands with 0.7); the change is YAML-only.
- The 5 existing open issues/PRs have been backfilled with module labels manually.

Milestone assignment stays manual by design.