### PR TITLE
chore(changelog): switch to one fragment file per change

### DIFF
--- a/.github/workflows/claude-maintenance.yml
+++ b/.github/workflows/claude-maintenance.yml
@@ -52,8 +52,9 @@ jobs:
             4. Release readiness: compare main against the latest release tag
                (`git log $(git describe --tags --abbrev=0 origin/main)..HEAD --oneline`).
                If there are user-facing changes, summarize them and state whether a
-               release is worth cutting, and whether CHANGELOG.md's [Unreleased]
-               section reflects them.
+               release is worth cutting, and whether the pending changelog entries
+               reflect them - the fragments under changelog.d/ plus any entries
+               still inline under [Unreleased] in CHANGELOG.md.
             5. Quality drift: check for obvious problems introduced recently
                (untested new modules under src/, TODO/FIXME comments added in the
                last month, files that grew past ~600 lines).

--- a/.github/workflows/claude-release-prep.yml
+++ b/.github/workflows/claude-release-prep.yml
@@ -42,24 +42,36 @@ jobs:
             The checkout is the main branch, which is the only long-lived branch.
 
             Requested version: "${{ inputs.version }}". If empty, derive the bump
-            by applying this rule to the [Unreleased] section of CHANGELOG.md -
-            do not use judgement, apply the rule.
+            by applying this rule to the pending changes - do not use judgement,
+            apply the rule.
+
+            The pending changes come from two places and you must read both. A
+            release that reads only one of them silently drops half the notes.
+              - the fragment files under changelog.d/, each named
+                <key>.<category>.md, where the category is the second-to-last
+                dot-separated part of the file name. changelog.d/README is
+                documentation, not a fragment.
+              - any entries still sitting inline under [Unreleased] in
+                CHANGELOG.md, left over from before the switch to fragments.
 
             First read the current version from package.json. Let PRE_1_0 be true
             when its major component is 0. Do not assume this - read it, because
             the answer changes the first branch below and it changes for good the
             day this project ships 1.0.0.
 
-              - any entry under Removed, or any entry explicitly marked breaking
+              - any pending change in the removed category, or any entry
+                explicitly marked breaking
                 -> minor if PRE_1_0, otherwise major
                 (SemVer treats 0.y.z as an unstable public API, so a breaking
                 change is conventionally a minor below 1.0 and a major at or
                 above it)
-              - otherwise any entry under Added or Deprecated -> minor
+              - otherwise any pending change in the added or deprecated
+                categories -> minor
                 (SemVer rule 7 requires a minor for a deprecation on its own)
-              - otherwise, entries only under Fixed / Changed / Security -> patch
-              - no user-facing entries at all -> STOP. Do not cut a release that
-                contains only CI, test, or refactor commits.
+              - otherwise, pending changes only in the fixed / changed /
+                security categories -> patch
+              - no fragments and no inline entries at all -> STOP. Do not cut a
+                release that contains only CI, test, or refactor commits.
             State the version you read, whether PRE_1_0 was true, which rule
             branch fired, and why, in the PR body.
 
@@ -69,13 +81,28 @@ jobs:
             2. Review changes since the last release:
                `git log $(git describe --tags --abbrev=0 origin/main)..HEAD --oneline`
                plus the diff summary. Identify user-facing changes.
-            3. Update CHANGELOG.md following Keep a Changelog: create a section for
-               the new version dated today (UTC), grouped under Added / Changed /
-               Fixed as appropriate, written for end users (what changed in the
-               editor experience, not internal refactor details). Keep an empty
-               [Unreleased] section on top. Add the version compare-link to the
-               link-definition block at the bottom, and repoint [Unreleased] at
-               the new tag.
+            3. Update CHANGELOG.md following Keep a Changelog: create a section
+               for the new version dated today (UTC) out of the pending changes,
+               written for end users (what changed in the editor experience, not
+               internal refactor details).
+               - Group the entries under Added / Changed / Deprecated / Removed /
+                 Fixed / Security, in that order, keeping only the categories
+                 that have entries.
+               - Each fragment becomes one "- <prose>" bullet. When its key is
+                 numeric, append " ([#N])" to that bullet and make sure the
+                 matching "[#N]: https://github.com/VukeFN/verse-auto-imports/issues/N"
+                 line exists in the issue-reference block at the bottom of the
+                 file. A tag with no definition renders as literal text, and
+                 that has shipped here before. A slug key gets neither a tag nor
+                 a definition.
+               - Copy any inline [Unreleased] entries into the same categories
+                 verbatim; they already carry their tag and their definition.
+               - Leave [Unreleased] holding only its pointer line to changelog.d/,
+                 with no category headings under it.
+               - Add the version compare-link to the link-definition block at the
+                 bottom, and repoint [Unreleased] at the new tag.
+               - `git rm` every fragment file the new section consumed. Leave
+                 changelog.d/README in place.
             4. Set the new version in package.json (version field only; do not
                touch other fields or package-lock.json by hand - run
                `npm install --package-lock-only` after the bump to sync it).

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@ src/**
 .vscode/**
 .github/**
 .claude/**
+changelog.d/**
 CLAUDE.md
 tsconfig.json
 tsconfig.integration.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 ## [Unreleased]
 
+Pending changes are kept as one file per change under [changelog.d/](changelog.d/) and assembled here at release.
+
 ### Changed
 
 - **Commands Grouped Under a Verse Auto Imports Category**: every command now appears in the command palette as **Verse Auto Imports: Optimize Imports**, **Verse Auto Imports: Show Quick Menu** and so on. The `Verse: ` prefix was hardcoded into each command title, which read as though the commands belonged to Epic's official Verse extension; it now lives in the palette category field, where VS Code renders it in front of the title and groups the extension's commands together. The command IDs are unchanged, so existing keybindings and tasks that reference `verseAutoImports.*` keep working ([#94])

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Read the code for structure. These are the things reading one file won't tell yo
 - Prettier formats all TypeScript (config in `.prettierrc.json`, 4-space). Run `npm run format` before committing; CI runs `npm run format:check` and fails on unformatted code.
 - TypeScript with relative imports (no path aliases).
 - No emojis anywhere — code, comments, docs, commits, release notes.
-- Every user-facing change gets a `CHANGELOG.md` entry under `[Unreleased]` (Keep a Changelog format). When the change resolves a tracked issue, end the entry with a reference-style `[#N]` tag and add a matching `[#N]: <issue-url>` line to the link-definition block at the bottom of the file.
+- Every user-facing change gets a changelog fragment, not an edit to `CHANGELOG.md`: one file at `changelog.d/<key>.<category>.md` holding the entry prose only. The key is the tracked issue number, or a short slug when nothing tracks the change; the category is one of the Keep a Changelog six, lowercase. Never write a leading `- `, the `([#N])` tag, or a link definition — release assembly generates all three, and hand-writing them in one shared file is what made parallel branches conflict on `CHANGELOG.md`. See [changelog.d/README](changelog.d/README).
 - Use conventional commits.
 
 ## Testing

--- a/changelog.d/README
+++ b/changelog.d/README
@@ -1,0 +1,49 @@
+changelog.d - one file per user-facing change, assembled into CHANGELOG.md at
+release time.
+
+Why this directory exists
+-------------------------
+
+Every branch that writes an entry under the [Unreleased] heading of
+CHANGELOG.md, and appends a link definition at the bottom of it, touches the
+same two regions of the same file. The second such branch to merge conflicts
+every time, on a file neither change is really about. Resolving that conflict by
+hand is also the riskiest moment in the flow, because the correct resolution is
+to keep both entries and a dropped entry is invisible afterwards.
+
+Two branches that add two differently named files cannot conflict.
+
+File name
+---------
+
+    <key>.<category>.md
+
+The key is the tracked issue number, for example 153.fixed.md. Use a short slug
+instead when nothing tracks the change, for example crlf-endings.fixed.md. A
+numeric key gets an ([#N]) tag and its matching link definition at assembly; a
+slug gets neither.
+
+The category is one of the Keep a Changelog six, lowercase: added, changed,
+deprecated, removed, fixed, security.
+
+File content
+------------
+
+The entry prose only, written for end users - what changed in the editor
+experience, not internal refactor details.
+
+Do not write a leading "- ". Do not write the ([#N]) tag. Do not add a link
+definition. Release assembly generates all three, because all three are exactly
+what conflicts when branches write them by hand.
+
+Assembly reads every .md file in this directory as a fragment and stops on one
+it cannot parse as <key>.<category>.md. A file with no .md extension is skipped
+instead. That is why this README has no extension - named README.md it would be
+read as a fragment and stop the release. Do not give it one.
+
+Assembly happens in the release workflow, which writes issue links as
+https://github.com/VukeFN/... to match the definitions already at the bottom of
+CHANGELOG.md. If you assemble by hand with a tool that derives the URL from a
+config value, pass the owner name with that same capitalisation. GitHub treats
+the owner as case-insensitive, so only the uniformity of that block is at stake.
+


### PR DESCRIPTION
Closes #153

A user-facing change now writes `changelog.d/<key>.<category>.md` holding the entry prose only, instead of editing the two regions of `CHANGELOG.md` that every parallel branch was editing. Two branches adding two differently named files cannot conflict.

## What is here

| File | Why |
| --- | --- |
| `changelog.d/README` | Creates the directory and documents the convention. **No file extension on purpose** - assembly reads every `.md` file in the directory as a fragment, so a `README.md` would be parsed as one and stop the release. |
| `CHANGELOG.md` | The pointer line under `[Unreleased]`, so a reader on GitHub does not see an empty section and conclude nothing has changed. The four entries already inline there stay put; assembly folds them in. |
| `CLAUDE.md` | The code-style rule said to edit `CHANGELOG.md` under `[Unreleased]` and hand-write the `[#N]` tag and its link definition. Left alone, every future contributor and agent would have reverted the change on their next PR. |
| `.github/workflows/claude-release-prep.yml` | The release path. It derived the version bump from the `[Unreleased]` section and wrote the release notes from it; with fragments it would have found an empty section and hit its own "no user-facing entries -> STOP" branch. It now reads both sources, assembles, generates the tags and their definitions, and `git rm`s the fragments it consumed. |
| `.github/workflows/claude-maintenance.yml` | Release-readiness reported on `[Unreleased]` alone, which would now always read as empty. |
| `.vscodeignore` | Keeps a new top-level directory out of the packaged `.vsix`. |

## Not in this PR, and needed before it takes effect

`.claude/pipeline.json` is gitignored, so the config flip is untracked local state that cannot appear in a diff. Apply it in the shared checkout:

```json
    "changelog": {
        "mode": "fragments",
        "dir": "changelog.d",
        "path": "CHANGELOG.md",
        "style": "keep-a-changelog"
    },
```

Both keys are required. `mode` alone leaves `changelog.cjs add` failing with `no fragment directory`, and the value must be exactly `changelog.d` or the pointer line is rewritten at every release.

## The one judgement call worth flagging

The issue's in-scope list is three items - the directory, the config flip, the pointer line. Assembly is `changelog.cjs` in pipeline-kit, which lives on the maintainer's machine and is **not** available to a GitHub Actions runner, so the actual release path here is the workflow prompt. That is why `claude-release-prep.yml` is in the diff: without it the next release either stops or drops every fragment. It describes assembly in prose, which matches how that workflow already generates compare links and link definitions today - the risk profile is unchanged, not newly introduced. A committed, deterministic assembler that both CI and the maintainer call is the stronger fix and is a separate ticket.

## Acceptance criteria

**Two branches each adding a fragment merge in either order with no conflict.** Real merges via `git merge-tree --write-tree`, contrasted against the identical two changes made the old way:

```
fragments - one new file per change:
  A then B                     CLEAN
  B then A                     CLEAN

inline - both editing CHANGELOG.md (the old way):
  A then B                     CONFLICT
      Auto-merging CHANGELOG.md
      CONFLICT (content): Merge conflict in CHANGELOG.md
  B then A                     CONFLICT
      Auto-merging CHANGELOG.md
      CONFLICT (content): Merge conflict in CHANGELOG.md
```

**Assembling produces a release section containing both the inline entries and the fragments.** Two throwaway fragments plus the four entries already inline, none of them committed:

```
changelog.cjs: 2 fragment(s), 4 inline entry(ies)
## [Unreleased]

### Added

- **Verification Fixture A**: ... ([#147])

### Changed

- **Commands Grouped Under a Verse Auto Imports Category**: ... ([#94])

### Fixed

- **CRLF Files Keep Their Line Endings**: ... ([#139])
- **Snooze No Longer Disables Auto Import Permanently**: ... ([#132])
- **"Did you mean" Suggestions Are Shape-Checked Before Import**: ... ([#130])
- **Verification Fixture B**: ... ([#148])
```

The pointer line as written here is byte-identical to what assembly re-emits, so `[Unreleased]` does not churn across releases.

**Every `([#N])` tag in the result has a matching link definition.**

```
tags referenced : 120, 121, 130, 132, 139, 147, 148, 23, 41, 42, 43, 46, 63, 65,
                  67, 68, 69, 70, 76, 77, 90, 91, 93, 94, 95, 97
definitions     : 26 present
MISSING         : none - every ([#N]) tag has a definition

[Unreleased]: https://github.com/VukeFN/verse-auto-imports/compare/v0.9.0...HEAD
[0.9.0]: https://github.com/VukeFN/verse-auto-imports/compare/v0.8.0...v0.9.0
[#147]: https://github.com/VukeFN/verse-auto-imports/issues/147
[#148]: https://github.com/VukeFN/verse-auto-imports/issues/148
```

## Verification

```
> verse-auto-imports@0.8.0 compile
> tsc -p ./
```

```
> verse-auto-imports@0.8.0 test
> jest --verbose

Test Suites: 14 passed, 14 total
Tests:       221 passed, 221 total
Snapshots:   0 total
Time:        8.218 s
Ran all test suites.
```

```
> verse-auto-imports@0.8.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No source changed, so these three confirm the tree is unharmed rather than exercising the change; the acceptance evidence above is what tests it.

## Review

Verdict `PASS_WITH_SUGGESTIONS` from a fresh reviewer that ran assembly end-to-end against a scratch copy. No Critical findings. Two suggestions were defects in the README prose and are fixed in this branch: the extension-less README was justified by an inverted rule (a non-`.md` file is *skipped*, not a stop - the real hazard is that `README.md` would be *parsed*), and the capitalisation note was vague about how to keep it. Remaining suggestions, left alone as out of scope: `CHANGELOG.md` is CRLF throughout with no `.gitattributes`, so assembling locally with a tool that rejoins on `\n` would rewrite all 346 lines - the workflow path uses Edit and is unaffected.

No entry was added to the changelog for this PR: it changes repo process, not the extension.
