### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-04
+
 ### Added
 
 - **Clear Project Path Cache**: new command **Verse: Clear Project Path Cache** wipes both the in-memory cache and its persisted copy in workspace storage without rebuilding it, so the next lookup starts cold. Useful for recovering from a corrupt cache or testing cold-start behavior; ordinary rebuilds remain available via **Verse: Rebuild Project Path Cache** ([#93])
@@ -294,7 +296,8 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 
 <!-- Version comparisons. The chain starts at 0.6.0: no v0.4.x or v0.5.x tags exist. -->
 
-[Unreleased]: https://github.com/VukeFN/verse-auto-imports/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/VukeFN/verse-auto-imports/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/VukeFN/verse-auto-imports/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/VukeFN/verse-auto-imports/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/VukeFN/verse-auto-imports/compare/v0.6.4...v0.7.0
 [0.6.4]: https://github.com/VukeFN/verse-auto-imports/compare/v0.6.3...v0.6.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verse-auto-imports",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verse-auto-imports",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "verse-auto-imports",
   "displayName": "Verse Auto Imports",
   "description": "Automatically adds missing using statements in Verse files",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Version decision

Read `package.json`: current version **0.7.1**, so **PRE_1_0 = true**.

Applying the bump rule to the `[Unreleased]` section in order:

1. No entries under `Removed` and none marked breaking — first branch does not fire.
2. There is an entry under `Added` (**Clear Project Path Cache**) — **this branch fires: minor**.

Result: **0.7.1 -> 0.8.0**. The PRE_1_0 branch did not affect the outcome here, since the rule that fired was the `Added` one, which is a minor at any version.

## [0.8.0] - 2026-08-04

### Added

- **Clear Project Path Cache**: new command **Verse: Clear Project Path Cache** wipes both the in-memory cache and its persisted copy in workspace storage without rebuilding it, so the next lookup starts cold. Useful for recovering from a corrupt cache or testing cold-start behavior; ordinary rebuilds remain available via **Verse: Rebuild Project Path Cache** ([#93])

### Changed

- **Bundled Digests Refreshed to 41.10**: the pre-compiled API digests (`Fortnite`, `UnrealEngine`, `Verse`) were regenerated from `++Fortnite+Release-41.10-CL-55335788`, so import suggestions reflect the current UEFN API surface

### Fixed

- **Digest Files No Longer Logged as Scanner Errors** ([#95])
- **Digest Module Paths Resolved Correctly** ([#97])
- **Unrecognized Import Grouping No Longer Drops Imports** ([#121])
- **Trailing Comments No Longer Corrupt Rewritten Imports** ([#120])

Full entry text is in `CHANGELOG.md`.

## Verification

- `npm ci` clean
- `npm run compile` clean (tsc, no errors)
- `npm test`: 14 suites, 194 tests, all passing
- `npm run format:check` clean
- `package.json` version set to 0.8.0; `package-lock.json` synced with `npm install --package-lock-only` (both `version` fields updated, no other changes)

## What shipped since v0.7.1

Five PRs, closing five issues: #104 (#95), #105 (#93), #106 (#97), #124 (#121), #125 (#120).

## Maintainer checklist

- [ ] Merging this PR produces a **draft** GitHub Release
- [ ] Publishing that draft is what ships v0.8.0 to the VS Code Marketplace
- [ ] Nothing reaches users until the draft is published