### PR TITLE
feat(cache): add Clear Project Path Cache command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+### Added
+
+- **Clear Project Path Cache**: new command **Verse: Clear Project Path Cache** wipes both the in-memory cache and its persisted copy in workspace storage without rebuilding it, so the next lookup starts cold. Useful for recovering from a corrupt cache or testing cold-start behavior; ordinary rebuilds remain available via **Verse: Rebuild Project Path Cache** ([#93])
+
 ### Fixed
 
 - **Preserve Import Locations With Grouping**: with `behavior.preserveImportLocations` enabled (the default) and `behavior.importGrouping` set to `digestFirst` or `localFirst`, applying a quick fix to a file whose single import block sits below a header comment no longer deletes that block and rewrites the imports at the top of the file. The block is now regrouped in place at its original location ([#90])
@@ -292,3 +296,4 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#77]: https://github.com/VukeFN/verse-auto-imports/issues/77
 [#90]: https://github.com/VukeFN/verse-auto-imports/issues/90
 [#91]: https://github.com/VukeFN/verse-auto-imports/issues/91
+[#93]: https://github.com/VukeFN/verse-auto-imports/issues/93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+### Added
+
+- **Clear Project Path Cache**: new command **Verse: Clear Project Path Cache** wipes both the in-memory cache and its persisted copy in workspace storage without rebuilding it, so the next lookup starts cold. Useful for recovering from a corrupt cache or testing cold-start behavior; ordinary rebuilds remain available via **Verse: Rebuild Project Path Cache** ([#93])
+
 ### Fixed
 
 - **Digest Files No Longer Logged as Scanner Errors**: regenerating Epic's `Assets.digest.verse` no longer logs a `Failed to parse ... Content\Assets.digest.verse` error. The project path cache's file watcher reaches the out-of-workspace digest in the UEFN multi-root workspace; it now ignores every `*.digest.verse` change, create, and delete event, since digest files are generated API surface and never project declarations. The declaration cache was otherwise unaffected ([#95])
@@ -309,4 +313,8 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#77]: https://github.com/VukeFN/verse-auto-imports/issues/77
 [#90]: https://github.com/VukeFN/verse-auto-imports/issues/90
 [#91]: https://github.com/VukeFN/verse-auto-imports/issues/91
+<<<<<<< HEAD
 [#95]: https://github.com/VukeFN/verse-auto-imports/issues/95
+=======
+[#93]: https://github.com/VukeFN/verse-auto-imports/issues/93
+>>>>>>> 1781c84 (feat(cache): add Clear Project Path Cache command)

--- a/package.json
+++ b/package.json
@@ -93,6 +93,10 @@
         "title": "Verse: Rebuild Project Path Cache"
       },
       {
+        "command": "verseAutoImports.clearPathCache",
+        "title": "Verse: Clear Project Path Cache"
+      },
+      {
         "command": "verseAutoImports.showCacheStatus",
         "title": "Verse: Show Cache Status"
       }

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -71,6 +71,7 @@ export class CommandsHandler {
 
             // Cache
             ["verseAutoImports.rebuildPathCache", this.rebuildPathCache.bind(this)],
+            ["verseAutoImports.clearPathCache", this.clearPathCache.bind(this)],
             ["verseAutoImports.showCacheStatus", this.showCacheStatus.bind(this)],
 
             // Path conversion
@@ -302,6 +303,29 @@ export class CommandsHandler {
 
         const stats = this.deps.projectPathCache.getStats();
         vscode.window.showInformationMessage(`Project path cache rebuilt: ${stats.identifiers} identifiers from ${stats.files} files`);
+    }
+
+    /**
+     * Clears the project path cache without rebuilding it.
+     * Wipes both the in-memory state and the persisted workspace-storage copy;
+     * useful for testing cold-start behavior or recovering from a corrupt cache.
+     */
+    async clearPathCache(): Promise<void> {
+        if (!this.deps.projectPathCache) {
+            vscode.window.showWarningMessage("Project path cache is not enabled");
+            return;
+        }
+
+        try {
+            logger.info("CommandsHandler", "Clearing project path cache");
+
+            await this.deps.projectPathCache.clearAll();
+
+            vscode.window.showInformationMessage("Project path cache cleared");
+        } catch (error) {
+            logger.error("CommandsHandler", "Failed to clear project path cache", error);
+            vscode.window.showErrorMessage(`Failed to clear project path cache: ${error instanceof Error ? error.message : String(error)}`);
+        }
     }
 
     /**

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -226,6 +226,22 @@ export class ProjectPathCache {
     }
 
     /**
+     * Clear the in-memory cache and remove the persisted copy from workspace
+     * storage. Unlike {@link clear}, which only wipes in-memory state and is
+     * reused as the watcher-teardown hook, this also drops the stored payload
+     * so the next session starts cold. Use it to recover from a corrupt cache
+     * or to test cold-start behavior; it does not trigger a rebuild.
+     */
+    async clearAll(): Promise<void> {
+        this.clear();
+
+        await this.context.workspaceState.update(ProjectPathCache.CACHE_KEY, undefined);
+        await this.context.workspaceState.update(ProjectPathCache.LEGACY_METADATA_KEY, undefined);
+
+        logger.info("ProjectPathCache", "Persisted cache cleared from workspace storage");
+    }
+
+    /**
      * Save cache to VS Code workspace storage.
      */
     private async saveToStorage(): Promise<void> {

--- a/src/services/__tests__/ProjectPathCache.clearAll.test.ts
+++ b/src/services/__tests__/ProjectPathCache.clearAll.test.ts
@@ -1,0 +1,64 @@
+import { ProjectPathCache } from "../ProjectPathCache";
+
+/**
+ * Unit tests for ProjectPathCache persistence behavior.
+ *
+ * These exercise clearAll() against a tiny in-memory Memento stub, so they run
+ * under Jest without the VS Code runtime or workspace storage.
+ */
+describe("ProjectPathCache.clearAll", () => {
+    // Storage keys used by ProjectPathCache; kept in sync with its private
+    // statics so the test asserts on the actual persisted payload.
+    const CACHE_KEY = "projectPathTree";
+    const LEGACY_METADATA_KEY = "projectPathTreeMeta";
+
+    /** Minimal in-memory stand-in for vscode.Memento (workspaceState). */
+    class FakeMemento {
+        private readonly store: Map<string, unknown> = new Map();
+
+        get<T>(key: string): T | undefined {
+            return this.store.get(key) as T | undefined;
+        }
+
+        async update(key: string, value: unknown): Promise<void> {
+            if (value === undefined) {
+                this.store.delete(key);
+            } else {
+                this.store.set(key, value);
+            }
+        }
+
+        seed(key: string, value: unknown): void {
+            this.store.set(key, value);
+        }
+    }
+
+    type CacheParams = ConstructorParameters<typeof ProjectPathCache>;
+
+    function createCache(memento: FakeMemento): ProjectPathCache {
+        const context = { workspaceState: memento } as unknown as CacheParams[0];
+        const outputChannel = { appendLine: jest.fn() } as unknown as CacheParams[1];
+        const projectPathHandler = {} as unknown as CacheParams[2];
+        return new ProjectPathCache(context, outputChannel, projectPathHandler);
+    }
+
+    it("removes the persisted cache and legacy metadata from workspace storage", async () => {
+        const memento = new FakeMemento();
+        memento.seed(CACHE_KEY, { version: 2, nodes: [] });
+        memento.seed(LEGACY_METADATA_KEY, { some: "legacy" });
+
+        await createCache(memento).clearAll();
+
+        expect(memento.get(CACHE_KEY)).toBeUndefined();
+        expect(memento.get(LEGACY_METADATA_KEY)).toBeUndefined();
+    });
+
+    it("resolves cleanly when nothing is persisted", async () => {
+        const memento = new FakeMemento();
+
+        await expect(createCache(memento).clearAll()).resolves.toBeUndefined();
+
+        expect(memento.get(CACHE_KEY)).toBeUndefined();
+        expect(memento.get(LEGACY_METADATA_KEY)).toBeUndefined();
+    });
+});

--- a/src/test-integration/suite/commands.itest.ts
+++ b/src/test-integration/suite/commands.itest.ts
@@ -43,6 +43,7 @@ describe("commands and snooze (playbook T7/T8)", () => {
             "verseAutoImports.exportDebugLogs",
             "verseAutoImports.captureDiagnosticsCorpus",
             "verseAutoImports.rebuildPathCache",
+            "verseAutoImports.clearPathCache",
             "verseAutoImports.showCacheStatus",
         ];
         for (const commandId of expected) {


### PR DESCRIPTION
Fixes #93.

## What

Adds the `verseAutoImports.clearPathCache` command ("Verse: Clear Project Path Cache") that the smoke playbook's T7 expects but was never contributed.

- `ProjectPathCache.clearAll()`: clears in-memory state via the existing `clear()`, then removes both persisted workspace-storage keys (`projectPathTree` and the legacy `projectPathTreeMeta`). No rescan or rebuild is triggered — the point is cold-start testing and recovery from a corrupt cache.
- The watcher-teardown dispose hook keeps using in-memory-only `clear()`, so extension deactivation still never wipes the persisted cache.
- `CommandsHandler.clearPathCache()` mirrors `rebuildPathCache`'s disabled-cache guard and `showCacheStatus`'s error handling; the success message only shows when the persisted clear actually succeeded.
- Post-clear safety verified: `invalidateFiles`, `handleFileDelete`, and `saveToStorage` all early-return on empty cache, so a live watcher after clearing is a no-op.

The playbook itself is untouched — it was already correct once the command exists.

## Verification

- `npm run compile` clean
- `npm test`: 11 suites, 148 tests passing (2 new unit tests exercising `clearAll()` against an in-memory Memento fake)
- `verseAutoImports.clearPathCache` added to the integration suite's registered-command list
- Fresh-context review: no Critical/Major findings; its one Minor (missing error handling in the command) is fixed in this diff

## Note

Trivial changelog conflict with #104 is expected (both append a link-definition line after `[#91]`); resolve by keeping both lines.