### PR TITLE
test: add UEFN smoke-test fixture suite and playbook

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,9 +21,11 @@ package-lock.json
 
 # Test files
 test/**
+test-fixtures/**
 **/*.test.js
 **/*.spec.js
 vitest.config.*
+jest.config.js
 
 # Development artifacts
 *.vsix

--- a/test-fixtures/uefn-smoke/Content/Features/Combat/Weapons/t4_weapons_b.verse
+++ b/test-fixtures/uefn-smoke/Content/Features/Combat/Weapons/t4_weapons_b.verse
@@ -1,0 +1,4 @@
+# T4 case B support: second Combat/Weapons folder chain (under Features/).
+
+t4_weapon_b<public> := class:
+    Damage<public>:int = 20

--- a/test-fixtures/uefn-smoke/Content/Features/economy_b.verse
+++ b/test-fixtures/uefn-smoke/Content/Features/economy_b.verse
@@ -1,0 +1,6 @@
+# T4 case C support: explicit module declaration, second location (Features/).
+
+Economy<public> := module:
+    Shop<public> := module:
+        shop_item_b<public> := class:
+            Price<public>:int = 20

--- a/test-fixtures/uefn-smoke/Content/Gadgets/Tools/t4_tools.verse
+++ b/test-fixtures/uefn-smoke/Content/Gadgets/Tools/t4_tools.verse
@@ -1,0 +1,5 @@
+# T4 case A support: implicit folder module directly under Content.
+# Module path: Gadgets/Tools
+
+t4_tool<public> := class:
+    Name<public>:string = "tool"

--- a/test-fixtures/uefn-smoke/Content/Scripts/T1_auto_import.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T1_auto_import.verse
@@ -1,15 +1,19 @@
 # T1: auto-import from single-option compiler suggestions.
 #
 # Setup: general.autoImport ON (default). This file ships with no imports.
-# Expected: within the debounce window (default 3s) the extension adds:
+# Expected: within the debounce window the extension adds, exactly once each:
 #   using { /Fortnite.com/Devices }      (creative_device, button_device)
-#   using { /Verse.org/SpatialMath }     (vector3)
-#   using { /Verse.org/Simulation }      (player)
-# Devices must be added once (dedup), not once per identifier.
+#   using { /Fortnite.com/Characters }   (fort_character)
+#   using { /Verse.org/Simulation }      (player, and the editable attribute)
+# Devices and Simulation must be added once (dedup), not once per identifier.
+#
+# Verified against 41.10: vector3 is NOT usable here because the live compiler
+# reports it as multi-option (/Verse.org/SpatialMath and
+# /UnrealEngine.com/Temporary/SpatialMath) -- that scenario belongs to T2.
 
 t1_device := class(creative_device):
     @editable
     TestButton:button_device = button_device{}
 
-    var Position:vector3 = vector3{}
     var TrackedPlayers:[]player = array{}
+    var MaybeCharacter:?fort_character = false

--- a/test-fixtures/uefn-smoke/Content/Scripts/T1_auto_import.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T1_auto_import.verse
@@ -1,0 +1,15 @@
+# T1: auto-import from single-option compiler suggestions.
+#
+# Setup: general.autoImport ON (default). This file ships with no imports.
+# Expected: within the debounce window (default 3s) the extension adds:
+#   using { /Fortnite.com/Devices }      (creative_device, button_device)
+#   using { /Verse.org/SpatialMath }     (vector3)
+#   using { /Verse.org/Simulation }      (player)
+# Devices must be added once (dedup), not once per identifier.
+
+t1_device := class(creative_device):
+    @editable
+    TestButton:button_device = button_device{}
+
+    var Position:vector3 = vector3{}
+    var TrackedPlayers:[]player = array{}

--- a/test-fixtures/uefn-smoke/Content/Scripts/T2_multi_option.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T2_multi_option.verse
@@ -1,0 +1,10 @@
+# T2: multi-option handling. t2_shared_thing exists in BOTH the T2A and T2B
+# modules, so the compiler cannot suggest a single import.
+#
+# Expected (multiOptionStrategy = default "quickFix"): no auto-import fires;
+# the quick fix menu on the error offers one import action per candidate
+# (T2A and T2B). Record the exact compiler error text in the playbook -- this
+# validates our multi-option extractor patterns against live 41.10 messages.
+
+t2_consumer := class:
+    var Thing:?t2_shared_thing = false

--- a/test-fixtures/uefn-smoke/Content/Scripts/T3_assets.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T3_assets.verse
@@ -7,10 +7,12 @@
 # itself (e.g. "using { Folder1.image2 }" is wrong; "using { Folder1 }" is
 # acceptable). Record the exact error text and what the extension did.
 #
-# Known risk being validated: AssetsDigestParser only recognizes
-# "Name<public|internal|private> := class/struct" but 41.10 emits
-# "name<scoped {Project}>:texture = external {}" for instances and
-# "Name<scoped {Project}> := class<final><public>(material)" for materials.
+# Confirmed on live 41.10 (see the generated Assets.digest.verse): instances
+# are "name<scoped {...}>:texture = external {}" and class-generating assets
+# (materials, mesh components, VFX components) use "<scoped {...}>" visibility,
+# so AssetsDigestParser parses 0 names. The leaf-stripping below still works
+# because the extractor strips the suggestion segment matching the unknown
+# identifier - it does not need the digest for this error shape.
 
 t3_probe := class:
     # texture instance one folder deep (Folder1/image2)
@@ -19,8 +21,10 @@ t3_probe := class:
     # texture instance two folders deep (Folder1/InnerFolder/image3)
     GetInnerImage():texture = image3
 
-# Uncomment after Phase A adds Materials/TestMaterial in UEFN. Materials are
-# the only asset type that generates a CLASS in the digest, which is the exact
-# code path the 0.6.2 asset-class fix targets.
-# t3_material_probe := class:
-#     GetMaterial():TestMaterial_material = TestMaterial_material{}
+# Materials are the only asset type generating a CLASS whose fields matter.
+# Live 41.10 digest name is the asset's own name (TestMaterial - no _material
+# suffix, contrary to the Epic doc example). Expected: compiler suggests
+# Materials.TestMaterial; extension imports using { Materials }, never
+# using { Materials.TestMaterial }.
+t3_material_probe := class:
+    var MaybeMaterial:?TestMaterial = false

--- a/test-fixtures/uefn-smoke/Content/Scripts/T3_assets.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T3_assets.verse
@@ -1,0 +1,26 @@
+# T3: asset reference handling against the live 41.10 Assets.digest.verse.
+# Requires PLAYBOOK Phase A (assets created in UEFN) to be complete.
+#
+# Expected for each unqualified asset reference below: the compiler reports an
+# unknown identifier and suggests the qualified name (e.g. Folder1.image2).
+# The extension must NEVER produce an import that includes the asset name
+# itself (e.g. "using { Folder1.image2 }" is wrong; "using { Folder1 }" is
+# acceptable). Record the exact error text and what the extension did.
+#
+# Known risk being validated: AssetsDigestParser only recognizes
+# "Name<public|internal|private> := class/struct" but 41.10 emits
+# "name<scoped {Project}>:texture = external {}" for instances and
+# "Name<scoped {Project}> := class<final><public>(material)" for materials.
+
+t3_probe := class:
+    # texture instance one folder deep (Folder1/image2)
+    GetImage():texture = image2
+
+    # texture instance two folders deep (Folder1/InnerFolder/image3)
+    GetInnerImage():texture = image3
+
+# Uncomment after Phase A adds Materials/TestMaterial in UEFN. Materials are
+# the only asset type that generates a CLASS in the digest, which is the exact
+# code path the 0.6.2 asset-class fix targets.
+# t3_material_probe := class:
+#     GetMaterial():TestMaterial_material = TestMaterial_material{}

--- a/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
@@ -1,0 +1,24 @@
+# T4: path conversion CodeLens + module location lookup (issue #41 rebuild).
+# projectVersePath for this project: /vuke@fortnite.com/VerseAutoImports
+#
+# Case A (direct Content child, implicit folder module):
+#   Gadgets.Tools -> /vuke@fortnite.com/VerseAutoImports/Gadgets/Tools
+# Case B (ambiguous folder module): Combat/Weapons exists under BOTH
+#   Systems/ and Features/. Conversion must detect both locations and ask
+#   (or apply behavior.ambiguousImports mapping), never silently pick one.
+# Case C (explicit module declarations in files): Economy := module with
+#   nested Shop := module is declared in Systems/economy_a.verse AND
+#   Features/economy_b.verse. This exercises the declaration cache lookup and
+#   the module-definition regex across multiple files (issue #43 lastIndex
+#   fix). Expect both locations detected.
+#
+# Steps: hover each import line, use the conversion CodeLens, then run the
+# bulk "convert all" command. Also run "Rebuild Project Path Cache" first and
+# compare behavior with cache.enabled true vs false.
+
+using { Gadgets.Tools }
+using { Combat.Weapons }
+using { Economy.Shop }
+
+t4_consumer := class:
+    Tag:string = "t4"

--- a/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
@@ -4,8 +4,11 @@
 # Case A (direct Content child, implicit folder module):
 #   Gadgets.Tools -> /vuke@fortnite.com/VerseAutoImports/Gadgets/Tools
 # Case B (ambiguous folder module): Combat/Weapons exists under BOTH
-#   Systems/ and Features/. Conversion must detect both locations and ask
-#   (or apply behavior.ambiguousImports mapping), never silently pick one.
+#   Systems/ and Features/. KNOWN LIMITATION (issue #60, verified preexisting
+#   in 0.6.4): folder-chain modules outside the current file's ancestry and
+#   Content root resolve to 0 locations, so conversion reports "not found".
+#   Expect a graceful failure, never a silently wrong path. The compiler's own
+#   error suggests Systems.Combat / Features.Combat.
 # Case C (explicit module declarations in files): Economy := module with
 #   nested Shop := module is declared in Systems/economy_a.verse AND
 #   Features/economy_b.verse. This exercises the declaration cache lookup and

--- a/test-fixtures/uefn-smoke/Content/Scripts/T5_optimize.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T5_optimize.verse
@@ -2,13 +2,15 @@
 # 0.6.4 local-scope regressions.
 #
 # This file deliberately contains: a duplicate import, imports scattered
-# mid-file, a missing import (vector3), a local-scope using inside a function
-# body, and an indented-style using block at the bottom.
+# mid-file, a missing import (fort_character, single-option suggestion), a
+# local-scope using inside a function body, and an indented-style using block
+# at the bottom.
 #
 # Run "Verse: Optimize Imports" with general.autoImport ON, then again on a
-# reset copy with it OFF. Expected in both cases, as ONE atomic edit:
+# re-synced copy with it OFF. Expected in both cases, as ONE atomic edit:
 #   - all module imports consolidated at the top, deduplicated
-#   - using { /Verse.org/SpatialMath } ADDED (from the vector3 diagnostic)
+#   - using { /Fortnite.com/Characters } ADDED (from the fort_character
+#     diagnostic; must be single-option so optimize can apply it)
 #   - the indented "using:" block absorbed into the top block
 #   - the local-scope "using { Helper }" inside Describe() left untouched
 #   - no code between the scattered imports deleted
@@ -23,11 +25,11 @@ using { /Fortnite.com/Devices }
 using { /Verse.org/Simulation }
 
 t5_device := class(creative_device):
-    var Position:vector3 = vector3{}
+    var MaybeCharacter:?fort_character = false
 
     Describe(Helper:t5_helper):string =
         using { Helper }
-        GetLabel()
+        Helper.GetLabel()
 
 using:
     /Fortnite.com/Playspaces

--- a/test-fixtures/uefn-smoke/Content/Scripts/T5_optimize.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T5_optimize.verse
@@ -1,0 +1,33 @@
+# T5: Optimize Imports command (issue #42 atomic rewrite) plus the 0.6.3 and
+# 0.6.4 local-scope regressions.
+#
+# This file deliberately contains: a duplicate import, imports scattered
+# mid-file, a missing import (vector3), a local-scope using inside a function
+# body, and an indented-style using block at the bottom.
+#
+# Run "Verse: Optimize Imports" with general.autoImport ON, then again on a
+# reset copy with it OFF. Expected in both cases, as ONE atomic edit:
+#   - all module imports consolidated at the top, deduplicated
+#   - using { /Verse.org/SpatialMath } ADDED (from the vector3 diagnostic)
+#   - the indented "using:" block absorbed into the top block
+#   - the local-scope "using { Helper }" inside Describe() left untouched
+#   - no code between the scattered imports deleted
+#   - success toast only if the above actually happened
+
+using { /Verse.org/Simulation }
+
+t5_helper := class:
+    GetLabel<public>():string = "t5"
+
+using { /Fortnite.com/Devices }
+using { /Verse.org/Simulation }
+
+t5_device := class(creative_device):
+    var Position:vector3 = vector3{}
+
+    Describe(Helper:t5_helper):string =
+        using { Helper }
+        GetLabel()
+
+using:
+    /Fortnite.com/Playspaces

--- a/test-fixtures/uefn-smoke/Content/Scripts/T6_styles.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T6_styles.verse
@@ -1,0 +1,17 @@
+# T6: syntax style, grouping, and sorting settings matrix.
+#
+# Starting state: braced imports, unsorted, one local (project) import mixed
+# with digest imports. Walk the playbook steps flipping:
+#   behavior.importSyntax (curly <-> dot)
+#   behavior.importGrouping (none / digestFirst / localFirst)
+#   behavior.sortImportsAlphabetically
+# and run "Verse: Optimize Imports" after each flip. Verify layout matches the
+# setting and that repeated runs are idempotent.
+
+using { /Verse.org/Simulation }
+using { /Fortnite.com/Devices }
+using { Gadgets.Tools }
+using { /Verse.org/Colors }
+
+t6_marker := class:
+    Tag:string = "t6"

--- a/test-fixtures/uefn-smoke/Content/Systems/Combat/Weapons/t4_weapons_a.verse
+++ b/test-fixtures/uefn-smoke/Content/Systems/Combat/Weapons/t4_weapons_a.verse
@@ -1,0 +1,4 @@
+# T4 case B support: first Combat/Weapons folder chain (under Systems/).
+
+t4_weapon_a<public> := class:
+    Damage<public>:int = 10

--- a/test-fixtures/uefn-smoke/Content/Systems/economy_a.verse
+++ b/test-fixtures/uefn-smoke/Content/Systems/economy_a.verse
@@ -1,0 +1,6 @@
+# T4 case C support: explicit module declaration, first location (Systems/).
+
+Economy<public> := module:
+    Shop<public> := module:
+        shop_item_a<public> := class:
+            Price<public>:int = 10

--- a/test-fixtures/uefn-smoke/Content/T2A/t2_widget_a.verse
+++ b/test-fixtures/uefn-smoke/Content/T2A/t2_widget_a.verse
@@ -1,0 +1,5 @@
+# T2 support: first of two identically-named classes in different modules.
+# Folder T2A is an implicit module, so this is T2A.t2_shared_thing.
+
+t2_shared_thing<public> := class:
+    ValueA<public>:int = 1

--- a/test-fixtures/uefn-smoke/Content/T2B/t2_widget_b.verse
+++ b/test-fixtures/uefn-smoke/Content/T2B/t2_widget_b.verse
@@ -1,0 +1,5 @@
+# T2 support: second of two identically-named classes in different modules.
+# Folder T2B is an implicit module, so this is T2B.t2_shared_thing.
+
+t2_shared_thing<public> := class:
+    ValueB<public>:int = 2

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -111,9 +111,10 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 
 1. [ ] Case A `Gadgets.Tools`: CodeLens offers conversion; result is
        `using { /vuke@fortnite.com/VerseAutoImports/Gadgets/Tools }`.
-2. [ ] Case B `Combat.Weapons` (exists under Systems/ AND Features/): both
-       locations detected; user is prompted (or ambiguousImports mapping
-       applies); nothing silently picked. Record which locations were listed.
+2. [ ] Case B `Combat.Weapons` (exists under Systems/ AND Features/): KNOWN
+       LIMITATION (#60, preexisting in 0.6.4) - resolves 0 locations. Expect a
+       graceful "module not found" outcome, never a silently wrong path. The
+       ambiguity feature itself is validated by Case C.
 3. [ ] Case C `Economy.Shop` (explicit module declared in two files): both
        locations detected (Systems and Features). This exercises the cache
        lookup path and the #43 regex fix across multiple files.

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -1,0 +1,186 @@
+# UEFN Smoke Test Playbook
+
+Manual pre-release verification of the extension against a real UEFN project,
+real Verse LSP diagnostics, and real 41.10 digest files. Run this before every
+release; it is the gate the automated Jest suite cannot provide (that suite
+mocks the entire VS Code and UEFN environment).
+
+Test project: `C:\Users\abdel\Documents\Fortnite Projects\VerseAutoImports`
+Project Verse path: `/vuke@fortnite.com/VerseAutoImports`
+
+Conventions: check the box when the observed behavior matches Expected.
+Anything else goes in the Findings table at the bottom, verbatim (exact error
+text, exact inserted import), so extractor patterns can be fixed against
+reality.
+
+## Phase A: UEFN content setup (once per project)
+
+Asset reflection exposes exactly four asset types to Verse (meshes, textures,
+materials, Niagara VFX). Materials are the only type that generates a CLASS in
+`Assets.digest.verse`; the rest generate instances. We want every type, at
+more than one folder depth, so the digest exercises every declaration shape.
+
+In UEFN, create (names matter -- fixtures and expected digest entries use
+them):
+
+- [ ] Existing textures kept: `image1` (Content root), `Folder1/image2`,
+      `Folder1/InnerFolder/image3`
+- [ ] `Meshes/TestSphere` -- any static mesh, e.g. a sphere from the shapes
+      gallery
+- [ ] `Materials/TestMaterial` -- a material WITH at least one scalar or
+      vector parameter (parameterized materials generate class fields)
+- [ ] `VFX/TestVFX` -- any Niagara particle system
+- [ ] `Mixed/Deep/TestDeepTexture` -- any texture two folders deep
+
+Then push Verse changes (or Build Verse Code) in UEFN so
+`Assets.digest.verse` regenerates, and hand the digest to Claude to record
+the exact declaration syntax for all four types. This decides whether
+`AssetsDigestParser` still matches the live format (suspected dead against
+41.10: it only accepts `Name<public|internal|private> := class/struct`, the
+live digest emits `<scoped {...}>` specifiers and instance declarations).
+
+## Phase B: rig setup (each run)
+
+- [ ] Build and install the dev extension: `npm run compile && npx vsce
+      package`, then `code --install-extension verse-auto-imports-<ver>.vsix`
+      (or let Claude do it). Reload VS Code windows afterwards.
+- [ ] Open the project THROUGH UEFN (Verse menu > VS Code) so VS Code loads
+      the generated multi-root `VerseAutoImports.code-workspace` -- Content
+      plus the digest folders. This is the real-world layout; do not open the
+      Content folder directly except where a step says to.
+- [ ] UEFN stays open the whole session (it is the diagnostics source).
+- [ ] Sync fixtures: `powershell -File test-fixtures/uefn-smoke/sync.ps1
+      -ContentPath "C:\Users\abdel\Documents\Fortnite Projects\VerseAutoImports\Content"`
+- [ ] Open both output channels: "Verse Auto Imports" and "Verse Auto
+      Imports - Debug".
+
+## Phase C: test cases
+
+### T0 -- environment sanity (multi-root workspace)
+
+1. [ ] Status bar item appears; extension activates on opening a .verse file.
+2. [ ] Debug channel shows the project detected as
+       `/vuke@fortnite.com/VerseAutoImports` (from .uefnproject found in the
+       parent of Content).
+3. [ ] Run "Verse: Rebuild Project Path Cache". Debug log file count must
+       correspond to Content fixtures only -- if it reports scanning
+       hundreds of files or mentions digest folders (/Verse.org etc.), the
+       scan is leaking into other workspace roots. Record the count.
+4. [ ] Open `Fortnite.digest.verse` from the /Fortnite.com root: no CodeLens
+       spam, no auto-import activity triggered by it.
+
+### T1 -- auto-import, single suggestion (fixture: Scripts/T1_auto_import.verse)
+
+1. [ ] Open the file, confirm compile errors appear for creative_device,
+       button_device, vector3, player.
+2. [ ] Wait out the debounce (3s idle). Expected inserts, exactly once each:
+       `using { /Fortnite.com/Devices }`, `using { /Verse.org/SpatialMath }`,
+       `using { /Verse.org/Simulation }`.
+3. [ ] Record the exact compiler error text for one identifier (drift check
+       for extractor patterns).
+4. [ ] File compiles clean afterwards.
+
+### T2 -- multi-option (fixture: Scripts/T2_multi_option.verse + T2A/ + T2B/)
+
+1. [ ] Error on `t2_shared_thing` appears; record exact message text.
+2. [ ] No auto-import fires (default multiOptionStrategy).
+3. [ ] Quick fix menu offers BOTH candidates (T2A and T2B variants), one
+       action each.
+4. [ ] Applying one resolves the error; applied import is syntactically valid.
+
+### T3 -- asset references + digest watcher (fixture: Scripts/T3_assets.verse)
+
+1. [ ] Errors for `image2`/`image3` (and `texture`): record exact message
+       text including any "Did you mean ..." suggestion.
+2. [ ] Whatever the extension does (auto-import or quick fix), the resulting
+       import must NOT embed the asset name (`using { Folder1.image2 }` =
+       FAIL; `using { Folder1 }` or no action = acceptable).
+3. [ ] After Phase A, uncomment the material probe block and repeat for the
+       material class -- this is the code path AssetsDigestParser was built
+       for.
+4. [ ] Watcher (#43): with VS Code open, rename any texture in UEFN (or add
+       one) so Assets.digest.verse regenerates. Expected within seconds in
+       the Debug channel: "Assets.digest.verse changed" + cache clear, WITHOUT
+       reloading VS Code and without waiting for a TTL expiry.
+5. [ ] Secondary (single-root mode): open ONLY the Content folder in VS Code
+       (not the workspace file) and repeat step 4 -- this is the case the
+       RelativePattern fix in #43 specifically targets (digest lives outside
+       the workspace).
+
+### T4 -- path conversion (fixture: Scripts/T4_path_conversion.verse + support folders)
+
+1. [ ] Case A `Gadgets.Tools`: CodeLens offers conversion; result is
+       `using { /vuke@fortnite.com/VerseAutoImports/Gadgets/Tools }`.
+2. [ ] Case B `Combat.Weapons` (exists under Systems/ AND Features/): both
+       locations detected; user is prompted (or ambiguousImports mapping
+       applies); nothing silently picked. Record which locations were listed.
+3. [ ] Case C `Economy.Shop` (explicit module declared in two files): both
+       locations detected (Systems and Features). This exercises the cache
+       lookup path and the #43 regex fix across multiple files.
+4. [ ] Bulk command "Convert All Imports to Full Paths" handles all three
+       lines coherently in one pass.
+5. [ ] Cache off/on: set `cache.enabled` false, reload, repeat case C
+       (pure filesystem path), then re-enable, rebuild cache, repeat again.
+       Same results both ways; Debug log shows cache hits when enabled.
+6. [ ] Persistence: reload the window with cache enabled; Debug log shows the
+       cache loaded from storage rather than a cold rebuild.
+
+### T5 -- Optimize Imports (fixture: Scripts/T5_optimize.verse)
+
+1. [ ] With autoImport ON: run "Verse: Optimize Imports" once. All expected
+       outcomes in the fixture header hold; specifically the missing
+       SpatialMath import is added in the SAME single edit (no visible
+       intermediate state where imports vanish), the local-scope
+       `using { Helper }` is untouched, and one Ctrl+Z restores the original.
+2. [ ] Re-sync the fixture, set general.autoImport OFF, repeat: identical end
+       state.
+3. [ ] Toast text matches what actually happened.
+
+### T6 -- styles matrix (fixture: Scripts/T6_styles.verse)
+
+1. [ ] importSyntax curly -> dot: optimize rewrites the block to `using.`
+       style; flip back and it returns (idempotent on repeat runs).
+2. [ ] importGrouping digestFirst: digest imports first, blank line, then
+       `Gadgets.Tools`. localFirst reverses. none keeps flat.
+3. [ ] sortImportsAlphabetically respected within groups.
+4. [ ] behavior.emptyLinesAfterImports honored after each optimize.
+
+### T7 -- cache commands and settings
+
+1. [ ] "Verse: Rebuild Project Path Cache" and "Verse: Clear Project Path
+       Cache" both exist in the palette and log sensible results.
+2. [ ] Rebuild reports a plausible file/module count for the fixtures.
+3. [ ] Toggle the three cache.* settings; no errors on flip; behavior follows
+       (see T4.5).
+
+### T8 -- status bar and snooze (#43)
+
+1. [ ] Status bar menu opens; toggles reflect current settings.
+2. [ ] Snooze auto-imports; invoke snooze AGAIN from the command palette
+       while already snoozing; countdown stays coherent (single timer), and
+       cancel/expiry restores the normal state. Watch Debug channel for
+       duplicate-interval evidence.
+3. [ ] Enable auto-imports mid-snooze: snooze cancels automatically.
+
+## Phase D: verdict
+
+| Case | Pass | Finding # |
+|------|------|-----------|
+| T0   |      |           |
+| T1   |      |           |
+| T2   |      |           |
+| T3   |      |           |
+| T4   |      |           |
+| T5   |      |           |
+| T6   |      |           |
+| T7   |      |           |
+| T8   |      |           |
+
+Findings (number, verbatim evidence, suspected component):
+
+1.
+
+Exit criteria: every case passes, or every failure has a filed issue with a
+decision (fix before release / ship as known issue). When a failure looks
+preexisting rather than 0.7-introduced, install the Marketplace 0.6.4 build
+and repeat the case to classify it.

--- a/test-fixtures/uefn-smoke/sync.ps1
+++ b/test-fixtures/uefn-smoke/sync.ps1
@@ -1,0 +1,36 @@
+# Copies the smoke-test fixtures into a UEFN project's Content folder.
+# Usage:
+#   powershell -File test-fixtures/uefn-smoke/sync.ps1 -ContentPath "C:\...\<Project>\Content"
+#
+# Copy-only: never deletes anything in the target. Fixture files contain
+# deliberate compile errors (missing imports) -- that is the point.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ContentPath
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $ContentPath)) {
+    Write-Error "Content folder not found: $ContentPath"
+    exit 1
+}
+
+$source = Join-Path $PSScriptRoot "Content"
+
+$files = Get-ChildItem -Path $source -Recurse -File -Filter *.verse
+foreach ($file in $files) {
+    $relative = $file.FullName.Substring($source.Length).TrimStart("\")
+    $target = Join-Path $ContentPath $relative
+    $targetDir = Split-Path $target -Parent
+    if (-not (Test-Path $targetDir)) {
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    }
+    Copy-Item $file.FullName $target -Force
+    Write-Host "synced $relative"
+}
+
+Write-Host ""
+Write-Host "$($files.Count) fixture files synced to $ContentPath"
+Write-Host "Reminder: T5 must be re-synced between its ON/OFF runs."


### PR DESCRIPTION
## Summary

Manual pre-release smoke-test suite, born from and validated by the 0.7 release verification against a real UEFN 41.10 project:

- 13 Verse fixtures (T1 auto-import, T2 multi-option, T3 asset references, T4 path conversion, T5 optimize, T6 style matrix) with expected behavior documented in each header, aligned with live 41.10 compiler messages
- PLAYBOOK.md: step-by-step checklist (T0-T8) mapping every 0.7 fix and the 0.6.x regressions to concrete steps, including UEFN asset setup covering all four reflectable asset types
- sync.ps1 to copy fixtures into a scratch UEFN project
- .vscodeignore additions so test-fixtures/ and jest.config.js never ship in the packaged extension

Running this suite live surfaced and validated PRs #59 and #62 and produced issues #60, #61, #63.

## Verification

Fixtures are non-source files (.verse/.md/.ps1) plus a .vscodeignore change; `npm run compile` and `npm test` (51 tests) verified on develop after merge - results reported in the release thread. Packaging verified: `vsce package` output no longer contains the fixtures.