### PR TITLE
fix: read debounce delay and ambiguous mappings from their registered keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 - **Snooze Timer**: repeatedly starting snooze from the command palette no longer leaves extra countdown timers running, and an active snooze is cleaned up when the extension is disabled or reloaded ([#43])
 - **Diagnostics Noise in UEFN Workspaces**: the auto-import listener no longer tries to open VS Code internal documents (which logged an error on every edit preview) and no longer reprocesses Epic's read-only `*.digest.verse` files, which carry permanent compiler errors in the standard UEFN workspace, on every diagnostics update ([#46])
 - **Path Conversion Scan Scope**: the fallback scan for explicit module declarations no longer reads Epic's digest files on every lookup in the standard UEFN multi-root workspace; it is now scoped to the project folder
+- **Debounce Delay Setting Restored**: `general.autoImportDebounceDelay` now actually controls the auto-import debounce. The deprecated `general.diagnosticDelay` setting's registered default (1000ms) silently overrode it, so the intended 3000ms default never applied and changing the new setting had no effect. An explicitly set `diagnosticDelay` is still honored when the new setting is left unset ([#76])
+- **Ambiguous Import Mappings Reconnected**: the `behavior.ambiguousImports` setting (and its shipped `vector3`/`vector2`/`rotation` defaults) is applied again. The code read a stale pre-0.6.0 configuration key, so configured mappings never took effect and every activation logged a settings write error. Mappings stored under the pre-0.6.0 `verseAutoImports.ambiguousImports` key must be moved to `verseAutoImports.behavior.ambiguousImports` ([#77])
 
 ## [0.6.4] - 2026-02-14
 
@@ -271,3 +273,5 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#68]: https://github.com/VukeFN/verse-auto-imports/issues/68
 [#69]: https://github.com/VukeFN/verse-auto-imports/issues/69
 [#70]: https://github.com/VukeFN/verse-auto-imports/issues/70
+[#76]: https://github.com/VukeFN/verse-auto-imports/issues/76
+[#77]: https://github.com/VukeFN/verse-auto-imports/issues/77

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,13 +8,34 @@ import { ProjectPathHandler } from "./project";
 import { AssetsDigestParser, ProjectPathCache } from "./services";
 
 /**
- * Gets the configured debounce delay, handling backward compatibility
- * with the deprecated diagnosticDelay setting.
+ * Reads the explicit user-set value of a setting, ignoring its registered
+ * default. config.get cannot distinguish the two: for a registered setting it
+ * returns the package.json default instead of the passed fallback.
+ * Language-scoped values ("[verse]" blocks) are intentionally not consulted;
+ * the config is fetched without a scope, so they have never applied here.
+ */
+function getExplicitSetting(config: vscode.WorkspaceConfiguration, key: string): number | undefined {
+    const info = config.inspect<number>(key);
+    return info?.workspaceFolderValue ?? info?.workspaceValue ?? info?.globalValue;
+}
+
+/**
+ * Gets the configured debounce delay, handling backward compatibility with
+ * the deprecated diagnosticDelay setting. Only explicit overrides are
+ * considered so diagnosticDelay's registered default (1000) cannot shadow
+ * autoImportDebounceDelay; an explicit autoImportDebounceDelay wins over an
+ * explicit legacy value.
  */
 function getConfiguredDebounceDelay(config: vscode.WorkspaceConfiguration): number {
-    const legacyDelay = config.get<number | undefined>("general.diagnosticDelay", undefined);
-    const newDelay = config.get<number>("general.autoImportDebounceDelay", 3000);
-    return legacyDelay !== undefined ? legacyDelay : newDelay;
+    const explicitDelay = getExplicitSetting(config, "general.autoImportDebounceDelay");
+    if (explicitDelay !== undefined) {
+        return explicitDelay;
+    }
+    const explicitLegacyDelay = getExplicitSetting(config, "general.diagnosticDelay");
+    if (explicitLegacyDelay !== undefined) {
+        return explicitLegacyDelay;
+    }
+    return config.get<number>("general.autoImportDebounceDelay", 3000);
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -26,20 +47,6 @@ export function activate(context: vscode.ExtensionContext) {
     const outputChannel = logger.getUserChannel();
 
     const config = vscode.workspace.getConfiguration("verseAutoImports");
-    const existingMappings = config.get<Record<string, string>>("ambiguousImports", {});
-
-    if (Object.keys(existingMappings).length === 0) {
-        logger.info("Extension", "Setting default ambiguous import mappings");
-        config.update(
-            "ambiguousImports",
-            {
-                vector3: "/UnrealEngine.com/Temporary/SpatialMath",
-                vector2: "/UnrealEngine.com/Temporary/SpatialMath",
-                rotation: "/UnrealEngine.com/Temporary/SpatialMath",
-            },
-            vscode.ConfigurationTarget.Global,
-        );
-    }
 
     // Create core services
     logger.debug("Extension", "Creating handlers");

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -331,7 +331,7 @@ export class ImportSuggestionExtractor {
 
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
-        const ambiguousImportMappings = config.get<Record<string, string>>("ambiguousImports", {});
+        const ambiguousImportMappings = config.get<Record<string, string>>("behavior.ambiguousImports", {});
 
         const classification = this.classifyMessage(errorMessage);
 

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -107,7 +107,7 @@ describe("ImportSuggestionExtractor", () => {
         it("should prefer a configured ambiguous mapping over the inferred 'Did you mean' path", async () => {
             (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
                 get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
-                    if (key === "ambiguousImports") {
+                    if (key === "behavior.ambiguousImports") {
                         return { player: "/Verse.org/Simulation" };
                     }
                     return defaultValue;

--- a/src/test-integration/suite/regressionsConfig.itest.ts
+++ b/src/test-integration/suite/regressionsConfig.itest.ts
@@ -1,0 +1,70 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { DiagnosticInjector, assertNoDocumentChange, corpusMessage, countOccurrences, docText, openFixture, sleep, waitForDocumentChange } from "./helpers";
+
+/** The debounce the fixture workspace configures; restored after each test. */
+const FIXTURE_DEBOUNCE_MS = 100;
+
+/**
+ * Writes a workspace-level setting and gives the extension's
+ * onDidChangeConfiguration listener time to apply the new debounce before
+ * diagnostics are injected.
+ */
+async function setWorkspaceSetting(key: string, value: unknown): Promise<void> {
+    await vscode.workspace.getConfiguration("verseAutoImports").update(key, value, vscode.ConfigurationTarget.Workspace);
+    await sleep(300);
+}
+
+describe("configuration resolution regressions (issues #76/#77)", () => {
+    let injector: DiagnosticInjector;
+
+    beforeEach(() => {
+        injector = new DiagnosticInjector("verse-itest-config");
+    });
+
+    afterEach(async () => {
+        injector.dispose();
+        // Restore the fixture debounce explicitly (plain undefined would drop
+        // the fixture's own workspace value) and clear any legacy override.
+        await setWorkspaceSetting("general.autoImportDebounceDelay", FIXTURE_DEBOUNCE_MS);
+        await setWorkspaceSetting("general.diagnosticDelay", undefined);
+    });
+
+    it("#77: the default behavior.ambiguousImports mapping drives auto-import for a bare unknown identifier", async () => {
+        const document = await openFixture("r77_ambiguous_mapping.verse");
+        injector.inject(document, [corpusMessage("unknown-identifier-bare-ambiguous")], "vector3");
+
+        await waitForDocumentChange(document, (text) => text.includes("using { /UnrealEngine.com/Temporary/SpatialMath }"), "auto-import of the mapped SpatialMath path");
+        await sleep(500);
+
+        assert.strictEqual(countOccurrences(docText(document), "using { /UnrealEngine.com/Temporary/SpatialMath }"), 1, "mapped import must be inserted exactly once");
+    });
+
+    it("#76: autoImportDebounceDelay governs the debounce when diagnosticDelay is unset", async () => {
+        await setWorkspaceSetting("general.autoImportDebounceDelay", 3000);
+        const document = await openFixture("r76_debounce.verse");
+        injector.inject(document, [corpusMessage("unknown-with-suggestion-class-context")], "button_device");
+
+        // With the fix the effective debounce is 3000ms, so nothing may land
+        // this early. Before the fix the deprecated key's registered default
+        // (1000ms) won and the import arrived inside this window.
+        await assertNoDocumentChange(document, 1500);
+
+        // The import must still land once the configured debounce elapses.
+        await waitForDocumentChange(document, (text) => text.includes("using { /Fortnite.com/Devices }"), "auto-import after the 3000ms debounce", 4000);
+    });
+
+    it("#76: an explicit legacy diagnosticDelay is honored while the new key is unset", async () => {
+        await setWorkspaceSetting("general.autoImportDebounceDelay", undefined);
+        await setWorkspaceSetting("general.diagnosticDelay", FIXTURE_DEBOUNCE_MS);
+        const document = await openFixture("r76_legacy_delay.verse");
+        injector.inject(document, [corpusMessage("unknown-with-suggestion-module-context")], "editable");
+
+        // Without legacy support the effective debounce would fall back to the
+        // registered 3000ms default and this wait would time out.
+        await waitForDocumentChange(document, (text) => text.includes("using { /Verse.org/Simulation }"), "auto-import under the legacy delay", 2000);
+        await sleep(500);
+
+        assert.strictEqual(countOccurrences(docText(document), "using { /Verse.org/Simulation }"), 1, "import must be inserted exactly once");
+    });
+});

--- a/test-fixtures/corpus/41.10/diagnostics.json
+++ b/test-fixtures/corpus/41.10/diagnostics.json
@@ -102,6 +102,16 @@
                 "suggestions": ["using { /Verse.org/SpatialMath }", "using { /UnrealEngine.com/Temporary/SpatialMath }"],
                 "optimizePaths": []
             }
+        },
+        {
+            "id": "unknown-identifier-bare-ambiguous",
+            "source": "synthetic",
+            "context": "bare unknown identifier with no inline suggestion; pure extraction yields nothing (expected below), but in a real host the registered behavior.ambiguousImports default maps vector3 to /UnrealEngine.com/Temporary/SpatialMath - the integration suite asserts that mapped import (issue #77 regression)",
+            "message": "Unknown identifier `vector3`.\nUsed inside module /vukefn@fortnite.com/VerseAutoImports/Scripts.",
+            "expected": {
+                "suggestions": [],
+                "optimizePaths": []
+            }
         }
     ]
 }

--- a/test-fixtures/integration-workspace/Project/Content/r76_debounce.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r76_debounce.verse
@@ -1,0 +1,5 @@
+# Config regression (issue #76): autoImportDebounceDelay alone governs the
+# debounce; the deprecated diagnosticDelay registered default must not win.
+
+r76_device := class:
+    var MaybeButton:?button_device = false

--- a/test-fixtures/integration-workspace/Project/Content/r76_legacy_delay.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r76_legacy_delay.verse
@@ -1,0 +1,5 @@
+# Config regression (issue #76): an explicit legacy diagnosticDelay is still
+# honored while the new autoImportDebounceDelay key is unset.
+
+r76_legacy := class:
+    @editable Countdown:float = 5.0

--- a/test-fixtures/integration-workspace/Project/Content/r77_ambiguous_mapping.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r77_ambiguous_mapping.verse
@@ -1,0 +1,5 @@
+# Config regression (issue #77): a bare unknown identifier covered by the
+# default behavior.ambiguousImports mapping must auto-import the mapped path.
+
+r77_probe := class:
+    var Position:vector3 = vector3{}

--- a/test-fixtures/integration-workspace/VerseAutoImportsIT.code-workspace
+++ b/test-fixtures/integration-workspace/VerseAutoImportsIT.code-workspace
@@ -17,13 +17,10 @@
     ],
     "settings": {
         // Keep the auto-import debounce short so tests wait milliseconds, not
-        // seconds. Both keys are set on purpose: getConfiguredDebounceDelay()
-        // reads the deprecated general.diagnosticDelay with config.get(key,
-        // undefined), and in a real host that returns the registered default
-        // (1000) rather than undefined, so the legacy key always wins over
-        // autoImportDebounceDelay. Setting both makes the fixture correct
-        // regardless of which key the extension ends up honoring.
-        "verseAutoImports.general.diagnosticDelay": 100,
+        // seconds. Only the current key is set: the deprecated
+        // general.diagnosticDelay must stay unset here so the suite exercises
+        // the intended resolution order (issue #76 regression coverage relies
+        // on autoImportDebounceDelay governing the debounce on its own).
         "verseAutoImports.general.autoImportDebounceDelay": 100,
         "files.autoSave": "off",
     },


### PR DESCRIPTION
## Summary

Fixes the two config-resolution bugs surfaced by the extension-host harness (#75):

- **#76**: `getConfiguredDebounceDelay()` always returned the deprecated `general.diagnosticDelay` because `config.get(key, undefined)` returns a registered setting's package.json default (1000ms) rather than the passed fallback, silently shadowing `general.autoImportDebounceDelay` and reverting the deliberate 3000ms default. The delay is now resolved from explicit overrides via `config.inspect()`: an explicit `autoImportDebounceDelay` wins, an explicit legacy `diagnosticDelay` is still honored when the new key is unset, and the registered 3000ms default applies otherwise.
- **#77**: the ambiguous-import mappings were read and default-seeded under the pre-0.6.0 bare key `verseAutoImports.ambiguousImports` while the schema registers `verseAutoImports.behavior.ambiguousImports`, so configured mappings and the shipped `vector3`/`vector2`/`rotation` defaults never applied and every activation logged a failed settings write. The extractor now reads the registered key and the redundant default-seeding block in `activate()` is removed (the defaults ship in `package.json` contributes).

Known trade-off (documented in the changelog): mappings a pre-0.6.0 user customized under the bare key are no longer read and must be moved to `behavior.ambiguousImports`.

## Tests

- New integration regressions in `regressionsConfig.itest.ts`: the default mapping drives auto-import for a bare unknown identifier (#77); `autoImportDebounceDelay` alone governs the debounce (#76); an explicit legacy `diagnosticDelay` is still honored (#76 back-compat). Verified they discriminate: with the source fixes stashed, the first two fail and the back-compat test passes.
- New corpus entry `unknown-identifier-bare-ambiguous` (synthetic) covering the bare-identifier message shape.
- The fixture workspace now sets only `autoImportDebounceDelay`, as anticipated in #76.

## Results

- `npm run compile`: clean
- `npm test`: 107 passed (8 suites)
- `npm run test:integration`: 25 passed
- `npm run format:check`: clean

Closes #76
Closes #77