### PR TITLE
fix(imports): shape-check "Did you mean" suggestions before importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
-## [0.8.0] - 2026-08-04
+### Fixed
+
+- **"Did you mean" Suggestions Are Shape-Checked Before Import**: a "Did you mean" suggestion is now only turned into an import when it is a dotted chain of Verse identifiers; anything else, such as trailing sentence punctuation ("Did you mean Economy.Shop.") or prose ("Did you mean to use Bar.Baz instead?"), is dropped instead of being split into a plausible-looking but wrong import. Previously the raw suggestion text was split on its last period with no validation, so a trailing period produced an import one module level too deep (`using { Economy.Shop }` where `using { Economy }` is correct) and prose produced syntactically invalid Verse (`using { to use Bar }`), both emitted with high confidence and auto-inserted. Prose lines trailing a "Did you mean any of" option list are dropped the same way ([#130])
 
 ### Added
 
@@ -328,3 +330,4 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#97]: https://github.com/VukeFN/verse-auto-imports/issues/97
 [#120]: https://github.com/VukeFN/verse-auto-imports/issues/120
 [#121]: https://github.com/VukeFN/verse-auto-imports/issues/121
+[#130]: https://github.com/VukeFN/verse-auto-imports/issues/130

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 - **"Did you mean" Suggestions Are Shape-Checked Before Import**: a "Did you mean" suggestion is now only turned into an import when it is a dotted chain of Verse identifiers; anything else, such as trailing sentence punctuation ("Did you mean Economy.Shop.") or prose ("Did you mean to use Bar.Baz instead?"), is dropped instead of being split into a plausible-looking but wrong import. Previously the raw suggestion text was split on its last period with no validation, so a trailing period produced an import one module level too deep (`using { Economy.Shop }` where `using { Economy }` is correct) and prose produced syntactically invalid Verse (`using { to use Bar }`), both emitted with high confidence and auto-inserted. Prose lines trailing a "Did you mean any of" option list are dropped the same way ([#130])
 
+## [0.8.0] - 2026-08-04
+
 ### Added
 
 - **Clear Project Path Cache**: new command **Verse: Clear Project Path Cache** wipes both the in-memory cache and its persisted copy in workspace storage without rebuilding it, so the next lookup starts cold. Useful for recovering from a corrupt cache or testing cold-start behavior; ordinary rebuilds remain available via **Verse: Rebuild Project Path Cache** ([#93])

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -24,9 +24,14 @@ const PATTERNS = {
     USING_PATH: /using \{ (\/[^}]+) \}/g,
     /** Extracts path from "(/Path:)" format */
     PATH_IN_PARENS: /\((\/[^:)]+):\)/g,
-    /** A dotted chain of Verse identifiers, e.g. "Module.Submodule.Name" */
-    QUALIFIED_NAME: /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/,
 } as const;
+
+/**
+ * A dotted chain of Verse identifiers, e.g. "Module.Submodule.Name". Not part
+ * of the PATTERNS precedence cascade: it validates an already-extracted
+ * candidate rather than parsing a compiler message.
+ */
+const QUALIFIED_NAME = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 
 /** A resolvable import extracted from a compiler message. */
 interface ImportCandidate {
@@ -99,7 +104,7 @@ export class ImportSuggestionExtractor {
         // ("Economy.Shop.") or prose ("to use Bar.Baz instead?") reaches this
         // point; splitting those would produce a plausible-looking but wrong
         // import. Anything that is not a dotted identifier chain is dropped.
-        if (!PATTERNS.QUALIFIED_NAME.test(fullName)) {
+        if (!QUALIFIED_NAME.test(fullName)) {
             logger.debug("ImportSuggestionExtractor", `Rejecting suggestion text that is not a dotted identifier chain: ${fullName}`);
             return null;
         }

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -24,6 +24,8 @@ const PATTERNS = {
     USING_PATH: /using \{ (\/[^}]+) \}/g,
     /** Extracts path from "(/Path:)" format */
     PATH_IN_PARENS: /\((\/[^:)]+):\)/g,
+    /** A dotted chain of Verse identifiers, e.g. "Module.Submodule.Name" */
+    QUALIFIED_NAME: /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/,
 } as const;
 
 /** A resolvable import extracted from a compiler message. */
@@ -93,6 +95,15 @@ export class ImportSuggestionExtractor {
      * @returns The correct module path and class name, or null if invalid
      */
     private findCorrectModulePath(fullName: string): { modulePath: string; className: string } | null {
+        // "Did you mean" captures raw sentence text, so trailing punctuation
+        // ("Economy.Shop.") or prose ("to use Bar.Baz instead?") reaches this
+        // point; splitting those would produce a plausible-looking but wrong
+        // import. Anything that is not a dotted identifier chain is dropped.
+        if (!PATTERNS.QUALIFIED_NAME.test(fullName)) {
+            logger.debug("ImportSuggestionExtractor", `Rejecting suggestion text that is not a dotted identifier chain: ${fullName}`);
+            return null;
+        }
+
         const parts = fullName.split(".");
         if (parts.length < 2) {
             return null;

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -128,6 +128,44 @@ describe("ImportSuggestionExtractor", () => {
 
             expect(suggestions).toHaveLength(0);
         });
+
+        it("should drop a 'Did you mean' suggestion with trailing sentence punctuation", async () => {
+            // Regression #130: the trailing period used to create an empty last
+            // segment, so the split went one level too deep and produced
+            // `using { Economy.Shop }` where `using { Economy }` is correct.
+            const errorMessage = "Unknown identifier `Shop`. Did you mean Economy.Shop.";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(0);
+        });
+
+        it("should drop a 'Did you mean' suggestion that is prose rather than a path", async () => {
+            // Regression #130: this used to produce `using { to use Bar }`
+            const errorMessage = "Unknown identifier `Foo`. Did you mean to use Bar.Baz instead?";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(0);
+        });
+
+        it("should drop a prose 'Did you mean' suggestion without an unknown-identifier prefix", async () => {
+            // Regression #130: this used to produce `using { Self }`
+            const errorMessage = "This call is invalid. Did you mean Self.Widget?";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions).toHaveLength(0);
+        });
+
+        it("should drop prose lines trailing a 'Did you mean any of' option list", async () => {
+            // Regression #130: the trailing sentence used to become an option
+            const errorMessage = "Unknown identifier `Combat`. Did you mean any of: \nSystems.Combat\nFeatures.Combat\nUsed inside module /mygame@fortnite.com/MyGame/Scripts.";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Systems }", "using { Features }"]);
+        });
     });
 
     describe("extractImportsFromDiagnostics", () => {
@@ -178,6 +216,13 @@ describe("ImportSuggestionExtractor", () => {
             const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `image2`. Did you mean Folder1.image2")]);
 
             expect(paths).toEqual(["Folder1"]);
+        });
+
+        it("should not extract a path from a 'Did you mean' suggestion with trailing punctuation", () => {
+            // Regression #130: this used to add "Economy.Shop" instead of "Economy"
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `Shop`. Did you mean Economy.Shop.")]);
+
+            expect(paths).toEqual([]);
         });
 
         it("should deduplicate paths across diagnostics and skip unrelated ones", () => {


### PR DESCRIPTION
Closes #130

## What

A "Did you mean" suggestion is now only turned into an import when it is a dotted chain of Verse identifiers (`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`). Anything else is dropped instead of being split into a plausible-looking but wrong import.

The guard sits at the single chokepoint, `findCorrectModulePath`, so both callers are covered with one rule: `inferFromDidYouMean` (single suggestions) and `parseMultiOptionCandidates` (non-`/` option lines of a "Did you mean any of" list). Both already handle `null`, so no caller changed. This fixes all four bad rows from the issue:

| diagnostic text reaching the extractor | before | after |
|---|---|---|
| `Did you mean Economy.Shop.` | `using { Economy.Shop }` (one level too deep, auto-inserted) | dropped |
| `Did you mean to use Bar.Baz instead?` | `using { to use Bar }` (invalid Verse) | dropped |
| `Did you mean Self.Widget?` | `using { Self }` | dropped |
| `Used inside module /mygame@fortnite.com/MyGame/Scripts.` trailing an option list | became an "option" | dropped |

All five dotted candidates in the captured 41.10 corpus (`Systems.Combat`, `Features.Combat`, `Folder1.image2`, `Folder1.InnerFolder.image3`, `InventoryModule.item`) pass the check; the corpus replay test is unchanged and green, so no real message shape regresses.

## Deliberate omission: no leading-`/` acceptance

The issue's suggested direction mentions accepting "a leading `/` path" as a second legal shape. That half is intentionally not implemented. No corpus entry shows a slash path in a "Did you mean" suggestion, and the old `lastIndexOf(".")` fallback already mangled the common domain-dotted shape (`/Verse.org/Simulation` became `/Verse` + `org/Simulation`), so accepting slash paths would mean inventing a split rule for a message shape never observed. Dropping is the conservative failure mode: worst case a hypothetical valid suggestion produces no auto-import instead of a wrong one. If a future UEFN release starts emitting slash paths in "Did you mean", this is the recorded reason to revisit.

## Tests

Six regression tests added: one per bad row from the issue for `extractImportSuggestions` (the multi-option case asserts the prose line is dropped while the real options survive), plus the trailing-period case for `extractImportsFromDiagnostics`.

## Review gate

Fresh-context reviewer (Opus), two rounds. Round 1: FAIL — one Critical (the changelog edit had replaced the released `## [0.8.0]` heading; restored, the changelog diff is now purely additive), one Important (the leading-`/` omission, downgraded after rationale — documented above), one Suggestion (hoist the shape regex out of the `PATTERNS` message-parsing cascade; applied). Round 2: PASS_WITH_SUGGESTIONS, no blocking findings.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.8.0 compile
> tsc -p ./
```

`npm test`:

```
Test Suites: 14 passed, 14 total
Tests:       199 passed, 199 total
Snapshots:   0 total
Time:        6.612 s, estimated 8 s
Ran all test suites.
```

`npm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```
