### PR TITLE
fix: filter diagnostics events to real .verse files before processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Asset Changes Detected Promptly**: adding or renaming assets in UEFN is now picked up as soon as the assets digest regenerates, instead of after a delay. The file watcher for the out-of-workspace assets digest was not firing
 - **Ambiguous Module Detection**: when a module is defined in several files, path conversion no longer drops valid locations depending on the order files are scanned
 - **Snooze Timer**: repeatedly starting snooze from the command palette no longer leaves extra countdown timers running, and an active snooze is cleaned up when the extension is disabled or reloaded
+- **Diagnostics Noise in UEFN Workspaces**: the auto-import listener no longer tries to open VS Code internal documents (which logged an error on every edit preview) and no longer reprocesses Epic's read-only `*.digest.verse` files, which carry permanent compiler errors in the standard UEFN workspace, on every diagnostics update
 
 ## [0.6.4] - 2026-02-14
 

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -20,6 +20,21 @@ export class DiagnosticsHandler {
         logger.debug("DiagnosticsHandler", `Initialized with ${this.delayMs}ms delay`);
     }
 
+    /**
+     * Decides whether a diagnostics URI should be processed at all, before any
+     * document is opened. Diagnostics events also carry VS Code internal
+     * documents (e.g. private: replace-preview buffers, git: views) that throw
+     * on openTextDocument, and Epic's generated *.digest.verse files, which
+     * hold permanent LSP errors and must never be edited by the extension.
+     */
+    static shouldProcessUri(uri: { scheme: string; fsPath: string }): boolean {
+        if (uri.scheme !== "file") {
+            return false;
+        }
+        const fsPath = uri.fsPath.toLowerCase();
+        return fsPath.endsWith(".verse") && !fsPath.endsWith(".digest.verse");
+    }
+
     async handle(document: vscode.TextDocument) {
         const documentKey = path.basename(document.uri.fsPath);
 

--- a/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
+++ b/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
@@ -1,0 +1,36 @@
+import { DiagnosticsHandler } from "../DiagnosticsHandler";
+
+describe("DiagnosticsHandler.shouldProcessUri", () => {
+    const fileUri = (fsPath: string) => ({ scheme: "file", fsPath });
+
+    it("accepts a regular .verse file", () => {
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\Project\\Content\\Scripts\\device.verse"))).toBe(true);
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("/home/user/Content/device.verse"))).toBe(true);
+    });
+
+    it("rejects VS Code internal document schemes", () => {
+        // Replace-preview buffers appear in diagnostics events while an edit
+        // preview is in flight; opening them throws.
+        expect(DiagnosticsHandler.shouldProcessUri({ scheme: "private", fsPath: "/replacePreview" })).toBe(false);
+        expect(DiagnosticsHandler.shouldProcessUri({ scheme: "git", fsPath: "/repo/file.verse" })).toBe(false);
+        expect(DiagnosticsHandler.shouldProcessUri({ scheme: "output", fsPath: "extension-output" })).toBe(false);
+        expect(DiagnosticsHandler.shouldProcessUri({ scheme: "untitled", fsPath: "Untitled-1" })).toBe(false);
+    });
+
+    it("rejects Epic's generated digest files", () => {
+        // Digest files carry permanent LSP errors in a UEFN workspace and are
+        // read-only reference material; the extension must never process them.
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\VerseProject\\Fortnite\\Fortnite.digest.verse"))).toBe(false);
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\VerseProject\\P-Assets\\Assets.digest.verse"))).toBe(false);
+    });
+
+    it("rejects non-verse files", () => {
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\Project\\Content\\readme.md"))).toBe(false);
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\Project\\project.uefnproject"))).toBe(false);
+    });
+
+    it("is case-insensitive about the extension", () => {
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\Project\\Device.VERSE"))).toBe(true);
+        expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\Project\\Assets.DIGEST.verse"))).toBe(false);
+    });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,6 +157,9 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.onDidChangeDiagnostics(async (e) => {
             for (const uri of e.uris) {
+                if (!DiagnosticsHandler.shouldProcessUri(uri)) {
+                    continue;
+                }
                 try {
                     const document = await vscode.workspace.openTextDocument(uri);
                     if (document.languageId === "verse") {


### PR DESCRIPTION
## Summary

Found during the live UEFN smoke test (real 41.10 multi-root workspace). Two problems, one filter:

- Diagnostics events include VS Code internal documents (`private:` replace-preview buffers). `openTextDocument()` throws on them, so the extension logged `Error opening document private:/...#replacePreview` on every edit preview - noise every real user sees.
- Epic's generated `*.digest.verse` files (workspace roots in every UEFN project) carry ~40 permanent LSP errors. The extractor re-ran over all of them on every diagnostics cycle - wasted work per keystroke and a latent risk of ever editing Epic's read-only digest files.

`DiagnosticsHandler.shouldProcessUri()` now rejects non-`file:` schemes, non-`.verse` paths, and `*.digest.verse` before any document is opened. Opening the document before checking its language was also the first perf item noted in #46; this resolves that bullet.

## Verification

- `npm run compile` clean
- `npm test`: 6 suites, 51 tests pass (5 new regression tests for the URI filter)
- `npm run format:check` clean

Refs #46