### PR TITLE
release: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to the "Verse Auto Imports" extension will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked at the bottom of this file.
 
 ## [Unreleased]
+
+## [0.7.1] - 2026-08-02
 
 ### Fixed
 
@@ -274,6 +276,17 @@ Settings have been reorganized with new names (old settings will need to be upda
 ## Earlier Versions
 
 See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for complete changelog of earlier versions.
+
+<!-- Version comparisons. The chain starts at 0.6.0: no v0.4.x or v0.5.x tags exist. -->
+
+[Unreleased]: https://github.com/VukeFN/verse-auto-imports/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/VukeFN/verse-auto-imports/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/VukeFN/verse-auto-imports/compare/v0.6.4...v0.7.0
+[0.6.4]: https://github.com/VukeFN/verse-auto-imports/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/VukeFN/verse-auto-imports/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/VukeFN/verse-auto-imports/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/VukeFN/verse-auto-imports/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/VukeFN/verse-auto-imports/releases/tag/v0.6.0
 
 <!-- Issue references -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verse-auto-imports",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verse-auto-imports",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "verse-auto-imports",
   "displayName": "Verse Auto Imports",
   "description": "Automatically adds missing using statements in Verse files",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
First release under GitHub Flow (#117).

## Bump rule

`[Unreleased]` contained entries only under **Fixed** — nothing under Added, Deprecated or Removed, and nothing marked breaking. The deterministic rule therefore yields **patch**: `0.7.0` -> `0.7.1`.

## [0.7.1] - 2026-08-02

### Fixed

- **Preserve Import Locations With Grouping** — a quick fix on a file whose single import block sits below a header comment no longer deletes that block and rewrites imports at the top ([#90])
- **Import Sorting Respects Verse Resolution Order** — sorting no longer reorders a `using` block in a way that breaks compilation; rank-based ordering keeps providers ahead of dependent dotted imports ([#91])
- **Same-Directory Folder Imports Recognized** — a file-level bare `using { X }` is now recognized as a module import, so it participates in deduplication and Optimize Imports ([#65])

## Also in this PR

Brings `CHANGELOG.md` to Keep a Changelog 1.1.0: adds the Semantic Versioning statement (principle 7) and version compare-links (principle 4). `[0.7.0]` was previously a dead reference. The compare chain starts at 0.6.0 — no `v0.4.x` or `v0.5.x` tags exist.

## Verification

- `npm run compile` clean
- `npm test` — 146 passed, 10 suites
- `npm run format:check` clean
- `package.json` diff is the version line only; lockfile synced via `npm install --package-lock-only`

## After merge

Merging produces a **draft** GitHub Release. Publishing that draft is what ships to the Marketplace — it is not automatic.