### PR TITLE
chore: migrate to GitHub Flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
     commit-message:
       prefix: "deps"
 
@@ -14,6 +13,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
     commit-message:
       prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/claude-maintenance.yml
+++ b/.github/workflows/claude-maintenance.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -39,17 +39,17 @@ jobs:
           prompt: |
             You are the weekly maintenance agent for ${{ github.repository }},
             a VS Code extension for the Verse language. Read CLAUDE.md first.
-            The checkout is the develop branch.
+            The checkout is the main branch, which is the only long-lived branch.
 
             Inspect the repository and produce a short maintenance report:
 
             1. Repo health: run `npm ci`, `npm run compile`, and `npm test` on
-               develop. Report any failure with the relevant output.
+               main. Report any failure with the relevant output.
             2. Open issues: list open issues; flag any with no activity for more
                than 30 days, any unanswered questions, and any missing triage labels.
             3. Open PRs: list open PRs and their CI state; flag stale ones and any
                Dependabot majors waiting on a decision.
-            4. Release readiness: compare develop against the latest release tag
+            4. Release readiness: compare main against the latest release tag
                (`git log $(git describe --tags --abbrev=0 origin/main)..HEAD --oneline`).
                If there are user-facing changes, summarize them and state whether a
                release is worth cutting, and whether CHANGELOG.md's [Unreleased]

--- a/.github/workflows/claude-release-prep.yml
+++ b/.github/workflows/claude-release-prep.yml
@@ -21,10 +21,10 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Checkout develop
+      - name: Checkout main
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -39,11 +39,19 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Prepare a release of this VS Code extension. Read CLAUDE.md first.
-            The checkout is the develop branch.
+            The checkout is the main branch, which is the only long-lived branch.
 
-            Requested version: "${{ inputs.version }}". If empty, determine the
-            correct semver bump yourself from the nature of the unreleased changes
-            (features -> minor, fixes only -> patch).
+            Requested version: "${{ inputs.version }}". If empty, derive the bump
+            by applying this rule to the [Unreleased] section of CHANGELOG.md -
+            do not use judgement, apply the rule:
+              - any entry under Removed, or any entry explicitly marked breaking
+                -> minor (the project is on 0.x; this becomes major after 1.0.0)
+              - otherwise any entry under Added or Deprecated -> minor
+                (SemVer rule 7 requires a minor for a deprecation on its own)
+              - otherwise, entries only under Fixed / Changed / Security -> patch
+              - no user-facing entries at all -> STOP. Do not cut a release that
+                contains only CI, test, or refactor commits.
+            State which rule branch fired and why in the PR body.
 
             Steps:
             1. Verify the tree is releasable: `npm ci && npm run compile && npm test`.
@@ -55,19 +63,18 @@ jobs:
                the new version dated today (UTC), grouped under Added / Changed /
                Fixed as appropriate, written for end users (what changed in the
                editor experience, not internal refactor details). Keep an empty
-               [Unreleased] section on top.
+               [Unreleased] section on top. Add the version compare-link to the
+               link-definition block at the bottom, and repoint [Unreleased] at
+               the new tag.
             4. Set the new version in package.json (version field only; do not
                touch other fields or package-lock.json by hand - run
                `npm install --package-lock-only` after the bump to sync it).
-            5. Create branch release/vX.Y.Z from develop, commit everything as
-               "chore: prepare release vX.Y.Z", and push it.
-            6. Open a PR from release/vX.Y.Z to main titled "release: vX.Y.Z".
-               Body: the new changelog section, plus a checklist reminding the
-               maintainer that merging will produce a draft GitHub Release which
-               they publish to ship to the Marketplace.
-            7. Also open a PR from release/vX.Y.Z to develop if main and develop
-               have diverged, or note in the first PR that develop should be
-               synced after the release merge.
+            5. Create branch chore/release-vX.Y.Z from main, commit everything as
+               "chore: release vX.Y.Z", and push it.
+            6. Open a PR from chore/release-vX.Y.Z to main titled "release: vX.Y.Z".
+               Body: the new changelog section, the bump rule that fired, plus a
+               checklist reminding the maintainer that merging will produce a draft
+               GitHub Release which they publish to ship to the Marketplace.
 
             Rules: no emojis, no AI attribution in commits, conventional commit
             prefixes only.

--- a/.github/workflows/parse-digest.yml
+++ b/.github/workflows/parse-digest.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - 'src/utils/*.digest.verse'
-    branches: [develop, main]
+    branches: [main]
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/pr-artifact.yml
+++ b/.github/workflows/pr-artifact.yml
@@ -2,7 +2,7 @@ name: PR Build Artifact
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,15 +34,18 @@ Jest + ts-jest; `vscode` is mocked at `src/__mocks__/vscode.ts`. Tests live in `
 
 ## Git workflow
 
-- `main` = tagged releases; `develop` = integration. Feature and fix PRs target `develop`.
-- Branch prefixes: `feature/` `fix/` `refactor/`; `hotfix/` branches from `main`.
-- Release: a `release/vX.Y.Z` PR into `main` bumps the version and finalizes the changelog; publishing the GitHub Release ships to the Marketplace automatically.
+GitHub Flow: `main` is the only long-lived branch and the default branch. There is no `develop`.
+
+- Every change branches from `main` and returns by PR into `main`. Because PRs target the default branch, `Closes #N` in a PR body actually links and closes the issue — always use it.
+- Branch prefixes: `feature/` `fix/` `chore/` `docs/` `test/` `refactor/`. A hotfix is just a `fix/` branch; it needs no special path.
+- Release: a `chore/release-vX.Y.Z` PR into `main` bumps the version and finalizes the changelog. Merging it produces a draft GitHub Release; publishing that draft ships to the Marketplace.
+- `release/X.Y` branches are cut **retroactively**, and only to patch an older released line. Do not create one in advance.
 
 ## Rules for automated agents (GitHub Actions runs)
 
 YOU MUST:
 
-- Never push to `main` or `develop` — always branch and open a PR.
+- Never push to `main` — always branch and open a PR.
 - Never change the `package.json` `version` except during release prep.
 - Never close issues — label and comment; leave closing to the maintainer.
 - Run `npm run compile` and `npm test` before opening a PR, and report the results in it.


### PR DESCRIPTION
Retires `develop`. `main` becomes the only long-lived branch; all work returns to it by PR.

## Why

PRs targeting `develop` meant GitHub never interpreted closing keywords — they are only honoured on PRs against the **default** branch. Verified: PR #103 carries `Fixes #90`, `Fixes #91`, `Fixes #65` in its body and its `closingIssuesReferences` is empty. The links were never created, so every "closes" written to date has been inert text.

Pointing every PR at `main` fixes that, removes the back-merge failure class outright, and is a prerequisite for stacked PRs if we adopt them later.

## Evidence for the model

- 35+ major repos enumerated by live branch listing carry no permanent `develop`.
- 16 of 20 VS Code extension repos have no release branches at all.
- GitLens bumps version and changelog directly on `main`, tags, and cuts `release/{major}.{minor}` only "if needed".

## Changes

| File | Change |
|---|---|
| `.github/dependabot.yml` | Drop `target-branch` from both ecosystems so it follows the default branch |
| `ci.yml`, `parse-digest.yml`, `pr-artifact.yml` | Trigger on `main` only |
| `claude-maintenance.yml` | Check out `main` |
| `claude-release-prep.yml` | Check out `main`; cut `chore/release-vX.Y.Z` from `main`; drop the develop-sync step; replace the model's semver judgement with a deterministic rule over changelog categories, plus a gate refusing to release when nothing user-facing changed |
| `CLAUDE.md` | Document the model and the real prefix set; note that `release/X.Y` is cut retroactively |

`main` was already fast-forwarded to `develop` (they were identical, `main` a strict ancestor) — no content is lost by retiring it.

## Verification

- `npm run compile` clean
- `npm test` — 146 passed, 10 suites
- Post-merge: confirm a PR to `main` with a closing keyword produces a non-empty `closingIssuesReferences`