### PR TITLE
ci: trigger CI on merge_group so a merge queue can gate on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Required for the merge queue: a queued PR is built on a temporary
-  # gh-readonly-queue/main/... ref, which is neither a push nor a pull_request.
-  # Without this the required checks never report and the queue hangs.
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for the merge queue: a queued PR is built on a temporary
+  # gh-readonly-queue/main/... ref, which is neither a push nor a pull_request.
+  # Without this the required checks never report and the queue hangs.
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   build:


### PR DESCRIPTION
Step 1 of #152. Lands alone, before the ruleset change.

A queued PR is built on a temporary `gh-readonly-queue/main/...` ref, which is neither a `push` nor a `pull_request`. Per GitHub's docs, without a `merge_group` trigger "the merge will fail as the required status check will not be reported" — the queue would wait forever on a `build` that never runs. So the trigger has to be on `main` *before* the `merge_queue` rule exists, not after.

`checks_requested` is the only valid activity type today; naming it explicitly is what the docs recommend so the workflow stays specific if more are added.

No changelog entry: CI plumbing is not user-facing, and `CLAUDE.md` scopes the requirement to changes that are.

## Verification

```
npm run compile      tsc, no errors
npm test             14 suites, 221 tests, all passed
npm run format:check All matched files use Prettier code style!
```

`push` and `pull_request` resolve byte-identically to before; `merge_group` is a correctly-indented sibling. Jobs still resolve to `[build, test-integration]`.

## Review

`verdict: PASS_WITH_SUGGESTIONS`, no Critical findings. Two things worth recording, neither blocking:

**Important, pre-existing, and it falsifies a premise in #152.** `pr-artifact.yml` has a job named `build` — the same string as the sole required check context. PR #149's head SHA carries two check runs called `build`, both from the `github-actions` app, which `integration_id` cannot disambiguate. It does not hang the queue, because `pr-artifact.yml` is `pull_request`-only and a merge group sees exactly one `build`. But it means `build` denotes two things on a PR and one in the queue, and `pr-artifact.yml`'s version runs neither the tests nor the format check. **Worth renaming to `package` before step 2**, not after.

**Suggestion, deliberately not taken.** `merge_group` carries no `branches:` filter while the other two are pinned to `[main]`. `on.merge_group.branches` appears to work but is undocumented (github/docs#32879), and relying on an undocumented filter seemed worse than the asymmetry. Correct as written, since the queue is only being enabled on the default branch.

Closes #152