### PR TITLE
fix(imports): block preservation, resolution-order sorting, and bare import classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 ### Fixed
 
 - **Preserve Import Locations With Grouping**: with `behavior.preserveImportLocations` enabled (the default) and `behavior.importGrouping` set to `digestFirst` or `localFirst`, applying a quick fix to a file whose single import block sits below a header comment no longer deletes that block and rewrites the imports at the top of the file. The block is now regrouped in place at its original location ([#90])
+- **Import Sorting Respects Verse Resolution Order**: with `behavior.sortImportsAlphabetically` enabled (the default), sorting no longer reorders a `using` block in a way that breaks compilation. Because Verse resolves `using` statements top-down, a dotted local import such as `using { Economy.Shop }` needs its first segment (`Economy`) already in scope, which a bare local import like `using { Features }` provides. Plain alphabetical sorting placed `Economy.Shop` before `Features` and reintroduced the original "Unknown identifier" error. Sorting now uses rank-based ordering: absolute paths first (alphabetical), then bare local imports, then dotted local imports (alphabetical). Bare local imports now precede dotted ones and keep their original relative order, because import order is semantic in Verse — a nested child must follow the parent that provides it. When sorting is enabled (the default config included), the quick fix now merges new imports into the existing import block in this rank order rather than appending them below it, so a new provider import can no longer land beneath a consumer that depends on it. When sorting is disabled, order is left untouched as before ([#91])
 
 ## [0.7.0] - 2026-07-11
 
@@ -288,3 +289,4 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#76]: https://github.com/VukeFN/verse-auto-imports/issues/76
 [#77]: https://github.com/VukeFN/verse-auto-imports/issues/77
 [#90]: https://github.com/VukeFN/verse-auto-imports/issues/90
+[#91]: https://github.com/VukeFN/verse-auto-imports/issues/91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Preserve Import Locations With Grouping**: with `behavior.preserveImportLocations` enabled (the default) and `behavior.importGrouping` set to `digestFirst` or `localFirst`, applying a quick fix to a file whose single import block sits below a header comment no longer deletes that block and rewrites the imports at the top of the file. The block is now regrouped in place at its original location ([#90])
+
 ## [0.7.0] - 2026-07-11
 
 ### Added
@@ -283,3 +287,4 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#70]: https://github.com/VukeFN/verse-auto-imports/issues/70
 [#76]: https://github.com/VukeFN/verse-auto-imports/issues/76
 [#77]: https://github.com/VukeFN/verse-auto-imports/issues/77
+[#90]: https://github.com/VukeFN/verse-auto-imports/issues/90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 - **Preserve Import Locations With Grouping**: with `behavior.preserveImportLocations` enabled (the default) and `behavior.importGrouping` set to `digestFirst` or `localFirst`, applying a quick fix to a file whose single import block sits below a header comment no longer deletes that block and rewrites the imports at the top of the file. The block is now regrouped in place at its original location ([#90])
 - **Import Sorting Respects Verse Resolution Order**: with `behavior.sortImportsAlphabetically` enabled (the default), sorting no longer reorders a `using` block in a way that breaks compilation. Because Verse resolves `using` statements top-down, a dotted local import such as `using { Economy.Shop }` needs its first segment (`Economy`) already in scope, which a bare local import like `using { Features }` provides. Plain alphabetical sorting placed `Economy.Shop` before `Features` and reintroduced the original "Unknown identifier" error. Sorting now uses rank-based ordering: absolute paths first (alphabetical), then bare local imports, then dotted local imports (alphabetical). Bare local imports now precede dotted ones and keep their original relative order, because import order is semantic in Verse — a nested child must follow the parent that provides it. When sorting is enabled (the default config included), the quick fix now merges new imports into the existing import block in this rank order rather than appending them below it, so a new provider import can no longer land beneath a consumer that depends on it. When sorting is disabled, order is left untouched as before ([#91])
+- **Same-Directory Folder Imports Recognized**: a file-level bare `using { X }` (a same-directory folder-module import) is now recognized as a module import. Previously every bare `using { X }` was treated as a local-scope using, so such imports were invisible to deduplication and "Optimize Imports", and the extension did not recognize an import it had itself inserted. A bare `using` at the top of a `.verse` file can only be a module import, since local-scope `using` is legal only inside a function body. These imports keep their original relative order among themselves, because import order is semantic in Verse — a nested child must follow the parent that provides it ([#65])
 
 ## [0.7.0] - 2026-07-11
 
@@ -282,6 +283,7 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#43]: https://github.com/VukeFN/verse-auto-imports/issues/43
 [#46]: https://github.com/VukeFN/verse-auto-imports/issues/46
 [#63]: https://github.com/VukeFN/verse-auto-imports/issues/63
+[#65]: https://github.com/VukeFN/verse-auto-imports/issues/65
 [#67]: https://github.com/VukeFN/verse-auto-imports/issues/67
 [#68]: https://github.com/VukeFN/verse-auto-imports/issues/68
 [#69]: https://github.com/VukeFN/verse-auto-imports/issues/69

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
         "verseAutoImports.behavior.sortImportsAlphabetically": {
           "type": "boolean",
           "default": true,
-          "description": "When true, sorts imports alphabetically. When false, preserves the original order.",
+          "description": "When true, sorts imports: absolute paths and dotted references alphabetically, while bare local imports keep their relative order and precede dotted ones to preserve Verse's top-down using resolution. When false, preserves the original order.",
           "order": 12
         },
         "verseAutoImports.behavior.importGrouping": {

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -72,7 +72,7 @@ export class ImportDocumentEditor {
 
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
-        const preserveImportLocations = config.get<boolean>("behavior.preserveImportLocations", false);
+        const preserveImportLocations = config.get<boolean>("behavior.preserveImportLocations", true);
         const sortAlphabetically = config.get<boolean>("behavior.sortImportsAlphabetically", true);
         const importGrouping = config.get<string>("behavior.importGrouping", "none");
 
@@ -194,17 +194,23 @@ export class ImportDocumentEditor {
                     const allImportsArray = Array.from(allPaths);
                     const groupedImports = this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping);
 
-                    // Replace all existing imports with grouped version
                     if (importBlocks.length > 0) {
-                        // Delete all existing import blocks
-                        for (let i = importBlocks.length - 1; i >= 0; i--) {
+                        // Replace the first existing block in place so it stays at its
+                        // original location rather than relocating to the top of the file.
+                        // Delete any additional blocks defensively (by construction this
+                        // branch only sees one block when grouping != "none", since 2+
+                        // gapped blocks are handled by the hasGrouping branch above).
+                        const firstBlock = importBlocks[0];
+                        edit.replace(document.uri, new vscode.Range(new vscode.Position(firstBlock.start, 0), new vscode.Position(firstBlock.end + 1, 0)), groupedImports.join("\n") + "\n");
+
+                        for (let i = importBlocks.length - 1; i >= 1; i--) {
                             const block = importBlocks[i];
                             edit.delete(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)));
                         }
+                    } else {
+                        // No existing imports - insert grouped imports at the top
+                        edit.insert(document.uri, new vscode.Position(0, 0), groupedImports.join("\n") + "\n\n");
                     }
-
-                    // Insert grouped imports at the top
-                    edit.insert(document.uri, new vscode.Position(0, 0), groupedImports.join("\n") + "\n\n");
                 } else {
                     // No grouping or no existing imports - use original behavior
                     const newImportPathsArray = Array.from(newImportPaths);

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -30,9 +30,9 @@ export class ImportDocumentEditor {
         // Get existing paths in this block for combined sorting
         const existingBlockPaths = block.imports.map((imp) => imp.path);
 
-        const combinedPaths = [...existingBlockPaths, ...newPaths];
+        let combinedPaths = [...existingBlockPaths, ...newPaths];
         if (sortAlphabetically) {
-            combinedPaths.sort((a, b) => a.localeCompare(b));
+            combinedPaths = this.formatter.sortImportsByRank(combinedPaths);
         }
 
         // Format all imports for this block
@@ -214,12 +214,28 @@ export class ImportDocumentEditor {
                 } else {
                     // No grouping or no existing imports - use original behavior
                     const newImportPathsArray = Array.from(newImportPaths);
-                    const newImports = this.formatter.groupAndFormatImports(newImportPathsArray, preferDotSyntax, sortAlphabetically, importGrouping);
 
-                    if (importBlocks.length > 0 && importBlocks[0].start === 0) {
-                        edit.insert(document.uri, new vscode.Position(importBlocks[0].end + 1, 0), newImports.join("\n") + "\n");
+                    if (sortAlphabetically && importBlocks.length > 0) {
+                        // Merge the new imports into the first existing block in
+                        // place so the combined block is rank-ordered (bare
+                        // module providers before the dotted consumers that
+                        // depend on them). Appending the new imports after the
+                        // block instead could place a provider such as
+                        // `using { Features }` below a consumer such as
+                        // `using { Economy.Shop }`, which breaks Verse's
+                        // top-down using resolution.
+                        this.createBlockReplacementEdit(edit, document, importBlocks[0], newImportPathsArray, preferDotSyntax, true);
                     } else {
-                        edit.insert(document.uri, new vscode.Position(0, 0), newImports.join("\n") + "\n\n");
+                        // Sorting off or no existing block: keep the original
+                        // append-in-place behavior and leave existing lines
+                        // untouched.
+                        const newImports = this.formatter.groupAndFormatImports(newImportPathsArray, preferDotSyntax, sortAlphabetically, importGrouping);
+
+                        if (importBlocks.length > 0 && importBlocks[0].start === 0) {
+                            edit.insert(document.uri, new vscode.Position(importBlocks[0].end + 1, 0), newImports.join("\n") + "\n");
+                        } else {
+                            edit.insert(document.uri, new vscode.Position(0, 0), newImports.join("\n") + "\n\n");
+                        }
                     }
                 }
             }

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -129,6 +129,63 @@ export class ImportFormatter {
     }
 
     /**
+     * Sorts import paths for a `using` block using rank-based ordering rather
+     * than plain alphabetical order.
+     *
+     * Verse resolves `using` statements top-down: a statement can only see
+     * identifiers brought into scope by statements above it. This matters
+     * because `using` has two meanings — a module import (`using { /Path }`,
+     * `using { Foo.Bar }`) and a local-scope using (`using { Variable }`) —
+     * and a dotted module import's first segment is itself only in scope if
+     * some other import (a bare module reference) already provided it. For
+     * example `using { Economy.Shop }` needs `Economy` in scope, which
+     * `using { Features }` provides if `Features` declares the `Economy`
+     * submodule. Plain alphabetical sorting can reorder `Economy.Shop` before
+     * `Features` (E < F) and break compilation even though both imports are
+     * individually valid.
+     *
+     * Paths are grouped into three ranks, and only alphabetized within a rank:
+     * - Rank 0 — absolute paths (start with `/`): self-contained, sorted alphabetically.
+     * - Rank 1 — bare identifiers (no `/`, no `.`): kept in their original
+     *   input order, never alphabetized, since the relative order between
+     *   bare module imports is semantic — a nested child must follow the
+     *   parent that provides it.
+     * - Rank 2 — everything else (dotted references such as `Economy.Shop`,
+     *   and any other non-absolute form): sorted alphabetically.
+     *
+     * A lower rank always precedes a higher rank, so bare imports precede
+     * dotted ones, guaranteeing a provider precedes anything that might
+     * depend on it. The sort is stable, so rank 1 entries keep their input
+     * order (the comparator returns 0 for two rank-1 paths).
+     *
+     * @param paths Import paths to sort
+     * @returns A new array with paths ordered by rank, then alphabetically within rank 0 and rank 2
+     */
+    sortImportsByRank(paths: string[]): string[] {
+        const rankOf = (path: string): number => {
+            if (path.startsWith("/")) {
+                return 0;
+            }
+            if (!path.includes(".") && !path.includes("/")) {
+                return 1;
+            }
+            return 2;
+        };
+
+        return [...paths].sort((a, b) => {
+            const rankDifference = rankOf(a) - rankOf(b);
+            if (rankDifference !== 0) {
+                return rankDifference;
+            }
+            if (rankOf(a) === 1) {
+                // Bare identifiers keep their input order; relative order is semantic.
+                return 0;
+            }
+            return a.localeCompare(b);
+        });
+    }
+
+    /**
      * Groups and formats imports based on the configuration settings.
      * @param importPaths Array of import paths to group and format
      * @param preferDotSyntax Whether to use dot syntax for imports
@@ -138,14 +195,15 @@ export class ImportFormatter {
      */
     groupAndFormatImports(importPaths: string[], preferDotSyntax: boolean, sortAlphabetically: boolean, importGrouping: string): string[] {
         if (importGrouping === "none") {
-            // Legacy behavior: simple alphabetical sort if enabled
-            const sortedPaths = sortAlphabetically ? [...importPaths].sort((a, b) => a.localeCompare(b)) : importPaths;
+            // Rank-based sort if enabled (see sortImportsByRank for why plain
+            // alphabetical order is unsafe for local imports)
+            const sortedPaths = sortAlphabetically ? this.sortImportsByRank(importPaths) : importPaths;
             return sortedPaths.map((path) => this.formatImportStatement(path, preferDotSyntax));
         }
 
         // New grouping behavior: separate digest and local imports
-        const digestImports: string[] = [];
-        const localImports: string[] = [];
+        let digestImports: string[] = [];
+        let localImports: string[] = [];
 
         for (const path of importPaths) {
             if (this.isDigestImport(path)) {
@@ -155,10 +213,12 @@ export class ImportFormatter {
             }
         }
 
-        // Sort within groups if enabled
+        // Sort within groups if enabled. digestImports are always absolute
+        // paths, so rank sort and plain alphabetical sort are equivalent
+        // there; the same helper is used for both groups for consistency.
         if (sortAlphabetically) {
-            digestImports.sort((a, b) => a.localeCompare(b));
-            localImports.sort((a, b) => a.localeCompare(b));
+            digestImports = this.sortImportsByRank(digestImports);
+            localImports = this.sortImportsByRank(localImports);
         }
 
         // Format the imports

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -1,5 +1,17 @@
 import * as vscode from "vscode";
 
+/** Options controlling `ImportFormatter.isModuleImport`'s classification. */
+export interface IsModuleImportOptions {
+    /**
+     * Whether the line being checked sits at file scope (column 0 of a
+     * `.verse` file, or directly inside a module-definition body) rather than
+     * inside a function body. The static method only sees a trimmed line, so
+     * it cannot determine this itself — the caller must attest to the
+     * position.
+     */
+    atFileScope?: boolean;
+}
+
 /**
  * Handles import formatting, syntax preferences, grouping, and path utilities.
  */
@@ -17,34 +29,55 @@ export class ImportFormatter {
      * - Indented: `using:` followed by an indented path on the next line
      *
      * All three styles can express either a module import or a local-scope using.
-     * Detection is content-based: paths (starting with `/`) and dot-notation module
-     * references (containing `.`) indicate module imports. Bare identifiers indicate
-     * local-scope using.
+     * Detection has two modes:
+     *
+     * - Default (`options.atFileScope` absent or `false`): content-based only.
+     *   Paths (starting with `/`) and dot-notation module references
+     *   (containing `.`) indicate module imports. Bare identifiers indicate
+     *   local-scope using. This mode is used by call sites that lack
+     *   positional context (they see a matched line in isolation and cannot
+     *   attest to where it sits in the file).
+     * - `options.atFileScope: true`: additionally treats a bare identifier as
+     *   a module import (a same-directory folder-module import, e.g.
+     *   `using { Features }`). This is legal per the Book of Verse only
+     *   because module `using` is valid at file level or module-definition
+     *   body level, while local-scope `using{instance}` is legal only inside
+     *   function bodies — so a bare `using { X }` at file scope can only be a
+     *   module import, never a legal local-scope using. Callers must only
+     *   pass this when they know the line is not inside a function body.
      *
      * @param line The line to check
      * @param nextLine The following line in the document (needed for indented style
      *   where the content is on the next line). When not provided and the line is
      *   `using:`, conservatively returns `true`.
+     * @param options Classification options; see above.
      */
-    static isModuleImport(line: string, nextLine?: string): boolean {
+    static isModuleImport(line: string, nextLine?: string, options?: IsModuleImportOptions): boolean {
         const trimmed = line.trim();
         if (!trimmed.startsWith("using")) {
             return false;
         }
+
+        const atFileScope = options?.atFileScope ?? false;
+        const isModuleImportContent = (content: string): boolean => {
+            if (content.startsWith("/")) {
+                return true;
+            }
+            if (content.includes(".")) {
+                return true;
+            }
+            if (atFileScope && /^[A-Za-z_][A-Za-z0-9_]*$/.test(content)) {
+                return true;
+            }
+            return false;
+        };
 
         // Indented style: using:
         //     /Verse.org/Simulation
         // Content is on the next line — use nextLine for content-based detection.
         if (/^using\s*:\s*$/.test(trimmed)) {
             if (nextLine !== undefined) {
-                const content = nextLine.trim();
-                if (content.startsWith("/")) {
-                    return true;
-                }
-                if (content.includes(".")) {
-                    return true;
-                }
-                return false;
+                return isModuleImportContent(nextLine.trim());
             }
             // Without next line context, conservatively assume module import
             return true;
@@ -53,27 +86,13 @@ export class ImportFormatter {
         // Dotted style: using. <content>
         const dotMatch = trimmed.match(/^using\.\s+(.+)/);
         if (dotMatch) {
-            const content = dotMatch[1].trim();
-            if (content.startsWith("/")) {
-                return true;
-            }
-            if (content.includes(".")) {
-                return true;
-            }
-            return false;
+            return isModuleImportContent(dotMatch[1].trim());
         }
 
         // Braced style: using { /path } or using{Variable}
         const curlyMatch = trimmed.match(/^using\s*\{\s*([^}]+)\s*\}/);
         if (curlyMatch) {
-            const content = curlyMatch[1].trim();
-            if (content.startsWith("/")) {
-                return true;
-            }
-            if (content.includes(".")) {
-                return true;
-            }
-            return false;
+            return isModuleImportContent(curlyMatch[1].trim());
         }
 
         return false;

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -22,7 +22,12 @@ export interface ScannedImport {
  *   consumed as one two-line entry so editing operations never orphan the
  *   path line or lose its path.
  * - Content classification (module import vs local-scope using) is delegated
- *   to ImportFormatter.isModuleImport and unchanged here.
+ *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
+ *   every candidate here already sits at column 0. This means a bare
+ *   identifier at file level, e.g. `using { Features }`, is now collected as
+ *   a module import (a same-directory folder-module import): module `using`
+ *   is only legal at file level or module-definition body level, so a bare
+ *   `using` at column 0 can never be a legal local-scope using.
  */
 export function scanModuleImports(lines: string[]): ScannedImport[] {
     const formatter = new ImportFormatter();
@@ -42,7 +47,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         const trimmed = line.trim();
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
 
-        if (!ImportFormatter.isModuleImport(trimmed, nextLine)) {
+        if (!ImportFormatter.isModuleImport(trimmed, nextLine, { atFileScope: true })) {
             i += 1;
             continue;
         }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -254,6 +254,69 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(insertsAtTop).toHaveLength(0);
     });
 
+    it("preserve + digestFirst: a new bare local import is ordered before an existing dotted local import in its block (rank sort, not alphabetical)", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "digestFirst",
+        });
+        const header = ["# Header comment line 1", "# Header comment line 2", ""];
+        const input = [...header, "using { /Verse.org/Simulation }", "", "using { Economy.Shop }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+
+        const replace = operations.find((op) => op.kind === "replace");
+        expect(replace).toBeDefined();
+        expect(replace!.text).toBe("using { Features }\nusing { Economy.Shop }\n");
+    });
+
+    it("preserve + grouping none + sort on (default config): merges a new bare provider into the existing block in rank order", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "none",
+            "behavior.sortImportsAlphabetically": true,
+        });
+        const input = ["using { Economy.Shop }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+
+        const replace = operations.find((op) => op.kind === "replace");
+        expect(replace).toBeDefined();
+        expect(replace!.range!.start.line).toBe(0);
+        expect(replace!.text).toBe("using { Features }\nusing { Economy.Shop }\n");
+
+        // The new import is not appended after the block.
+        const insertsAfterBlock = operations.filter((op) => op.kind === "insert" && op.position!.line === 1);
+        expect(insertsAfterBlock).toHaveLength(0);
+    });
+
+    it("preserve + grouping none + sort OFF: keeps the original append-after-block behavior and leaves existing lines untouched", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "none",
+            "behavior.sortImportsAlphabetically": false,
+        });
+        const input = ["using { Economy.Shop }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+
+        // No block is rewritten; the existing import line stays as-is.
+        expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+        const insert = operations.find((op) => op.kind === "insert");
+        expect(insert).toBeDefined();
+        expect(insert!.position!.line).toBe(1);
+        expect(insert!.text).toBe("using { Features }\n");
+    });
+
     it("preserve + digestFirst: inserts at the top when the file has no existing imports", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -132,6 +132,15 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
     });
 
     it("consolidates an indented-style pair without losing its path or orphaning its line", async () => {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                if (key === "behavior.preserveImportLocations") {
+                    return false;
+                }
+                return defaultValue;
+            }),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
         const input = ["using:", "    /Verse.org/Simulation", "", "hello := 1"].join("\n");
 
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
@@ -160,6 +169,15 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
     });
 
     it("leaves a module-scoped using inside its module body during consolidation", async () => {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                if (key === "behavior.preserveImportLocations") {
+                    return false;
+                }
+                return defaultValue;
+            }),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
         const input = ["using { /Top }", "", "Utilities := module:", "    using { /Verse.org/Random }", "", "    GenerateId<public>():int = 1"].join("\n");
 
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
@@ -174,6 +192,87 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(deletes).toHaveLength(1);
         expect(deletes[0].range!.start.line).toBe(0);
         expect(deletes[0].range!.end.line).toBe(1);
+    });
+
+    function mockConfig(overrides: Record<string, unknown>): void {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                if (key in overrides) {
+                    return overrides[key];
+                }
+                return defaultValue;
+            }),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+    }
+
+    it("preserve + digestFirst: replaces a single import block below a header in place, not at the top", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "digestFirst",
+        });
+        const header = ["# Header comment line 1", "# Header comment line 2", ""];
+        const input = [...header, "using { /Verse.org/Simulation }", "using { /Fortnite.com/Devices }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+
+        const replace = operations.find((op) => op.kind === "replace");
+        expect(replace).toBeDefined();
+        expect(replace!.range!.start.line).toBe(3);
+        expect(replace!.text).toContain("/Fortnite.com/Random");
+        expect(replace!.text).toContain("/Verse.org/Simulation");
+        expect(replace!.text).toContain("/Fortnite.com/Devices");
+
+        // Nothing is inserted above the header comment.
+        const insertsAtTop = operations.filter((op) => op.kind === "insert" && op.position!.line === 0);
+        expect(insertsAtTop).toHaveLength(0);
+    });
+
+    it("preserve + localFirst: replaces a single import block below a header in place, not at the top", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "localFirst",
+        });
+        const header = ["# Header comment line 1", "# Header comment line 2", ""];
+        const input = [...header, "using { /Verse.org/Simulation }", "using { /Fortnite.com/Devices }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+
+        const replace = operations.find((op) => op.kind === "replace");
+        expect(replace).toBeDefined();
+        expect(replace!.range!.start.line).toBe(3);
+        expect(replace!.text).toContain("/Fortnite.com/Random");
+        expect(replace!.text).toContain("/Verse.org/Simulation");
+
+        const insertsAtTop = operations.filter((op) => op.kind === "insert" && op.position!.line === 0);
+        expect(insertsAtTop).toHaveLength(0);
+    });
+
+    it("preserve + digestFirst: inserts at the top when the file has no existing imports", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "digestFirst",
+        });
+        const input = ["hello := 1", "world := 2"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+
+        const insert = operations.find((op) => op.kind === "insert");
+        expect(insert).toBeDefined();
+        expect(insert!.position!.line).toBe(0);
+        expect(insert!.text).toContain("/Fortnite.com/Random");
+
+        expect(operations.some((op) => op.kind === "replace")).toBe(false);
+        expect(operations.some((op) => op.kind === "delete")).toBe(false);
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -70,9 +70,17 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent("code()", ["/New"], curlyNoSort)).toBe("using { /New }\n\ncode()");
     });
 
-    it("leaves local-scope using statements in the body", () => {
-        const input = "using { /A }\nusing { LocalVar }\ncode()";
-        expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe("using { /A }\n\nusing { LocalVar }\ncode()");
+    it("hoists a bare column-0 using into the block as a module import", () => {
+        // A bare `using { X }` at column 0 can only be a module import (see
+        // ImportScanner's header comment), so it is collected like any other
+        // import rather than left in the body.
+        const input = "using { /A }\nusing { Features }\ncode()";
+        expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe("using { /A }\nusing { Features }\n\ncode()");
+    });
+
+    it("leaves a function-body local-scope using statement in the body", () => {
+        const input = ["using { /A }", "F():void =", "    using { LocalVar }", "    code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe(["using { /A }", "", "F():void =", "    using { LocalVar }", "    code()"].join("\n"));
     });
 
     it("collapses extra blank lines left by removed top imports", () => {
@@ -88,6 +96,11 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
     it("ignores blank additional paths", () => {
         const input = "using { /A }\ncode()";
         expect(editor.buildOrganizedContent(input, ["", "   "], curlyNoSort)).toBe("using { /A }\n\ncode()");
+    });
+
+    it("orders bare folder imports in input order before dotted references, never alphabetized", () => {
+        const input = ["using { Economy.Shop }", "using { Zeta }", "using { Alpha }", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Zeta }", "using { Alpha }", "using { Economy.Shop }", "", "code()"].join("\n"));
     });
 
     it("leaves a module-scoped using inside its module body", () => {
@@ -163,6 +176,15 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const input = ["using:", "    /Verse.org/Simulation", "", "hello := 1"].join("\n");
 
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Verse.org/Simulation }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("dedupes a bare folder import that already exists at column 0 and makes no edit", async () => {
+        const input = ["using { Features }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
         expect(success).toBe(true);
         expect(applyEditMock()).not.toHaveBeenCalled();

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -1,0 +1,53 @@
+import { ImportFormatter } from "../ImportFormatter";
+
+describe("ImportFormatter.sortImportsByRank", () => {
+    let formatter: ImportFormatter;
+
+    beforeEach(() => {
+        formatter = new ImportFormatter();
+    });
+
+    it("orders absolute paths before bare identifiers before dotted references", () => {
+        expect(formatter.sortImportsByRank(["Economy.Shop", "/Verse.org/Simulation", "Features"])).toEqual(["/Verse.org/Simulation", "Features", "Economy.Shop"]);
+    });
+
+    it("keeps bare identifiers in their original input order", () => {
+        expect(formatter.sortImportsByRank(["Zeta", "Economy.Shop", "Alpha"])).toEqual(["Zeta", "Alpha", "Economy.Shop"]);
+    });
+
+    it("alphabetizes absolute paths among themselves", () => {
+        expect(formatter.sortImportsByRank(["/Verse.org/Simulation", "/Fortnite.com/Devices"])).toEqual(["/Fortnite.com/Devices", "/Verse.org/Simulation"]);
+    });
+
+    it("alphabetizes dotted references among themselves", () => {
+        expect(formatter.sortImportsByRank(["Systems.Economy", "Features.Economy"])).toEqual(["Features.Economy", "Systems.Economy"]);
+    });
+});
+
+describe("ImportFormatter.groupAndFormatImports", () => {
+    let formatter: ImportFormatter;
+
+    beforeEach(() => {
+        formatter = new ImportFormatter();
+    });
+
+    it("digestFirst with sorting: local group orders the bare import before the dotted import that depends on it", () => {
+        const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Economy.Shop", "Features"], false, true, "digestFirst");
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Features }", "using { Economy.Shop }"]);
+    });
+
+    it("grouping none with sorting: absolute paths first (alpha), then bare (input order), then dotted (alpha)", () => {
+        const result = formatter.groupAndFormatImports(["Systems.Economy", "/Verse.org/Simulation", "Zeta", "/Fortnite.com/Devices", "Alpha", "Features.Economy"], false, true, "none");
+        expect(result).toEqual(["using { /Fortnite.com/Devices }", "using { /Verse.org/Simulation }", "using { Zeta }", "using { Alpha }", "using { Features.Economy }", "using { Systems.Economy }"]);
+    });
+
+    it("grouping none without sorting: leaves the original order untouched", () => {
+        const result = formatter.groupAndFormatImports(["Zeta", "Economy.Shop", "/Verse.org/Simulation"], false, false, "none");
+        expect(result).toEqual(["using { Zeta }", "using { Economy.Shop }", "using { /Verse.org/Simulation }"]);
+    });
+
+    it("digestFirst without sorting: leaves the original order untouched within each group", () => {
+        const result = formatter.groupAndFormatImports(["Zeta", "/Verse.org/Simulation", "Economy.Shop"], false, false, "digestFirst");
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Zeta }", "using { Economy.Shop }"]);
+    });
+});

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -1,5 +1,47 @@
 import { ImportFormatter } from "../ImportFormatter";
 
+describe("ImportFormatter.isModuleImport", () => {
+    it("default mode: a bare identifier is not a module import", () => {
+        expect(ImportFormatter.isModuleImport("using { Features }")).toBe(false);
+    });
+
+    it("atFileScope: a bare identifier is a module import", () => {
+        expect(ImportFormatter.isModuleImport("using { Features }", undefined, { atFileScope: true })).toBe(true);
+    });
+
+    it("a slash-form relative path is never a module import, in either mode", () => {
+        expect(ImportFormatter.isModuleImport("using { Sub/Deep }")).toBe(false);
+        expect(ImportFormatter.isModuleImport("using { Sub/Deep }", undefined, { atFileScope: true })).toBe(false);
+    });
+
+    it("a parent-relative path keeps its pre-existing dot-rule classification (out of scope to change)", () => {
+        // `../UI/MainMenu` contains a dot (from `..`), so the pre-existing
+        // content rule classifies it as a module import. The atFileScope flag
+        // only adds bare-identifier recognition and never removes anything, so
+        // the classification is identical in both modes. Special handling of
+        // `../` forms is explicitly out of scope, and the default mode must stay
+        // byte-for-byte unchanged, so this behavior is left as-is.
+        expect(ImportFormatter.isModuleImport("using { ../UI/MainMenu }")).toBe(true);
+        expect(ImportFormatter.isModuleImport("using { ../UI/MainMenu }", undefined, { atFileScope: true })).toBe(true);
+    });
+
+    it("an absolute path is a module import in both modes", () => {
+        expect(ImportFormatter.isModuleImport("using { /Verse.org/Simulation }")).toBe(true);
+        expect(ImportFormatter.isModuleImport("using { /Verse.org/Simulation }", undefined, { atFileScope: true })).toBe(true);
+    });
+
+    it("a dotted reference is a module import in both modes", () => {
+        expect(ImportFormatter.isModuleImport("using { Economy.Shop }")).toBe(true);
+        expect(ImportFormatter.isModuleImport("using { Economy.Shop }", undefined, { atFileScope: true })).toBe(true);
+    });
+
+    it("atFileScope: recognizes a bare identifier uniformly across all three syntactic styles", () => {
+        expect(ImportFormatter.isModuleImport("using { Features }", undefined, { atFileScope: true })).toBe(true);
+        expect(ImportFormatter.isModuleImport("using. Features", undefined, { atFileScope: true })).toBe(true);
+        expect(ImportFormatter.isModuleImport("using:", "    Features", { atFileScope: true })).toBe(true);
+    });
+});
+
 describe("ImportFormatter.sortImportsByRank", () => {
     let formatter: ImportFormatter;
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -22,8 +22,17 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(lines)).toEqual([]);
     });
 
-    it("skips local-scope using at column 0", () => {
-        expect(scanModuleImports(["using { LocalVar }"])).toEqual([]);
+    it("collects a bare identifier at column 0 as a module import (folder-relative)", () => {
+        // A module `using` is only legal at file level or module-definition
+        // body level; local-scope `using{instance}` is only legal inside a
+        // function body. So a bare `using { X }` at column 0 can only be a
+        // same-directory folder-module import, never a local-scope using.
+        expect(scanModuleImports(["using { Features }"])).toEqual([{ path: "Features", startLine: 0, endLine: 0 }]);
+    });
+
+    it("skips local-scope using inside a function body", () => {
+        const lines = ["F():void =", "    using { LocalVar }", "    code()"];
+        expect(scanModuleImports(lines)).toEqual([]);
     });
 
     it("skips a using: line whose next line is not an indented path", () => {

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -69,7 +69,7 @@ export class StatusBarHandler {
     async showMenu(): Promise<void> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const autoImportEnabled = config.get<boolean>("general.autoImport", true);
-        const preserveLocations = config.get<boolean>("behavior.preserveImportLocations", false);
+        const preserveLocations = config.get<boolean>("behavior.preserveImportLocations", true);
         const useDigestFiles = config.get<boolean>("experimental.useDigestFiles", false);
         const importSyntax = config.get<string>("behavior.importSyntax", "curly");
         const showCodeLens = config.get<boolean>("pathConversion.enableCodeLens", true);


### PR DESCRIPTION
Fixes three import-pipeline bugs from the 2026-07-11 smoke run and the Book-of-Verse conformance review. One commit per ticket; all three overlap on ImportFormatter/ImportDocumentEditor, hence a single serialized branch.

## #90 - preserveImportLocations ignored with grouping and a single block (9a3622e)

With preserve on and grouping set, a single import block below a header comment was deleted and rewritten at line 0. The preserve path now replaces the first existing block in place at its own range; insert-at-top only applies when the file has no imports. Also aligns the code fallbacks for the setting (editor and status bar) with the package.json default of `true`.

## #91 - alphabetical sorting breaks order-dependent local usings (2844609)

Verse resolves `using` top-down, so sorting `Economy.Shop` above the `Features` import that provides `Economy` reintroduced the compile error. All sort sites now use a stable rank order: absolute paths (alphabetical), then bare identifiers (original order preserved - relative order between bare module imports is semantic), then dotted references (alphabetical). Review found the default config (preserve + grouping none) still appended a new provider below an existing consumer; the quick fix now merges new imports into the existing block in rank order when sorting is enabled. Sorting disabled remains untouched. The `sortImportsAlphabetically` description was updated to match. Topological ordering via ProjectPathCache was considered and rejected (couples the pure formatter to a workspace-scanning service; degrades anyway when the cache is cold).

## #65 - bare file-level using invisible to the import pipeline (c5da525)

Narrowed per the live 41.10 validation recorded on the issue: the slash and parent-relative book forms are rejected by the live compiler and stay out of scope. The remaining gap: a bare `using { X }` at column 0 can only be a same-directory folder-module import (module using is legal only at file/module level; local-scope using only inside function bodies - confirmed against the Book of Verse, docs/16_modules.md). `isModuleImport` gains an opt-in `atFileScope` mode; only the file-top scanner passes it, so CodeLens/PathConverter call sites keep the conservative default. Bare imports now dedupe, take part in Optimize Imports, and are never alphabetized among themselves.

Known residual risk (accepted): a bare import depending on a dotted one (`using { A.B }` then `using { C }` with C inside B) would be reordered bare-before-dotted when sorting is on. The book documents no such chain and it has not been observed live.

## Verification

- `npm run compile`: clean
- `npm test`: 146/146 passing, 10 suites (develop baseline was 124; +22 regression tests across the three fixes)
- `npm run format:check`: clean
- Each ticket's diff got an independent fresh-context review; reviewers empirically confirmed the new regression tests fail against the pre-fix code. The #91 review's Major finding (default-config append path) was fixed and re-verified.

Fixes #90
Fixes #91
Fixes #65