### PR TITLE
chore: sync improved issue templates to the default branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,11 +2,28 @@ name: Bug report
 description: Report a problem with the extension
 labels: [bug]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. The version and environment
+        fields below are the details we almost always have to ask for, so filling
+        them in up front gets your issue looked at faster.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the open and closed issues and did not find a duplicate.
+          required: true
+        - label: I am on the latest version of the extension (or I note the version below and it still reproduces).
+          required: true
+
   - type: textarea
     id: what-happened
     attributes:
       label: What happened
-      description: What did you do, what did you expect, and what happened instead?
+      description: What did you do, what did you expect, and what happened instead? Include the steps to reproduce.
       placeholder: e.g. saved a file with an unknown identifier and the wrong using statement was added
     validations:
       required: true
@@ -15,7 +32,7 @@ body:
     id: extension-version
     attributes:
       label: Extension version
-      description: Extensions panel -> Verse Auto Imports -> version number
+      description: Extensions panel -> Verse Auto Imports -> version number.
       placeholder: e.g. 0.6.4
     validations:
       required: true
@@ -24,10 +41,32 @@ body:
     id: vscode-version
     attributes:
       label: VS Code version
-      description: Help -> About
+      description: Help -> About.
       placeholder: e.g. 1.101.0
     validations:
       required: true
+
+  - type: input
+    id: uefn-version
+    attributes:
+      label: UEFN / Fortnite version
+      description: The UEFN build the project is on, from UEFN Help -> About or the Epic Games Launcher. The digest format changes between builds, so this matters for triage.
+      placeholder: e.g. 41.10
+    validations:
+      required: true
+
+  - type: dropdown
+    id: workspace-layout
+    attributes:
+      label: How is the project open in VS Code
+      description: The extension detects the .uefnproject differently depending on how the workspace was opened.
+      options:
+        - Opened from UEFN via "Verse -> Open in VS Code"
+        - Opened the project folder directly in VS Code
+        - Multi-root workspace (several folders)
+        - Other / not sure
+    validations:
+      required: false
 
   - type: textarea
     id: compiler-error
@@ -47,4 +86,11 @@ body:
     id: settings
     attributes:
       label: Relevant settings
-      description: Any verseAutoImports.* settings you changed from their defaults.
+      description: Any verseAutoImports.* settings you changed from their defaults (Settings -> search "verseAutoImports").
+
+  - type: textarea
+    id: debug-logs
+    attributes:
+      label: Debug logs
+      description: Run the "Export Debug Logs" command from the Command Palette (under the Verse category), or copy the contents of the "Verse Auto Imports - Debug" Output channel, and paste the relevant lines here.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation and troubleshooting (Wiki)
+    url: https://github.com/vukefn/verse-auto-imports/wiki
+    about: Setup, configuration, and common problems are covered in the Wiki. Please check there before filing a new issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,14 @@ name: Feature request
 description: Suggest an improvement or new capability
 labels: [enhancement]
 body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the open and closed issues and did not find a duplicate.
+          required: true
+
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## Summary

The improved issue forms from #66 (which capture extension version, VS Code version, UEFN version, and add a config.yml) merged only into `develop`. GitHub serves issue templates from the **default branch (main)**, so those improvements have been inert — people opening issues today still get the old minimal form. This brings the three `ISSUE_TEMPLATE` files to `main` so they actually take effect.

## Why only the templates

`develop` and `main` also differ in `ci.yml` and `parse-digest.yml`, but those must **not** come to `main` yet: they call npm scripts (`test`, `format`, `parse-digest`) that do not exist in `main`'s `package.json`, so they stay develop-only until the 0.7 release bumps everything together. The labeling workflows added in #58 already operate from the default branch, so they don't need a develop copy either.

## Doubles as the labeler's first live test

This is the first PR opened since #58 merged. It touches `.github/**` only, so the new `actions/labeler` should auto-apply `area: ci` on open. If that label appears without me adding it, the path-based PR labeling is confirmed working end to end.

## Verification

- Pure GitHub Form YAML; no code, no compile/test impact.
- After merge, open the new-issue page and confirm the richer bug/feature forms render.