### PR TITLE
fix: unify diagnostic message parsing across auto-import and optimize paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Optimize Imports Diagnostic Parsing**: "Optimize Imports" no longer inserts a malformed import when the compiler suggests an assignment fix (for example `using { to write 'set Foo }`), and no longer adds every candidate module of an ambiguous "one of" error at once; ambiguous cases are left to the quick-fix menu
+- **Quick Fix Menu Noise**: "Did you mean any of" compiler suggestions no longer produce import options for bare identifiers (such as local definitions echoed in the option list), which generated invalid `using` statements when applied
 - **Path Conversion with Project Cache**: "Use Absolute Path" and related commands produced malformed import paths or wrong module suggestions when the project path cache was enabled (the default)
   - Cache results now use the same location format as the filesystem scan instead of raw declaration paths
   - Module names are matched exactly: unrelated identifiers like `MyUtils` no longer match `Utils`, and class or struct names are never offered as module locations

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -26,6 +26,25 @@ const PATTERNS = {
     PATH_IN_PARENS: /\((\/[^:)]+):\)/g,
 } as const;
 
+/** A resolvable import extracted from a compiler message. */
+interface ImportCandidate {
+    path: string;
+    description: string;
+}
+
+/**
+ * Classification of a single compiler message. Both extraction entry points
+ * (suggestion extraction for auto-import/quick fixes and path extraction for
+ * Optimize Imports) consume this, so message filters and pattern precedence
+ * exist exactly once.
+ */
+type DiagnosticClassification =
+    | { kind: "ignored" }
+    | { kind: "none" }
+    | { kind: "multiOption"; candidates: ImportCandidate[] }
+    | { kind: "singleImport"; candidate: ImportCandidate }
+    | { kind: "identifier"; identifier: string; inferred?: ImportCandidate };
+
 /**
  * Handles parsing error messages and diagnostics to extract import suggestions.
  */
@@ -106,13 +125,16 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Parses error messages for multi-option import suggestions.
+     * Parses error messages for multi-option import candidates.
      * Handles three patterns:
      * 1. "Did you mean any of:\n<options>"
      * 2. "Did you forget to specify one of:\nusing { /Path }\nusing { /Path }"
      * 3. "Identifier X could be one of many types: (/Path1:)X or (/Path2:)X"
+     *
+     * Returns null when no multi-option pattern matches; an empty array when a
+     * pattern matched but no option was importable (e.g. only bare identifiers).
      */
-    private parseMultiOptionSuggestions(errorMessage: string): string[] {
+    private parseMultiOptionCandidates(errorMessage: string): ImportCandidate[] | null {
         // Pattern 1: "Did you mean any of:\n<options>"
         const match1 = errorMessage.match(PATTERNS.DID_YOU_MEAN_ANY);
         if (match1) {
@@ -121,7 +143,25 @@ export class ImportSuggestionExtractor {
                 .map((line) => line.trim())
                 .filter((line) => line.length > 0);
             logger.debug("ImportSuggestionExtractor", `Found ${options.length} multi-options (pattern 1): ${options.join(", ")}`);
-            return options;
+
+            const candidates: ImportCandidate[] = [];
+            for (const option of options) {
+                if (option.startsWith("/")) {
+                    // Direct module path
+                    candidates.push({ path: option, description: `Import from ${option}` });
+                    continue;
+                }
+                // Fully qualified name (e.g., "Module.ClassName" or "Module.AssetClass.Member")
+                const result = this.findCorrectModulePath(option);
+                if (result && result.modulePath) {
+                    candidates.push({ path: result.modulePath, description: `${result.className} from ${result.modulePath}` });
+                } else {
+                    // Bare identifiers (e.g. a local definition echoed in the option
+                    // list) carry no module path and are not importable.
+                    logger.debug("ImportSuggestionExtractor", `Dropping non-importable multi-option entry: ${option}`);
+                }
+            }
+            return candidates;
         }
 
         // Pattern 2: "Did you forget to specify one of:\nusing { /Path }\nusing { /Path }"
@@ -129,7 +169,7 @@ export class ImportSuggestionExtractor {
         if (match2) {
             const options = this.extractUsingPaths(match2[1]);
             logger.debug("ImportSuggestionExtractor", `Found ${options.length} multi-options (pattern 2): ${options.join(", ")}`);
-            return options;
+            return options.map((path) => ({ path, description: `Import from ${path}` }));
         }
 
         // Pattern 3: "Identifier X could be one of many types: (/Path1:)X or (/Path2:)X"
@@ -137,10 +177,96 @@ export class ImportSuggestionExtractor {
         if (match3) {
             const options = this.extractParenPaths(match3[1]);
             logger.debug("ImportSuggestionExtractor", `Found ${options.length} multi-options (pattern 3): ${options.join(", ")}`);
-            return options;
+            return options.map((path) => ({ path, description: `Import from ${path}` }));
         }
 
-        return [];
+        return null;
+    }
+
+    /**
+     * Derives an import candidate from a "Did you mean Namespace.Component"
+     * suggestion. Returns null for suggestions without a module path (single
+     * segment names never produce an import).
+     */
+    private inferFromDidYouMean(errorMessage: string): ImportCandidate | null {
+        const didYouMeanMatch = errorMessage.match(PATTERNS.DID_YOU_MEAN_SINGLE);
+        if (!didYouMeanMatch) {
+            return null;
+        }
+        const fullName = didYouMeanMatch[1].trim();
+        const result = this.findCorrectModulePath(fullName);
+        if (result && result.modulePath) {
+            return { path: result.modulePath, description: `Inferred import for ${fullName}` };
+        }
+        return null;
+    }
+
+    /**
+     * Classifies a compiler message into exactly one import-relevant category.
+     * Pattern precedence is load-bearing: multi-option patterns are checked
+     * before single-option ones so a new pattern must not shadow an existing one.
+     */
+    private classifyMessage(errorMessage: string): DiagnosticClassification {
+        // Assignment hints ("Did you mean to write 'set ...'") are never import problems
+        if (errorMessage.includes("Did you mean to write 'set")) {
+            logger.debug("ImportSuggestionExtractor", `Ignoring 'set' suggestion error`);
+            return { kind: "ignored" };
+        }
+
+        // Fast path: nothing import-shaped in the message
+        if (
+            !errorMessage.includes("using") &&
+            !errorMessage.includes("Unknown identifier") &&
+            !errorMessage.includes("Did you forget") &&
+            !errorMessage.includes("Did you mean") &&
+            !errorMessage.includes("could be one of many types")
+        ) {
+            return { kind: "none" };
+        }
+
+        // Multi-option patterns first. A single surviving candidate is
+        // unambiguous; an empty result falls through so the unknown-identifier
+        // handling below still gets a chance to resolve the message.
+        const candidates = this.parseMultiOptionCandidates(errorMessage);
+        if (candidates !== null) {
+            if (candidates.length > 1) {
+                return { kind: "multiOption", candidates };
+            }
+            if (candidates.length === 1) {
+                return { kind: "singleImport", candidate: candidates[0] };
+            }
+        }
+
+        // "Unknown identifier `x`. Did you forget to specify using { /Path }"
+        const specificMatch = errorMessage.match(PATTERNS.UNKNOWN_WITH_SUGGESTION);
+        if (specificMatch) {
+            const identifierMatch = errorMessage.match(PATTERNS.UNKNOWN_IDENTIFIER);
+            const name = identifierMatch ? identifierMatch[1] : specificMatch[1];
+            return { kind: "singleImport", candidate: { path: specificMatch[1], description: `Import ${name} from ${specificMatch[1]}` } };
+        }
+
+        // "Did you forget to specify using { /Path }"
+        const forgetMatch = errorMessage.match(PATTERNS.FORGET_SINGLE);
+        if (forgetMatch) {
+            return { kind: "singleImport", candidate: { path: forgetMatch[1], description: `Standard import for ${forgetMatch[1]}` } };
+        }
+
+        // "Unknown identifier `x`" without an inline path: the consumer decides
+        // how to resolve it (configured mapping, digest lookup, or the inferred
+        // "Did you mean" path).
+        const unknownMatch = errorMessage.match(PATTERNS.UNKNOWN_IDENTIFIER);
+        if (unknownMatch) {
+            const inferred = this.inferFromDidYouMean(errorMessage);
+            return { kind: "identifier", identifier: unknownMatch[1], inferred: inferred ?? undefined };
+        }
+
+        // "Did you mean Namespace.Component" without an unknown-identifier prefix
+        const inferred = this.inferFromDidYouMean(errorMessage);
+        if (inferred) {
+            return { kind: "singleImport", candidate: inferred };
+        }
+
+        return { kind: "none" };
     }
 
     /**
@@ -203,113 +329,69 @@ export class ImportSuggestionExtractor {
     async extractImportSuggestions(errorMessage: string): Promise<ImportSuggestion[]> {
         logger.debug("ImportSuggestionExtractor", `Extracting import suggestions from error: ${errorMessage}`);
 
-        // Ignore errors that suggest using 'set' instead of import issues
-        if (errorMessage.includes("Did you mean to write 'set")) {
-            logger.debug("ImportSuggestionExtractor", `Ignoring 'set' suggestion error`);
-            return [];
-        }
-
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const ambiguousImportMappings = config.get<Record<string, string>>("ambiguousImports", {});
 
-        // Check for multi-option "Did you mean any of" pattern first
-        const multiOptions = this.parseMultiOptionSuggestions(errorMessage);
-        if (multiOptions.length > 0) {
-            logger.debug("ImportSuggestionExtractor", `Found multi-option pattern with ${multiOptions.length} options`);
-            const suggestions: ImportSuggestion[] = [];
+        const classification = this.classifyMessage(errorMessage);
 
-            for (const option of multiOptions) {
-                // Check if option is a module path (starts with /)
-                if (option.startsWith("/")) {
-                    // Direct module path from "using { /Path }" format
-                    const importStatement = this.formatter.formatImportStatement(option, preferDotSyntax);
+        switch (classification.kind) {
+            case "ignored":
+            case "none":
+                logger.debug("ImportSuggestionExtractor", "No import suggestions found in error message");
+                return [];
 
-                    logger.trace("ImportSuggestionExtractor", `Multi-option (module path): ${option}`);
+            case "multiOption":
+                logger.debug("ImportSuggestionExtractor", `Found multi-option pattern with ${classification.candidates.length} options`);
+                return classification.candidates.map((candidate) =>
+                    this.createImportSuggestion(this.formatter.formatImportStatement(candidate.path, preferDotSyntax), "error_message", "high", candidate.description),
+                );
 
-                    suggestions.push(this.createImportSuggestion(importStatement, "error_message", "high", `Import from ${option}`));
-                } else {
-                    // Fully qualified class name (e.g., "Module.ClassName" or "Module.AssetClass.Member")
-                    const result = this.findCorrectModulePath(option);
-                    if (result && result.modulePath) {
-                        const importStatement = this.formatter.formatImportStatement(result.modulePath, preferDotSyntax);
+            case "singleImport": {
+                const importStatement = this.formatter.formatImportStatement(classification.candidate.path, preferDotSyntax);
+                logger.debug("ImportSuggestionExtractor", `Found import statement: ${importStatement}`);
+                return [this.createImportSuggestion(importStatement, "error_message", "high", classification.candidate.description)];
+            }
 
-                        logger.debug("ImportSuggestionExtractor", `Multi-option: ${option} -> namespace: ${result.modulePath}, class: ${result.className}`);
-
-                        suggestions.push(this.createImportSuggestion(importStatement, "error_message", "high", `${result.className} from ${result.modulePath}`));
-                    } else {
-                        // No namespace detected, treat as simple reference
-                        const importStatement = this.formatter.formatImportStatement(option, preferDotSyntax);
-                        logger.trace("ImportSuggestionExtractor", `Multi-option (no namespace): ${option}`);
-
-                        suggestions.push(this.createImportSuggestion(importStatement, "error_message", "medium", `Import ${option}`));
-                    }
+            case "identifier": {
+                // Configured ambiguous mappings take precedence
+                if (ambiguousImportMappings[classification.identifier]) {
+                    const preferredPath = ambiguousImportMappings[classification.identifier];
+                    const importStatement = this.formatter.formatImportStatement(preferredPath, preferDotSyntax);
+                    logger.debug("ImportSuggestionExtractor", `Using configured path for ambiguous class ${classification.identifier}: ${importStatement}`);
+                    return [this.createImportSuggestion(importStatement, "error_message", "high", `Configured import for ${classification.identifier}`)];
                 }
+
+                // Then digest-based lookup
+                const digestSuggestions = await this.lookupIdentifierInDigest(classification.identifier);
+                if (digestSuggestions.length > 0) {
+                    logger.debug("ImportSuggestionExtractor", `Found digest-based suggestions for unknown identifier: ${classification.identifier}`);
+                    return digestSuggestions;
+                }
+
+                // Finally the path inferred from a "Did you mean" suggestion
+                if (classification.inferred) {
+                    const importStatement = this.formatter.formatImportStatement(classification.inferred.path, preferDotSyntax);
+                    logger.debug("ImportSuggestionExtractor", `Inferred import statement: ${importStatement}`);
+                    return [this.createImportSuggestion(importStatement, "error_message", "high", classification.inferred.description)];
+                }
+
+                logger.debug("ImportSuggestionExtractor", "No import suggestions found in error message");
+                return [];
             }
 
-            return suggestions;
-        }
-
-        // Check for unknown identifier with ambiguous mapping or digest lookup
-        const classNameMatch = errorMessage.match(PATTERNS.UNKNOWN_IDENTIFIER);
-        if (classNameMatch) {
-            const className = classNameMatch[1];
-
-            // Check if this unknown identifier error also includes a specific import suggestion
-            const specificSuggestionMatch = errorMessage.match(PATTERNS.UNKNOWN_WITH_SUGGESTION);
-            if (specificSuggestionMatch) {
-                const path = specificSuggestionMatch[1];
-                const importStatement = this.formatter.formatImportStatement(path, preferDotSyntax);
-                logger.debug("ImportSuggestionExtractor", `Found specific import suggestion for unknown identifier ${className}: ${importStatement}`);
-                return [this.createImportSuggestion(importStatement, "error_message", "high", `Import ${className} from ${path}`)];
-            }
-
-            // First check configured ambiguous mappings
-            if (ambiguousImportMappings[className]) {
-                const preferredPath = ambiguousImportMappings[className];
-                const importStatement = this.formatter.formatImportStatement(preferredPath, preferDotSyntax);
-
-                logger.debug("ImportSuggestionExtractor", `Using configured path for ambiguous class ${className}: ${importStatement}`);
-                return [this.createImportSuggestion(importStatement, "error_message", "high", `Configured import for ${className}`)];
-            }
-
-            // Try digest-based lookup for unknown identifier
-            const digestSuggestions = await this.lookupIdentifierInDigest(className);
-            if (digestSuggestions.length > 0) {
-                logger.debug("ImportSuggestionExtractor", `Found digest-based suggestions for unknown identifier: ${className}`);
-                return digestSuggestions;
+            default: {
+                const exhaustive: never = classification;
+                return exhaustive;
             }
         }
-
-        // Pattern: "Did you forget to specify using { /Path }"
-        const forgetMatch = errorMessage.match(PATTERNS.FORGET_SINGLE);
-        if (forgetMatch) {
-            const path = forgetMatch[1];
-            const importStatement = this.formatter.formatImportStatement(path, preferDotSyntax);
-            logger.debug("ImportSuggestionExtractor", `Found import statement: ${importStatement}`);
-            return [this.createImportSuggestion(importStatement, "error_message", "high", `Standard import for ${path}`)];
-        }
-
-        // Pattern: "Did you mean Namespace.Component" (single option)
-        const didYouMeanMatch = errorMessage.match(PATTERNS.DID_YOU_MEAN_SINGLE);
-        if (didYouMeanMatch) {
-            const fullName = didYouMeanMatch[1].trim();
-            const result = this.findCorrectModulePath(fullName);
-            logger.trace("ImportSuggestionExtractor", `Finding module path for: ${fullName}`);
-            if (result && result.modulePath) {
-                const importStatement = this.formatter.formatImportStatement(result.modulePath, preferDotSyntax);
-                logger.debug("ImportSuggestionExtractor", `Inferred import statement: ${importStatement} (class: ${result.className})`);
-                return [this.createImportSuggestion(importStatement, "error_message", "high", `Inferred import for ${fullName}`)];
-            }
-        }
-
-        logger.debug("ImportSuggestionExtractor", "No import suggestions found in error message");
-        return [];
     }
 
     /**
-     * Extracts import suggestions from VS Code diagnostics.
-     * Parses error messages to find missing imports.
+     * Extracts unambiguous import paths from VS Code diagnostics for the
+     * Optimize Imports command. Only single, unambiguous suggestions are
+     * collected: multi-option (ambiguous) messages need a user choice and are
+     * left to the quick-fix menu, and non-import messages contribute nothing.
      */
     extractImportsFromDiagnostics(diagnostics: vscode.Diagnostic[]): string[] {
         logger.debug("ImportSuggestionExtractor", `Extracting imports from ${diagnostics.length} diagnostics`);
@@ -317,57 +399,33 @@ export class ImportSuggestionExtractor {
         const suggestedPaths = new Set<string>();
 
         for (const diagnostic of diagnostics) {
-            const errorMessage = diagnostic.message;
+            const classification = this.classifyMessage(diagnostic.message);
 
-            // Skip non-import related errors
-            if (!errorMessage.includes("using") && !errorMessage.includes("Unknown identifier") && !errorMessage.includes("Did you forget") && !errorMessage.includes("Did you mean")) {
-                continue;
-            }
+            switch (classification.kind) {
+                case "singleImport":
+                    suggestedPaths.add(classification.candidate.path);
+                    logger.debug("ImportSuggestionExtractor", `Found path: ${classification.candidate.path}`);
+                    break;
 
-            // Pattern: "Unknown identifier `x`. Did you forget to specify using { /Path }"
-            const unknownWithSuggestionMatch = errorMessage.match(PATTERNS.UNKNOWN_WITH_SUGGESTION);
-            if (unknownWithSuggestionMatch) {
-                suggestedPaths.add(unknownWithSuggestionMatch[1]);
-                logger.debug("ImportSuggestionExtractor", `Found path from unknown identifier with suggestion: ${unknownWithSuggestionMatch[1]}`);
-                continue;
-            }
+                case "identifier":
+                    if (classification.inferred) {
+                        suggestedPaths.add(classification.inferred.path);
+                        logger.debug("ImportSuggestionExtractor", `Found inferred path: ${classification.inferred.path}`);
+                    }
+                    break;
 
-            // Pattern: "Did you forget to specify using { /Path }"
-            const forgetMatch = errorMessage.match(PATTERNS.FORGET_SINGLE);
-            if (forgetMatch) {
-                suggestedPaths.add(forgetMatch[1]);
-                logger.debug("ImportSuggestionExtractor", `Found path from 'forget' pattern: ${forgetMatch[1]}`);
-                continue;
-            }
+                case "multiOption":
+                    // Ambiguous candidates need a user choice; never bulk-add them
+                    logger.debug("ImportSuggestionExtractor", `Skipping ambiguous diagnostic with ${classification.candidates.length} candidates`);
+                    break;
 
-            // Pattern: "Did you forget to specify one of:" (multiple options)
-            const multiMatch = errorMessage.match(PATTERNS.FORGET_ONE_OF);
-            if (multiMatch) {
-                for (const path of this.extractUsingPaths(multiMatch[1])) {
-                    suggestedPaths.add(path);
-                    logger.debug("ImportSuggestionExtractor", `Found path from multi-option: ${path}`);
-                }
-                continue;
-            }
+                case "ignored":
+                case "none":
+                    break;
 
-            // Pattern: "Identifier X could be one of many types: (/Path1:)X or (/Path2:)X"
-            const identifierMatch = errorMessage.match(PATTERNS.IDENTIFIER_MANY_TYPES);
-            if (identifierMatch) {
-                for (const path of this.extractParenPaths(identifierMatch[1])) {
-                    suggestedPaths.add(path);
-                    logger.debug("ImportSuggestionExtractor", `Found path from identifier pattern: ${path}`);
-                }
-                continue;
-            }
-
-            // Pattern: "Did you mean Module.Class" - extract module
-            const didYouMeanMatch = errorMessage.match(PATTERNS.DID_YOU_MEAN_SINGLE);
-            if (didYouMeanMatch) {
-                const fullName = didYouMeanMatch[1].trim();
-                const result = this.findCorrectModulePath(fullName);
-                if (result && result.modulePath) {
-                    suggestedPaths.add(result.modulePath);
-                    logger.debug("ImportSuggestionExtractor", `Found path from 'did you mean': ${result.modulePath}`);
+                default: {
+                    const exhaustive: never = classification;
+                    return exhaustive;
                 }
             }
         }

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -7,6 +7,8 @@ describe("ImportSuggestionExtractor", () => {
     let formatter: ImportFormatter;
     let outputChannel: vscode.OutputChannel;
 
+    const diag = (message: string): vscode.Diagnostic => ({ message }) as vscode.Diagnostic;
+
     beforeEach(() => {
         outputChannel = vscode.window.createOutputChannel("test");
         formatter = new ImportFormatter();
@@ -24,6 +26,169 @@ describe("ImportSuggestionExtractor", () => {
             expect(suggestions[0].source).toBe("error_message");
             expect(suggestions[0].confidence).toBe("high");
             expect(suggestions[0].modulePath).toBe("/Verse.org/Simulation");
+        });
+
+        it("should parse 'Unknown identifier with inline suggestion' into a high-confidence suggestion", async () => {
+            const errorMessage = "Unknown identifier `player`. Did you forget to specify using { /Verse.org/Simulation }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(1);
+            expect(suggestions[0].importStatement).toBe("using { /Verse.org/Simulation }");
+            expect(suggestions[0].confidence).toBe("high");
+            expect(suggestions[0].description).toBe("Import player from /Verse.org/Simulation");
+        });
+
+        it("should ignore 'set' assignment suggestions", async () => {
+            const errorMessage = "This variable can only be modified with 'set'. Did you mean to write 'set Foo.Bar = 1'?";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(0);
+        });
+
+        it("should return one suggestion per qualified option in a 'Did you mean any of' list", async () => {
+            const errorMessage = "Unknown identifier `thing`. Did you mean any of:\nModuleA.thing\nModuleB.thing";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { ModuleA }", "using { ModuleB }"]);
+            expect(suggestions.every((s) => s.confidence === "high")).toBe(true);
+        });
+
+        it("should drop bare identifier options from 'Did you mean any of' lists", async () => {
+            // Real compiler shape (Script Error 3506): the option list echoes a
+            // local definition (`item`) that is not importable.
+            const errorMessage = "Unknown identifier `item`. Did you mean any of:\nInventoryModule.item\nitem";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(1);
+            expect(suggestions[0].importStatement).toBe("using { InventoryModule }");
+            expect(suggestions.map((s) => s.importStatement)).not.toContain("using { item }");
+        });
+
+        it("should return nothing when every 'Did you mean any of' option is a bare identifier", async () => {
+            const errorMessage = "Unknown identifier `item`. Did you mean any of:\nitem\nother";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(0);
+        });
+
+        it("should return one suggestion per path in a 'Did you forget to specify one of' list", async () => {
+            const errorMessage = "Unknown identifier `thing`. Did you forget to specify one of:\nusing { /GameA/Combat }\nusing { /GameB/Combat }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { /GameA/Combat }", "using { /GameB/Combat }"]);
+            expect(suggestions.every((s) => s.confidence === "high")).toBe(true);
+        });
+
+        it("should return one suggestion per path in a 'could be one of many types' message", async () => {
+            const errorMessage = "Identifier vector3 could be one of many types: (/Verse.org/SpatialMath:)vector3 or (/UnrealEngine.com/Temporary/SpatialMath:)vector3";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { /Verse.org/SpatialMath }", "using { /UnrealEngine.com/Temporary/SpatialMath }"]);
+        });
+
+        it("should infer the module path from a single 'Did you mean Module.Member' suggestion", async () => {
+            // The asset-import case: the import must not embed the asset name
+            const errorMessage = "Unknown identifier `image2`. Did you mean Folder1.image2";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(1);
+            expect(suggestions[0].importStatement).toBe("using { Folder1 }");
+            expect(suggestions[0].confidence).toBe("high");
+        });
+
+        it("should prefer a configured ambiguous mapping over the inferred 'Did you mean' path", async () => {
+            (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+                get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                    if (key === "ambiguousImports") {
+                        return { player: "/Verse.org/Simulation" };
+                    }
+                    return defaultValue;
+                }),
+                update: jest.fn().mockResolvedValue(undefined),
+            });
+            const errorMessage = "Unknown identifier `player`. Did you mean SomeModule.player";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(1);
+            expect(suggestions[0].importStatement).toBe("using { /Verse.org/Simulation }");
+            expect(suggestions[0].description).toBe("Configured import for player");
+        });
+
+        it("should return nothing for messages without import-related content", async () => {
+            const suggestions = await extractor.extractImportSuggestions("Expected expression after operator");
+
+            expect(suggestions).toHaveLength(0);
+        });
+    });
+
+    describe("extractImportsFromDiagnostics", () => {
+        it("should ignore 'set' assignment suggestions instead of extracting garbage paths", () => {
+            // Regression: the greedy "Did you mean" fallback used to extract
+            // "to write 'set Foo" from this message.
+            const paths = extractor.extractImportsFromDiagnostics([diag("This variable can only be modified with 'set'. Did you mean to write 'set Foo.Bar = 1'?")]);
+
+            expect(paths).toEqual([]);
+        });
+
+        it("should extract the path from a single 'Did you forget to specify' message", () => {
+            const paths = extractor.extractImportsFromDiagnostics([diag("This identifier is unknown. Did you forget to specify using { /Verse.org/Simulation }")]);
+
+            expect(paths).toEqual(["/Verse.org/Simulation"]);
+        });
+
+        it("should extract the path from an unknown identifier with inline suggestion", () => {
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `player`. Did you forget to specify using { /Verse.org/Simulation }")]);
+
+            expect(paths).toEqual(["/Verse.org/Simulation"]);
+        });
+
+        it("should not bulk-add the candidates of a 'Did you forget to specify one of' message", () => {
+            // Ambiguous candidates need a user choice via the quick-fix menu;
+            // importing all of them at once would create a name collision.
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `thing`. Did you forget to specify one of:\nusing { /GameA/Combat }\nusing { /GameB/Combat }")]);
+
+            expect(paths).toEqual([]);
+        });
+
+        it("should not bulk-add the candidates of a 'could be one of many types' message", () => {
+            const paths = extractor.extractImportsFromDiagnostics([
+                diag("Identifier vector3 could be one of many types: (/Verse.org/SpatialMath:)vector3 or (/UnrealEngine.com/Temporary/SpatialMath:)vector3"),
+            ]);
+
+            expect(paths).toEqual([]);
+        });
+
+        it("should not add candidates from a 'Did you mean any of' list", () => {
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `thing`. Did you mean any of:\nModuleA.thing\nModuleB.thing")]);
+
+            expect(paths).toEqual([]);
+        });
+
+        it("should extract the inferred module path from a 'Did you mean Module.Member' message", () => {
+            // The asset-import case: `using { Folder1 }`, never `using { Folder1.image2 }`
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `image2`. Did you mean Folder1.image2")]);
+
+            expect(paths).toEqual(["Folder1"]);
+        });
+
+        it("should deduplicate paths across diagnostics and skip unrelated ones", () => {
+            const paths = extractor.extractImportsFromDiagnostics([
+                diag("Unknown identifier `button_device`. Did you forget to specify using { /Fortnite.com/Devices }"),
+                diag("Unknown identifier `creative_device`. Did you forget to specify using { /Fortnite.com/Devices }"),
+                diag("This variable can only be modified with 'set'. Did you mean to write 'set Foo.Bar = 1'?"),
+                diag("Expected expression after operator"),
+            ]);
+
+            expect(paths).toEqual(["/Fortnite.com/Devices"]);
         });
     });
 });


### PR DESCRIPTION
Closes #69, closes #70.

## What

`extractImportSuggestions` (auto-import, quick fixes) and `extractImportsFromDiagnostics` (Optimize Imports) were two divergent pattern pipelines. Both now consume a single private message classifier (`classifyMessage`), so the `'set'` filter and the load-bearing pattern precedence (multi-option before single-option) exist exactly once. Public API and the ImportHandler facade are unchanged; `extractImportsFromDiagnostics` stays sync with the same signature.

Fixes, in behavior terms:

- Optimize Imports no longer inserts a malformed import (for example `using { to write 'set Foo }`) when a "Did you mean to write 'set ...'" diagnostic is pending (#69)
- Optimize Imports no longer bulk-adds every candidate of an ambiguous "one of:" / "could be one of many types" error; ambiguous cases are left to the quick-fix menu (deliberate behavior change, changelog entry included)
- "Did you mean any of:" option lists no longer turn bare identifiers (local definitions echoed by the compiler, per the real Script Error 3506 shape) into invalid `using { item }` quick fixes (#70). A list that degenerates to one importable candidate is treated as unambiguous.

Preserved invariants, each locked by a regression test: single "Did you forget to specify" extraction on both paths, `Did you mean Folder1.image2` -> `using { Folder1 }` on both paths (the asset-import behavior validated by smoke case T3), configured `ambiguousImports` mappings beating inferred paths, and digest lookup precedence.

## Checks

- `npm run compile`: clean
- `npm test`: 6 suites, 69/69 passing (18 new regression tests in `ImportSuggestionExtractor.test.ts`)
- `npm run format`: applied
