### PR TITLE
chore: collect version and environment info in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,11 +2,28 @@ name: Bug report
 description: Report a problem with the extension
 labels: [bug]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. The version and environment
+        fields below are the details we almost always have to ask for, so filling
+        them in up front gets your issue looked at faster.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the open and closed issues and did not find a duplicate.
+          required: true
+        - label: I am on the latest version of the extension (or I note the version below and it still reproduces).
+          required: true
+
   - type: textarea
     id: what-happened
     attributes:
       label: What happened
-      description: What did you do, what did you expect, and what happened instead?
+      description: What did you do, what did you expect, and what happened instead? Include the steps to reproduce.
       placeholder: e.g. saved a file with an unknown identifier and the wrong using statement was added
     validations:
       required: true
@@ -15,7 +32,7 @@ body:
     id: extension-version
     attributes:
       label: Extension version
-      description: Extensions panel -> Verse Auto Imports -> version number
+      description: Extensions panel -> Verse Auto Imports -> version number.
       placeholder: e.g. 0.6.4
     validations:
       required: true
@@ -24,10 +41,32 @@ body:
     id: vscode-version
     attributes:
       label: VS Code version
-      description: Help -> About
+      description: Help -> About.
       placeholder: e.g. 1.101.0
     validations:
       required: true
+
+  - type: input
+    id: uefn-version
+    attributes:
+      label: UEFN / Fortnite version
+      description: The UEFN build the project is on, from UEFN Help -> About or the Epic Games Launcher. The digest format changes between builds, so this matters for triage.
+      placeholder: e.g. 41.10
+    validations:
+      required: true
+
+  - type: dropdown
+    id: workspace-layout
+    attributes:
+      label: How is the project open in VS Code
+      description: The extension detects the .uefnproject differently depending on how the workspace was opened.
+      options:
+        - Opened from UEFN via "Verse -> Open in VS Code"
+        - Opened the project folder directly in VS Code
+        - Multi-root workspace (several folders)
+        - Other / not sure
+    validations:
+      required: false
 
   - type: textarea
     id: compiler-error
@@ -47,4 +86,11 @@ body:
     id: settings
     attributes:
       label: Relevant settings
-      description: Any verseAutoImports.* settings you changed from their defaults.
+      description: Any verseAutoImports.* settings you changed from their defaults (Settings -> search "verseAutoImports").
+
+  - type: textarea
+    id: debug-logs
+    attributes:
+      label: Debug logs
+      description: Run the "Export Debug Logs" command from the Command Palette (under the Verse category), or copy the contents of the "Verse Auto Imports - Debug" Output channel, and paste the relevant lines here.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation and troubleshooting (Wiki)
+    url: https://github.com/vukefn/verse-auto-imports/wiki
+    about: Setup, configuration, and common problems are covered in the Wiki. Please check there before filing a new issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,14 @@ name: Feature request
 description: Suggest an improvement or new capability
 labels: [enhancement]
 body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the open and closed issues and did not find a duplicate.
+          required: true
+
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## What

Improve the GitHub issue templates so the triage bot stops having to ask reporters for the same environment details on every bug.

## Evidence (what the bot asked for, with issue numbers)

Only three issues have been through the `claude-issue-triage` bot so far, and the pattern is clear:

- **Extension version** and **VS Code version** were explicitly requested as missing in #63 and #60. The triage workflow's step 4 checks for both on every bug.
- **UEFN / Fortnite build** is load-bearing but was not captured anywhere: #63 is entirely about the "41.10 Assets.digest.verse format", #61 is about a 41.10 internal-module error, and #60's triage note calls out "Verse/UEFN 41.10" as relevant context. The digest format changes between builds, so this is needed for triage.
- A **Verse snippet or compiler error** is checked by the workflow; the bot noted these were "sufficient" when present (#63). Those fields already existed.

## Changes

`bug_report.yml`
- Added required **UEFN / Fortnite version** field (from UEFN Help > About / Epic Games Launcher).
- Added a **"How is the project open in VS Code"** dropdown (UEFN Verse > Open in VS Code vs folder opened directly vs multi-root) - the extension detects the `.uefnproject` differently per layout.
- Added an optional **Debug logs** field pointing at the "Export Debug Logs" command and the "Verse Auto Imports - Debug" output channel (both real extension features).
- Added a required "searched existing issues" checkbox to support the bot's duplicate-check step.
- Kept the existing required extension version / VS Code version / description fields.

`feature_request.yml`
- Added only the "searched existing issues" checkbox (the bot runs a duplicate check on enhancements too, e.g. #61). No info-request questions have ever been posted on a feature request, so no other fields were added.

`config.yml` (new)
- `blank_issues_enabled: false` so reporters use a form.
- Contact link to the Wiki (Wiki is enabled on this repo; Discussions is not).

## Checks

- `npm run compile`: clean (exit 0).
- `npm test`: 6 suites, 51/51 tests passing.
- All three YAML files validated with a parser.

No source, `package.json` version, or `CHANGELOG.md` changes (repo-facing tooling only).
