### PR TITLE
docs: document the squash-only merge convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ GitHub Flow: `main` is the only long-lived branch and the default branch. There 
 
 - Every change branches from `main` and returns by PR into `main`. Because PRs target the default branch, `Closes #N` in a PR body actually links and closes the issue — always use it.
 - Branch prefixes: `feature/` `fix/` `chore/` `docs/` `test/` `refactor/`. A hotfix is just a `fix/` branch; it needs no special path.
+- Merge method: every PR into `main` is **squash-merged**. The `Default Branch` ruleset restricts it — `squash` is the only merge method allowed there — so this is not convention alone, though repo admins can bypass that ruleset. Repo settings still permit merge commits, which governs any branch the ruleset does not cover.
+- A squash merge replays the branch as one new commit, so a branch's own commits **never become ancestors of `main`**. Any check shaped like "is this commit on `main`" reports a fully-landed branch as unmerged; compare file content instead. Merge commits earlier in the history predate this convention — do not infer the merge method from `git log`.
 - Release: a `chore/release-vX.Y.Z` PR into `main` bumps the version and finalizes the changelog. Merging it produces a draft GitHub Release; publishing that draft ships to the Marketplace.
 - `release/X.Y` branches are cut **retroactively**, and only to patch an older released line. Do not create one in advance.
 


### PR DESCRIPTION
Closes #159

Adds two bullets to `## Git workflow` in `CLAUDE.md`: the merge method, and the ancestry consequence that follows from it.

The convention was only ever recorded in an untracked `.claude/` file (`.gitignore:39` is `.claude`; `git ls-files .claude` returns 0), so it bound one machine and was invisible to the GitHub Actions agents that read the tracked `CLAUDE.md`. The history compounds it: the four most recent commits on `main` are single-parent squashes, everything below `bdbed3a` is a merge commit, so an agent inferring the method from `git log` gets the wrong answer.

## Claims verified against live config

Each statement in the new text was checked before it was written, not asserted:

| Claim | Checked | Result |
| --- | --- | --- |
| Squash is the only method allowed on `main` | `gh api repos/{owner}/{repo}/rulesets/10574682` | `Default Branch`, active, `include: ["~DEFAULT_BRANCH"]`, `allowed_merge_methods: ["squash"]` |
| Repo settings still permit merge commits | `gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed` | `true`, `true`, `false` |
| Those settings govern branches the ruleset misses | rulesets 10575531 (`Hotfix Branches`) and 10575495 (`Release Branches`) | both active, neither carries a `pull_request` rule, so neither restricts a merge method |
| Admins can bypass the ruleset | same ruleset endpoint | `bypass_actors: [{actor_type: "RepositoryRole", bypass_mode: "always"}]` |

The last row is why the text says the ruleset "restricts" the method and notes the admin bypass, rather than claiming absolute enforcement. It came out of the review gate.

## Scope

In: the two bullets. Out: repo settings and the rulesets, both untouched, per the issue.

No `CHANGELOG.md` entry — `CLAUDE.md` is contributor and agent instruction, not a user-facing extension change.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.8.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.8.0 test
> jest --verbose

Test Suites: 14 passed, 14 total
Tests:       221 passed, 221 total
Snapshots:   0 total
Time:        8.501 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.8.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The change is markdown only, so none of the three exercises it; `format:check` globs `**/*.ts` and does not cover `CLAUDE.md` at all. They are reported because the repo asks for them, not as evidence about this diff.

## Review gate

Fresh reviewer, separate context, briefed with the diff, the issue body, `CLAUDE.md` and the smell baseline.

Verdict: `PASS_WITH_SUGGESTIONS`. No Critical findings.

The one Important finding was the admin-bypass overstatement, and it is fixed above. Three Suggestions were not taken, deliberately: splitting the second bullet in three, dropping the clause about branches the ruleset does not cover (it tracks the issue's own wording, and it is accurate), and documenting the `gh pr merge --subject` invocation. The third is a real gap in the tracked docs but sits outside this issue's acceptance criteria; it is worth its own ticket.

## Follow-up spotted, not actioned

`CLAUDE.md:40` says a hotfix "is just a `fix/` branch; it needs no special path", while an active `Hotfix Branches` ruleset covers `refs/heads/hotfix/**`. Nothing targets that pattern today, so it is harmless, but it is the same doc-versus-config drift this issue exists to close.
