### PR TITLE
chore: sync .gitignore with develop (ignore build artifacts, patch files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ Thumbs.db
 .claude
 .codex
 .gemini
+
+# Patch files
+*.patch
+out-integration/


### PR DESCRIPTION
## Summary

Brings `main`'s `.gitignore` in line with `develop` by adding three generic ignore lines it was missing:

```
# Patch files
*.patch
out-integration/
```

`out-integration/` is the `tsconfig.integration.json` build output (compiled JS from the integration-test harness). It was already ignored on `develop` but not `main`, so it showed up as untracked noise whenever working on a `main`-based branch. These lines reach `main` at the next release merge regardless; pulling them forward now silences the noise and keeps the two `.gitignore` files from drifting.

No code impact, pure ignore rules. After this, the file is byte-identical to develop's.