### PR TITLE
fix(imports): write imports with the document's own line ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+### Fixed
+
+- **CRLF Files Keep Their Line Endings**: editing imports in a file saved with Windows line endings no longer mixes CRLF and LF. The writers split the document on `\n` and rejoined with `\n`, so every rewritten import line came back LF-only while the untouched body lines kept their carriage returns. Because the rebuilt text could then never equal the original, the "nothing changed" check in **Optimize Imports** never matched, and the command replaced and saved the whole document on every invocation — a full-file diff each time. Imports, the blank line after the import block, and the document body are now written with the line ending the file already uses ([#139])
+
 ## [0.8.0] - 2026-08-04
 
 ### Added
@@ -328,3 +332,4 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#97]: https://github.com/VukeFN/verse-auto-imports/issues/97
 [#120]: https://github.com/VukeFN/verse-auto-imports/issues/120
 [#121]: https://github.com/VukeFN/verse-auto-imports/issues/121
+[#139]: https://github.com/VukeFN/verse-auto-imports/issues/139

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -88,4 +88,9 @@ const ConfigurationTarget = {
     WorkspaceFolder: 3,
 };
 
-export { workspace, window, DiagnosticSeverity, StatusBarAlignment, ConfigurationTarget, Position, Range, WorkspaceEdit };
+const EndOfLine = {
+    LF: 1,
+    CRLF: 2,
+};
+
+export { workspace, window, DiagnosticSeverity, StatusBarAlignment, ConfigurationTarget, EndOfLine, Position, Range, WorkspaceEdit };

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -10,6 +10,39 @@ interface ImportBlock {
     imports: ScannedImport[];
 }
 
+/** The line ending a document is written with. */
+export type LineEnding = "\r\n" | "\n";
+
+/** Splits text into lines without keeping the carriage return of a CRLF pair. */
+const LINE_SPLIT = /\r?\n/;
+
+/**
+ * Detects the dominant line ending of a text, or null when it has no line
+ * break at all and therefore carries no evidence either way.
+ *
+ * Every writer joins with this rather than a hardcoded "\n": on Windows
+ * `files.eol` resolves to CRLF, so joining with LF produces a mixed-ending
+ * buffer and, because the rebuilt text can then never equal the original,
+ * defeats the `organized === text` short-circuit in organizeImports.
+ *
+ * The text is the authority, not TextDocument.eol: the two can disagree, and
+ * only matching what is actually in the buffer keeps a rebuild idempotent.
+ */
+export function detectEol(text: string): LineEnding | null {
+    const crlf = (text.match(/\r\n/g) ?? []).length;
+    const lf = (text.match(/\n/g) ?? []).length - crlf;
+    if (crlf === 0 && lf === 0) {
+        return null;
+    }
+    // A tie means the text is already mixed; LF is the portable choice.
+    return crlf > lf ? "\r\n" : "\n";
+}
+
+/** The line ending VS Code writes new lines with in this document. */
+function documentEol(document: vscode.TextDocument): LineEnding {
+    return document.eol === vscode.EndOfLine.CRLF ? "\r\n" : "\n";
+}
+
 /**
  * Handles all document modifications for imports.
  */
@@ -26,7 +59,15 @@ export class ImportDocumentEditor {
     /**
      * Creates an edit to replace an import block with combined and formatted imports.
      */
-    private createBlockReplacementEdit(edit: vscode.WorkspaceEdit, document: vscode.TextDocument, block: ImportBlock, newPaths: string[], preferDotSyntax: boolean, sortAlphabetically: boolean): void {
+    private createBlockReplacementEdit(
+        edit: vscode.WorkspaceEdit,
+        document: vscode.TextDocument,
+        block: ImportBlock,
+        newPaths: string[],
+        preferDotSyntax: boolean,
+        sortAlphabetically: boolean,
+        eol: LineEnding,
+    ): void {
         // Get existing paths in this block for combined sorting
         const existingBlockPaths = block.imports.map((imp) => imp.path);
 
@@ -39,7 +80,7 @@ export class ImportDocumentEditor {
         const formattedImports = combinedPaths.map((path) => this.formatter.formatImportStatement(path, preferDotSyntax));
 
         // Replace the entire block
-        edit.replace(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)), formattedImports.join("\n") + "\n");
+        edit.replace(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)), formattedImports.join(eol) + eol);
     }
 
     /**
@@ -48,7 +89,7 @@ export class ImportDocumentEditor {
      */
     extractExistingImports(document: vscode.TextDocument): string[] {
         logger.debug("ImportDocumentEditor", "Extracting existing imports from document");
-        const lines = document.getText().split("\n");
+        const lines = document.getText().split(LINE_SPLIT);
         const imports = new Set<string>();
 
         for (const imp of scanModuleImports(lines)) {
@@ -82,7 +123,8 @@ export class ImportDocumentEditor {
         });
 
         const text = document.getText();
-        const lines = text.split("\n");
+        const eol = detectEol(text) ?? documentEol(document);
+        const lines = text.split(LINE_SPLIT);
         const scannedImports = scanModuleImports(lines);
 
         const importBlocks: ImportBlock[] = [];
@@ -163,12 +205,12 @@ export class ImportDocumentEditor {
 
                 // Add digest imports to digest block
                 if (newDigestPaths.length > 0 && digestBlockIndex >= 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], newDigestPaths, preferDotSyntax, sortAlphabetically);
+                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], newDigestPaths, preferDotSyntax, sortAlphabetically, eol);
                 }
 
                 // Add local imports to local block
                 if (newLocalPaths.length > 0 && localBlockIndex >= 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], newLocalPaths, preferDotSyntax, sortAlphabetically);
+                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], newLocalPaths, preferDotSyntax, sortAlphabetically, eol);
                 }
 
                 // Handle imports that don't have a matching block
@@ -181,9 +223,9 @@ export class ImportDocumentEditor {
 
                     // Add unhandled imports at the appropriate position
                     if (importBlocks.length > 0) {
-                        edit.insert(document.uri, new vscode.Position(importBlocks[importBlocks.length - 1].end + 1, 0), unhandledImports.join("\n") + "\n");
+                        edit.insert(document.uri, new vscode.Position(importBlocks[importBlocks.length - 1].end + 1, 0), unhandledImports.join(eol) + eol);
                     } else {
-                        edit.insert(document.uri, new vscode.Position(0, 0), unhandledImports.join("\n") + "\n\n");
+                        edit.insert(document.uri, new vscode.Position(0, 0), unhandledImports.join(eol) + eol + eol);
                     }
                 }
             } else {
@@ -201,7 +243,7 @@ export class ImportDocumentEditor {
                         // branch only sees one block when grouping != "none", since 2+
                         // gapped blocks are handled by the hasGrouping branch above).
                         const firstBlock = importBlocks[0];
-                        edit.replace(document.uri, new vscode.Range(new vscode.Position(firstBlock.start, 0), new vscode.Position(firstBlock.end + 1, 0)), groupedImports.join("\n") + "\n");
+                        edit.replace(document.uri, new vscode.Range(new vscode.Position(firstBlock.start, 0), new vscode.Position(firstBlock.end + 1, 0)), groupedImports.join(eol) + eol);
 
                         for (let i = importBlocks.length - 1; i >= 1; i--) {
                             const block = importBlocks[i];
@@ -209,7 +251,7 @@ export class ImportDocumentEditor {
                         }
                     } else {
                         // No existing imports - insert grouped imports at the top
-                        edit.insert(document.uri, new vscode.Position(0, 0), groupedImports.join("\n") + "\n\n");
+                        edit.insert(document.uri, new vscode.Position(0, 0), groupedImports.join(eol) + eol + eol);
                     }
                 } else {
                     // No grouping or no existing imports - use original behavior
@@ -224,7 +266,7 @@ export class ImportDocumentEditor {
                         // `using { Features }` below a consumer such as
                         // `using { Economy.Shop }`, which breaks Verse's
                         // top-down using resolution.
-                        this.createBlockReplacementEdit(edit, document, importBlocks[0], newImportPathsArray, preferDotSyntax, true);
+                        this.createBlockReplacementEdit(edit, document, importBlocks[0], newImportPathsArray, preferDotSyntax, true, eol);
                     } else {
                         // Sorting off or no existing block: keep the original
                         // append-in-place behavior and leave existing lines
@@ -232,9 +274,9 @@ export class ImportDocumentEditor {
                         const newImports = this.formatter.groupAndFormatImports(newImportPathsArray, preferDotSyntax, sortAlphabetically, importGrouping);
 
                         if (importBlocks.length > 0 && importBlocks[0].start === 0) {
-                            edit.insert(document.uri, new vscode.Position(importBlocks[0].end + 1, 0), newImports.join("\n") + "\n");
+                            edit.insert(document.uri, new vscode.Position(importBlocks[0].end + 1, 0), newImports.join(eol) + eol);
                         } else {
-                            edit.insert(document.uri, new vscode.Position(0, 0), newImports.join("\n") + "\n\n");
+                            edit.insert(document.uri, new vscode.Position(0, 0), newImports.join(eol) + eol + eol);
                         }
                     }
                 }
@@ -248,7 +290,7 @@ export class ImportDocumentEditor {
             const formattedImports = this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping);
 
             // Insert imports at top with minimal spacing (will be fixed by ensureEmptyLinesAfterImports)
-            const importsText = formattedImports.join("\n") + "\n";
+            const importsText = formattedImports.join(eol) + eol;
             edit.insert(document.uri, new vscode.Position(0, 0), importsText);
 
             // Remove existing import blocks (in reverse order to maintain line numbers)
@@ -282,6 +324,10 @@ export class ImportDocumentEditor {
      * (`using:` plus the indented path on the next line). Local-scope `using`
      * statements are left where they are. Returns null when the document has
      * no module imports and no additional paths (nothing to organize).
+     *
+     * The result keeps the text's own line ending, so rebuilding an already
+     * organized document reproduces it byte for byte and organizeImports can
+     * skip the edit.
      */
     buildOrganizedContent(
         text: string,
@@ -290,9 +336,12 @@ export class ImportDocumentEditor {
             preferDotSyntax: boolean;
             sortAlphabetically: boolean;
             importGrouping: string;
+            /** Line ending to use when the text has no line break to detect one from. */
+            fallbackEol?: LineEnding;
         },
     ): string | null {
-        const lines = text.split("\n");
+        const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
+        const lines = text.split(LINE_SPLIT);
         const scannedImports = scanModuleImports(lines);
 
         const paths = scannedImports.map((imp) => imp.path);
@@ -321,10 +370,10 @@ export class ImportDocumentEditor {
         const remainingBody = body.slice(firstContent);
 
         if (remainingBody.length === 0) {
-            return formatted.join("\n") + "\n";
+            return formatted.join(eol) + eol;
         }
 
-        return [...formatted, "", ...remainingBody].join("\n");
+        return [...formatted, "", ...remainingBody].join(eol);
     }
 
     /**
@@ -344,6 +393,7 @@ export class ImportDocumentEditor {
             preferDotSyntax,
             sortAlphabetically,
             importGrouping,
+            fallbackEol: documentEol(document),
         });
 
         if (organized === null || organized === text) {
@@ -381,7 +431,8 @@ export class ImportDocumentEditor {
         logger.debug("ImportDocumentEditor", `Ensuring ${emptyLinesAfterImports} empty lines after imports`);
 
         const text = document.getText();
-        const lines = text.split("\n");
+        const eol = detectEol(text) ?? documentEol(document);
+        const lines = text.split(LINE_SPLIT);
 
         // Find the last file-level import (module imports only: not local-scope
         // using, and not module-scoped imports inside module bodies)
@@ -431,7 +482,7 @@ export class ImportDocumentEditor {
 
         if (lineDifference > 0) {
             // Need to add empty lines
-            const newLines = "\n".repeat(lineDifference);
+            const newLines = eol.repeat(lineDifference);
             const insertPosition = new vscode.Position(lastImportLine + 1, 0);
             edit.insert(document.uri, insertPosition, newLines);
             logger.info("ImportDocumentEditor", `Adding ${lineDifference} empty lines after imports`);

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -44,6 +44,14 @@ function documentEol(document: vscode.TextDocument): LineEnding {
 }
 
 /**
+ * The line ending every write into this document must use. One home for the
+ * policy so the writers cannot drift apart on it.
+ */
+function resolveEol(document: vscode.TextDocument, text: string): LineEnding {
+    return detectEol(text) ?? documentEol(document);
+}
+
+/**
  * Handles all document modifications for imports.
  */
 export class ImportDocumentEditor {
@@ -123,7 +131,7 @@ export class ImportDocumentEditor {
         });
 
         const text = document.getText();
-        const eol = detectEol(text) ?? documentEol(document);
+        const eol = resolveEol(document, text);
         const lines = text.split(LINE_SPLIT);
         const scannedImports = scanModuleImports(lines);
 
@@ -431,7 +439,7 @@ export class ImportDocumentEditor {
         logger.debug("ImportDocumentEditor", `Ensuring ${emptyLinesAfterImports} empty lines after imports`);
 
         const text = document.getText();
-        const eol = detectEol(text) ?? documentEol(document);
+        const eol = resolveEol(document, text);
         const lines = text.split(LINE_SPLIT);
 
         // Find the last file-level import (module imports only: not local-scope

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1,6 +1,29 @@
-import { ImportDocumentEditor } from "../ImportDocumentEditor";
+import { detectEol, ImportDocumentEditor } from "../ImportDocumentEditor";
 import { ImportFormatter } from "../ImportFormatter";
 import * as vscode from "vscode";
+
+describe("detectEol", () => {
+    it("returns null for a text with no line break", () => {
+        expect(detectEol("code()")).toBeNull();
+    });
+
+    it("detects LF", () => {
+        expect(detectEol("a\nb\n")).toBe("\n");
+    });
+
+    it("detects CRLF", () => {
+        expect(detectEol("a\r\nb\r\n")).toBe("\r\n");
+    });
+
+    it("takes the dominant ending in a mixed text", () => {
+        expect(detectEol("a\r\nb\r\nc\n")).toBe("\r\n");
+        expect(detectEol("a\nb\nc\r\n")).toBe("\n");
+    });
+
+    it("prefers LF on a tie", () => {
+        expect(detectEol("a\r\nb\n")).toBe("\n");
+    });
+});
 
 describe("ImportDocumentEditor.buildOrganizedContent", () => {
     let editor: ImportDocumentEditor;
@@ -109,6 +132,35 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             ["using { /Top }", "", "Utilities := module:", "    using { /Verse.org/Random }", "", "    GenerateId<public>():int = 1"].join("\n"),
         );
     });
+
+    // A CRLF document must come back CRLF throughout: joining with LF left the
+    // body lines carrying their original "\r" and produced a mixed buffer.
+    it("keeps CRLF endings when reorganizing a CRLF document", () => {
+        const input = "using { /B }\r\nusing { /A }\r\ncode()\r\n";
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe("using { /A }\r\nusing { /B }\r\n\r\ncode()\r\n");
+    });
+
+    it("reproduces an already organized CRLF document exactly, so organize can skip the edit", () => {
+        const input = "using { /A }\r\n\r\ncode()\r\n";
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
+    });
+
+    it("keeps CRLF endings when adding a path to a CRLF document", () => {
+        const input = "using { /Existing }\r\ncode()\r\n";
+        expect(editor.buildOrganizedContent(input, ["/Added"], curlySorted)).toBe("using { /Added }\r\nusing { /Existing }\r\n\r\ncode()\r\n");
+    });
+
+    it("keeps CRLF endings for a CRLF file that is nothing but imports", () => {
+        expect(editor.buildOrganizedContent("using { /B }\r\nusing { /A }", [], curlySorted)).toBe("using { /A }\r\nusing { /B }\r\n");
+    });
+
+    it("uses the fallback ending when the text has no line break to detect one from", () => {
+        expect(editor.buildOrganizedContent("code()", ["/New"], { ...curlyNoSort, fallbackEol: "\r\n" })).toBe("using { /New }\r\n\r\ncode()");
+    });
+
+    it("still writes LF for an LF document even when the fallback is CRLF", () => {
+        expect(editor.buildOrganizedContent("using { /A }\ncode()", [], { ...curlyNoSort, fallbackEol: "\r\n" })).toBe("using { /A }\n\ncode()");
+    });
 });
 
 interface RecordedOperation {
@@ -118,11 +170,12 @@ interface RecordedOperation {
     text?: string;
 }
 
-function fakeDocument(text: string): vscode.TextDocument {
-    const lines = text.split("\n");
+function fakeDocument(text: string, eol: number = vscode.EndOfLine.LF): vscode.TextDocument {
+    const lines = text.split(/\r?\n/);
     return {
         uri: { toString: () => "file:///test.verse" },
         getText: () => text,
+        eol,
         lineCount: lines.length,
         lineAt: (index: number) => ({ range: { end: new vscode.Position(index, lines[index].length) } }),
     } as unknown as vscode.TextDocument;
@@ -339,6 +392,46 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(insert!.text).toBe("using { Features }\n");
     });
 
+    it("writes CRLF endings into a CRLF document when merging into an existing block", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "none",
+            "behavior.sortImportsAlphabetically": true,
+        });
+        const input = "using { Economy.Shop }\r\n\r\nhello := 1\r\n";
+
+        const success = await editor.addImportsToDocument(fakeDocument(input, vscode.EndOfLine.CRLF), ["using { Features }"]);
+
+        expect(success).toBe(true);
+        const replace = appliedOperations(0).find((op) => op.kind === "replace");
+        expect(replace!.text).toBe("using { Features }\r\nusing { Economy.Shop }\r\n");
+    });
+
+    it("writes CRLF endings into a CRLF document when inserting a new block at the top", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "digestFirst",
+        });
+        const input = "hello := 1\r\nworld := 2\r\n";
+
+        const success = await editor.addImportsToDocument(fakeDocument(input, vscode.EndOfLine.CRLF), ["using { /Fortnite.com/Random }"]);
+
+        expect(success).toBe(true);
+        const insert = appliedOperations(0).find((op) => op.kind === "insert");
+        expect(insert!.text).toBe("using { /Fortnite.com/Random }\r\n\r\n");
+    });
+
+    it("writes CRLF endings into a CRLF document when consolidating at the top", async () => {
+        mockConfig({ "behavior.preserveImportLocations": false });
+        const input = "using { /Verse.org/Simulation }\r\n\r\nhello := 1\r\n";
+
+        const success = await editor.addImportsToDocument(fakeDocument(input, vscode.EndOfLine.CRLF), ["using { /Fortnite.com/Devices }"]);
+
+        expect(success).toBe(true);
+        const insert = appliedOperations(0).find((op) => op.kind === "insert");
+        expect(insert!.text).toBe("using { /Fortnite.com/Devices }\r\nusing { /Verse.org/Simulation }\r\n");
+    });
+
     it("preserve + digestFirst: inserts at the top when the file has no existing imports", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,
@@ -390,5 +483,17 @@ describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {
         expect(operations).toHaveLength(1);
         expect(operations[0].kind).toBe("insert");
         expect(operations[0].position!.line).toBe(1);
+    });
+
+    // This runs right after both writers, so an LF blank line here would put
+    // back the mixed endings they now avoid.
+    it("inserts a CRLF blank line in a CRLF document", async () => {
+        const input = "using { /Top }\r\ncode()\r\n";
+
+        const success = await editor.ensureEmptyLinesAfterImports(fakeDocument(input, vscode.EndOfLine.CRLF));
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+        expect(operations[0].text).toBe("\r\n");
     });
 });


### PR DESCRIPTION
Closes #139

## What was wrong

`buildOrganizedContent` and `addImportsToDocument` split the document on `"\n"` and rejoined with `"\n"`. Body lines therefore kept the `\r` of their CRLF pairs while every regenerated import line came back LF-only, so on Windows — where `files.eol` resolves to CRLF — each import edit left a mixed-ending buffer.

The same defect made the rebuilt text unable to equal the original, so the `organized === text` short-circuit in `organizeImports` never fired. Optimize Imports did a full-document replace plus `document.save()` on every invocation, even on a file that was already organized.

## The fix

Both writers now split on `/\r?\n/` and join with the line ending the text already uses.

Detection reads the text rather than `TextDocument.eol`, because the two can disagree and only matching what is actually in the buffer makes a rebuild reproduce the document byte for byte — which is what lets the idempotency check fire. `TextDocument.eol` is the fallback for the one case the text gives no evidence for: a file with no line break at all.

`ensureEmptyLinesAfterImports` is changed too. It is not named in the ticket, but it runs at the tail of both writers and again on save, so leaving it on `"\n"` would insert a lone LF straight back into the document the writers had just made consistent — the fix is incomplete without it.

## Tests

Twelve new tests in `ImportDocumentEditor.test.ts`, covering `detectEol` directly plus CRLF behaviour of all three methods, including the exact idempotency case from the issue.

They were confirmed to bite: with the EOL detection forced back to LF, ten of them fail, and with the source fully reverted the suite does not compile. The test-document helper and the `vscode` mock gained `eol` / `EndOfLine` to support this.

## Verification

```
$ npm run compile
> tsc -p ./
(clean)

$ npm test
Test Suites: 14 passed, 14 total
Tests:       209 passed, 209 total
Snapshots:   0 total
Time:        6.82 s

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

## Review

Reviewed by a fresh model against the ticket and the repo conventions: verdict `PASS_WITH_SUGGESTIONS`, no Critical findings. The one suggestion applied is the second commit, which collapses the duplicated EOL-resolution expression into a single `resolveEol` helper. The remaining suggestions were left alone as out of scope: `ImportPathConverter.ts:533` still splits on `"\n"`, which is harmless there (its replacement text contains no newline) but would be worth aligning in a follow-up.
