### PR TITLE
fix(ui): hold snooze state in memory instead of user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Snooze No Longer Disables Auto Import Permanently**: **Verse: Snooze Auto Import** no longer writes `general.autoImport: false` into your user settings. It previously did, and only an in-memory timer ever wrote the value back, so a window reload, a VS Code restart, an update, or a crash during the five-minute snooze left auto import switched off for good — with no countdown in the status bar and no message connecting it to a snooze taken days earlier. The snooze is now held in memory and consulted by the auto-import check, which also means a reload simply ends the snooze instead of extending it forever. The status menu shows `Snoozed (M:SS)` on the Auto Import row while one is active. If an earlier snooze already left the setting off, re-enable **Auto Import** from the status bar menu once ([#132])
+
 ## [0.8.0] - 2026-08-04
 
 ### Added
@@ -328,3 +332,4 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#97]: https://github.com/VukeFN/verse-auto-imports/issues/97
 [#120]: https://github.com/VukeFN/verse-auto-imports/issues/120
 [#121]: https://github.com/VukeFN/verse-auto-imports/issues/121
+[#132]: https://github.com/VukeFN/verse-auto-imports/issues/132

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -70,6 +70,10 @@ const window = {
     setStatusBarMessage: jest.fn(),
 };
 
+const languages = {
+    getDiagnostics: jest.fn().mockReturnValue([]),
+};
+
 const DiagnosticSeverity = {
     Error: 0,
     Warning: 1,
@@ -88,4 +92,4 @@ const ConfigurationTarget = {
     WorkspaceFolder: 3,
 };
 
-export { workspace, window, DiagnosticSeverity, StatusBarAlignment, ConfigurationTarget, Position, Range, WorkspaceEdit };
+export { workspace, window, languages, DiagnosticSeverity, StatusBarAlignment, ConfigurationTarget, Position, Range, WorkspaceEdit };

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -16,7 +16,9 @@ export class DiagnosticsHandler {
         // Consulted when a debounce timer fires, not when it is scheduled, so
         // a snooze started while a timer is already pending still suppresses
         // that import. Returns false when nothing is suppressing auto-import.
-        private isAutoImportSuppressed: () => boolean = () => false,
+        // Required rather than defaulted: a call site that forgot it would
+        // lose suppression silently at runtime instead of failing the build.
+        private isAutoImportSuppressed: () => boolean,
     ) {
         // Use the shared, fully-wired ImportHandler so the auto-import path has
         // the same asset-class detection and precompiled digests as quick fixes.

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -13,6 +13,10 @@ export class DiagnosticsHandler {
     constructor(
         private outputChannel: vscode.OutputChannel,
         importHandler: ImportHandler,
+        // Consulted when a debounce timer fires, not when it is scheduled, so
+        // a snooze started while a timer is already pending still suppresses
+        // that import. Returns false when nothing is suppressing auto-import.
+        private isAutoImportSuppressed: () => boolean = () => false,
     ) {
         // Use the shared, fully-wired ImportHandler so the auto-import path has
         // the same asset-class detection and precompiled digests as quick fixes.
@@ -69,7 +73,7 @@ export class DiagnosticsHandler {
                 logger.debug("DiagnosticsHandler", `Processing diagnostics for ${documentKey} after delay`);
 
                 const config = vscode.workspace.getConfiguration("verseAutoImports");
-                const autoImportEnabled = config.get<boolean>("general.autoImport", true);
+                const autoImportEnabled = config.get<boolean>("general.autoImport", true) && !this.isAutoImportSuppressed();
                 const multiOptionStrategy = config.get<string>("behavior.multiOptionStrategy", "quickfix");
 
                 const autoImportSuggestions = new Set<string>();

--- a/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
+++ b/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
@@ -1,4 +1,6 @@
+import * as vscode from "vscode";
 import { DiagnosticsHandler } from "../DiagnosticsHandler";
+import { ImportHandler } from "../../imports";
 
 describe("DiagnosticsHandler.shouldProcessUri", () => {
     const fileUri = (fsPath: string) => ({ scheme: "file", fsPath });
@@ -32,5 +34,59 @@ describe("DiagnosticsHandler.shouldProcessUri", () => {
     it("is case-insensitive about the extension", () => {
         expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\Project\\Device.VERSE"))).toBe(true);
         expect(DiagnosticsHandler.shouldProcessUri(fileUri("C:\\Project\\Assets.DIGEST.verse"))).toBe(false);
+    });
+});
+
+describe("DiagnosticsHandler auto-import suppression", () => {
+    const DELAY_MS = 10;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`." }]);
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    function makeImportHandler(): ImportHandler {
+        return {
+            extractImportSuggestions: jest.fn().mockResolvedValue([{ importStatement: "using { /Fortnite.com/Devices }", confidence: "high" }]),
+            addImportsToDocument: jest.fn().mockResolvedValue(undefined),
+        } as unknown as ImportHandler;
+    }
+
+    function makeDocument(): vscode.TextDocument {
+        return { uri: { scheme: "file", fsPath: "C:\\Project\\Content\\device.verse" }, languageId: "verse" } as unknown as vscode.TextDocument;
+    }
+
+    it("auto-imports when nothing suppresses it", async () => {
+        const importHandler = makeImportHandler();
+        const handler = new DiagnosticsHandler(vscode.window.createOutputChannel("test"), importHandler, () => false);
+        handler.setDelay(DELAY_MS);
+
+        await handler.handle(makeDocument());
+        await jest.advanceTimersByTimeAsync(DELAY_MS);
+
+        expect(importHandler.addImportsToDocument).toHaveBeenCalledTimes(1);
+    });
+
+    // Regression: the debounce timer re-reads the auto-import decision when it
+    // fires, so a snooze started while a timer is already pending suppresses
+    // that import too. Gating only where the timer is scheduled left a window
+    // of one debounce delay (3s by default) in which a snooze was ignored.
+    it("does not auto-import when a snooze starts after the timer is scheduled", async () => {
+        const importHandler = makeImportHandler();
+        let snoozed = false;
+        const handler = new DiagnosticsHandler(vscode.window.createOutputChannel("test"), importHandler, () => snoozed);
+        handler.setDelay(DELAY_MS);
+
+        await handler.handle(makeDocument());
+        snoozed = true;
+        await jest.advanceTimersByTimeAsync(DELAY_MS);
+
+        expect(importHandler.addImportsToDocument).not.toHaveBeenCalled();
     });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,7 +171,9 @@ export function activate(context: vscode.ExtensionContext) {
                     const document = await vscode.workspace.openTextDocument(uri);
                     if (document.languageId === "verse") {
                         const config = vscode.workspace.getConfiguration("verseAutoImports");
-                        if (config.get<boolean>("general.autoImport", true)) {
+                        // The snooze is in-memory state, not a setting, so it
+                        // is checked here rather than read back from config.
+                        if (config.get<boolean>("general.autoImport", true) && !statusBarHandler.isSnoozeActive()) {
                             await diagnosticsHandler.handle(document);
                         }
                     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,8 +56,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Create handlers and providers
     const importHandler = new ImportHandler(outputChannel, assetsDigestParser, context);
-    const diagnosticsHandler = new DiagnosticsHandler(outputChannel, importHandler);
     const statusBarHandler = new StatusBarHandler(outputChannel);
+    const diagnosticsHandler = new DiagnosticsHandler(outputChannel, importHandler, () => statusBarHandler.isSnoozeActive());
     const importPathConverter = new ImportPathConverter(outputChannel, projectPathCache);
     const importCodeLensProvider = new ImportCodeLensProvider(outputChannel);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,6 +173,10 @@ export function activate(context: vscode.ExtensionContext) {
                         const config = vscode.workspace.getConfiguration("verseAutoImports");
                         // The snooze is in-memory state, not a setting, so it
                         // is checked here rather than read back from config.
+                        // This is only the cheap early exit; the authoritative
+                        // check is in the debounce callback, which has to
+                        // re-check because a snooze can start after a timer
+                        // has already been scheduled.
                         if (config.get<boolean>("general.autoImport", true) && !statusBarHandler.isSnoozeActive()) {
                             await diagnosticsHandler.handle(document);
                         }

--- a/src/test-integration/suite/commands.itest.ts
+++ b/src/test-integration/suite/commands.itest.ts
@@ -6,17 +6,6 @@ function globalAutoImport(): boolean | undefined {
     return vscode.workspace.getConfiguration("verseAutoImports").inspect<boolean>("general.autoImport")?.globalValue;
 }
 
-async function waitForGlobalAutoImport(expected: boolean, timeoutMs: number = 3000): Promise<void> {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-        if (globalAutoImport() === expected) {
-            return;
-        }
-        await sleep(50);
-    }
-    throw new Error(`general.autoImport globalValue did not become ${expected} within ${timeoutMs}ms (currently ${globalAutoImport()})`);
-}
-
 describe("commands and snooze (playbook T7/T8)", () => {
     before(async () => {
         // Guarantees activation so all commands are registered.
@@ -57,19 +46,25 @@ describe("commands and snooze (playbook T7/T8)", () => {
         await vscode.commands.executeCommand("verseAutoImports.rebuildPathCache");
     });
 
-    it("T8: snooze disables auto-import globally; re-snoozing stays coherent; cancel restores", async () => {
+    // Regression (#132): the snooze used to write general.autoImport: false
+    // into global user settings, so a reload during the snooze left auto-import
+    // off permanently. Snooze state is now in-memory and settings stay clean.
+    it("T8: snooze leaves user settings untouched; re-snoozing stays coherent; cancel is clean", async () => {
+        const before = globalAutoImport();
         try {
             await vscode.commands.executeCommand("verseAutoImports.snoozeAutoImport");
-            await waitForGlobalAutoImport(false);
+            await sleep(300);
+            assert.strictEqual(globalAutoImport(), before, "snooze must not write general.autoImport to user settings");
 
             // Re-invoking while already snoozed must not corrupt the state
-            // (single timer per the 0.6.x snooze fix); the setting stays off.
+            // (single timer per the 0.6.x snooze fix).
             await vscode.commands.executeCommand("verseAutoImports.snoozeAutoImport");
             await sleep(300);
-            assert.strictEqual(globalAutoImport(), false, "auto-import must stay disabled while snoozed");
+            assert.strictEqual(globalAutoImport(), before, "re-snoozing must not write general.autoImport either");
 
             await vscode.commands.executeCommand("verseAutoImports.cancelSnooze");
-            await waitForGlobalAutoImport(true);
+            await sleep(300);
+            assert.strictEqual(globalAutoImport(), before, "cancelling must not write general.autoImport either");
         } finally {
             // Never leak a snoozed state into later suites: cancel again and
             // clear the global override so the default (true) applies.

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -31,7 +31,9 @@ export class StatusBarHandler {
             if (event.affectsConfiguration("verseAutoImports")) {
                 // A snooze does not touch the setting, so this only fires when
                 // the user turns auto import on themselves mid-snooze. Take
-                // that as "imports now, please" and drop the snooze.
+                // that as "imports now, please" and drop the snooze. The raw
+                // field, not isSnoozeActive(): the question here is whether
+                // there is any snooze to clear, an expired one included.
                 if (event.affectsConfiguration("verseAutoImports.general.autoImport") && this.snoozeEndTime !== null) {
                     const config = vscode.workspace.getConfiguration("verseAutoImports");
                     const autoImportEnabled = config.get<boolean>("general.autoImport", true);

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -29,7 +29,9 @@ export class StatusBarHandler {
         // Listen for configuration changes to update status bar
         vscode.workspace.onDidChangeConfiguration((event) => {
             if (event.affectsConfiguration("verseAutoImports")) {
-                // Check if auto import was manually enabled while snooze is active
+                // A snooze does not touch the setting, so this only fires when
+                // the user turns auto import on themselves mid-snooze. Take
+                // that as "imports now, please" and drop the snooze.
                 if (event.affectsConfiguration("verseAutoImports.general.autoImport") && this.snoozeEndTime !== null) {
                     const config = vscode.workspace.getConfiguration("verseAutoImports");
                     const autoImportEnabled = config.get<boolean>("general.autoImport", true);
@@ -56,7 +58,7 @@ export class StatusBarHandler {
     }
 
     updateDisplay(): void {
-        if (this.snoozeEndTime !== null) {
+        if (this.isSnoozeActive()) {
             // Snooze is active - show text with countdown
             const remaining = this.getRemainingTime();
             this.statusBarItem.text = `Verse Auto Imports (${remaining})`;
@@ -115,7 +117,7 @@ export class StatusBarHandler {
         let autoImportDescription: string;
         if (!autoImportEnabled) {
             autoImportDescription = "Disabled";
-        } else if (this.snoozeEndTime !== null) {
+        } else if (this.isSnoozeActive()) {
             autoImportDescription = `Snoozed (${this.getRemainingTime()})`;
         } else {
             autoImportDescription = "Enabled";
@@ -131,7 +133,7 @@ export class StatusBarHandler {
         });
 
         // Snooze section
-        if (this.snoozeEndTime !== null) {
+        if (this.isSnoozeActive()) {
             const remaining = this.getRemainingTime();
 
             items.push({
@@ -469,7 +471,7 @@ export class StatusBarHandler {
     }
 
     private extendSnooze(minutes: number): void {
-        if (this.snoozeEndTime === null) return;
+        if (!this.isSnoozeActive()) return;
 
         logger.debug("StatusBarHandler", `Extending snooze by ${minutes} minutes`);
         this.snoozeEndTime += minutes * MS_PER_MINUTE;

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -44,6 +44,17 @@ export class StatusBarHandler {
         });
     }
 
+    /**
+     * Whether auto imports are currently suppressed by a snooze. Snooze state
+     * is deliberately in-memory only: it is ephemeral and time-boxed, so it
+     * must not outlive the extension host. Persisting it (or mirroring it into
+     * user settings) is what could leave auto imports off forever after a
+     * reload mid-snooze.
+     */
+    isSnoozeActive(): boolean {
+        return this.snoozeEndTime !== null && Date.now() < this.snoozeEndTime;
+    }
+
     updateDisplay(): void {
         if (this.snoozeEndTime !== null) {
             // Snooze is active - show text with countdown
@@ -99,9 +110,20 @@ export class StatusBarHandler {
             kind: vscode.QuickPickItemKind.Separator,
         });
 
+        // A snooze no longer flips the setting, so the row would otherwise
+        // report "Enabled" while imports are suppressed.
+        let autoImportDescription: string;
+        if (!autoImportEnabled) {
+            autoImportDescription = "Disabled";
+        } else if (this.snoozeEndTime !== null) {
+            autoImportDescription = `Snoozed (${this.getRemainingTime()})`;
+        } else {
+            autoImportDescription = "Enabled";
+        }
+
         items.push({
             label: toggleIcon(autoImportEnabled, "Auto Import"),
-            description: autoImportEnabled ? "Enabled" : "Disabled",
+            description: autoImportDescription,
             action: async () => {
                 await config.update("general.autoImport", !autoImportEnabled, vscode.ConfigurationTarget.Global);
                 logger.debug("StatusBarHandler", `Auto import toggled: ${!autoImportEnabled}`);
@@ -425,12 +447,11 @@ export class StatusBarHandler {
         // palette while already snoozed) cannot orphan a running interval.
         this.clearSnoozeState();
 
-        // Set snooze end time
+        // Set snooze end time. This is the whole of the snooze state: the
+        // auto-import path consults isSnoozeActive(), and no user setting is
+        // touched, so nothing can survive the extension host and leave auto
+        // imports disabled.
         this.snoozeEndTime = Date.now() + minutes * MS_PER_MINUTE;
-
-        // Disable auto imports
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
-        config.update("general.autoImport", false, vscode.ConfigurationTarget.Global);
 
         // Start countdown interval
         this.snoozeInterval = setInterval(() => {
@@ -469,9 +490,6 @@ export class StatusBarHandler {
         logger.debug("StatusBarHandler", "Cancelling snooze");
         this.clearSnoozeState();
 
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
-        config.update("general.autoImport", true, vscode.ConfigurationTarget.Global);
-
         this.updateDisplay();
         vscode.window.showInformationMessage("Auto imports resumed");
     }
@@ -488,9 +506,6 @@ export class StatusBarHandler {
     private endSnooze(): void {
         logger.debug("StatusBarHandler", "Snooze timer expired");
         this.clearSnoozeState();
-
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
-        config.update("general.autoImport", true, vscode.ConfigurationTarget.Global);
 
         this.updateDisplay();
         vscode.window.showInformationMessage("Auto imports resumed automatically");

--- a/src/ui/__tests__/StatusBarHandler.test.ts
+++ b/src/ui/__tests__/StatusBarHandler.test.ts
@@ -58,3 +58,84 @@ describe("StatusBarHandler snooze timer lifecycle", () => {
         expect(jest.getTimerCount()).toBe(0);
     });
 });
+
+describe("StatusBarHandler snooze state", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    function makeHandler(): StatusBarHandler {
+        const outputChannel = vscode.window.createOutputChannel("test");
+        return new StatusBarHandler(outputChannel);
+    }
+
+    function updateMock(): jest.Mock {
+        return vscode.workspace.getConfiguration("verseAutoImports").update as jest.Mock;
+    }
+
+    it("suppresses auto imports while snoozed", () => {
+        const handler = makeHandler();
+        expect(handler.isSnoozeActive()).toBe(false);
+
+        handler.startSnooze(5);
+        expect(handler.isSnoozeActive()).toBe(true);
+    });
+
+    it("stops suppressing auto imports once the snooze expires", () => {
+        const handler = makeHandler();
+        handler.startSnooze(5);
+
+        jest.advanceTimersByTime(5 * 60000);
+
+        expect(handler.isSnoozeActive()).toBe(false);
+    });
+
+    it("stops suppressing auto imports when the snooze is cancelled", () => {
+        const handler = makeHandler();
+        handler.startSnooze(5);
+
+        handler.cancelSnooze();
+
+        expect(handler.isSnoozeActive()).toBe(false);
+    });
+
+    // Regression: a snooze used to write general.autoImport: false into global
+    // user settings and only the in-memory interval ever restored it, so a
+    // window reload during the snooze disabled auto imports permanently.
+    it("does not touch user settings when a snooze starts, expires or is cancelled", () => {
+        const update = updateMock();
+        const handler = makeHandler();
+        update.mockClear();
+
+        handler.startSnooze(5);
+        expect(update).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(5 * 60000);
+        expect(update).not.toHaveBeenCalled();
+
+        handler.startSnooze(5);
+        handler.cancelSnooze();
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it("leaves nothing disabled behind when disposed mid-snooze", () => {
+        const update = updateMock();
+        const handler = makeHandler();
+        update.mockClear();
+
+        handler.startSnooze(5);
+        // Stands in for a window reload: dispose runs, the process goes away.
+        handler.dispose();
+
+        expect(update).not.toHaveBeenCalled();
+
+        // A fresh handler, as created on the next activation, is not snoozed.
+        expect(makeHandler().isSnoozeActive()).toBe(false);
+    });
+});

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -162,9 +162,9 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
        cancel/expiry restores the normal state. Watch Debug channel for
        duplicate-interval evidence.
 3. [ ] Disable then re-enable auto-imports mid-snooze: snooze cancels
-       automatically on the re-enable. (A snooze no longer flips the setting
-       itself, so it reads Enabled throughout; the Auto Import row shows
-       "Snoozed (M:SS)".)
+       automatically on the re-enable. The snooze itself never flips the
+       setting, so before you touch it the Auto Import row reads
+       "Snoozed (M:SS)" with its checkbox still ticked.
 4. [ ] #132: snooze, then reload the window inside the 5 minutes. Auto-import
        must work again immediately, and settings.json must hold no
        verseAutoImports.general.autoImport entry.

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -161,7 +161,16 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
        while already snoozing; countdown stays coherent (single timer), and
        cancel/expiry restores the normal state. Watch Debug channel for
        duplicate-interval evidence.
-3. [ ] Enable auto-imports mid-snooze: snooze cancels automatically.
+3. [ ] Disable then re-enable auto-imports mid-snooze: snooze cancels
+       automatically on the re-enable. (A snooze no longer flips the setting
+       itself, so it reads Enabled throughout; the Auto Import row shows
+       "Snoozed (M:SS)".)
+4. [ ] #132: snooze, then reload the window inside the 5 minutes. Auto-import
+       must work again immediately, and settings.json must hold no
+       verseAutoImports.general.autoImport entry.
+5. [ ] #132: trigger a diagnostic and snooze within the debounce window
+       (general.autoImportDebounceDelay, 3s by default) before the import
+       lands. Nothing is imported.
 
 ### T9 -- book-construct validation (fixtures: T9/) [gates #65 and #71]
 


### PR DESCRIPTION
Closes #132

## The bug

`StatusBarHandler.startSnooze()` implemented **Verse: Snooze Auto Import** by writing `general.autoImport: false` into global user settings, and the only thing that ever wrote it back was the in-memory `setInterval`. `dispose()` cleared that interval and restored nothing, and nothing re-checked the setting on activate. A window reload, a VS Code restart or update, a crash, or an extension-host restart inside the five-minute window therefore left auto import switched off permanently — with no countdown in the status bar (`snoozeEndTime` is null on the next activation) and no message tying it to a snooze taken days earlier.

## The fix

The snooze is now the `snoozeEndTime` field alone, exposed as `isSnoozeActive()`. No durable configuration is touched, so nothing can outlive the extension host; a reload simply ends the snooze instead of extending it forever.

Two places consult it, deliberately:

- `extension.ts` gates the diagnostics listener — the cheap early exit.
- `DiagnosticsHandler` takes an `isAutoImportSuppressed: () => boolean` predicate and evaluates it **inside** the debounce callback, alongside the `general.autoImport` read it guards. Without this second check, a debounce timer already pending when the user hits snooze would fire and import anyway, up to `general.autoImportDebounceDelay` (3s by default) into the snooze — and snoozing while an import is about to land is the normal reason to reach for it. The old code got this for free, because the setting it flipped was re-read at fire time.

This also removes the three un-awaited `config.update` calls the issue flagged as its secondary point: they are deleted rather than awaited, so an unhandled rejection on a failed settings write is no longer reachable from the snooze path.

The status menu's Auto Import row now reads `Snoozed (M:SS)` while a snooze runs, since the setting it reflects no longer changes.

## Not in scope

Users who already have `general.autoImport: false` stuck in their settings from this bug get no in-product recovery — a `false` there is indistinguishable from a deliberate choice, so clearing it on activate would be wrong. The changelog entry tells them to re-enable **Auto Import** from the status bar menu once. A one-time notification for that population would be a separate ticket.

## Tests

- `src/ui/__tests__/StatusBarHandler.test.ts` — snooze state is active/inactive as expected, and no `config.update` is issued when a snooze starts, expires, is cancelled, or is disposed mid-snooze.
- `src/diagnostics/__tests__/DiagnosticsHandler.test.ts` — a snooze that starts *after* the debounce timer is scheduled still suppresses that import.
- `src/test-integration/suite/commands.itest.ts` — T8 rewritten: snooze, re-snooze and cancel must all leave `general.autoImport` in user settings untouched.
- `test-fixtures/uefn-smoke/PLAYBOOK.md` — T8 step 3 no longer assumes the snooze flips the setting; two manual steps added for reload-mid-snooze and snooze-inside-the-debounce-window.

Both new regression tests were checked against the old behavior: reinstating the settings write fails the two `StatusBarHandler` assertions, and dropping the predicate fails the `DiagnosticsHandler` one.

The layer-2 integration suite was not run — it is not among this repo's configured verify commands and needs a VS Code extension host.

## Verification

```
$ npm run compile

> verse-auto-imports@0.8.0 compile
> tsc -p ./

$ npm test

> verse-auto-imports@0.8.0 test
> jest --verbose

Test Suites: 14 passed, 14 total
Tests:       201 passed, 201 total
Snapshots:   0 total
Time:        8.265 s, estimated 9 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.8.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
