### PR TITLE
ci: harden release prep turn limit and Discord announce step

### DIFF
--- a/.github/workflows/claude-release-prep.yml
+++ b/.github/workflows/claude-release-prep.yml
@@ -87,7 +87,12 @@ jobs:
                GitHub Release which they publish to ship to the Marketplace.
 
             Rules: no emojis, no AI attribution in commits, conventional commit
-            prefixes only.
+            prefixes only. Create exactly one branch (chore/release-vX.Y.Z) and
+            open exactly one PR (the release PR in step 6). Do not open any
+            other PR or branch, do not file issues, and do not run checks or
+            fixes beyond what the steps above ask for - pushing the release
+            branch and opening the release PR take priority over everything
+            optional.
           claude_args: |
             --allowedTools "Bash(npm ci),Bash(npm run compile),Bash(npm test),Bash(npm install --package-lock-only),Bash(git:*),Bash(gh pr:*),Bash(gh api:*),Read,Write,Edit,Grep,Glob"
-            --max-turns 30
+            --max-turns 60

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,10 +48,29 @@ jobs:
           RELEASE_BODY: ${{ github.event.release.body }}
           RELEASE_URL: ${{ github.event.release.html_url }}
         run: |
-          # Escape special characters for JSON
-          ESCAPED_BODY=$(echo "$RELEASE_BODY" | jq -Rs '.')
+          # Discord renders HTML in embed descriptions as literal text and
+          # rejects descriptions over 4096 characters. Strip only known HTML
+          # tags - a bare <[^>]*> pattern would also eat the Verse specifiers
+          # these release notes quote, like <public> - and run sed over the
+          # whole input (-z) so a tag wrapped across lines is still caught.
+          CLEAN_BODY=$(printf '%s' "$RELEASE_BODY" | sed -Ez 's#</?(a|b|br|center|details|div|em|font|h[1-6]|hr|i|img|p|picture|source|span|strong|summary)\b[^>]*>|<!--[^>]*-->##g')
+          MAX_BODY_LENGTH=3900
+          if [ "${#CLEAN_BODY}" -gt "$MAX_BODY_LENGTH" ]; then
+            # Cut back to the last newline under the budget so the cut cannot
+            # land mid-line, then point at the full notes.
+            CLEAN_BODY="${CLEAN_BODY:0:$MAX_BODY_LENGTH}"
+            CLEAN_BODY="${CLEAN_BODY%$'\n'*}"$'\n\n'"[Full release notes](${RELEASE_URL})"
+          fi
+          if [ -z "$CLEAN_BODY" ]; then
+            CLEAN_BODY="See the [GitHub Release](${RELEASE_URL})."
+          fi
 
-          curl -H "Content-Type: application/json" \
+          # Escape special characters for JSON
+          ESCAPED_BODY=$(printf '%s' "$CLEAN_BODY" | jq -Rs '.')
+
+          # --fail-with-body makes a rejected webhook fail the step; this runs
+          # after the Marketplace publish, so failing here is safe and honest.
+          curl --fail-with-body -H "Content-Type: application/json" \
             -d "{
               \"content\": \"@everyone\",
               \"embeds\": [{


### PR DESCRIPTION
Closes #102

## What

Two release-pipeline reliability fixes from the v0.7.0 release postmortem.

**claude-release-prep.yml**

- `--max-turns` raised 30 to 60. Run 29170709473 died at the cap after the release commit but before pushing the branch and opening the PR.
- The prompt now forbids intermediate PRs, extra branches, filed issues, and checks beyond the listed steps, and states that pushing the release branch and opening the release PR take priority over everything optional.

**publish.yml, Discord announce step**

- Strips only a known-HTML tag allowlist instead of every `<...>` token: release notes in this repo quote Verse specifiers (`<public>`, `<native>`, `<scoped {module}>`, ...) that a blanket strip would silently delete. `sed -Ez` runs over the whole body, so a tag wrapped across lines is still caught.
- Truncates to a 3900-char budget (Discord caps embed descriptions at 4096), cutting back to the last newline and appending a link to the full notes. Measured against real bodies: `[0.7.0]` (7561 chars, the release that blew the cap) truncates to 3909; `[0.8.0]` (3529 chars) passes through whole.
- Falls back to the release link when the stripped body is empty.
- `curl --fail-with-body`, so a rejected webhook fails the step instead of reporting success. The step runs after the Marketplace publish, so failing is safe and honest.

No CHANGELOG entry: both files are release automation with no effect on the shipped extension.

## Verification

```
> verse-auto-imports@0.8.0 compile
> tsc -p ./

> verse-auto-imports@0.8.0 test
> jest --verbose

Test Suites: 14 passed, 14 total
Tests:       221 passed, 221 total
Snapshots:   0 total
Time:        5.332 s, estimated 9 s
Ran all test suites.

> verse-auto-imports@0.8.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Both workflows parse with js-yaml. The announce-step bash was exercised locally (GNU sed 4.9, bash 5.x, same family as ubuntu-latest): every Verse specifier appearing in CHANGELOG.md survives byte-for-byte, single-line and hand-wrapped multi-line HTML tags and comments are stripped, worst-case output is 3988 chars (108 under the cap), and empty or HTML-only bodies fall back to the release link.

## Review

Fresh-model review gate: round 1 FAIL - Critical: the first cut used a blanket `<[^>]*>` strip, which deleted Verse specifiers from real release bodies; fixed with the tag-name allowlist. Round 2: PASS_WITH_SUGGESTIONS.

Suggestions on record, not taken here:

- Building the whole webhook payload with `jq -n --arg ...` would escape `RELEASE_TAG` and `RELEASE_URL` too; left out because it rewrites payload assembly this ticket does not touch.
- The allowlist omits tags such as `kbd`, `code`, `pre`. No release body in this repo's history contains any HTML beyond two comments, and the failure mode is benign (visible markup, not deleted content). If such tags appear later, extend the list, checking each short name against the Verse specifier vocabulary first.
