### PR TITLE
refactor(test): standardize smoke-fixture project handle and paths

### DIFF
--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -112,7 +112,7 @@ export class ProjectPathHandler {
     }
 
     /**
-     * Gets the project's Verse path (e.g., /vuke@fortnite.com/Highjacked)
+     * Gets the project's Verse path (e.g., /vukefn@fortnite.com/MyGame)
      */
     async getProjectVersePath(): Promise<string | null> {
         if (this.projectVersePath) {

--- a/test-fixtures/corpus/41.10/diagnostics.json
+++ b/test-fixtures/corpus/41.10/diagnostics.json
@@ -7,7 +7,7 @@
             "id": "unknown-with-suggestion-class-context",
             "source": "captured",
             "context": "uefn-smoke T1: identifier used inside a class",
-            "message": "Unknown identifier `button_device`.\nUsed inside class /vuke@fortnite.com/VerseAutoImports/Scripts/t1_device.\n Did you forget to specify using { /Fortnite.com/Devices }",
+            "message": "Unknown identifier `button_device`.\nUsed inside class /vukefn@fortnite.com/VerseAutoImports/Scripts/t1_device.\n Did you forget to specify using { /Fortnite.com/Devices }",
             "expected": {
                 "suggestions": ["using { /Fortnite.com/Devices }"],
                 "optimizePaths": ["/Fortnite.com/Devices"]
@@ -17,7 +17,7 @@
             "id": "unknown-with-suggestion-module-context",
             "source": "captured",
             "context": "uefn-smoke T1: identifier used inside a module",
-            "message": "Unknown identifier `editable`.\nUsed inside module /vuke@fortnite.com/VerseAutoImports/Scripts.\n Did you forget to specify using { /Verse.org/Simulation }",
+            "message": "Unknown identifier `editable`.\nUsed inside module /vukefn@fortnite.com/VerseAutoImports/Scripts.\n Did you forget to specify using { /Verse.org/Simulation }",
             "expected": {
                 "suggestions": ["using { /Verse.org/Simulation }"],
                 "optimizePaths": ["/Verse.org/Simulation"]
@@ -27,7 +27,7 @@
             "id": "unknown-with-suggestion-function-context",
             "source": "captured",
             "context": "uefn-smoke T3: identifier used inside a function",
-            "message": "Unknown identifier `texture`.\nUsed inside function /vuke@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetImage.\n Did you forget to specify using { /Verse.org/Assets }",
+            "message": "Unknown identifier `texture`.\nUsed inside function /vukefn@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetImage.\n Did you forget to specify using { /Verse.org/Assets }",
             "expected": {
                 "suggestions": ["using { /Verse.org/Assets }"],
                 "optimizePaths": ["/Verse.org/Assets"]
@@ -37,7 +37,7 @@
             "id": "did-you-mean-any-of-qualified-options",
             "source": "captured",
             "context": "uefn-smoke T4: module name exists under two parents; note the trailing space after 'any of: '",
-            "message": "Unknown identifier `Combat`.\nUsed inside module /vuke@fortnite.com/VerseAutoImports/Scripts.\n Did you mean any of: \nSystems.Combat\nFeatures.Combat",
+            "message": "Unknown identifier `Combat`.\nUsed inside module /vukefn@fortnite.com/VerseAutoImports/Scripts.\n Did you mean any of: \nSystems.Combat\nFeatures.Combat",
             "expected": {
                 "suggestions": ["using { Systems }", "using { Features }"],
                 "optimizePaths": []
@@ -47,7 +47,7 @@
             "id": "did-you-mean-single-asset",
             "source": "captured",
             "context": "uefn-smoke T3: asset reference; the import must not embed the asset name",
-            "message": "Unknown identifier `image2`.\nUsed inside function /vuke@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetImage.\n Did you mean Folder1.image2",
+            "message": "Unknown identifier `image2`.\nUsed inside function /vukefn@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetImage.\n Did you mean Folder1.image2",
             "expected": {
                 "suggestions": ["using { Folder1 }"],
                 "optimizePaths": ["Folder1"]
@@ -57,7 +57,7 @@
             "id": "did-you-mean-single-asset-nested",
             "source": "captured",
             "context": "uefn-smoke T3: asset two folders deep",
-            "message": "Unknown identifier `image3`.\nUsed inside function /vuke@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetInnerImage.\n Did you mean Folder1.InnerFolder.image3",
+            "message": "Unknown identifier `image3`.\nUsed inside function /vukefn@fortnite.com/VerseAutoImports/Scripts/t3_probe/GetInnerImage.\n Did you mean Folder1.InnerFolder.image3",
             "expected": {
                 "suggestions": ["using { Folder1.InnerFolder }"],
                 "optimizePaths": ["Folder1.InnerFolder"]

--- a/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
@@ -1,8 +1,8 @@
 # T4: path conversion CodeLens + module location lookup (issue #41 rebuild).
-# projectVersePath for this project: /vuke@fortnite.com/VerseAutoImports
+# projectVersePath for this project: /vukefn@fortnite.com/VerseAutoImports
 #
 # Case A (direct Content child, implicit folder module):
-#   Gadgets.Tools -> /vuke@fortnite.com/VerseAutoImports/Gadgets/Tools
+#   Gadgets.Tools -> /vukefn@fortnite.com/VerseAutoImports/Gadgets/Tools
 # Case B (ambiguous folder module): Combat/Weapons exists under BOTH
 #   Systems/ and Features/. KNOWN LIMITATION (issue #60, verified preexisting
 #   in 0.6.4): folder-chain modules outside the current file's ancestry and

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -5,8 +5,8 @@ real Verse LSP diagnostics, and real 41.10 digest files. Run this before every
 release; it is the gate the automated Jest suite cannot provide (that suite
 mocks the entire VS Code and UEFN environment).
 
-Test project: `C:\Users\abdel\Documents\Fortnite Projects\VerseAutoImports`
-Project Verse path: `/vuke@fortnite.com/VerseAutoImports`
+Test project: `%USERPROFILE%\Documents\Fortnite Projects\VerseAutoImports`
+Project Verse path: `/vukefn@fortnite.com/VerseAutoImports`
 
 Conventions: check the box when the observed behavior matches Expected.
 Anything else goes in the Findings table at the bottom, verbatim (exact error
@@ -50,7 +50,7 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
       Content folder directly except where a step says to.
 - [ ] UEFN stays open the whole session (it is the diagnostics source).
 - [ ] Sync fixtures: `powershell -File test-fixtures/uefn-smoke/sync.ps1
-      -ContentPath "C:\Users\abdel\Documents\Fortnite Projects\VerseAutoImports\Content"`
+      -ContentPath "$env:USERPROFILE\Documents\Fortnite Projects\VerseAutoImports\Content"`
 - [ ] Open both output channels: "Verse Auto Imports" and "Verse Auto
       Imports - Debug".
 
@@ -60,7 +60,7 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 
 1. [ ] Status bar item appears; extension activates on opening a .verse file.
 2. [ ] Debug channel shows the project detected as
-       `/vuke@fortnite.com/VerseAutoImports` (from .uefnproject found in the
+       `/vukefn@fortnite.com/VerseAutoImports` (from .uefnproject found in the
        parent of Content).
 3. [ ] Run "Verse: Rebuild Project Path Cache". Debug log file count must
        correspond to Content fixtures only -- if it reports scanning
@@ -110,7 +110,7 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 ### T4 -- path conversion (fixture: Scripts/T4_path_conversion.verse + support folders)
 
 1. [ ] Case A `Gadgets.Tools`: CodeLens offers conversion; result is
-       `using { /vuke@fortnite.com/VerseAutoImports/Gadgets/Tools }`.
+       `using { /vukefn@fortnite.com/VerseAutoImports/Gadgets/Tools }`.
 2. [ ] Case B `Combat.Weapons` (exists under Systems/ AND Features/): KNOWN
        LIMITATION (#60, preexisting in 0.6.4) - resolves 0 locations. Expect a
        graceful "module not found" outcome, never a silently wrong path. The


### PR DESCRIPTION
Standardizes the example Verse project handle used across the smoke-test material and makes the playbook portable.

- Use the publisher handle `vukefn@fortnite.com` for the example `projectVersePath` in the smoke playbook, the T4 path-conversion fixture, the 41.10 diagnostics corpus, and the `ProjectPathHandler` doc comment (previously an ad-hoc handle).
- Replace the hardcoded home directory in the playbook with `%USERPROFILE%` / `$env:USERPROFILE` so the steps work for any user.

No runtime behavior change. Corpus extraction assertions key off the suggested imports, not the enclosing module path, so they are unaffected.

Verification: `npm run compile` clean, `npm test` 105/105 pass, `npm run format:check` clean.