### PR TITLE
feat(ui): use a command category instead of the "Verse:" title prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+### Changed
+
+- **Commands Grouped Under a Verse Auto Imports Category**: every command now appears in the command palette as **Verse Auto Imports: Optimize Imports**, **Verse Auto Imports: Show Quick Menu** and so on. The `Verse: ` prefix was hardcoded into each command title, which read as though the commands belonged to Epic's official Verse extension; it now lives in the palette category field, where VS Code renders it in front of the title and groups the extension's commands together. The command IDs are unchanged, so existing keybindings and tasks that reference `verseAutoImports.*` keep working ([#94])
+
 ### Fixed
 
 - **CRLF Files Keep Their Line Endings**: editing imports in a file saved with Windows line endings no longer mixes CRLF and LF. The writers split the document on `\n` and rejoined with `\n`, so every rewritten import line came back LF-only while the untouched body lines kept their carriage returns. Because the rebuilt text could then never equal the original, the "nothing changed" check in **Optimize Imports** never matched, and the command replaced and saved the whole document on every invocation — a full-file diff each time. Imports, the blank line after the import block, and the document body are now written with the line ending the file already uses ([#139])
-- **Snooze No Longer Disables Auto Import Permanently**: **Verse: Snooze Auto Import** no longer writes `general.autoImport: false` into your user settings. It previously did, and only an in-memory timer ever wrote the value back, so a window reload, a VS Code restart, an update, or a crash during the five-minute snooze left auto import switched off for good — with no countdown in the status bar and no message connecting it to a snooze taken days earlier. The snooze is now held in memory and consulted by the auto-import check, which also means a reload simply ends the snooze instead of extending it forever. The status menu shows `Snoozed (M:SS)` on the Auto Import row while one is active. If an earlier snooze already left the setting off, re-enable **Auto Import** from the status bar menu once ([#132])
+- **Snooze No Longer Disables Auto Import Permanently**: **Verse Auto Imports: Snooze Auto Import** no longer writes `general.autoImport: false` into your user settings. It previously did, and only an in-memory timer ever wrote the value back, so a window reload, a VS Code restart, an update, or a crash during the five-minute snooze left auto import switched off for good — with no countdown in the status bar and no message connecting it to a snooze taken days earlier. The snooze is now held in memory and consulted by the auto-import check, which also means a reload simply ends the snooze instead of extending it forever. The status menu shows `Snoozed (M:SS)` on the Auto Import row while one is active. If an earlier snooze already left the setting off, re-enable **Auto Import** from the status bar menu once ([#132])
 - **"Did you mean" Suggestions Are Shape-Checked Before Import**: a "Did you mean" suggestion is now only turned into an import when it is a dotted chain of Verse identifiers; anything else, such as trailing sentence punctuation ("Did you mean Economy.Shop.") or prose ("Did you mean to use Bar.Baz instead?"), is dropped instead of being split into a plausible-looking but wrong import. Previously the raw suggestion text was split on its last period with no validation, so a trailing period produced an import one module level too deep (`using { Economy.Shop }` where `using { Economy }` is correct) and prose produced syntactically invalid Verse (`using { to use Bar }`), both emitted with high confidence and auto-inserted. Prose lines trailing a "Did you mean any of" option list are dropped the same way ([#130])
 
 ## [0.8.0] - 2026-08-04
@@ -330,6 +334,7 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 [#90]: https://github.com/VukeFN/verse-auto-imports/issues/90
 [#91]: https://github.com/VukeFN/verse-auto-imports/issues/91
 [#93]: https://github.com/VukeFN/verse-auto-imports/issues/93
+[#94]: https://github.com/VukeFN/verse-auto-imports/issues/94
 [#95]: https://github.com/VukeFN/verse-auto-imports/issues/95
 [#97]: https://github.com/VukeFN/verse-auto-imports/issues/97
 [#120]: https://github.com/VukeFN/verse-auto-imports/issues/120

--- a/package.json
+++ b/package.json
@@ -26,79 +26,98 @@
     "commands": [
       {
         "command": "verseAutoImports.showStatusMenu",
-        "title": "Verse: Show Quick Menu"
+        "title": "Show Quick Menu",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.optimizeImports",
-        "title": "Verse: Optimize Imports"
+        "title": "Optimize Imports",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.addSingleImport",
-        "title": "Verse: Add Import"
+        "title": "Add Import",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.toggleAutoImport",
-        "title": "Verse: Toggle Auto Import"
+        "title": "Toggle Auto Import",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.togglePreserveLocations",
-        "title": "Verse: Toggle Preserve Import Locations"
+        "title": "Toggle Preserve Import Locations",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.toggleImportSyntax",
-        "title": "Verse: Toggle Import Syntax"
+        "title": "Toggle Import Syntax",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.toggleDigestFiles",
-        "title": "Verse: Toggle Digest Files"
+        "title": "Toggle Digest Files",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.toggleFullPathCodeLens",
-        "title": "Verse: Toggle Path Conversion Helper"
+        "title": "Toggle Path Conversion Helper",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.snoozeAutoImport",
-        "title": "Verse: Snooze Auto Import"
+        "title": "Snooze Auto Import",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.cancelSnooze",
-        "title": "Verse: Cancel Snooze"
+        "title": "Cancel Snooze",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.convertToFullPath",
-        "title": "Verse: Use Absolute Path"
+        "title": "Use Absolute Path",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.convertAllToFullPath",
-        "title": "Verse: Use Absolute Paths for All"
+        "title": "Use Absolute Paths for All",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.convertToRelativePath",
-        "title": "Verse: Use Relative Path"
+        "title": "Use Relative Path",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.convertAllToRelativePath",
-        "title": "Verse: Use Relative Paths for All"
+        "title": "Use Relative Paths for All",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.exportDebugLogs",
-        "title": "Verse: Export Debug Logs"
+        "title": "Export Debug Logs",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.captureDiagnosticsCorpus",
-        "title": "Verse: Capture Diagnostics Corpus"
+        "title": "Capture Diagnostics Corpus",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.rebuildPathCache",
-        "title": "Verse: Rebuild Project Path Cache"
+        "title": "Rebuild Project Path Cache",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.clearPathCache",
-        "title": "Verse: Clear Project Path Cache"
+        "title": "Clear Project Path Cache",
+        "category": "Verse Auto Imports"
       },
       {
         "command": "verseAutoImports.showCacheStatus",
-        "title": "Verse: Show Cache Status"
+        "title": "Show Cache Status",
+        "category": "Verse Auto Imports"
       }
     ],
     "configuration": {

--- a/test-fixtures/corpus/README.md
+++ b/test-fixtures/corpus/README.md
@@ -57,8 +57,8 @@ and asserts, for each entry, the output of both extraction paths.
 
 1. During a smoke session (see `test-fixtures/uefn-smoke/PLAYBOOK.md`), open
    the fixture files so the Verse LSP reports their diagnostics.
-2. Run the command **Verse: Capture Diagnostics Corpus**. It writes the
-   verbatim diagnostics of all open `.verse` files to a JSON file.
+2. Run the command **Verse Auto Imports: Capture Diagnostics Corpus**. It
+   writes the verbatim diagnostics of all open `.verse` files to a JSON file.
 3. Curate the capture into entries: keep one entry per distinct message
    shape, fill in the two `expected` arrays, mark `source: "captured"`.
 4. For a new UEFN version, create a new folder rather than editing the old

--- a/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T4_path_conversion.verse
@@ -16,8 +16,9 @@
 #   fix). Expect both locations detected.
 #
 # Steps: hover each import line, use the conversion CodeLens, then run the
-# bulk "convert all" command. Also run "Rebuild Project Path Cache" first and
-# compare behavior with cache.enabled true vs false.
+# bulk "convert all" command. Also run
+# "Verse Auto Imports: Rebuild Project Path Cache" first and compare behavior
+# with cache.enabled true vs false.
 
 using { Gadgets.Tools }
 using { Combat.Weapons }

--- a/test-fixtures/uefn-smoke/Content/Scripts/T5_optimize.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T5_optimize.verse
@@ -6,8 +6,9 @@
 # local-scope using inside a function body, and an indented-style using block
 # at the bottom.
 #
-# Run "Verse: Optimize Imports" with general.autoImport ON, then again on a
-# re-synced copy with it OFF. Expected in both cases, as ONE atomic edit:
+# Run "Verse Auto Imports: Optimize Imports" with general.autoImport ON, then
+# again on a re-synced copy with it OFF. Expected in both cases, as ONE atomic
+# edit:
 #   - all module imports consolidated at the top, deduplicated
 #   - using { /Fortnite.com/Characters } ADDED (from the fort_character
 #     diagnostic; must be single-option so optimize can apply it)

--- a/test-fixtures/uefn-smoke/Content/Scripts/T6_styles.verse
+++ b/test-fixtures/uefn-smoke/Content/Scripts/T6_styles.verse
@@ -5,8 +5,8 @@
 #   behavior.importSyntax (curly <-> dot)
 #   behavior.importGrouping (none / digestFirst / localFirst)
 #   behavior.sortImportsAlphabetically
-# and run "Verse: Optimize Imports" after each flip. Verify layout matches the
-# setting and that repeated runs are idempotent.
+# and run "Verse Auto Imports: Optimize Imports" after each flip. Verify
+# layout matches the setting and that repeated runs are idempotent.
 
 using { /Verse.org/Simulation }
 using { /Fortnite.com/Devices }

--- a/test-fixtures/uefn-smoke/Content/T9/t9_relative_imports.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/t9_relative_imports.verse
@@ -1,7 +1,7 @@
 # T9 cases A-C: relative import forms documented in the Book of Verse
 # (16_modules, "Local and Relative Imports"). Uncomment ONE case at a time,
 # push Verse changes, and record the verbatim outcome (clean compile or the
-# exact diagnostic) via "Verse: Capture Diagnostics Corpus".
+# exact diagnostic) via "Verse Auto Imports: Capture Diagnostics Corpus".
 # Results gate the fix design for issue #65.
 
 # Case A: bare same-directory module import (module folder T9/Sub)

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -62,10 +62,11 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 2. [ ] Debug channel shows the project detected as
        `/vukefn@fortnite.com/VerseAutoImports` (from .uefnproject found in the
        parent of Content).
-3. [ ] Run "Verse: Rebuild Project Path Cache". Debug log file count must
-       correspond to Content fixtures only -- if it reports scanning
-       hundreds of files or mentions digest folders (/Verse.org etc.), the
-       scan is leaking into other workspace roots. Record the count.
+3. [ ] Run "Verse Auto Imports: Rebuild Project Path Cache". Debug log file
+       count must correspond to Content fixtures only -- if it reports
+       scanning hundreds of files or mentions digest folders (/Verse.org
+       etc.), the scan is leaking into other workspace roots. Record the
+       count.
 4. [ ] Open `Fortnite.digest.verse` from the /Fortnite.com root: no CodeLens
        spam, no auto-import activity triggered by it.
 
@@ -128,10 +129,10 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 
 ### T5 -- Optimize Imports (fixture: Scripts/T5_optimize.verse)
 
-1. [ ] With autoImport ON: run "Verse: Optimize Imports" once. All expected
-       outcomes in the fixture header hold; specifically the missing
-       SpatialMath import is added in the SAME single edit (no visible
-       intermediate state where imports vanish), the local-scope
+1. [ ] With autoImport ON: run "Verse Auto Imports: Optimize Imports" once.
+       All expected outcomes in the fixture header hold; specifically the
+       missing SpatialMath import is added in the SAME single edit (no
+       visible intermediate state where imports vanish), the local-scope
        `using { Helper }` is untouched, and one Ctrl+Z restores the original.
 2. [ ] Re-sync the fixture, set general.autoImport OFF, repeat: identical end
        state.
@@ -148,8 +149,9 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 
 ### T7 -- cache commands and settings
 
-1. [ ] "Verse: Rebuild Project Path Cache" and "Verse: Clear Project Path
-       Cache" both exist in the palette and log sensible results.
+1. [ ] "Verse Auto Imports: Rebuild Project Path Cache" and
+       "Verse Auto Imports: Clear Project Path Cache" both exist in the
+       palette and log sensible results.
 2. [ ] Rebuild reports a plausible file/module count for the fixtures.
 3. [ ] Toggle the three cache.* settings; no errors on flip; behavior follows
        (see T4.5).
@@ -178,9 +180,10 @@ Each case checks whether live UEFN accepts a construct documented in the Book
 of Verse; the results decide the fix design for #65 (relative import
 classification) and #71 (import aliases), and give live regression coverage
 for #67/#68. For every case record the verbatim outcome (clean compile, or
-the exact diagnostic) with "Verse: Capture Diagnostics Corpus", then fold new
-message shapes into test-fixtures/corpus/<UEFN version>/diagnostics.json with
-expectations filled in (see test-fixtures/corpus/README.md).
+the exact diagnostic) with "Verse Auto Imports: Capture Diagnostics Corpus",
+then fold new message shapes into
+test-fixtures/corpus/<UEFN version>/diagnostics.json with expectations filled
+in (see test-fixtures/corpus/README.md).
 
 1. [ ] Case A bare same-directory import: in t9_relative_imports.verse,
        uncomment `using { Sub }` (plus the probe line). Compiles or exact
@@ -193,7 +196,8 @@ expectations filled in (see test-fixtures/corpus/README.md).
        synced. Then remove the indented `/Verse.org/Simulation` pair, wait
        for the auto-import to re-add it, and confirm the module-scoped
        `using { /Verse.org/Random }` was not moved, deleted, or duplicated.
-       Run "Verse: Optimize Imports" and save: same expectation (#67 live).
+       Run "Verse Auto Imports: Optimize Imports" and save: same expectation
+       (#67 live).
 5. [ ] Case E indented style (same file): re-sync the fixture so the
        `using:` pair is back, then trigger any auto-import in the file (e.g.
        reference `button_device`). The pair must be consolidated into the
@@ -204,8 +208,8 @@ expectations filled in (see test-fixtures/corpus/README.md).
        `using { /Verse.org/SpatialMath }` below and confirm the extension
        does not add duplicates or misbehave in the file (#71).
 7. [ ] Capture: with all T9 files open and their diagnostics present, run
-       "Verse: Capture Diagnostics Corpus" and curate the output into the
-       corpus folder for this UEFN version.
+       "Verse Auto Imports: Capture Diagnostics Corpus" and curate the output
+       into the corpus folder for this UEFN version.
 
 ## Phase D: verdict
 

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -119,8 +119,8 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 3. [ ] Case C `Economy.Shop` (explicit module declared in two files): both
        locations detected (Systems and Features). This exercises the cache
        lookup path and the #43 regex fix across multiple files.
-4. [ ] Bulk command "Convert All Imports to Full Paths" handles all three
-       lines coherently in one pass.
+4. [ ] Bulk command "Verse Auto Imports: Use Absolute Paths for All" handles
+       all three lines coherently in one pass.
 5. [ ] Cache off/on: set `cache.enabled` false, reload, repeat case C
        (pure filesystem path), then re-enable, rebuild cache, repeat again.
        Same results both ways; Debug log shows cache hits when enabled.


### PR DESCRIPTION
Closes #94

All 19 contributed commands hardcoded `Verse: ` into their titles and set no category, so the command palette listed them as though they belonged to Epic's official Verse extension. The prefix now lives in `contributes.commands[].category` ("Verse Auto Imports"), which VS Code renders in front of the title and uses to group an extension's commands together. The palette now reads **Verse Auto Imports: Optimize Imports**.

Command IDs are unchanged, so keybindings and tasks referencing `verseAutoImports.*` keep working. `contributes` holds only `icons`, `commands` and `configuration` - no menus, keybindings or walkthroughs needed a matching change.

Documentation touched: `test-fixtures/uefn-smoke/PLAYBOOK.md`, `test-fixtures/corpus/README.md` and four smoke fixture headers. The still-unreleased `[#132]` changelog entry was renamed too, since it ships in the same version and would otherwise document a palette entry that never existed. Released changelog sections are left as the historical record.

A second commit fixes two references the sweep would have missed - they were stale for a different reason, naming commands that do not exist ("Convert All Imports to Full Paths", a bare "Rebuild Project Path Cache").

The ticket also asks for the wiki. That is a separate repository documenting the released extension, so it is deliberately not in this PR - the wiki edit belongs with the release that ships this change.

## Verification

```
$ npm run compile
> tsc -p ./

$ npm test
Test Suites: 14 passed, 14 total
Tests:       221 passed, 221 total
Snapshots:   0 total
Time:        9.388 s
Ran all test suites.

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

Manifest checked programmatically: 19 commands, every one carrying the category, no title retaining a prefix, and the sorted set of command IDs byte-identical to `main`.

## Review

Reviewed by a separate agent against the ticket and the repo conventions. Verdict: PASS_WITH_SUGGESTIONS, no Critical findings. Both suggestions were the stale references above; both are fixed in `9d9baa2`.