### PR TITLE
fix(imports): fall back to ungrouped output for an unrecognised importGrouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 - **Digest Files No Longer Logged as Scanner Errors**: regenerating Epic's `Assets.digest.verse` no longer logs a `Failed to parse ... Content\Assets.digest.verse` error. The project path cache's file watcher reaches the out-of-workspace digest in the UEFN multi-root workspace; it now ignores every `*.digest.verse` change, create, and delete event, since digest files are generated API surface and never project declarations. The declaration cache was otherwise unaffected ([#95])
 - **Digest Module Paths Resolved Correctly**: the bundled API digest parser now attributes each declaration to the correct module. It previously tracked `# Module import path:` comments as ambient state with no indentation model, so a comment leaked onto later comment-less modules — `button_device` and `trigger_device` resolved to `/Fortnite.com/AI/movement_types` instead of `/Fortnite.com/Devices`. It also required `<public>` to appear immediately after the identifier, so `<native><public>` declarations were dropped entirely, leaving `creative_device`, `agent`, `player`, and `vector3` unimportable and producing no `/Fortnite.com/Devices` entry in the module index. Module scope is now derived from indentation (like the assets digest parser): a pending import-path comment applies to the next module only, then resolution falls back to a `(/path:)` scope qualifier, the enclosing module, or the file's root domain, and specifier order no longer affects which declarations are recognized ([#97])
+- **Unrecognized Import Grouping No Longer Drops Imports**: an out-of-enum `behavior.importGrouping` value now falls back to ungrouped output instead of removing every import from the file. Only `digestFirst` and `localFirst` were handled when combining the grouped output, so any other value returned an empty list and the rewrite deleted the imports it was meant to reorder. The settings UI constrains the value to the declared enum, so this was reachable only through a hand-edited `settings.json`, a case mismatch such as `digestfirst`, or a workspace settings file carried from an older version — but the failure was silent and total ([#121])
 
 ## [0.7.1] - 2026-08-02
 
@@ -318,12 +319,7 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#77]: https://github.com/VukeFN/verse-auto-imports/issues/77
 [#90]: https://github.com/VukeFN/verse-auto-imports/issues/90
 [#91]: https://github.com/VukeFN/verse-auto-imports/issues/91
-<<<<<<< HEAD
-<<<<<<< HEAD
-[#95]: https://github.com/VukeFN/verse-auto-imports/issues/95
-=======
 [#93]: https://github.com/VukeFN/verse-auto-imports/issues/93
->>>>>>> 1781c84 (feat(cache): add Clear Project Path Cache command)
-=======
+[#95]: https://github.com/VukeFN/verse-auto-imports/issues/95
 [#97]: https://github.com/VukeFN/verse-auto-imports/issues/97
->>>>>>> c160e71 (chore(digest): refresh bundled digests to 41.10 and regenerate data)
+[#121]: https://github.com/VukeFN/verse-auto-imports/issues/121

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -209,11 +209,13 @@ export class ImportFormatter {
      * @param importPaths Array of import paths to group and format
      * @param preferDotSyntax Whether to use dot syntax for imports
      * @param sortAlphabetically Whether to sort imports alphabetically
-     * @param importGrouping The grouping strategy ('none', 'digestFirst', or 'localFirst')
+     * @param importGrouping The grouping strategy ('none', 'digestFirst', or 'localFirst').
+     *   Any other value falls back to 'none', so a setting typo or a renamed
+     *   enum member degrades to ungrouped output rather than dropping imports.
      * @returns Array of formatted import statements with potential empty lines for grouping
      */
     groupAndFormatImports(importPaths: string[], preferDotSyntax: boolean, sortAlphabetically: boolean, importGrouping: string): string[] {
-        if (importGrouping === "none") {
+        if (importGrouping !== "digestFirst" && importGrouping !== "localFirst") {
             // Rank-based sort if enabled (see sortImportsByRank for why plain
             // alphabetical order is unsafe for local imports)
             const sortedPaths = sortAlphabetically ? this.sortImportsByRank(importPaths) : importPaths;
@@ -244,23 +246,16 @@ export class ImportFormatter {
         const formattedDigestImports = digestImports.map((path) => this.formatImportStatement(path, preferDotSyntax));
         const formattedLocalImports = localImports.map((path) => this.formatImportStatement(path, preferDotSyntax));
 
-        // Combine based on configuration
-        let formattedImports: string[] = [];
-        if (importGrouping === "digestFirst") {
-            formattedImports = [...formattedDigestImports];
-            // Add spacing between groups if both have imports
-            if (formattedDigestImports.length > 0 && formattedLocalImports.length > 0) {
-                formattedImports.push(""); // Empty line between groups
-            }
-            formattedImports.push(...formattedLocalImports);
-        } else if (importGrouping === "localFirst") {
-            formattedImports = [...formattedLocalImports];
-            // Add spacing between groups if both have imports
-            if (formattedLocalImports.length > 0 && formattedDigestImports.length > 0) {
-                formattedImports.push(""); // Empty line between groups
-            }
-            formattedImports.push(...formattedDigestImports);
+        // Combine based on configuration. Only the two grouped strategies reach
+        // this point, so both branches of the pair are covered.
+        const [firstGroup, secondGroup] = importGrouping === "digestFirst" ? [formattedDigestImports, formattedLocalImports] : [formattedLocalImports, formattedDigestImports];
+
+        const formattedImports: string[] = [...firstGroup];
+        // Add spacing between groups if both have imports
+        if (firstGroup.length > 0 && secondGroup.length > 0) {
+            formattedImports.push(""); // Empty line between groups
         }
+        formattedImports.push(...secondGroup);
 
         return formattedImports;
     }

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -92,4 +92,24 @@ describe("ImportFormatter.groupAndFormatImports", () => {
         const result = formatter.groupAndFormatImports(["Zeta", "/Verse.org/Simulation", "Economy.Shop"], false, false, "digestFirst");
         expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Zeta }", "using { Economy.Shop }"]);
     });
+
+    it("localFirst with sorting: local group precedes the digest group", () => {
+        const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Economy.Shop", "Features"], false, true, "localFirst");
+        expect(result).toEqual(["using { Features }", "using { Economy.Shop }", "", "using { /Verse.org/Simulation }"]);
+    });
+
+    // An out-of-enum value reaches here from a hand-edited settings.json, a case
+    // mismatch, a workspace settings file carried from an older version, or a
+    // future rename of an enum member. Dropping every import would silently
+    // delete the user's source, so an unrecognised value degrades to "none".
+    it.each(["typo", "digestfirst", "", "None"])("an unrecognised grouping value %p falls back to ungrouped output instead of dropping imports", (grouping) => {
+        const paths = ["/Verse.org/Simulation", "Features", "Features.Economy"];
+        const result = formatter.groupAndFormatImports(paths, false, false, grouping);
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "using { Features }", "using { Features.Economy }"]);
+    });
+
+    it("an unrecognised grouping value still honours sorting", () => {
+        const result = formatter.groupAndFormatImports(["Economy.Shop", "/Verse.org/Simulation", "Features"], false, true, "typo");
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "using { Features }", "using { Economy.Shop }"]);
+    });
 });


### PR DESCRIPTION
Closes #121

## Problem

`ImportFormatter.groupAndFormatImports` returned an empty array for any `behavior.importGrouping` value it did not recognise, so a rewrite deleted every import in the file rather than leaving it alone.

`"none"` returned early; the remaining code was `if (importGrouping === "digestFirst") … else if (importGrouping === "localFirst") …` with no `else`, leaving `formattedImports` at its initial `[]`.

## Fix

- The early return now triggers for anything that is not `"digestFirst"` or `"localFirst"`, so an unrecognised value degrades to `"none"` behaviour (ungrouped, sorting still honoured) instead of dropping imports.
- The two combine branches are collapsed into one group-order pair, so the digestFirst and localFirst shapes cannot drift apart again.

Only the fallback path changes; `none`, `digestFirst` and `localFirst` produce byte-identical output to before.

## Tests

Five new cases in `src/imports/__tests__/ImportFormatter.test.ts` — four unrecognised values (`typo`, `digestfirst`, `""`, `None`) and one asserting sorting is still applied on the fallback path. Verified they fail against the unfixed source (5 failed, 16 passed) and pass with it. Also added a `localFirst` grouping case, which had no direct coverage.

`npm run compile` clean. `npm test`: 11 suites, 156 tests, all passing. `npm run format:check` clean.

## Not done

The issue also suggests logging once when the setting is out of enum. `ImportFormatter` has no logger dependency today, so that was left out to keep the change surgical — worth a follow-up if a silent fallback is considered too quiet.