### PR TITLE
ci: branch the release bump rule on whether the project is pre-1.0

### DIFF
--- a/.github/workflows/claude-release-prep.yml
+++ b/.github/workflows/claude-release-prep.yml
@@ -43,15 +43,25 @@ jobs:
 
             Requested version: "${{ inputs.version }}". If empty, derive the bump
             by applying this rule to the [Unreleased] section of CHANGELOG.md -
-            do not use judgement, apply the rule:
+            do not use judgement, apply the rule.
+
+            First read the current version from package.json. Let PRE_1_0 be true
+            when its major component is 0. Do not assume this - read it, because
+            the answer changes the first branch below and it changes for good the
+            day this project ships 1.0.0.
+
               - any entry under Removed, or any entry explicitly marked breaking
-                -> minor (the project is on 0.x; this becomes major after 1.0.0)
+                -> minor if PRE_1_0, otherwise major
+                (SemVer treats 0.y.z as an unstable public API, so a breaking
+                change is conventionally a minor below 1.0 and a major at or
+                above it)
               - otherwise any entry under Added or Deprecated -> minor
                 (SemVer rule 7 requires a minor for a deprecation on its own)
               - otherwise, entries only under Fixed / Changed / Security -> patch
               - no user-facing entries at all -> STOP. Do not cut a release that
                 contains only CI, test, or refactor commits.
-            State which rule branch fired and why in the PR body.
+            State the version you read, whether PRE_1_0 was true, which rule
+            branch fired, and why, in the PR body.
 
             Steps:
             1. Verify the tree is releasable: `npm ci && npm run compile && npm test`.


### PR DESCRIPTION
Closes #122

The Release Prep bump rule hard-coded the pre-1.0 branch. Correct today at 0.7.1; silently wrong the day this project ships 1.0.0.

## Before

```
  - any entry under Removed, or any entry explicitly marked breaking
    -> minor (the project is on 0.x; this becomes major after 1.0.0)
```

The parenthetical describes the right behaviour but is a note, not a condition the agent evaluates.

## After

Reads the version from `package.json`, derives `PRE_1_0` from its major component, and branches on it. A breaking change is a minor below 1.0 and a major at or above it. The workflow must now also state the version it read and which branch fired, so the version decision is auditable in the release PR rather than invisible.

## Verification

Prompt-only change to a `workflow_dispatch` workflow — no code path to test. Checked: no tabs introduced, the `prompt: |` block scalar indentation is unchanged, and the diff is confined to the rule text.

Found while dry-running pipeline onboarding against `highlightjs-verse`, which is at 1.2.0 — the old rule would have shipped a minor there for a breaking change.

No changelog entry: this is CI, not user-facing. Consistent with the rule's own last clause, which refuses to cut a release containing only CI changes.