### PR TITLE
docs(changelog): trace unreleased entries to their source issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to the "Verse Auto Imports" extension will be documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked at the bottom of this file.
+
 ## [Unreleased]
 
 ### Added
 
-- **Project Path Caching**: the extension now caches your project's module structure so relative-to-absolute path conversion resolves faster, especially in large projects. Enabled by default.
+- **Project Path Caching**: the extension now caches your project's module structure so relative-to-absolute path conversion resolves faster, especially in large projects. Enabled by default. ([#41])
   - New setting `cache.enableProjectCache` (default: on) to toggle caching
   - New setting `cache.autoRebuildOnStartup` (default: off) to rebuild the cache when VS Code starts
   - New setting `cache.watcherDebounceMs` (default: 500) to tune how quickly file changes refresh the cache
@@ -18,25 +20,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- **Faster Cache Rebuilds**: project files are scanned concurrently when rebuilding the path cache. The cache storage format changed; existing caches are rebuilt automatically on first use after updating.
+- **Faster Cache Rebuilds**: project files are scanned concurrently when rebuilding the path cache. The cache storage format changed; existing caches are rebuilt automatically on first use after updating. ([#41])
 
 ### Fixed
 
-- **Optimize Imports Diagnostic Parsing**: "Optimize Imports" no longer inserts a malformed import when the compiler suggests an assignment fix (for example `using { to write 'set Foo }`), and no longer adds every candidate module of an ambiguous "one of" error at once; ambiguous cases are left to the quick-fix menu
-- **Quick Fix Menu Noise**: "Did you mean any of" compiler suggestions no longer produce import options for bare identifiers (such as local definitions echoed in the option list), which generated invalid `using` statements when applied
-- **Path Conversion with Project Cache**: "Use Absolute Path" and related commands produced malformed import paths or wrong module suggestions when the project path cache was enabled (the default)
+- **Optimize Imports Diagnostic Parsing**: "Optimize Imports" no longer inserts a malformed import when the compiler suggests an assignment fix (for example `using { to write 'set Foo }`), and no longer adds every candidate module of an ambiguous "one of" error at once; ambiguous cases are left to the quick-fix menu ([#69])
+- **Quick Fix Menu Noise**: "Did you mean any of" compiler suggestions no longer produce import options for bare identifiers (such as local definitions echoed in the option list), which generated invalid `using` statements when applied ([#70])
+- **Path Conversion with Project Cache**: "Use Absolute Path" and related commands produced malformed import paths or wrong module suggestions when the project path cache was enabled (the default) ([#41])
   - Cache results now use the same location format as the filesystem scan instead of raw declaration paths
   - Module names are matched exactly: unrelated identifiers like `MyUtils` no longer match `Utils`, and class or struct names are never offered as module locations
   - Cached results are validated against the filesystem before use, with automatic fallback to a full scan when the cache is stale
   - The search near the current file runs first again, so the nearest module is preferred over project-wide matches
-- **Optimize Imports Reliability**: with auto-import enabled (the default), "Optimize Imports" could momentarily strip every import, report success, and leave the file unorganized while the imports reappeared a moment later. The command now organizes imports in a single step and never leaves the file without them; behavior no longer depends on the auto-import debounce delay
-- **Auto-Import Asset Class Names**: automatic imports now exclude asset class names from the import path, matching the quick-fix behavior. Previously the automatic path could import `using { A.B.ClassName }` where the quick fix correctly used `using { A.B }`
-- **Indented Imports No Longer Corrupted**: adding an import to a file that uses the indented style (`using:` with the path on the next line) no longer deletes the `using:` line while leaving the path line orphaned, which lost the existing import and broke compilation
-- **Module-Scoped Imports Left in Place**: a `using` statement inside a module body is no longer moved to the top of the file by auto-import or "Optimize Imports", and saving no longer inserts blank lines after it in the middle of the module
-- **Asset Changes Detected Promptly**: adding or renaming assets in UEFN is now picked up as soon as the assets digest regenerates, instead of after a delay. The file watcher for the out-of-workspace assets digest was not firing
-- **Ambiguous Module Detection**: when a module is defined in several files, path conversion no longer drops valid locations depending on the order files are scanned
-- **Snooze Timer**: repeatedly starting snooze from the command palette no longer leaves extra countdown timers running, and an active snooze is cleaned up when the extension is disabled or reloaded
-- **Diagnostics Noise in UEFN Workspaces**: the auto-import listener no longer tries to open VS Code internal documents (which logged an error on every edit preview) and no longer reprocesses Epic's read-only `*.digest.verse` files, which carry permanent compiler errors in the standard UEFN workspace, on every diagnostics update
+- **Optimize Imports Reliability**: with auto-import enabled (the default), "Optimize Imports" could momentarily strip every import, report success, and leave the file unorganized while the imports reappeared a moment later. The command now organizes imports in a single step and never leaves the file without them; behavior no longer depends on the auto-import debounce delay ([#42])
+- **Auto-Import Asset Class Names**: automatic imports now exclude asset class names from the import path, matching the quick-fix behavior. Previously the automatic path could import `using { A.B.ClassName }` where the quick fix correctly used `using { A.B }` ([#43])
+- **Indented Imports No Longer Corrupted**: adding an import to a file that uses the indented style (`using:` with the path on the next line) no longer deletes the `using:` line while leaving the path line orphaned, which lost the existing import and broke compilation ([#68])
+- **Module-Scoped Imports Left in Place**: a `using` statement inside a module body is no longer moved to the top of the file by auto-import or "Optimize Imports", and saving no longer inserts blank lines after it in the middle of the module ([#67])
+- **Asset Changes Detected Promptly**: adding or renaming assets in UEFN is now picked up as soon as the assets digest regenerates, instead of after a delay. The file watcher for the out-of-workspace assets digest was not firing ([#43])
+- **Ambiguous Module Detection**: when a module is defined in several files, path conversion no longer drops valid locations depending on the order files are scanned ([#43])
+- **Snooze Timer**: repeatedly starting snooze from the command palette no longer leaves extra countdown timers running, and an active snooze is cleaned up when the extension is disabled or reloaded ([#43])
+- **Diagnostics Noise in UEFN Workspaces**: the auto-import listener no longer tries to open VS Code internal documents (which logged an error on every edit preview) and no longer reprocesses Epic's read-only `*.digest.verse` files, which carry permanent compiler errors in the standard UEFN workspace, on every diagnostics update ([#46])
 - **Path Conversion Scan Scope**: the fallback scan for explicit module declarations no longer reads Epic's digest files on every lookup in the standard UEFN multi-root workspace; it is now scoped to the project folder
 
 ## [0.6.4] - 2026-02-14
@@ -49,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Local-Scope Using Conflicts**: Local-scope `using` statements (e.g., `using{Variable}`) inside function bodies were incorrectly treated as module imports, causing them to be grouped with actual imports, deleted during import optimization, or shown in CodeLens path conversion (#23)
+- **Local-Scope Using Conflicts**: Local-scope `using` statements (e.g., `using{Variable}`) inside function bodies were incorrectly treated as module imports, causing them to be grouped with actual imports, deleted during import optimization, or shown in CodeLens path conversion ([#23])
 
 ## [0.6.2] - 2026-02-05
 
@@ -257,3 +259,15 @@ Settings have been reorganized with new names (old settings will need to be upda
 ## Earlier Versions
 
 See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for complete changelog of earlier versions.
+
+<!-- Issue references -->
+
+[#23]: https://github.com/VukeFN/verse-auto-imports/issues/23
+[#41]: https://github.com/VukeFN/verse-auto-imports/issues/41
+[#42]: https://github.com/VukeFN/verse-auto-imports/issues/42
+[#43]: https://github.com/VukeFN/verse-auto-imports/issues/43
+[#46]: https://github.com/VukeFN/verse-auto-imports/issues/46
+[#67]: https://github.com/VukeFN/verse-auto-imports/issues/67
+[#68]: https://github.com/VukeFN/verse-auto-imports/issues/68
+[#69]: https://github.com/VukeFN/verse-auto-imports/issues/69
+[#70]: https://github.com/VukeFN/verse-auto-imports/issues/70

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Read the code for structure. These are the things reading one file won't tell yo
 - Prettier formats all TypeScript (config in `.prettierrc.json`, 4-space). Run `npm run format` before committing; CI runs `npm run format:check` and fails on unformatted code.
 - TypeScript with relative imports (no path aliases).
 - No emojis anywhere — code, comments, docs, commits, release notes.
-- Every user-facing change gets a `CHANGELOG.md` entry under `[Unreleased]` (Keep a Changelog format).
+- Every user-facing change gets a `CHANGELOG.md` entry under `[Unreleased]` (Keep a Changelog format). When the change resolves a tracked issue, end the entry with a reference-style `[#N]` tag and add a matching `[#N]: <issue-url>` line to the link-definition block at the bottom of the file.
 - Use conventional commits.
 
 ## Testing


### PR DESCRIPTION
## What

Make each changelog entry traceable to the issue it resolves, using Keep a Changelog reference-style links.

- Adopt a `[#N]` reference-style convention: entries that resolve a tracked issue end with a `[#N]` tag, and the link targets live in an `<!-- Issue references -->` block at the bottom of the file.
- Backfill the 0.7.0 `[Unreleased]` entries with their source issues (traced through each entry's commit and PR).
- Convert the existing `(#23)` reference in 0.6.3 to the new format.
- Document the convention in `CLAUDE.md` so future entries follow it.

## Backfill mapping

| Entry | PR | Issue |
| --- | --- | --- |
| Project Path Caching / Faster Cache Rebuilds / Path Conversion with Project Cache | #47 | #41 |
| Optimize Imports Diagnostic Parsing | #72 | #69 |
| Quick Fix Menu Noise | #72 | #70 |
| Optimize Imports Reliability | #53 | #42 |
| Auto-Import Asset Class Names / Asset Changes Detected Promptly / Ambiguous Module Detection / Snooze Timer | #56 | #43 |
| Indented Imports No Longer Corrupted | #73 | #68 |
| Module-Scoped Imports Left in Place | #73 | #67 |
| Diagnostics Noise in UEFN Workspaces | #59 | #46 |

Issue links were resolved from each merged PR's `Closes #N` reference, not inferred from titles.

Two entries are intentionally left unreferenced:

- **Capture Diagnostics Corpus** (PR #74) - a tooling/test feature with no associated issue.
- **Path Conversion Scan Scope** (PR #62) - the PR cited no closing issue. It may belong to the #46 cleanup umbrella, but that was not asserted rather than guessed.

## Notes

- Docs-only change; no TypeScript touched. `npm run format:check` (scoped to `**/*.ts`) passes.
- The `/changelog-entry` slash command was also updated locally to teach the new convention, but `.claude/` is gitignored in this repo, so that change is not part of this PR.
