### PR TITLE
ci: rename the pr-artifact job to `package` so it stops colliding with the required check

### DIFF
--- a/.github/workflows/pr-artifact.yml
+++ b/.github/workflows/pr-artifact.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  package:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Prerequisite for the ruleset half of #152 — it should land before the `merge_queue` rule, not after.

`pr-artifact.yml` named its job `build`, the same string as the sole required status check context (produced by `ci.yml`). Both come from the `github-actions` app, so `integration_id` cannot disambiguate them: PR #149's head SHA carried two check runs called `build`.

It has been harmless so far, because `pr-artifact.yml` is `pull_request`-only and a merge group therefore sees exactly one `build`. Under a queue it stops being harmless — the required context would resolve against two runs on a PR and one in the queue, so the gate means different things on either side of it. And `pr-artifact.yml`'s `build` runs neither `npm test` nor `npm run format:check`; it compiles and packages. One of the two things answering to the required gate never ran the suite.

`package` says what the job actually does. No `needs:` anywhere referenced the old name, so nothing else changes.

No changelog entry — CI plumbing is not user-facing.

## Verification

```
npm run compile      tsc, no errors
npm test             14 suites, 221 tests passed
npm run format:check All matched files use Prettier code style!
```

The real check is on this PR itself: its head SHA should now carry exactly **one** check run named `build`, and one named `package`.

Closes #155