### PR TITLE
test: extension-host integration harness with injected compiler diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,9 @@ jobs:
 
       - name: Run integration tests
         run: npm run test:integration
+
+      - name: Package VSIX
+        run: npx --yes @vscode/vsce package --out itest.vsix
+
+      - name: Run packaged VSIX activation test
+        run: npm run test:integration:vsix -- itest.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,30 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  test-integration:
+    # windows-latest matches the platform the extension is developed and used
+    # on; the extension-host suite needs no display server there.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache VS Code test install
+        uses: actions/cache@v4
+        with:
+          path: .vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            vscode-test-${{ runner.os }}-
+
+      - name: Run integration tests
+        run: npm run test:integration

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Thumbs.db
 
 # Patch files
 *.patch
+out-integration/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,6 +10,7 @@ src/**
 .claude/**
 CLAUDE.md
 tsconfig.json
+tsconfig.integration.json
 
 # Git
 .git/**
@@ -26,6 +27,8 @@ test-fixtures/**
 **/*.spec.js
 vitest.config.*
 jest.config.js
+out-integration/**
+.vscode-test/**
 
 # Development artifacts
 *.vsix

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,9 @@ const config: Config = {
     testEnvironment: "node",
     roots: ["<rootDir>/src"],
     testMatch: ["**/__tests__/**/*.test.ts"],
+    // The extension-host integration suite (mocha, *.itest.ts) must never run
+    // under Jest; it requires a real VS Code instance.
+    testPathIgnorePatterns: ["<rootDir>/src/test-integration/"],
     moduleFileExtensions: ["ts", "js", "json"],
     moduleNameMapper: {
         "^vscode$": "<rootDir>/src/__mocks__/vscode.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,12 @@
       "version": "0.6.4",
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/mocha": "^10.0.10",
         "@types/node": "^26.1.0",
         "@types/vscode": "^1.85.0",
+        "@vscode/test-electron": "^3.0.0",
         "jest": "^30.3.0",
+        "mocha": "^11.7.6",
         "prettier": "^3.9.4",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
@@ -1258,6 +1261,13 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
@@ -1619,6 +1629,36 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/test-electron": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
+      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1643,6 +1683,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1863,6 +1913,13 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/browserslist": {
       "version": "4.28.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
@@ -1995,6 +2052,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -2017,6 +2090,35 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2148,6 +2250,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2186,6 +2295,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -2401,6 +2523,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2458,6 +2590,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-package-type": {
@@ -2544,12 +2689,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -2560,6 +2743,13 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -2637,6 +2827,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2649,6 +2872,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3415,6 +3658,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3423,6 +3679,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3451,6 +3717,23 @@
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3525,6 +3808,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -3559,6 +3855,161 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -3664,6 +4115,111 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3725,6 +4281,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -3887,6 +4450,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -3904,6 +4474,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -3919,6 +4499,36 @@
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3953,6 +4563,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -3962,6 +4612,23 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4048,6 +4715,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -4579,6 +5269,13 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -4644,6 +5341,13 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -4805,6 +5509,35 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -282,14 +282,18 @@
     "watch": "tsc -watch -p ./",
     "parse-digest": "ts-node src/scripts/parseDigestFiles.ts",
     "test": "jest --verbose",
+    "test:integration": "npm run compile && tsc -p tsconfig.integration.json && node out-integration/test-integration/runTests.js",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^26.1.0",
     "@types/vscode": "^1.85.0",
+    "@vscode/test-electron": "^3.0.0",
     "jest": "^30.3.0",
+    "mocha": "^11.7.6",
     "prettier": "^3.9.4",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -283,6 +283,7 @@
     "parse-digest": "ts-node src/scripts/parseDigestFiles.ts",
     "test": "jest --verbose",
     "test:integration": "npm run compile && tsc -p tsconfig.integration.json && node out-integration/test-integration/runTests.js",
+    "test:integration:vsix": "npm run compile && tsc -p tsconfig.integration.json && node out-integration/test-integration/runVsixTest.js",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
   },

--- a/src/test-integration/runTests.ts
+++ b/src/test-integration/runTests.ts
@@ -1,0 +1,49 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { runTests } from "@vscode/test-electron";
+
+/**
+ * Launches the Layer-2 integration suite: downloads VS Code, opens the fake
+ * UEFN fixture workspace, loads this extension from the repository root, and
+ * runs the mocha suite inside the extension host.
+ *
+ * The repository does not ship a `verse` language contribution (in production
+ * Epic's Verse extension provides it), so a stub extension that only registers
+ * the language id is loaded as a second development path. Without it the
+ * `onLanguage:verse` activation event would never fire in the test host.
+ */
+async function main(): Promise<void> {
+    // When the harness itself is started from a VS Code integrated terminal,
+    // ELECTRON_RUN_AS_NODE=1 is inherited and makes the downloaded VS Code
+    // run as plain Node, which then tries to execute the workspace file as a
+    // script. Clear it so the test instance starts as a real VS Code.
+    delete process.env.ELECTRON_RUN_AS_NODE;
+
+    const repoRoot = path.resolve(__dirname, "..", "..");
+    const languageStubPath = path.join(repoRoot, "test-fixtures", "verse-language-stub");
+    const extensionTestsPath = path.join(__dirname, "suite");
+
+    // Run against a scratch copy of the fixture workspace: some flows under
+    // test (Optimize Imports) save documents, and the checked-in fixtures must
+    // stay pristine between runs.
+    const workspaceSource = path.join(repoRoot, "test-fixtures", "integration-workspace");
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "verse-auto-imports-itest-"));
+    fs.cpSync(workspaceSource, workspaceRoot, { recursive: true });
+    const workspaceFile = path.join(workspaceRoot, "VerseAutoImportsIT.code-workspace");
+
+    try {
+        await runTests({
+            extensionDevelopmentPath: [repoRoot, languageStubPath],
+            extensionTestsPath,
+            launchArgs: [workspaceFile, "--disable-extensions", "--disable-workspace-trust", "--disable-gpu"],
+        });
+    } finally {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+}
+
+main().catch((error: unknown) => {
+    console.error("Integration test run failed:", error);
+    process.exitCode = 1;
+});

--- a/src/test-integration/runVsixTest.ts
+++ b/src/test-integration/runVsixTest.ts
@@ -1,0 +1,65 @@
+import * as cp from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } from "@vscode/test-electron";
+
+/**
+ * Packaging regression check: installs a built .vsix (path given as the first
+ * CLI argument) into the test VS Code and runs only the activation suite
+ * against it. Unlike runTests.ts the extension is NOT loaded from the repo,
+ * so a packaging mistake (e.g. .vscodeignore excluding out/) fails here even
+ * though the normal integration suite passes.
+ */
+async function main(): Promise<void> {
+    delete process.env.ELECTRON_RUN_AS_NODE;
+
+    const vsixArg = process.argv[2];
+    if (!vsixArg) {
+        throw new Error("Usage: node runVsixTest.js <path-to-vsix>");
+    }
+    const vsixPath = path.resolve(vsixArg);
+    if (!fs.existsSync(vsixPath)) {
+        throw new Error(`VSIX not found: ${vsixPath}`);
+    }
+
+    const repoRoot = path.resolve(__dirname, "..", "..");
+    const languageStubPath = path.join(repoRoot, "test-fixtures", "verse-language-stub");
+    const extensionTestsPath = path.join(__dirname, "vsix-suite");
+
+    const workspaceSource = path.join(repoRoot, "test-fixtures", "integration-workspace");
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "verse-auto-imports-vsix-"));
+    fs.cpSync(workspaceSource, workspaceRoot, { recursive: true });
+    const workspaceFile = path.join(workspaceRoot, "VerseAutoImportsIT.code-workspace");
+
+    try {
+        const vscodeExecutablePath = await downloadAndUnzipVSCode();
+        const [cliPath, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+
+        // On Windows the CLI is a .cmd, which needs a shell; quote everything
+        // because the repo path contains spaces.
+        const quote = (value: string): string => `"${value}"`;
+        const installCommand = [quote(cliPath), ...cliArgs.map(quote), "--install-extension", quote(vsixPath)].join(" ");
+        const install = cp.spawnSync(installCommand, { stdio: "inherit", shell: true });
+        if (install.status !== 0) {
+            throw new Error(`Failed to install ${vsixPath} (exit code ${String(install.status)})`);
+        }
+
+        await runTests({
+            vscodeExecutablePath,
+            // Only the language stub is a development extension; the extension
+            // under test must come from the installed vsix. Deliberately no
+            // --disable-extensions for the same reason.
+            extensionDevelopmentPath: [languageStubPath],
+            extensionTestsPath,
+            launchArgs: [workspaceFile, "--disable-workspace-trust", "--disable-gpu"],
+        });
+    } finally {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+}
+
+main().catch((error: unknown) => {
+    console.error("VSIX activation test run failed:", error);
+    process.exitCode = 1;
+});

--- a/src/test-integration/suite/activation.itest.ts
+++ b/src/test-integration/suite/activation.itest.ts
@@ -1,0 +1,51 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+
+const EXTENSION_ID = "vukefn.verse-auto-imports";
+
+function contentRoot(): string {
+    const folder = vscode.workspace.workspaceFolders?.find((f) => f.name === "Content");
+    if (!folder) {
+        throw new Error("Fixture workspace is missing its Content folder; was the .code-workspace opened?");
+    }
+    return folder.uri.fsPath;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number, label: string): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (predicate()) {
+            return;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
+}
+
+describe("extension activation", () => {
+    it("activates via onLanguage:verse when a .verse file opens", async () => {
+        const extension = vscode.extensions.getExtension(EXTENSION_ID);
+        assert.ok(extension, `${EXTENSION_ID} not found in the test host`);
+
+        const probePath = path.join(contentRoot(), "activation_probe.verse");
+        const document = await vscode.workspace.openTextDocument(probePath);
+
+        // The verse-language-stub development extension registers the language
+        // id; if this fails the activation event below can never fire.
+        assert.strictEqual(document.languageId, "verse", "expected .verse files to get the verse language id");
+
+        await waitFor(() => extension.isActive, 15000, "extension activation");
+    });
+
+    it("activates even though the project's Assets.digest.verse cannot exist", async () => {
+        // The fixture .uefnproject title is VerseAutoImportsIntegrationHarness,
+        // so the %LOCALAPPDATA% UnrealEditorFortnite digest path resolves to a
+        // directory no UEFN install has. Activation must have degraded
+        // gracefully; auto-import still working is asserted by the auto-import
+        // suite against the same workspace.
+        const extension = vscode.extensions.getExtension(EXTENSION_ID);
+        assert.ok(extension, `${EXTENSION_ID} not found in the test host`);
+        assert.strictEqual(extension.isActive, true, "extension should be active despite the missing assets digest");
+    });
+});

--- a/src/test-integration/suite/activation.itest.ts
+++ b/src/test-integration/suite/activation.itest.ts
@@ -1,16 +1,7 @@
 import * as assert from "assert";
 import * as path from "path";
 import * as vscode from "vscode";
-
-const EXTENSION_ID = "vukefn.verse-auto-imports";
-
-function contentRoot(): string {
-    const folder = vscode.workspace.workspaceFolders?.find((f) => f.name === "Content");
-    if (!folder) {
-        throw new Error("Fixture workspace is missing its Content folder; was the .code-workspace opened?");
-    }
-    return folder.uri.fsPath;
-}
+import { EXTENSION_ID, contentRoot } from "./helpers";
 
 async function waitFor(predicate: () => boolean, timeoutMs: number, label: string): Promise<void> {
     const deadline = Date.now() + timeoutMs;

--- a/src/test-integration/suite/autoImport.itest.ts
+++ b/src/test-integration/suite/autoImport.itest.ts
@@ -1,0 +1,83 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { DiagnosticInjector, assertNoDocumentChange, corpusMessage, countOccurrences, openFixture, sleep, waitForDocumentChange } from "./helpers";
+
+describe("auto-import pipeline (playbook T1/T2/T3)", () => {
+    let injector: DiagnosticInjector;
+
+    beforeEach(() => {
+        injector = new DiagnosticInjector("verse-itest-auto");
+    });
+
+    afterEach(() => {
+        injector.dispose();
+    });
+
+    it("T1: a single corpus suggestion auto-imports exactly once", async () => {
+        const document = await openFixture("t1_single_suggestion.verse");
+        injector.inject(document, [corpusMessage("unknown-with-suggestion-class-context")], "button_device");
+
+        await waitForDocumentChange(document, (text) => text.includes("using { /Fortnite.com/Devices }"), "auto-import of /Fortnite.com/Devices");
+        await sleep(500);
+
+        assert.strictEqual(countOccurrences(document.getText(), "using { /Fortnite.com/Devices }"), 1, "import must be inserted exactly once");
+    });
+
+    it("T1: several single-suggestion diagnostics in one debounce window import once each", async () => {
+        const document = await openFixture("t1_multiple_singles.verse");
+        injector.inject(document, [
+            corpusMessage("unknown-with-suggestion-class-context"),
+            corpusMessage("unknown-with-suggestion-module-context"),
+            corpusMessage("unknown-with-suggestion-function-context"),
+        ]);
+
+        const statements = ["using { /Fortnite.com/Devices }", "using { /Verse.org/Simulation }", "using { /Verse.org/Assets }"];
+        await waitForDocumentChange(document, (text) => statements.every((statement) => text.includes(statement)), "auto-import of all three suggestions");
+        await sleep(500);
+
+        const text = document.getText();
+        for (const statement of statements) {
+            assert.strictEqual(countOccurrences(text, statement), 1, `expected exactly one '${statement}'`);
+        }
+    });
+
+    it("T3: an asset suggestion imports the containing folder, never the asset itself", async () => {
+        const document = await openFixture("t3_asset_reference.verse");
+        injector.inject(document, [corpusMessage("did-you-mean-single-asset")], "image2");
+
+        await waitForDocumentChange(document, (text) => text.includes("using { Folder1 }"), "auto-import of Folder1");
+        await sleep(500);
+
+        const text = document.getText();
+        assert.strictEqual(countOccurrences(text, "using { Folder1 }"), 1);
+        assert.ok(!text.includes("using { Folder1.image2 }"), "the import must not embed the asset name");
+    });
+
+    it("T2: multi-option diagnostics do not auto-import under the default quickfix strategy", async () => {
+        const document = await openFixture("t2_multi_option.verse");
+        injector.inject(document, [corpusMessage("forget-one-of-two-paths")], "thing");
+
+        await assertNoDocumentChange(document);
+    });
+
+    it("T2: quick fixes offer every candidate of a multi-option diagnostic", async () => {
+        const document = await openFixture("t2_multi_option.verse");
+        injector.inject(document, [corpusMessage("did-you-mean-any-of-qualified-options")], "combat_probe");
+        await sleep(300);
+
+        const anchor = document.getText().indexOf("combat_probe");
+        assert.ok(anchor !== -1, "fixture is missing the combat_probe anchor");
+        const range = new vscode.Range(document.positionAt(anchor), document.positionAt(anchor + "combat_probe".length));
+
+        const actions = await vscode.commands.executeCommand<vscode.CodeAction[]>("vscode.executeCodeActionProvider", document.uri, range);
+        const titles = (actions ?? []).map((action) => action.title);
+        assert.ok(
+            titles.some((title) => title.includes("using { Systems }")),
+            `missing 'using { Systems }' quick fix, got: ${titles.join(" | ")}`,
+        );
+        assert.ok(
+            titles.some((title) => title.includes("using { Features }")),
+            `missing 'using { Features }' quick fix, got: ${titles.join(" | ")}`,
+        );
+    });
+});

--- a/src/test-integration/suite/autoImport.itest.ts
+++ b/src/test-integration/suite/autoImport.itest.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { DiagnosticInjector, assertNoDocumentChange, corpusMessage, countOccurrences, openFixture, sleep, waitForDocumentChange } from "./helpers";
+import { DiagnosticInjector, assertNoDocumentChange, corpusMessage, countOccurrences, docText, openFixture, sleep, waitForDocumentChange } from "./helpers";
 
 describe("auto-import pipeline (playbook T1/T2/T3)", () => {
     let injector: DiagnosticInjector;
@@ -20,7 +20,7 @@ describe("auto-import pipeline (playbook T1/T2/T3)", () => {
         await waitForDocumentChange(document, (text) => text.includes("using { /Fortnite.com/Devices }"), "auto-import of /Fortnite.com/Devices");
         await sleep(500);
 
-        assert.strictEqual(countOccurrences(document.getText(), "using { /Fortnite.com/Devices }"), 1, "import must be inserted exactly once");
+        assert.strictEqual(countOccurrences(docText(document), "using { /Fortnite.com/Devices }"), 1, "import must be inserted exactly once");
     });
 
     it("T1: several single-suggestion diagnostics in one debounce window import once each", async () => {
@@ -35,7 +35,7 @@ describe("auto-import pipeline (playbook T1/T2/T3)", () => {
         await waitForDocumentChange(document, (text) => statements.every((statement) => text.includes(statement)), "auto-import of all three suggestions");
         await sleep(500);
 
-        const text = document.getText();
+        const text = docText(document);
         for (const statement of statements) {
             assert.strictEqual(countOccurrences(text, statement), 1, `expected exactly one '${statement}'`);
         }
@@ -48,7 +48,7 @@ describe("auto-import pipeline (playbook T1/T2/T3)", () => {
         await waitForDocumentChange(document, (text) => text.includes("using { Folder1 }"), "auto-import of Folder1");
         await sleep(500);
 
-        const text = document.getText();
+        const text = docText(document);
         assert.strictEqual(countOccurrences(text, "using { Folder1 }"), 1);
         assert.ok(!text.includes("using { Folder1.image2 }"), "the import must not embed the asset name");
     });

--- a/src/test-integration/suite/commands.itest.ts
+++ b/src/test-integration/suite/commands.itest.ts
@@ -1,0 +1,79 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { openFixture, sleep } from "./helpers";
+
+function globalAutoImport(): boolean | undefined {
+    return vscode.workspace.getConfiguration("verseAutoImports").inspect<boolean>("general.autoImport")?.globalValue;
+}
+
+async function waitForGlobalAutoImport(expected: boolean, timeoutMs: number = 3000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (globalAutoImport() === expected) {
+            return;
+        }
+        await sleep(50);
+    }
+    throw new Error(`general.autoImport globalValue did not become ${expected} within ${timeoutMs}ms (currently ${globalAutoImport()})`);
+}
+
+describe("commands and snooze (playbook T7/T8)", () => {
+    before(async () => {
+        // Guarantees activation so all commands are registered.
+        await openFixture("activation_probe.verse");
+    });
+
+    it("T7/T8: every contributed command is registered", async () => {
+        const registered = await vscode.commands.getCommands(true);
+        const expected = [
+            "verseAutoImports.showStatusMenu",
+            "verseAutoImports.optimizeImports",
+            "verseAutoImports.addSingleImport",
+            "verseAutoImports.toggleAutoImport",
+            "verseAutoImports.togglePreserveLocations",
+            "verseAutoImports.toggleImportSyntax",
+            "verseAutoImports.toggleDigestFiles",
+            "verseAutoImports.toggleFullPathCodeLens",
+            "verseAutoImports.snoozeAutoImport",
+            "verseAutoImports.cancelSnooze",
+            "verseAutoImports.convertToFullPath",
+            "verseAutoImports.convertAllToFullPath",
+            "verseAutoImports.convertToRelativePath",
+            "verseAutoImports.convertAllToRelativePath",
+            "verseAutoImports.exportDebugLogs",
+            "verseAutoImports.captureDiagnosticsCorpus",
+            "verseAutoImports.rebuildPathCache",
+            "verseAutoImports.showCacheStatus",
+        ];
+        for (const commandId of expected) {
+            assert.ok(registered.includes(commandId), `command ${commandId} is not registered`);
+        }
+    });
+
+    it("T7: rebuild path cache completes against the fixture workspace", async () => {
+        // Resolving without throwing is the assertion: the cache scan must
+        // cope with the multi-root fixture layout (Content plus digest roots).
+        await vscode.commands.executeCommand("verseAutoImports.rebuildPathCache");
+    });
+
+    it("T8: snooze disables auto-import globally; re-snoozing stays coherent; cancel restores", async () => {
+        try {
+            await vscode.commands.executeCommand("verseAutoImports.snoozeAutoImport");
+            await waitForGlobalAutoImport(false);
+
+            // Re-invoking while already snoozed must not corrupt the state
+            // (single timer per the 0.6.x snooze fix); the setting stays off.
+            await vscode.commands.executeCommand("verseAutoImports.snoozeAutoImport");
+            await sleep(300);
+            assert.strictEqual(globalAutoImport(), false, "auto-import must stay disabled while snoozed");
+
+            await vscode.commands.executeCommand("verseAutoImports.cancelSnooze");
+            await waitForGlobalAutoImport(true);
+        } finally {
+            // Never leak a snoozed state into later suites: cancel again and
+            // clear the global override so the default (true) applies.
+            await vscode.commands.executeCommand("verseAutoImports.cancelSnooze");
+            await vscode.workspace.getConfiguration("verseAutoImports").update("general.autoImport", undefined, vscode.ConfigurationTarget.Global);
+        }
+    });
+});

--- a/src/test-integration/suite/helpers.ts
+++ b/src/test-integration/suite/helpers.ts
@@ -74,6 +74,20 @@ export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Normalizes CRLF to LF. Fixture checkouts on Windows CI (and real user
+ * documents) carry CRLF; assertions and predicates always see LF so they can
+ * use literal \n and $ anchors.
+ */
+export function normalizeEol(text: string): string {
+    return text.replace(/\r\n/g, "\n");
+}
+
+/** The document text with line endings normalized to LF, for assertions. */
+export function docText(document: vscode.TextDocument): string {
+    return normalizeEol(document.getText());
+}
+
 export function countOccurrences(text: string, needle: string): number {
     let count = 0;
     let index = text.indexOf(needle);
@@ -138,7 +152,7 @@ export class DiagnosticInjector {
  * final document text for diagnosis.
  */
 export function waitForDocumentChange(document: vscode.TextDocument, predicate: (text: string) => boolean, label: string, timeoutMs: number = 5000): Promise<void> {
-    if (predicate(document.getText())) {
+    if (predicate(docText(document))) {
         return Promise.resolve();
     }
     return new Promise<void>((resolve, reject) => {
@@ -151,7 +165,7 @@ export function waitForDocumentChange(document: vscode.TextDocument, predicate: 
             if (event.document.uri.toString() !== document.uri.toString()) {
                 return;
             }
-            if (predicate(event.document.getText())) {
+            if (predicate(docText(event.document))) {
                 clearTimeout(timer);
                 subscription?.dispose();
                 resolve();
@@ -207,5 +221,5 @@ export async function runOptimizeImports(document: vscode.TextDocument): Promise
     await vscode.window.showTextDocument(document, { preview: false });
     await vscode.commands.executeCommand("verseAutoImports.optimizeImports");
     await sleep(500);
-    return document.getText();
+    return docText(document);
 }

--- a/src/test-integration/suite/helpers.ts
+++ b/src/test-integration/suite/helpers.ts
@@ -1,0 +1,211 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+export const EXTENSION_ID = "vukefn.verse-auto-imports";
+
+/** One entry in test-fixtures/corpus/<version>/diagnostics.json. */
+interface CorpusEntry {
+    id: string;
+    source: string;
+    context: string;
+    message: string;
+    expected: {
+        suggestions: string[];
+        optimizePaths: string[];
+    };
+}
+
+interface CorpusFile {
+    uefnVersion: string;
+    entries: CorpusEntry[];
+}
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const CORPUS_PATH = path.join(REPO_ROOT, "test-fixtures", "corpus", "41.10", "diagnostics.json");
+
+let corpusCache: CorpusFile | null = null;
+
+/**
+ * Loads a recorded compiler message from the diagnostics corpus. The corpus is
+ * the single source of truth for message shapes; tests never hand-write
+ * compiler messages.
+ */
+export function corpusMessage(id: string): string {
+    if (!corpusCache) {
+        corpusCache = JSON.parse(fs.readFileSync(CORPUS_PATH, "utf8")) as CorpusFile;
+    }
+    const entry = corpusCache.entries.find((candidate) => candidate.id === id);
+    if (!entry) {
+        throw new Error(`Corpus entry '${id}' not found in ${CORPUS_PATH}`);
+    }
+    return entry.message;
+}
+
+/** Root of the Content workspace folder inside the (temp-copied) fixture workspace. */
+export function contentRoot(): string {
+    const folder = vscode.workspace.workspaceFolders?.find((candidate) => candidate.name === "Content");
+    if (!folder) {
+        throw new Error("Fixture workspace is missing its Content folder; was the .code-workspace opened?");
+    }
+    return folder.uri.fsPath;
+}
+
+export async function ensureActivated(): Promise<void> {
+    const extension = vscode.extensions.getExtension(EXTENSION_ID);
+    if (!extension) {
+        throw new Error(`${EXTENSION_ID} not found in the test host`);
+    }
+    if (!extension.isActive) {
+        await extension.activate();
+    }
+}
+
+/** Opens a Content fixture, shows it in the active editor, and makes sure the extension is up. */
+export async function openFixture(fileName: string): Promise<vscode.TextDocument> {
+    const document = await vscode.workspace.openTextDocument(path.join(contentRoot(), fileName));
+    await vscode.window.showTextDocument(document, { preview: false });
+    await ensureActivated();
+    return document;
+}
+
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function countOccurrences(text: string, needle: string): number {
+    let count = 0;
+    let index = text.indexOf(needle);
+    while (index !== -1) {
+        count++;
+        index = text.indexOf(needle, index + needle.length);
+    }
+    return count;
+}
+
+/**
+ * Injects diagnostics through a test-owned DiagnosticCollection. The extension
+ * consumes diagnostics via onDidChangeDiagnostics/getDiagnostics without
+ * filtering by source (extension.ts), so recorded compiler messages injected
+ * here drive the exact same pipeline as live Verse LSP output.
+ */
+export class DiagnosticInjector {
+    private readonly collection: vscode.DiagnosticCollection;
+
+    constructor(name: string) {
+        this.collection = vscode.languages.createDiagnosticCollection(name);
+    }
+
+    /**
+     * Sets one Error diagnostic per message on the document. When an anchor
+     * identifier is given and present in the document, the diagnostics point
+     * at its first occurrence (needed for range-based quick fix queries);
+     * otherwise they sit at the start of the file.
+     */
+    inject(document: vscode.TextDocument, messages: string[], anchorIdentifier?: string): void {
+        const range = this.rangeFor(document, anchorIdentifier);
+        const diagnostics = messages.map((message) => {
+            const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
+            diagnostic.source = "Verse";
+            return diagnostic;
+        });
+        this.collection.set(document.uri, diagnostics);
+    }
+
+    private rangeFor(document: vscode.TextDocument, anchorIdentifier?: string): vscode.Range {
+        if (anchorIdentifier) {
+            const offset = document.getText().indexOf(anchorIdentifier);
+            if (offset !== -1) {
+                return new vscode.Range(document.positionAt(offset), document.positionAt(offset + anchorIdentifier.length));
+            }
+        }
+        return new vscode.Range(0, 0, 0, 1);
+    }
+
+    clear(): void {
+        this.collection.clear();
+    }
+
+    dispose(): void {
+        this.collection.dispose();
+    }
+}
+
+/**
+ * Resolves once the document text satisfies the predicate, driven by
+ * onDidChangeTextDocument rather than polling. Rejects on timeout with the
+ * final document text for diagnosis.
+ */
+export function waitForDocumentChange(document: vscode.TextDocument, predicate: (text: string) => boolean, label: string, timeoutMs: number = 5000): Promise<void> {
+    if (predicate(document.getText())) {
+        return Promise.resolve();
+    }
+    return new Promise<void>((resolve, reject) => {
+        let subscription: vscode.Disposable | undefined;
+        const timer = setTimeout(() => {
+            subscription?.dispose();
+            reject(new Error(`Timed out after ${timeoutMs}ms waiting for ${label}. Document text:\n${document.getText()}`));
+        }, timeoutMs);
+        subscription = vscode.workspace.onDidChangeTextDocument((event) => {
+            if (event.document.uri.toString() !== document.uri.toString()) {
+                return;
+            }
+            if (predicate(event.document.getText())) {
+                clearTimeout(timer);
+                subscription?.dispose();
+                resolve();
+            }
+        });
+    });
+}
+
+/**
+ * Negative-case helper: fails if the document receives any edit within the
+ * window. The window comfortably covers the fixture workspace's 100ms
+ * auto-import debounce.
+ */
+export async function assertNoDocumentChange(document: vscode.TextDocument, windowMs: number = 1500): Promise<void> {
+    const edits: string[] = [];
+    const subscription = vscode.workspace.onDidChangeTextDocument((event) => {
+        if (event.document.uri.toString() === document.uri.toString() && event.contentChanges.length > 0) {
+            edits.push(event.contentChanges.map((change) => JSON.stringify(change.text)).join(", "));
+        }
+    });
+    await sleep(windowMs);
+    subscription.dispose();
+    assert.strictEqual(edits.length, 0, `Expected no edits to ${path.basename(document.uri.fsPath)} within ${windowMs}ms, got inserts: ${edits.join(" | ")}`);
+}
+
+/**
+ * Workspace-level configuration overrides with teardown. Workspace scope
+ * overrides both the fixture defaults and any Global writes made by the
+ * extension, and restoring to undefined removes the override again.
+ */
+export class WorkspaceSettings {
+    private readonly touchedKeys = new Set<string>();
+
+    async set(key: string, value: unknown): Promise<void> {
+        this.touchedKeys.add(key);
+        await vscode.workspace.getConfiguration("verseAutoImports").update(key, value, vscode.ConfigurationTarget.Workspace);
+    }
+
+    async restoreAll(): Promise<void> {
+        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        for (const key of this.touchedKeys) {
+            await config.update(key, undefined, vscode.ConfigurationTarget.Workspace);
+        }
+        this.touchedKeys.clear();
+    }
+}
+
+/**
+ * Runs Optimize Imports on the document (which must become the active editor)
+ * and waits out the async on-save spacing pass before returning the text.
+ */
+export async function runOptimizeImports(document: vscode.TextDocument): Promise<string> {
+    await vscode.window.showTextDocument(document, { preview: false });
+    await vscode.commands.executeCommand("verseAutoImports.optimizeImports");
+    await sleep(500);
+    return document.getText();
+}

--- a/src/test-integration/suite/importStyles.itest.ts
+++ b/src/test-integration/suite/importStyles.itest.ts
@@ -1,0 +1,91 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { WorkspaceSettings, openFixture, runOptimizeImports } from "./helpers";
+
+describe("import styles matrix (playbook T6)", () => {
+    const settings = new WorkspaceSettings();
+    let document: vscode.TextDocument;
+
+    before(async () => {
+        await settings.set("general.autoImport", false);
+        document = await openFixture("t6_styles.verse");
+    });
+
+    after(async () => {
+        await settings.restoreAll();
+    });
+
+    function lineIndexContaining(text: string, fragment: string): number {
+        return text.split("\n").findIndex((line) => line.includes(fragment));
+    }
+
+    it("importSyntax dot rewrites the block; flipping back restores curly", async () => {
+        await settings.set("behavior.importSyntax", "dot");
+        let text = await runOptimizeImports(document);
+        assert.ok(/^using\. \/Verse\.org\/Simulation$/m.test(text), `expected dot syntax, got:\n${text}`);
+        assert.ok(!text.includes("using { /Verse.org/Simulation }"), "curly form must be gone after the dot rewrite");
+
+        await settings.set("behavior.importSyntax", "curly");
+        text = await runOptimizeImports(document);
+        assert.ok(text.includes("using { /Verse.org/Simulation }"), `expected curly syntax back, got:\n${text}`);
+        assert.ok(!/^using\./m.test(text), "dot form must be gone after flipping back");
+    });
+
+    it("importGrouping digestFirst puts digest imports before local ones; localFirst reverses", async () => {
+        await settings.set("behavior.importGrouping", "digestFirst");
+        let text = await runOptimizeImports(document);
+        let digestIndex = lineIndexContaining(text, "/Fortnite.com/Devices");
+        let localIndex = lineIndexContaining(text, "Gadgets.Tools");
+        assert.ok(digestIndex !== -1 && localIndex !== -1, `imports missing after optimize:\n${text}`);
+        assert.ok(digestIndex < localIndex, `digestFirst violated:\n${text}`);
+
+        await settings.set("behavior.importGrouping", "localFirst");
+        text = await runOptimizeImports(document);
+        digestIndex = lineIndexContaining(text, "/Fortnite.com/Devices");
+        localIndex = lineIndexContaining(text, "Gadgets.Tools");
+        assert.ok(digestIndex !== -1 && localIndex !== -1, `imports missing after optimize:\n${text}`);
+        assert.ok(localIndex < digestIndex, `localFirst violated:\n${text}`);
+
+        await settings.set("behavior.importGrouping", "none");
+    });
+
+    it("sortImportsAlphabetically orders the block", async () => {
+        await settings.set("behavior.sortImportsAlphabetically", true);
+        const text = await runOptimizeImports(document);
+        const devices = lineIndexContaining(text, "/Fortnite.com/Devices");
+        const simulation = lineIndexContaining(text, "/Verse.org/Simulation");
+        assert.ok(devices !== -1 && simulation !== -1, `imports missing after optimize:\n${text}`);
+        assert.ok(devices < simulation, `alphabetical sort violated (/Fortnite.com/Devices must precede /Verse.org/Simulation):\n${text}`);
+    });
+
+    it("emptyLinesAfterImports is honored after optimize", async () => {
+        await settings.set("behavior.emptyLinesAfterImports", 2);
+
+        // The spacing pass runs on save, and Optimize only saves a dirty
+        // document; after the previous subtests the block is already organized
+        // so the rewrite itself is a no-op. Dirty the document the way a real
+        // edit session would before optimizing.
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(document.uri, new vscode.Position(document.lineCount, 0), "\n# spacing probe\n");
+        assert.ok(await vscode.workspace.applyEdit(edit), "probe edit failed");
+
+        const text = await runOptimizeImports(document);
+        const lines = text.split("\n");
+
+        let lastImport = -1;
+        lines.forEach((line, index) => {
+            if (line.startsWith("using")) {
+                lastImport = index;
+            }
+        });
+        assert.ok(lastImport !== -1, `no import block found:\n${text}`);
+
+        let blanks = 0;
+        let cursor = lastImport + 1;
+        while (cursor < lines.length && lines[cursor].trim() === "") {
+            blanks++;
+            cursor++;
+        }
+        assert.strictEqual(blanks, 2, `expected exactly 2 blank lines after the import block:\n${text}`);
+    });
+});

--- a/src/test-integration/suite/index.ts
+++ b/src/test-integration/suite/index.ts
@@ -1,0 +1,34 @@
+import * as fs from "fs";
+import * as path from "path";
+import Mocha from "mocha";
+
+/**
+ * Mocha entry point called by the extension host (via
+ * `--extensionTestsPath`). Collects every compiled `*.itest.js` file in this
+ * directory tree. The `.itest` suffix keeps the files out of the Jest unit
+ * run, which matches `*.test.ts`.
+ */
+export async function run(): Promise<void> {
+    const mocha = new Mocha({
+        ui: "bdd",
+        color: true,
+        timeout: 30000,
+    });
+
+    const entries = fs.readdirSync(__dirname, { recursive: true, encoding: "utf8" });
+    for (const entry of entries.sort()) {
+        if (entry.endsWith(".itest.js")) {
+            mocha.addFile(path.join(__dirname, entry));
+        }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+        mocha.run((failures) => {
+            if (failures > 0) {
+                reject(new Error(`${failures} integration test(s) failed`));
+            } else {
+                resolve();
+            }
+        });
+    });
+}

--- a/src/test-integration/suite/optimize.itest.ts
+++ b/src/test-integration/suite/optimize.itest.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { DiagnosticInjector, WorkspaceSettings, corpusMessage, countOccurrences, openFixture, runOptimizeImports, sleep } from "./helpers";
+import { DiagnosticInjector, WorkspaceSettings, corpusMessage, countOccurrences, normalizeEol, openFixture, runOptimizeImports, sleep } from "./helpers";
 
 describe("Optimize Imports (playbook T5)", () => {
     it("consolidates, dedupes, and adds missing imports atomically; local-scope using untouched", async () => {
@@ -15,7 +15,7 @@ describe("Optimize Imports (playbook T5)", () => {
             const intermediateStates: string[] = [];
             const subscription = vscode.workspace.onDidChangeTextDocument((event) => {
                 if (event.document.uri.toString() === document.uri.toString()) {
-                    intermediateStates.push(event.document.getText());
+                    intermediateStates.push(normalizeEol(event.document.getText()));
                 }
             });
             const text = await runOptimizeImports(document);

--- a/src/test-integration/suite/optimize.itest.ts
+++ b/src/test-integration/suite/optimize.itest.ts
@@ -1,0 +1,61 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { DiagnosticInjector, WorkspaceSettings, corpusMessage, countOccurrences, openFixture, runOptimizeImports, sleep } from "./helpers";
+
+describe("Optimize Imports (playbook T5)", () => {
+    it("consolidates, dedupes, and adds missing imports atomically; local-scope using untouched", async () => {
+        const settings = new WorkspaceSettings();
+        await settings.set("general.autoImport", false);
+        const injector = new DiagnosticInjector("verse-itest-t5");
+        try {
+            const document = await openFixture("t5_optimize.verse");
+            injector.inject(document, [corpusMessage("unknown-with-suggestion-function-context")]);
+            await sleep(300);
+
+            const intermediateStates: string[] = [];
+            const subscription = vscode.workspace.onDidChangeTextDocument((event) => {
+                if (event.document.uri.toString() === document.uri.toString()) {
+                    intermediateStates.push(event.document.getText());
+                }
+            });
+            const text = await runOptimizeImports(document);
+            subscription.dispose();
+
+            // Atomicity proxy: the document must never pass through a state
+            // with no imports at all (the pre-#42 remove-then-re-add shape).
+            assert.ok(intermediateStates.length >= 1, "optimize should have edited the document");
+            for (const state of intermediateStates) {
+                assert.ok(/^using /m.test(state), `imports vanished in an intermediate state:\n${state}`);
+            }
+
+            const lines = text.split("\n");
+            assert.strictEqual(countOccurrences(text, "using { /Verse.org/Simulation }"), 1, "duplicate import must be deduplicated");
+            assert.strictEqual(countOccurrences(text, "using { /Fortnite.com/Devices }"), 1);
+            assert.strictEqual(countOccurrences(text, "using { /Verse.org/Assets }"), 1, "the missing import from current diagnostics must be added");
+            assert.strictEqual(countOccurrences(text, "/Fortnite.com/Playspaces"), 1, "the indented pair must be absorbed with its path intact");
+
+            // All file-level imports end up above the first declaration.
+            const firstCodeLine = lines.findIndex((line) => line.includes(":= class"));
+            assert.ok(firstCodeLine !== -1, "fixture declarations disappeared");
+            const fileLevelImports = ["using { /Verse.org/Simulation }", "using { /Fortnite.com/Devices }", "using { /Verse.org/Assets }", "using { /Fortnite.com/Playspaces }"];
+            for (const statement of fileLevelImports) {
+                const lineIndex = lines.findIndex((line) => line.trim() === statement);
+                assert.ok(lineIndex !== -1 && lineIndex < firstCodeLine, `${statement} must sit in the top import block, got:\n${text}`);
+            }
+
+            // The local-scope using stays indented inside Describe().
+            const localUsing = lines.findIndex((line) => line.includes("using { Helper }"));
+            assert.ok(localUsing !== -1, "local-scope using must not be deleted");
+            assert.ok(/^\s+using \{ Helper \}/.test(lines[localUsing]), "local-scope using must stay indented in the function body");
+            const describeLine = lines.findIndex((line) => line.includes("Describe("));
+            assert.ok(describeLine !== -1 && localUsing > describeLine, "local-scope using must stay inside the function");
+
+            // No code between the scattered imports was deleted.
+            assert.ok(text.includes("t5_helper := class"), "t5_helper class lost");
+            assert.ok(text.includes("Helper.GetLabel()"), "function body lost");
+        } finally {
+            injector.dispose();
+            await settings.restoreAll();
+        }
+    });
+});

--- a/src/test-integration/suite/regressions72.itest.ts
+++ b/src/test-integration/suite/regressions72.itest.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { DiagnosticInjector, WorkspaceSettings, assertNoDocumentChange, corpusMessage, countOccurrences, openFixture, runOptimizeImports, sleep, waitForDocumentChange } from "./helpers";
+import { DiagnosticInjector, WorkspaceSettings, assertNoDocumentChange, corpusMessage, countOccurrences, docText, openFixture, runOptimizeImports, sleep, waitForDocumentChange } from "./helpers";
 
 describe("PR #72 regressions (issues #69/#70)", () => {
     let injector: DiagnosticInjector;
@@ -26,7 +26,7 @@ describe("PR #72 regressions (issues #69/#70)", () => {
         await waitForDocumentChange(document, (text) => text.includes("using { InventoryModule }"), "auto-import of InventoryModule");
         await sleep(500);
 
-        const text = document.getText();
+        const text = docText(document);
         assert.strictEqual(countOccurrences(text, "using { InventoryModule }"), 1);
         assert.ok(!/^using \{ item \}/m.test(text), "a bare identifier option must never be imported");
     });

--- a/src/test-integration/suite/regressions72.itest.ts
+++ b/src/test-integration/suite/regressions72.itest.ts
@@ -1,0 +1,53 @@
+import * as assert from "assert";
+import { DiagnosticInjector, WorkspaceSettings, assertNoDocumentChange, corpusMessage, countOccurrences, openFixture, runOptimizeImports, sleep, waitForDocumentChange } from "./helpers";
+
+describe("PR #72 regressions (issues #69/#70)", () => {
+    let injector: DiagnosticInjector;
+
+    beforeEach(() => {
+        injector = new DiagnosticInjector("verse-itest-r72");
+    });
+
+    afterEach(() => {
+        injector.dispose();
+    });
+
+    it("a 'set' assignment hint never triggers an insert", async () => {
+        const document = await openFixture("r72_set_hint.verse");
+        injector.inject(document, [corpusMessage("set-assignment-hint")], "Count");
+
+        await assertNoDocumentChange(document);
+    });
+
+    it("bare identifier options never become imports; the remaining candidate is unambiguous", async () => {
+        const document = await openFixture("r72_bare_identifier.verse");
+        injector.inject(document, [corpusMessage("did-you-mean-any-of-bare-option")], "item");
+
+        await waitForDocumentChange(document, (text) => text.includes("using { InventoryModule }"), "auto-import of InventoryModule");
+        await sleep(500);
+
+        const text = document.getText();
+        assert.strictEqual(countOccurrences(text, "using { InventoryModule }"), 1);
+        assert.ok(!/^using \{ item \}/m.test(text), "a bare identifier option must never be imported");
+    });
+
+    it("Optimize Imports does not bulk-add ambiguous candidates or 'set' hints", async () => {
+        const settings = new WorkspaceSettings();
+        await settings.set("general.autoImport", false);
+        try {
+            const document = await openFixture("r72_optimize_guard.verse");
+            injector.inject(document, [corpusMessage("forget-one-of-two-paths"), corpusMessage("identifier-many-types"), corpusMessage("set-assignment-hint")], "thing");
+            await sleep(300);
+
+            const text = await runOptimizeImports(document);
+
+            assert.strictEqual(countOccurrences(text, "using { /Verse.org/Simulation }"), 1, "the existing import must survive optimize");
+            const forbidden = ["/GameA/Combat", "/GameB/Combat", "/Verse.org/SpatialMath", "/UnrealEngine.com/Temporary/SpatialMath", "to write 'set"];
+            for (const fragment of forbidden) {
+                assert.ok(!text.includes(fragment), `optimize must not add anything containing '${fragment}', got:\n${text}`);
+            }
+        } finally {
+            await settings.restoreAll();
+        }
+    });
+});

--- a/src/test-integration/suite/regressions73.itest.ts
+++ b/src/test-integration/suite/regressions73.itest.ts
@@ -1,0 +1,87 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { DiagnosticInjector, WorkspaceSettings, corpusMessage, countOccurrences, openFixture, runOptimizeImports, sleep, waitForDocumentChange } from "./helpers";
+
+function assertNoOrphanedUsingLine(text: string): void {
+    const lines = text.split("\n");
+    lines.forEach((line, index) => {
+        if (line.trim() === "using:") {
+            const next = lines[index + 1] ?? "";
+            assert.ok(/^\s+\S/.test(next), `orphaned 'using:' at line ${index}; next line is '${next}'`);
+        }
+    });
+}
+
+function assertModuleScopedUsingInPlace(text: string, moduleName: string): void {
+    assert.strictEqual(countOccurrences(text, "using { /Verse.org/Random }"), 1, "the module-scoped using must appear exactly once");
+    const lines = text.split("\n");
+    const moduleLine = lines.findIndex((line) => line.includes(`${moduleName} := module:`));
+    const usingLine = lines.findIndex((line) => line.includes("using { /Verse.org/Random }"));
+    assert.ok(moduleLine !== -1, "module declaration disappeared");
+    assert.ok(usingLine > moduleLine, "the module-scoped using must stay below the module declaration, not hoisted to the top");
+    assert.ok(/^\s+using/.test(lines[usingLine]), "the module-scoped using must stay indented inside the module body");
+}
+
+describe("PR #73 regressions (issues #67/#68)", () => {
+    let injector: DiagnosticInjector;
+
+    beforeEach(() => {
+        injector = new DiagnosticInjector("verse-itest-r73");
+    });
+
+    afterEach(() => {
+        injector.dispose();
+    });
+
+    it("an indented using: pair survives auto-import with its path intact", async () => {
+        const document = await openFixture("r73_indented_using.verse");
+        injector.inject(document, [corpusMessage("unknown-with-suggestion-class-context")], "button_device");
+
+        await waitForDocumentChange(document, (text) => text.includes("using { /Fortnite.com/Devices }"), "auto-import of /Fortnite.com/Devices");
+        await sleep(500);
+
+        const text = document.getText();
+        assert.strictEqual(countOccurrences(text, "/Fortnite.com/Playspaces"), 1, "the indented import's path must survive exactly once");
+        assertNoOrphanedUsingLine(text);
+    });
+
+    it("auto-import leaves a module-scoped using in place", async () => {
+        const document = await openFixture("r73_module_body_auto.verse");
+        injector.inject(document, [corpusMessage("unknown-with-suggestion-class-context")], "button_device");
+
+        await waitForDocumentChange(document, (text) => text.includes("using { /Fortnite.com/Devices }"), "auto-import of /Fortnite.com/Devices");
+        await sleep(500);
+
+        assertModuleScopedUsingInPlace(document.getText(), "r73_utilities_auto");
+    });
+
+    it("Optimize Imports leaves a module-scoped using in place", async () => {
+        const settings = new WorkspaceSettings();
+        await settings.set("general.autoImport", false);
+        try {
+            const document = await openFixture("r73_module_body_optimize.verse");
+            const text = await runOptimizeImports(document);
+
+            assertModuleScopedUsingInPlace(text, "r73_utilities_optimize");
+            assert.strictEqual(countOccurrences(text, "using { /Verse.org/Simulation }"), 1);
+            assert.strictEqual(countOccurrences(text, "using { /Fortnite.com/Devices }"), 1);
+        } finally {
+            await settings.restoreAll();
+        }
+    });
+
+    it("on-save spacing is not applied inside a module body", async () => {
+        const document = await openFixture("r67_module_body_save.verse");
+
+        // Dirty the document with an edit far away from any import, then save
+        // to run the on-save spacing pass.
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(document.uri, new vscode.Position(document.lineCount, 0), "\n# save probe\n");
+        assert.ok(await vscode.workspace.applyEdit(edit), "probe edit failed");
+        assert.ok(await document.save(), "save failed");
+        await sleep(500);
+
+        const text = document.getText();
+        assert.ok(text.includes("using { /Verse.org/Random }\n    GenerateId"), `no blank line may be inserted after the module-scoped using, got:\n${text}`);
+    });
+});

--- a/src/test-integration/suite/regressions73.itest.ts
+++ b/src/test-integration/suite/regressions73.itest.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { DiagnosticInjector, WorkspaceSettings, corpusMessage, countOccurrences, openFixture, runOptimizeImports, sleep, waitForDocumentChange } from "./helpers";
+import { DiagnosticInjector, WorkspaceSettings, corpusMessage, countOccurrences, docText, openFixture, runOptimizeImports, sleep, waitForDocumentChange } from "./helpers";
 
 function assertNoOrphanedUsingLine(text: string): void {
     const lines = text.split("\n");
@@ -40,7 +40,7 @@ describe("PR #73 regressions (issues #67/#68)", () => {
         await waitForDocumentChange(document, (text) => text.includes("using { /Fortnite.com/Devices }"), "auto-import of /Fortnite.com/Devices");
         await sleep(500);
 
-        const text = document.getText();
+        const text = docText(document);
         assert.strictEqual(countOccurrences(text, "/Fortnite.com/Playspaces"), 1, "the indented import's path must survive exactly once");
         assertNoOrphanedUsingLine(text);
     });
@@ -52,7 +52,7 @@ describe("PR #73 regressions (issues #67/#68)", () => {
         await waitForDocumentChange(document, (text) => text.includes("using { /Fortnite.com/Devices }"), "auto-import of /Fortnite.com/Devices");
         await sleep(500);
 
-        assertModuleScopedUsingInPlace(document.getText(), "r73_utilities_auto");
+        assertModuleScopedUsingInPlace(docText(document), "r73_utilities_auto");
     });
 
     it("Optimize Imports leaves a module-scoped using in place", async () => {
@@ -81,7 +81,7 @@ describe("PR #73 regressions (issues #67/#68)", () => {
         assert.ok(await document.save(), "save failed");
         await sleep(500);
 
-        const text = document.getText();
+        const text = docText(document);
         assert.ok(text.includes("using { /Verse.org/Random }\n    GenerateId"), `no blank line may be inserted after the module-scoped using, got:\n${text}`);
     });
 });

--- a/src/test-integration/vsix-suite/index.ts
+++ b/src/test-integration/vsix-suite/index.ts
@@ -1,0 +1,28 @@
+import * as path from "path";
+import Mocha from "mocha";
+
+/**
+ * Minimal suite for the packaged-vsix run: only the activation tests. The
+ * injection-driven suites stay in the development-path run (runTests.ts);
+ * this run exists to catch packaging regressions, and activation is the
+ * signal for those.
+ */
+export async function run(): Promise<void> {
+    const mocha = new Mocha({
+        ui: "bdd",
+        color: true,
+        timeout: 30000,
+    });
+
+    mocha.addFile(path.join(__dirname, "..", "suite", "activation.itest.js"));
+
+    await new Promise<void>((resolve, reject) => {
+        mocha.run((failures) => {
+            if (failures > 0) {
+                reject(new Error(`${failures} vsix activation test(s) failed`));
+            } else {
+                resolve();
+            }
+        });
+    });
+}

--- a/test-fixtures/integration-workspace/FakeDigests/Fortnite.com/Fortnite.digest.verse
+++ b/test-fixtures/integration-workspace/FakeDigests/Fortnite.com/Fortnite.digest.verse
@@ -1,0 +1,6 @@
+# Stand-in for the read-only Fortnite.com digest root that UEFN adds to the
+# generated .code-workspace. Content is irrelevant; only the workspace shape
+# matters. The extension must never edit or auto-import into digest files.
+
+Devices<public> := module:
+    button_device<public> := class:

--- a/test-fixtures/integration-workspace/FakeDigests/Verse.org/Verse.digest.verse
+++ b/test-fixtures/integration-workspace/FakeDigests/Verse.org/Verse.digest.verse
@@ -1,0 +1,6 @@
+# Stand-in for the read-only Verse.org digest root that UEFN adds to the
+# generated .code-workspace. Content is irrelevant; only the workspace shape
+# matters. The extension must never edit or auto-import into digest files.
+
+Simulation<public> := module:
+    agent<public> := class:

--- a/test-fixtures/integration-workspace/Project/Content/activation_probe.verse
+++ b/test-fixtures/integration-workspace/Project/Content/activation_probe.verse
@@ -1,0 +1,4 @@
+# Opened by the activation test purely to fire the onLanguage:verse
+# activation event. No diagnostics are ever injected on this file.
+
+activation_probe := module:

--- a/test-fixtures/integration-workspace/Project/Content/r67_module_body_save.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r67_module_body_save.verse
@@ -1,0 +1,10 @@
+# Regression #67 (PR #73): the on-save import spacing pass must only apply to
+# the file-top import block, never inside a module body. The module-scoped
+# using below is intentionally NOT followed by a blank line; the pre-fix bug
+# inserted one there on save.
+
+using { /Verse.org/Simulation }
+
+r67_utilities := module:
+    using { /Verse.org/Random }
+    GenerateId<public>():int = GetRandomInt(1, 100)

--- a/test-fixtures/integration-workspace/Project/Content/r72_bare_identifier.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r72_bare_identifier.verse
@@ -1,0 +1,6 @@
+# Regression #70 (PR #72): a "Did you mean any of:" list echoing a local
+# definition (bare identifier) must never become `using { item }`. The one
+# importable candidate left is unambiguous and gets imported.
+
+r72_inventory := class:
+    var MaybeItem:?item = false

--- a/test-fixtures/integration-workspace/Project/Content/r72_optimize_guard.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r72_optimize_guard.verse
@@ -1,0 +1,8 @@
+# Regression #69/#70 (PR #72), Optimize path: ambiguous one-of lists,
+# many-types lists, and 'set' hints in the current diagnostics must not be
+# bulk-added by Optimize Imports.
+
+using { /Verse.org/Simulation }
+
+r72_optimize_probe := class:
+    var MaybeThing:?thing = false

--- a/test-fixtures/integration-workspace/Project/Content/r72_set_hint.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r72_set_hint.verse
@@ -1,0 +1,6 @@
+# Regression #69 (PR #72): assignment hints ("Did you mean to write 'set ...'")
+# are never import problems and must not trigger any insert.
+
+r72_set_probe := class:
+    var Count:int = 0
+    Bump():void = set Count = 1

--- a/test-fixtures/integration-workspace/Project/Content/r73_indented_using.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r73_indented_using.verse
@@ -1,0 +1,9 @@
+# Regression #68 (PR #73): an indented `using:` pair must survive an
+# auto-import with its path intact; the #68 failure shape was a lost path
+# plus an orphaned line.
+
+using:
+    /Fortnite.com/Playspaces
+
+r73_indented := class:
+    var MaybeButton:?button_device = false

--- a/test-fixtures/integration-workspace/Project/Content/r73_module_body_auto.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r73_module_body_auto.verse
@@ -1,0 +1,12 @@
+# Regression #67 (PR #73): a module-scoped using must not be hoisted,
+# deleted, or duplicated when auto-import adds a file-level import.
+
+using { /Verse.org/Simulation }
+
+r73_utilities_auto := module:
+    using { /Verse.org/Random }
+
+    GenerateId<public>():int = GetRandomInt(1, 100)
+
+r73_probe_auto := class:
+    var MaybeButton:?button_device = false

--- a/test-fixtures/integration-workspace/Project/Content/r73_module_body_optimize.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r73_module_body_optimize.verse
@@ -1,0 +1,10 @@
+# Regression #67 (PR #73): Optimize Imports must leave a module-scoped using
+# in place - not hoist it into the file-level import block.
+
+using { /Verse.org/Simulation }
+using { /Fortnite.com/Devices }
+
+r73_utilities_optimize := module:
+    using { /Verse.org/Random }
+
+    GenerateId<public>():int = GetRandomInt(1, 100)

--- a/test-fixtures/integration-workspace/Project/Content/t1_multiple_singles.verse
+++ b/test-fixtures/integration-workspace/Project/Content/t1_multiple_singles.verse
@@ -1,0 +1,7 @@
+# Playbook T1: several single-suggestion diagnostics arriving in the same
+# debounce window must each produce exactly one import, applied together.
+
+t1_gadget := class:
+    var MaybeButton:?button_device = false
+    GetImage():texture = DefaultTexture
+    Register(Who:agent):void = {}

--- a/test-fixtures/integration-workspace/Project/Content/t1_single_suggestion.verse
+++ b/test-fixtures/integration-workspace/Project/Content/t1_single_suggestion.verse
@@ -1,0 +1,5 @@
+# Auto-import basic loop (playbook T1): a single high-confidence suggestion
+# injected from the corpus must insert exactly one import at the top.
+
+t1_device := class:
+    var MaybeButton:?button_device = false

--- a/test-fixtures/integration-workspace/Project/Content/t2_multi_option.verse
+++ b/test-fixtures/integration-workspace/Project/Content/t2_multi_option.verse
@@ -1,0 +1,7 @@
+# Playbook T2: ambiguous multi-option diagnostics with the default quickfix
+# strategy must not auto-import anything; every candidate must surface as a
+# quick fix instead.
+
+t2_widget := class:
+    var MaybeThing:?thing = false
+    var MaybeCombat:?combat_probe = false

--- a/test-fixtures/integration-workspace/Project/Content/t3_asset_reference.verse
+++ b/test-fixtures/integration-workspace/Project/Content/t3_asset_reference.verse
@@ -1,0 +1,5 @@
+# Playbook T3 (extractor half): a "Did you mean Folder1.image2" asset
+# suggestion must import the containing folder, never the asset itself.
+
+t3_probe := class:
+    GetImage():texture = image2

--- a/test-fixtures/integration-workspace/Project/Content/t5_optimize.verse
+++ b/test-fixtures/integration-workspace/Project/Content/t5_optimize.verse
@@ -1,0 +1,21 @@
+# Playbook T5: Optimize Imports port. Deliberately contains a duplicate
+# import, imports scattered mid-file, a local-scope using inside a function
+# body, and an indented-style using pair at the bottom. A missing import
+# (injected diagnostic) must be added in the same rewrite, and the local-scope
+# using must survive untouched.
+
+using { /Verse.org/Simulation }
+
+t5_helper := class:
+    GetLabel<public>():string = "t5"
+
+using { /Fortnite.com/Devices }
+using { /Verse.org/Simulation }
+
+t5_device := class:
+    Describe(Helper:t5_helper):string =
+        using { Helper }
+        Helper.GetLabel()
+
+using:
+    /Fortnite.com/Playspaces

--- a/test-fixtures/integration-workspace/Project/Content/t6_styles.verse
+++ b/test-fixtures/integration-workspace/Project/Content/t6_styles.verse
@@ -1,0 +1,10 @@
+# Playbook T6: styles matrix. Optimize Imports rewrites this block under
+# different importSyntax / importGrouping / sorting / spacing settings. The
+# Gadgets.Tools import is the local (non-digest) member of the block.
+
+using { /Verse.org/Simulation }
+using { /Fortnite.com/Devices }
+using { Gadgets.Tools }
+
+t6_probe := class:
+    var Count:int = 0

--- a/test-fixtures/integration-workspace/Project/VerseAutoImportsIntegrationHarness.uefnproject
+++ b/test-fixtures/integration-workspace/Project/VerseAutoImportsIntegrationHarness.uefnproject
@@ -1,0 +1,6 @@
+{
+    "title": "VerseAutoImportsIntegrationHarness",
+    "bindings": {
+        "projectVersePath": "/vukefn@fortnite.com/VerseAutoImportsIntegrationHarness"
+    }
+}

--- a/test-fixtures/integration-workspace/VerseAutoImportsIT.code-workspace
+++ b/test-fixtures/integration-workspace/VerseAutoImportsIT.code-workspace
@@ -1,0 +1,30 @@
+{
+    // Mirrors the multi-root workspace UEFN generates (Verse menu > VS Code):
+    // the project's Content folder plus read-only digest roots.
+    "folders": [
+        {
+            "name": "Content",
+            "path": "Project/Content",
+        },
+        {
+            "name": "Fortnite.com",
+            "path": "FakeDigests/Fortnite.com",
+        },
+        {
+            "name": "Verse.org",
+            "path": "FakeDigests/Verse.org",
+        },
+    ],
+    "settings": {
+        // Keep the auto-import debounce short so tests wait milliseconds, not
+        // seconds. Both keys are set on purpose: getConfiguredDebounceDelay()
+        // reads the deprecated general.diagnosticDelay with config.get(key,
+        // undefined), and in a real host that returns the registered default
+        // (1000) rather than undefined, so the legacy key always wins over
+        // autoImportDebounceDelay. Setting both makes the fixture correct
+        // regardless of which key the extension ends up honoring.
+        "verseAutoImports.general.diagnosticDelay": 100,
+        "verseAutoImports.general.autoImportDebounceDelay": 100,
+        "files.autoSave": "off",
+    },
+}

--- a/test-fixtures/verse-language-stub/package.json
+++ b/test-fixtures/verse-language-stub/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "verse-language-stub",
+    "displayName": "Verse Language Stub (integration tests only)",
+    "description": "Registers the 'verse' language id inside the integration test host. In production Epic's Verse extension contributes the language; without this stub the onLanguage:verse activation event never fires in the test VS Code.",
+    "version": "0.0.1",
+    "publisher": "vukefn",
+    "engines": {
+        "vscode": "^1.85.0"
+    },
+    "contributes": {
+        "languages": [
+            {
+                "id": "verse",
+                "aliases": ["Verse"],
+                "extensions": [".verse"]
+            }
+        ]
+    }
+}

--- a/tsconfig.integration.json
+++ b/tsconfig.integration.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "out-integration",
+        "rootDir": "src",
+        "esModuleInterop": true,
+        "types": ["node", "mocha"]
+    },
+    "include": ["src/test-integration/**/*"],
+    "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,14 @@
         "target": "ES2020",
         "outDir": "out",
         "rootDir": "src",
-        "sourceMap": true
+        "sourceMap": true,
+        // Restrict ambient type packages: @types/jest and @types/mocha (used
+        // by the integration harness) both declare describe/it globals and
+        // conflict when auto-included together.
+        "types": ["node", "jest"]
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+    // src/test-integration compiles via tsconfig.integration.json (mocha,
+    // @vscode/test-electron); including it here would break npm run compile.
+    "exclude": ["node_modules", "src/test-integration"]
 }


### PR DESCRIPTION
## What

Layer-2 extension-host test harness: `npm run test:integration` downloads a real VS Code via @vscode/test-electron, opens a fake UEFN multi-root workspace (Content + digest roots + `.uefnproject` one level above Content), loads the extension from the repo, and runs a mocha suite inside the extension host. 22 tests, ~18s locally after the first VS Code download.

## How injection works

Tests create their own `vscode.languages.createDiagnosticCollection` and set recorded compiler messages from `test-fixtures/corpus/41.10/diagnostics.json` (single source of truth, never hand-written) on open fixture documents. Because the extension consumes diagnostics through `onDidChangeDiagnostics`/`getDiagnostics` without filtering by source (`extension.ts`), the injected messages drive the exact same pipeline as live Verse LSP output: activation -> debounce -> extraction -> WorkspaceEdit -> document text.

## Playbook coverage (for slimming PLAYBOOK.md in a follow-up)

Now automated:
- T0 (partial): activation in the multi-root workspace, graceful degradation with an unreachable `Assets.digest.verse`
- T1: single and batched auto-imports, exactly-once
- T2: no auto-import on ambiguity (default quickfix strategy); quick fixes offer every candidate
- T3 (extractor half): asset suggestions import the folder, never the asset name
- T5: Optimize atomicity, dedup, missing-import add, indented pair absorbed, local-scope `using` untouched
- T6: styles matrix (dot/curly round-trip, digestFirst/localFirst grouping, alphabetical sort, emptyLinesAfterImports)
- T7 (partial): all 18 commands registered; path cache rebuild copes with the multi-root layout
- T8 (partial): snooze/re-snooze/cancel keep `general.autoImport` coherent
- PR #72 regressions (#69/#70) and PR #73 regressions (#67/#68), all on the real host
- Packaging: `vsce package` + install the vsix into the test VS Code + assert activation (`npm run test:integration:vsix`)

Still live-only: T0 status bar visuals, T3 digest watcher + real digest formats, T4 path conversion CodeLens flows, T6 visual toast text, T7 cache persistence across reloads, T8 countdown display/mid-snooze manual toggle, T9 book-construct validation (needs live UEFN).

## Notable details

- The repo doesn't contribute the `verse` language id (Epic's Verse extension does in production), so `test-fixtures/verse-language-stub/` is loaded as a second `--extensionDevelopmentPath`; without it `onLanguage:verse` never fires in the test host.
- The launcher clears `ELECTRON_RUN_AS_NODE` (inherited from VS Code integrated terminals, makes the test instance run as plain Node) and copies the fixture workspace to a temp dir so saves (Optimize) never mutate checked-in fixtures.
- The fixture workspace sets BOTH `general.diagnosticDelay` and `general.autoImportDebounceDelay` to 100ms. In a real host, `config.get("general.diagnosticDelay", undefined)` returns the registered default (1000), never `undefined`, so `getConfiguredDebounceDelay()` always takes the legacy branch and `autoImportDebounceDelay` (schema has no minimum) is effectively dead in production. Worth a follow-up issue.
- Second finding surfaced by the harness: every activation logs `Unable to write to User Settings because verseAutoImports.ambiguousImports is not a registered configuration` - `extension.ts` reads/writes the pre-0.6.0 key instead of `behavior.ambiguousImports`. Also follow-up material.
- `@types/mocha` alongside `@types/jest` forced a `"types"` restriction in both tsconfigs (their globals conflict); main compile output scope is unchanged and `out/` stays free of test code.
- `.gitignore` gained one line (`out-integration/`, the harness build output) alongside the requested `.vscode-test/` check (already present).
- No CHANGELOG entry: test infrastructure only, no user-facing extension change.

## Verification

- `npm run format:check`: clean
- `npm run compile`: clean, `out/` contains no test-integration output
- `npm test`: 105 passed, 8 suites (unchanged)
- `npm run test:integration`: 22 passing
- `npm run test:integration:vsix -- itest.vsix`: 2 passing (activation from the installed vsix)
- windows-latest CI job: green (integration suite + packaged vsix activation). First run surfaced that CI checkouts give fixtures CRLF endings; assertions now normalize EOLs (verified locally against CRLF-converted fixtures), which also mirrors real Windows documents.
