### PR TITLE
test(mocks): give the mock vscode.Uri a per-path toString()

### DIFF
--- a/src/__mocks__/__tests__/vscode.test.ts
+++ b/src/__mocks__/__tests__/vscode.test.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+
+// Regression for #169: the mock Uri had no toString(), so every instance
+// stringified to "[object Object]". Any test keying per-document state on
+// uri.toString() - as DiagnosticsHandler, CommandsHandler,
+// ImportCodeLensProvider and extension.ts all do in production - silently
+// collapsed every document onto one key and passed for the wrong reason.
+describe("mock vscode.Uri", () => {
+    it("gives same-named files in different folders distinct keys", () => {
+        const weapons = vscode.Uri.file("C:\\Project\\Content\\Weapons\\utils.verse");
+        const ui = vscode.Uri.file("C:\\Project\\Content\\UI\\utils.verse");
+
+        expect(weapons.toString()).not.toBe(ui.toString());
+    });
+
+    it("gives the same path the same key", () => {
+        const first = vscode.Uri.file("C:\\Project\\Content\\device.verse");
+        const second = vscode.Uri.file("C:\\Project\\Content\\device.verse");
+
+        expect(first.toString()).toBe(second.toString());
+    });
+
+    it("renders a Windows path the way VS Code does", () => {
+        expect(vscode.Uri.file("C:\\Project\\Content\\device.verse").toString()).toBe("file:///c%3A/Project/Content/device.verse");
+    });
+
+    it("renders a POSIX path with a single root slash", () => {
+        expect(vscode.Uri.file("/home/user/Content/device.verse").toString()).toBe("file:///home/user/Content/device.verse");
+    });
+
+    it("keeps fsPath and scheme available alongside the key", () => {
+        const uri = vscode.Uri.file("C:\\Project\\Content\\device.verse");
+
+        expect(uri.fsPath).toBe("C:\\Project\\Content\\device.verse");
+        expect(uri.scheme).toBe("file");
+    });
+});

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -58,8 +58,9 @@ class Uri {
      * Renders the file URI the way VS Code does for the path shapes these tests
      * use: backslashes become forward slashes, and a Windows drive letter is
      * lowercased with its colon percent-encoded, so "C:\\a\\b.verse" becomes
-     * "file:///c%3A/a/b.verse". It is not a general URI encoder - a path holding
-     * "#", "?", a space or non-ASCII would not match real VS Code output.
+     * "file:///c%3A/a/b.verse". It is not a general URI encoder - a UNC path, or
+     * one holding "#", "?", a space or non-ASCII, would not match real VS Code
+     * output.
      */
     toString(): string {
         const forwardSlashed = this.fsPath.replace(/\\/g, "/");

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -37,11 +37,34 @@ class WorkspaceEdit {
     }
 }
 
+/**
+ * Carries a toString() because production code keys per-document state on it -
+ * DiagnosticsHandler's debounce maps, CommandsHandler, ImportCodeLensProvider
+ * and extension.ts all do. Without one, every instance would inherit
+ * Object.prototype.toString, stringify to "[object Object]", and collapse every
+ * document in a test onto a single map entry - so a collision test would pass
+ * *because* the collision it asserts against happened.
+ */
 class Uri {
+    readonly scheme = "file";
+
     private constructor(public readonly fsPath: string) {}
 
     static file(fsPath: string): Uri {
         return new Uri(fsPath);
+    }
+
+    /**
+     * Renders the file URI the way VS Code does for the path shapes these tests
+     * use: backslashes become forward slashes, and a Windows drive letter is
+     * lowercased with its colon percent-encoded, so "C:\\a\\b.verse" becomes
+     * "file:///c%3A/a/b.verse". It is not a general URI encoder - a path holding
+     * "#", "?", a space or non-ASCII would not match real VS Code output.
+     */
+    toString(): string {
+        const forwardSlashed = this.fsPath.replace(/\\/g, "/");
+        const rooted = forwardSlashed.startsWith("/") ? forwardSlashed : `/${forwardSlashed}`;
+        return `file://${rooted.replace(/^\/([A-Za-z]):/, (_match, drive: string) => `/${drive.toLowerCase()}%3A`)}`;
     }
 }
 

--- a/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
+++ b/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
@@ -47,18 +47,13 @@ function makeImportHandler(): ImportHandler {
 }
 
 /**
- * The uri carries a toString() because DiagnosticsHandler keys its debounce
- * state on it, exactly as vscode.Uri does at runtime. A plain object literal
- * would stringify every document to "[object Object]" and collapse them all
- * onto one key, hiding the very collision these tests exist to catch.
+ * Builds the uri with the shared vscode mock, whose Uri carries a per-path
+ * toString(); DiagnosticsHandler keys its debounce state on it. A uri that
+ * stringifies the same for every path would collapse them all onto one key and
+ * hide the very collision the tests below exist to catch.
  */
 function makeDocument(fsPath = "C:\\Project\\Content\\device.verse"): vscode.TextDocument {
-    const uri = {
-        scheme: "file",
-        fsPath,
-        toString: () => `file:///${fsPath.replace(/\\/g, "/")}`,
-    };
-    return { uri, languageId: "verse" } as unknown as vscode.TextDocument;
+    return { uri: vscode.Uri.file(fsPath), languageId: "verse" } as unknown as vscode.TextDocument;
 }
 
 describe("DiagnosticsHandler auto-import suppression", () => {


### PR DESCRIPTION
Closes #169

## What changed

`src/__mocks__/vscode.ts` — the mock `Uri` now carries a `toString()`. Without one it inherited `Object.prototype.toString` and every instance stringified to `"[object Object]"`, so any test keying per-document state on `uri.toString()` collapsed every document onto a single map entry and passed *because* the collision it was written to catch had happened.

`src/diagnostics/__tests__/DiagnosticsHandler.test.ts` — dropped the local `makeDocument()` workaround (a hand-built `uri` with its own `toString`) in favour of `vscode.Uri.file()`.

`src/__mocks__/__tests__/vscode.test.ts` — new, pins the contract directly: distinct paths give distinct keys, the same path gives the same key, and the rendered shape is what it claims to be.

## The encoding decision

The ticket left this open. This mirrors real VS Code for the path shapes the tests use: backslashes become forward slashes, and a Windows drive letter is lowercased with its colon percent-encoded, so `C:\Project\device.verse` renders as `file:///c%3A/Project/device.verse`. The docstring states plainly how far that fidelity goes — a UNC path, or one holding `#`, `?`, a space or non-ASCII, would not match real output. A partial imitation presented as complete would be the same class of trap as the bug being fixed.

Also added `readonly scheme = "file"` to the mock `Uri`. The workaround being removed carried `scheme: "file"`, and `DiagnosticsHandler.shouldProcessUri` reads it — without this, replacing the workaround with the shared mock would have quietly lost a field.

## Proof the tests now fail for the right reason

Renaming the new `toString()` so it no longer overrides `Object.prototype.toString`, then running the affected suites:

```
Test Suites: 2 failed, 2 total
Tests:       5 failed, 9 passed, 14 total
```

The failures include both of `DiagnosticsHandler`'s same-name collision tests from #134/#168 — which passed before this change with the shared mock, and could not have caught #168.

## Verification

`npm run compile`

```
> verse-auto-imports@0.8.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.8.0 test
> jest --verbose

Test Suites: 17 passed, 17 total
Tests:       255 passed, 255 total
Snapshots:   0 total
Time:        11.019 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.8.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## No changelog fragment

Test infrastructure only. Production code was already correct — `vscode.Uri` implements `toString()` properly at runtime — so nothing changes in the editor experience.

## Review

Reviewed by a separate model in a fresh context: **PASS_WITH_SUGGESTIONS**, no Critical or Important findings.

- *Suggestion*: the UNC path shape was not named in the docstring's caveat list. Taken — b0ba76a.
- *Suggestion*: `CommandsHandler`, `ImportCodeLensProvider` and `extension.ts` also key on `uri.toString()` and still have no regression test exercising that keying through the fixed mock. Not taken here — the ticket's suggested fix did not ask for it, and it is a separate piece of work.
