### PR TITLE
test: versioned diagnostics corpus, capture command, and playbook T9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - New setting `cache.watcherDebounceMs` (default: 500) to tune how quickly file changes refresh the cache
   - New command **Verse: Rebuild Project Path Cache** to refresh the cache on demand
   - New command **Verse: Show Cache Status** to inspect the current cache state
+- **Capture Diagnostics Corpus**: new command **Verse: Capture Diagnostics Corpus** exports the verbatim compiler diagnostics of open Verse files to JSON. Used to maintain the message-format regression corpus (`test-fixtures/corpus/`) that guards import extraction against wording changes between UEFN releases
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
         "title": "Verse: Export Debug Logs"
       },
       {
+        "command": "verseAutoImports.captureDiagnosticsCorpus",
+        "title": "Verse: Capture Diagnostics Corpus"
+      },
+      {
         "command": "verseAutoImports.rebuildPathCache",
         "title": "Verse: Rebuild Project Path Cache"
       },

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -67,6 +67,7 @@ export class CommandsHandler {
 
             // Debug/Logs
             ["verseAutoImports.exportDebugLogs", this.exportDebugLogs.bind(this)],
+            ["verseAutoImports.captureDiagnosticsCorpus", this.captureDiagnosticsCorpus.bind(this)],
 
             // Cache
             ["verseAutoImports.rebuildPathCache", this.rebuildPathCache.bind(this)],
@@ -218,6 +219,58 @@ export class CommandsHandler {
             }
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to export debug logs: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+
+    /**
+     * Captures the current Verse compiler diagnostics of all open documents to
+     * a JSON file. Used to maintain the message-format regression corpus in
+     * test-fixtures/corpus (see its README for the curation workflow).
+     */
+    async captureDiagnosticsCorpus(): Promise<void> {
+        try {
+            interface CapturedDocument {
+                file: string;
+                diagnostics: Array<{ severity: number; startLine: number; message: string }>;
+            }
+
+            const documents: CapturedDocument[] = [];
+            for (const [uri, diagnostics] of vscode.languages.getDiagnostics()) {
+                if (!uri.path.endsWith(".verse") || diagnostics.length === 0) {
+                    continue;
+                }
+                documents.push({
+                    file: uri.toString(),
+                    diagnostics: diagnostics.map((diagnostic) => ({
+                        severity: diagnostic.severity,
+                        startLine: diagnostic.range.start.line,
+                        message: diagnostic.message,
+                    })),
+                });
+            }
+
+            if (documents.length === 0) {
+                vscode.window.showInformationMessage("No Verse diagnostics to capture");
+                return;
+            }
+
+            const target = await vscode.window.showSaveDialog({
+                filters: { JSON: ["json"] },
+                saveLabel: "Save diagnostics capture",
+            });
+            if (!target) {
+                return;
+            }
+
+            const payload = { capturedAt: new Date().toISOString(), documents };
+            await vscode.workspace.fs.writeFile(target, Buffer.from(JSON.stringify(payload, null, 4) + "\n", "utf8"));
+
+            const action = await vscode.window.showInformationMessage(`Captured diagnostics from ${documents.length} file(s) to ${target.fsPath}`, "Open File");
+            if (action === "Open File") {
+                await vscode.commands.executeCommand("vscode.open", target);
+            }
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to capture diagnostics: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 

--- a/src/imports/__tests__/diagnosticsCorpus.test.ts
+++ b/src/imports/__tests__/diagnosticsCorpus.test.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+import * as path from "path";
+import { ImportSuggestionExtractor } from "../ImportSuggestionExtractor";
+import { ImportFormatter } from "../ImportFormatter";
+import * as vscode from "vscode";
+
+interface CorpusEntry {
+    id: string;
+    source: "captured" | "book" | "synthetic";
+    context?: string;
+    message: string;
+    expected: {
+        suggestions: string[];
+        optimizePaths: string[];
+    };
+}
+
+interface CorpusFile {
+    uefnVersion: string;
+    capturedAt: string;
+    notes?: string;
+    entries: CorpusEntry[];
+}
+
+const corpusRoot = path.resolve(__dirname, "../../../test-fixtures/corpus");
+
+const corpora: CorpusFile[] = fs
+    .readdirSync(corpusRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(corpusRoot, entry.name, "diagnostics.json"))
+    .filter((file) => fs.existsSync(file))
+    .map((file) => JSON.parse(fs.readFileSync(file, "utf8")) as CorpusFile);
+
+describe("diagnostics corpus", () => {
+    it("has at least one corpus version with entries", () => {
+        expect(corpora.length).toBeGreaterThan(0);
+        expect(corpora.every((corpus) => corpus.entries.length > 0)).toBe(true);
+    });
+
+    for (const corpus of corpora) {
+        describe(`UEFN ${corpus.uefnVersion}`, () => {
+            let extractor: ImportSuggestionExtractor;
+
+            beforeEach(() => {
+                const outputChannel = vscode.window.createOutputChannel("test");
+                extractor = new ImportSuggestionExtractor(outputChannel, new ImportFormatter());
+            });
+
+            it.each(corpus.entries.map((entry) => [entry.id, entry] as const))("%s: suggestion extraction", async (_id, entry) => {
+                const suggestions = await extractor.extractImportSuggestions(entry.message);
+                expect(suggestions.map((suggestion) => suggestion.importStatement)).toEqual(entry.expected.suggestions);
+            });
+
+            it.each(corpus.entries.map((entry) => [entry.id, entry] as const))("%s: optimize path extraction", (_id, entry) => {
+                const paths = extractor.extractImportsFromDiagnostics([{ message: entry.message } as vscode.Diagnostic]);
+                expect(paths).toEqual(entry.expected.optimizePaths);
+            });
+        });
+    }
+});

--- a/test-fixtures/corpus/41.10/diagnostics.json
+++ b/test-fixtures/corpus/41.10/diagnostics.json
@@ -1,0 +1,107 @@
+{
+    "uefnVersion": "41.10",
+    "capturedAt": "2026-07-03",
+    "notes": "Captured entries come verbatim from the 2026-07-03 smoke session debug logs (real Verse LSP against the VerseAutoImports test project). Book entries are compiler output preserved in the Book of Verse sources. Synthetic entries are hand-written shapes awaiting live capture.",
+    "entries": [
+        {
+            "id": "unknown-with-suggestion-class-context",
+            "source": "captured",
+            "context": "uefn-smoke T1: identifier used inside a class",
+            "message": "Unknown identifier `button_device`.\nUsed inside class /vuke@fortnite.com/VerseAutoImports/Scripts/t1_device.\n Did you forget to specify using { /Fortnite.com/Devices }",
+            "expected": {
+                "suggestions": ["using { /Fortnite.com/Devices }"],
+                "optimizePaths": ["/Fortnite.com/Devices"]
+            }
+        },
+        {
+            "id": "unknown-with-suggestion-module-context",
+            "source": "captured",
+            "context": "uefn-smoke T1: identifier used inside a module",
+            "message": "Unknown identifier `editable`.\nUsed inside module /vuke@fortnite.com/VerseAutoImports/Scripts.\n Did you forget to specify using { /Verse.org/Simulation }",
+            "expected": {
+                "suggestions": ["using { /Verse.org/Simulation }"],
+                "optimizePaths": ["/Verse.org/Simulation"]
+            }
+        },
+        {
+            "id": "unknown-with-suggestion-function-context",
+            "source": "captured",
+            "context": "uefn-smoke T3: identifier used inside a function",
+            "message": "Unknown identifier `texture`.\nUsed inside function /vuke@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetImage.\n Did you forget to specify using { /Verse.org/Assets }",
+            "expected": {
+                "suggestions": ["using { /Verse.org/Assets }"],
+                "optimizePaths": ["/Verse.org/Assets"]
+            }
+        },
+        {
+            "id": "did-you-mean-any-of-qualified-options",
+            "source": "captured",
+            "context": "uefn-smoke T4: module name exists under two parents; note the trailing space after 'any of: '",
+            "message": "Unknown identifier `Combat`.\nUsed inside module /vuke@fortnite.com/VerseAutoImports/Scripts.\n Did you mean any of: \nSystems.Combat\nFeatures.Combat",
+            "expected": {
+                "suggestions": ["using { Systems }", "using { Features }"],
+                "optimizePaths": []
+            }
+        },
+        {
+            "id": "did-you-mean-single-asset",
+            "source": "captured",
+            "context": "uefn-smoke T3: asset reference; the import must not embed the asset name",
+            "message": "Unknown identifier `image2`.\nUsed inside function /vuke@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetImage.\n Did you mean Folder1.image2",
+            "expected": {
+                "suggestions": ["using { Folder1 }"],
+                "optimizePaths": ["Folder1"]
+            }
+        },
+        {
+            "id": "did-you-mean-single-asset-nested",
+            "source": "captured",
+            "context": "uefn-smoke T3: asset two folders deep",
+            "message": "Unknown identifier `image3`.\nUsed inside function /vuke@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetInnerImage.\n Did you mean Folder1.InnerFolder.image3",
+            "expected": {
+                "suggestions": ["using { Folder1.InnerFolder }"],
+                "optimizePaths": ["Folder1.InnerFolder"]
+            }
+        },
+        {
+            "id": "did-you-mean-any-of-bare-option",
+            "source": "book",
+            "context": "Book of Verse 16_modules (Script Error 3506): option list echoes a local definition; the bare option must not become an import. The one importable candidate left is treated as unambiguous, so Optimize adds it too",
+            "message": "Unknown identifier `item`. Did you mean any of:\nInventoryModule.item\nitem",
+            "expected": {
+                "suggestions": ["using { InventoryModule }"],
+                "optimizePaths": ["InventoryModule"]
+            }
+        },
+        {
+            "id": "set-assignment-hint",
+            "source": "synthetic",
+            "context": "assignment hint, never an import problem; guards the greedy Did-you-mean fallback",
+            "message": "This variable can only be modified with 'set'. Did you mean to write 'set Foo.Bar = 1'?",
+            "expected": {
+                "suggestions": [],
+                "optimizePaths": []
+            }
+        },
+        {
+            "id": "forget-one-of-two-paths",
+            "source": "synthetic",
+            "context": "ambiguous inline list; Optimize must not bulk-add both",
+            "message": "Unknown identifier `thing`. Did you forget to specify one of:\nusing { /GameA/Combat }\nusing { /GameB/Combat }",
+            "expected": {
+                "suggestions": ["using { /GameA/Combat }", "using { /GameB/Combat }"],
+                "optimizePaths": []
+            }
+        },
+        {
+            "id": "identifier-many-types",
+            "source": "synthetic",
+            "context": "ambiguous type identifier; Optimize must not bulk-add both",
+            "message": "Identifier vector3 could be one of many types: (/Verse.org/SpatialMath:)vector3 or (/UnrealEngine.com/Temporary/SpatialMath:)vector3",
+            "expected": {
+                "suggestions": ["using { /Verse.org/SpatialMath }", "using { /UnrealEngine.com/Temporary/SpatialMath }"],
+                "optimizePaths": []
+            }
+        }
+    ]
+}

--- a/test-fixtures/corpus/README.md
+++ b/test-fixtures/corpus/README.md
@@ -1,0 +1,65 @@
+# Diagnostics Corpus
+
+Versioned collection of verbatim Verse compiler messages and the extractions
+the extension must produce for them. This is the drift detector for Epic
+changing error wording between UEFN releases: when a new UEFN version ships,
+capture a new corpus folder and the test run shows exactly which extraction
+patterns broke.
+
+## Layout
+
+One folder per UEFN release, each with a `diagnostics.json`:
+
+```
+test-fixtures/corpus/
+    41.10/
+        diagnostics.json
+    <next UEFN version>/
+        diagnostics.json
+```
+
+`src/imports/__tests__/diagnosticsCorpus.test.ts` loads every version folder
+and asserts, for each entry, the output of both extraction paths.
+
+## Schema
+
+```json
+{
+    "uefnVersion": "41.10",
+    "capturedAt": "2026-07-03",
+    "notes": "optional free text",
+    "entries": [
+        {
+            "id": "unique-kebab-slug",
+            "source": "captured | book | synthetic",
+            "context": "optional: where the message came from",
+            "message": "verbatim compiler message, newlines preserved",
+            "expected": {
+                "suggestions": ["using { /Fortnite.com/Devices }"],
+                "optimizePaths": ["/Fortnite.com/Devices"]
+            }
+        }
+    ]
+}
+```
+
+- `expected.suggestions`: import statements `extractImportSuggestions` must
+  return, in order (the auto-import and quick-fix path).
+- `expected.optimizePaths`: paths `extractImportsFromDiagnostics` must return
+  (the Optimize Imports path). Ambiguous multi-option messages expect `[]`
+  here by design.
+- `source`: `captured` = recorded from a live UEFN session (highest value),
+  `book` = preserved compiler output from the Book of Verse, `synthetic` =
+  hand-written shape awaiting live capture. Replace synthetic entries with
+  captured ones when the real message is observed.
+
+## Workflow
+
+1. During a smoke session (see `test-fixtures/uefn-smoke/PLAYBOOK.md`), open
+   the fixture files so the Verse LSP reports their diagnostics.
+2. Run the command **Verse: Capture Diagnostics Corpus**. It writes the
+   verbatim diagnostics of all open `.verse` files to a JSON file.
+3. Curate the capture into entries: keep one entry per distinct message
+   shape, fill in the two `expected` arrays, mark `source: "captured"`.
+4. For a new UEFN version, create a new folder rather than editing the old
+   one; old folders document what previous compilers emitted.

--- a/test-fixtures/uefn-smoke/Content/T9/Sub/Deep/t9_deep_thing.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/Sub/Deep/t9_deep_thing.verse
@@ -1,0 +1,3 @@
+# Support module for T9 case B (subdirectory import of Sub/Deep).
+deep_thing<public> := class:
+    Value<public>:int = 0

--- a/test-fixtures/uefn-smoke/Content/T9/Sub/t9_sub_thing.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/Sub/t9_sub_thing.verse
@@ -1,0 +1,3 @@
+# Support module for T9 case A (same-directory import of Sub).
+sub_thing<public> := class:
+    Value<public>:int = 0

--- a/test-fixtures/uefn-smoke/Content/T9/t9_alias.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/t9_alias.verse
@@ -1,0 +1,10 @@
+# T9 case F: the import(...) module alias expression (book 16_modules,
+# "Module Aliases with import"). Uncomment to test whether live UEFN accepts
+# it; record the verbatim outcome. If it compiles, also add
+# `using { /Verse.org/SpatialMath }` below it and confirm the extension does
+# not behave differently in this file (issue #71).
+
+# T9Math := import(/Verse.org/SpatialMath)
+# T9AliasProbe():vector3 = T9Math.vector3{X := 0.0, Y := 0.0, Z := 0.0}
+
+t9_alias_placeholder:int = 0

--- a/test-fixtures/uefn-smoke/Content/T9/t9_module_body.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/t9_module_body.verse
@@ -1,0 +1,14 @@
+# T9 cases D-E: a module-scoped using inside a module body (case D) and the
+# indented import style at file level (case E). Both are valid Verse per the
+# book (16_modules). Expected with the extension active: NEITHER using is
+# moved, deleted, or duplicated by auto-import, Optimize Imports, or saving.
+
+using:
+    /Verse.org/Simulation
+
+t9_utilities := module:
+    using { /Verse.org/Random }
+
+    T9GenerateId<public>():int = GetRandomInt(1, 100)
+
+T9Probe(Who:agent):void = {}

--- a/test-fixtures/uefn-smoke/Content/T9/t9_relative_imports.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/t9_relative_imports.verse
@@ -1,0 +1,19 @@
+# T9 cases A-C: relative import forms documented in the Book of Verse
+# (16_modules, "Local and Relative Imports"). Uncomment ONE case at a time,
+# push Verse changes, and record the verbatim outcome (clean compile or the
+# exact diagnostic) via "Verse: Capture Diagnostics Corpus".
+# Results gate the fix design for issue #65.
+
+# Case A: bare same-directory module import (module folder T9/Sub)
+# using { Sub }
+
+# Case B: subdirectory path import
+# using { Sub/Deep }
+
+# Case C: sibling-folder import (Scripts is a sibling of T9)
+# using { ../Scripts }
+
+# Probe for case A (uncomment together with the case A import):
+# T9GetSub():sub_thing = sub_thing{}
+
+t9_relative_placeholder:int = 0

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -163,6 +163,41 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
        duplicate-interval evidence.
 3. [ ] Enable auto-imports mid-snooze: snooze cancels automatically.
 
+### T9 -- book-construct validation (fixtures: T9/) [gates #65 and #71]
+
+Each case checks whether live UEFN accepts a construct documented in the Book
+of Verse; the results decide the fix design for #65 (relative import
+classification) and #71 (import aliases), and give live regression coverage
+for #67/#68. For every case record the verbatim outcome (clean compile, or
+the exact diagnostic) with "Verse: Capture Diagnostics Corpus", then fold new
+message shapes into test-fixtures/corpus/<UEFN version>/diagnostics.json with
+expectations filled in (see test-fixtures/corpus/README.md).
+
+1. [ ] Case A bare same-directory import: in t9_relative_imports.verse,
+       uncomment `using { Sub }` (plus the probe line). Compiles or exact
+       error?
+2. [ ] Case B subdirectory import: re-comment A, uncomment
+       `using { Sub/Deep }`. Same question.
+3. [ ] Case C sibling import: re-comment B, uncomment `using { ../Scripts }`.
+       Same question.
+4. [ ] Case D module-body using (t9_module_body.verse): file compiles as
+       synced. Then remove the indented `/Verse.org/Simulation` pair, wait
+       for the auto-import to re-add it, and confirm the module-scoped
+       `using { /Verse.org/Random }` was not moved, deleted, or duplicated.
+       Run "Verse: Optimize Imports" and save: same expectation (#67 live).
+5. [ ] Case E indented style (same file): re-sync the fixture so the
+       `using:` pair is back, then trigger any auto-import in the file (e.g.
+       reference `button_device`). The pair must be consolidated into the
+       import block with its path intact; no orphaned indented line (#68
+       live).
+6. [ ] Case F alias (t9_alias.verse): uncomment the import(...) lines.
+       Compiles or exact error? If it compiles, add
+       `using { /Verse.org/SpatialMath }` below and confirm the extension
+       does not add duplicates or misbehave in the file (#71).
+7. [ ] Capture: with all T9 files open and their diagnostics present, run
+       "Verse: Capture Diagnostics Corpus" and curate the output into the
+       corpus folder for this UEFN version.
+
 ## Phase D: verdict
 
 | Case | Pass | Finding # |
@@ -176,6 +211,7 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 | T6   |      |           |
 | T7   |      |           |
 | T8   |      |           |
+| T9   |      |           |
 
 Findings (number, verbatim evidence, suspected component):
 


### PR DESCRIPTION
Phase 2 groundwork for the testing pipeline: makes compiler-message drift between UEFN releases detectable by tests, and equips the next smoke session to validate the book constructs gating #65 and #71.

Stacked on #72: the corpus expectations encode the fixed extraction behavior, so this PR is based on `fix/diagnostic-extraction-hardening` and should merge after it (GitHub will retarget to develop when #72 merges).

## What

- **`test-fixtures/corpus/41.10/diagnostics.json`** - verbatim compiler messages, each with the expected output of both extraction paths (`suggestions` for auto-import/quick fixes, `optimizePaths` for Optimize Imports). Seeded with six messages captured verbatim from the 2026-07-03 live 41.10 smoke session (including the real multi-line shape with the `Used inside ...` middle line and the trailing space after `Did you mean any of: `), the Script Error 3506 dump preserved in the Book of Verse, and three synthetic shapes marked for replacement by live captures.
- **`diagnosticsCorpus.test.ts`** - iterates every `test-fixtures/corpus/<version>/diagnostics.json`; when a new UEFN version ships, capturing a new folder immediately shows which patterns broke. Already proved itself during development: it caught an inconsistency between my seed expectations and the degenerate-multi-option policy from #72 (a "Did you mean any of" list reduced to one importable candidate is unambiguous, so Optimize adds it too - now documented in the entry's context field).
- **Verse: Capture Diagnostics Corpus** - new command that dumps the verbatim diagnostics of open `.verse` files to JSON via a save dialog, turning corpus curation into one palette action during a smoke session. Follows the exportDebugLogs UI pattern.
- **Playbook T9 + `Content/T9/` fixtures** - live validation cases for the book constructs: bare/subdirectory/`../` relative imports (gates the fix design for #65), `import(...)` aliases (gates #71), plus live regression checks for module-body `using` (#67) and the indented pair (#68).

## Checks

- `npm run compile`: clean
- `npm test`: 7 suites, 90/90 passing (21 new: 20 corpus assertions plus a corpus-presence sanity check)
- `npm run format`: applied
- `test-fixtures/**` is already excluded from the vsix via .vscodeignore
