### PR TITLE
fix: scope fallback module-definition scan to the project folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Asset Changes Detected Promptly**: adding or renaming assets in UEFN is now picked up as soon as the assets digest regenerates, instead of after a delay. The file watcher for the out-of-workspace assets digest was not firing
 - **Ambiguous Module Detection**: when a module is defined in several files, path conversion no longer drops valid locations depending on the order files are scanned
 - **Snooze Timer**: repeatedly starting snooze from the command palette no longer leaves extra countdown timers running, and an active snooze is cleaned up when the extension is disabled or reloaded
+- **Path Conversion Scan Scope**: the fallback scan for explicit module declarations no longer reads Epic's digest files on every lookup in the standard UEFN multi-root workspace; it is now scoped to the project folder
 
 ## [0.6.4] - 2026-02-14
 

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -231,7 +231,7 @@ export class ImportPathConverter {
 
     /**
      * Phase 2: Search for explicit module definitions in .verse files.
-     * Scans workspace for files containing module := module declarations.
+     * Scans the project folder for files containing Name := module declarations.
      */
     private async searchExplicitModuleDefinitions(modulePath: string, moduleName: string, pathSegments: string[], locations: string[]): Promise<void> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -242,7 +242,10 @@ export class ImportPathConverter {
         const workspaceIsContent = workspaceFolderName === CONTENT_FOLDER;
         if (workspaceIsContent) searchPattern = "**/*.verse";
 
-        const verseFiles = await vscode.workspace.findFiles(searchPattern, null, 100);
+        // Scope the scan to the project folder. The UEFN-generated workspace is
+        // multi-root (Content plus Epic's digest folders); a bare string glob
+        // would also read every *.digest.verse on each fallback scan.
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", 100);
         const modulePattern = ImportPathConverter.buildModuleDefinitionRegex(moduleName);
 
         for (const file of verseFiles) {


### PR DESCRIPTION
## Summary

Confirmed live during the 0.7 UEFN smoke test: the stage-1 debug log shows `Found module definition in: ...\Fortnite\Fortnite.digest.verse` on every fallback scan for an unresolved module. The UEFN-generated workspace is multi-root (Content plus Epic's digest folders), and a bare string glob in `findFiles` searches all roots - so each fallback lookup read and regexed the 572 KB Fortnite digest. The results were filtered out afterwards by the Content-prefix check, so behavior was correct but the work was wasted, and a digest module name matching the regex was a latent hazard.

Fix: scope the scan with `RelativePattern(workspaceFolders[0], pattern)` and exclude `*.digest.verse` defensively. Same approach as the assets-digest watcher fix in #56.

Preexisting behavior (0.6.4 has the same bare glob), not a 0.7 regression - but it only became visible in the real multi-root workspace, and the fix is three lines.

## Verification

- `npm run compile` clean
- `npm test`: 46 tests pass
- `npm run format:check` clean
- Live re-verification planned in smoke-test stage 2 (log must show no digest reads during T4 fallback lookups)