### PR TITLE
fix(imports): keep an import line that opens a block comment intact

### DIFF
--- a/changelog.d/166.fixed.md
+++ b/changelog.d/166.fixed.md
@@ -1,0 +1,1 @@
+**Organize imports**: an import line that opens a `<#` block comment is now left where it is instead of being rebuilt from its path alone. Rebuilding dropped the opener, which turned the commented-out import below it back into live code and orphaned its `#>`.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -52,6 +52,25 @@ function resolveEol(document: vscode.TextDocument, text: string): LineEnding {
 }
 
 /**
+ * The subset of scanned imports a writer is allowed to rebuild or move.
+ *
+ * Every writer here reconstructs an import line from its path alone, so an
+ * import whose line also opens a block comment has to be excluded from both
+ * halves of that: its lines never enter a range a writer replaces, and its
+ * path is never re-emitted somewhere else. Anything else either drops the
+ * opener - resurrecting the region below it - or relocates the opener so the
+ * comment swallows different lines than the author wrote it around. See
+ * ScannedImport.opensBlockComment.
+ *
+ * Such an import is still present for existence and deduplication purposes;
+ * only rewriting is off limits. Callers wanting "is this path imported"
+ * must read the unfiltered scan.
+ */
+function rewritableImports(scannedImports: ScannedImport[]): ScannedImport[] {
+    return scannedImports.filter((imp) => !imp.opensBlockComment);
+}
+
+/**
  * Handles all document modifications for imports.
  */
 export class ImportDocumentEditor {
@@ -184,7 +203,7 @@ export class ImportDocumentEditor {
         const scannedImports = scanModuleImports(lines);
 
         const importBlocks: ImportBlock[] = [];
-        for (const imp of scannedImports) {
+        for (const imp of rewritableImports(scannedImports)) {
             logger.debug("ImportDocumentEditor", `Found existing import at line ${imp.startLine}: ${imp.path}`);
 
             const lastBlock = importBlocks[importBlocks.length - 1];
@@ -200,7 +219,13 @@ export class ImportDocumentEditor {
 
         logger.debug("ImportDocumentEditor", `Found ${scannedImports.length} existing imports in ${importBlocks.length} blocks`);
 
+        // Existence is judged from every import, including one anchored by a
+        // block-comment opener: it is imported, so nothing needs adding for it.
         const existingPaths = new Set<string>(scannedImports.map((imp) => imp.path));
+        // Relocation is judged only from the movable ones. Re-emitting an
+        // anchored path at the top while its own line necessarily stays put
+        // would duplicate the import rather than move it.
+        const relocatablePaths = new Set<string>(rewritableImports(scannedImports).map((imp) => imp.path));
 
         const newImportPaths = new Set<string>();
         importStatements.forEach((imp) => {
@@ -288,7 +313,7 @@ export class ImportDocumentEditor {
                 // Either no existing grouping or need to create initial groups
                 if (importGrouping !== "none" && existingPaths.size > 0) {
                     // We have existing imports but no grouping - reorganize everything into groups
-                    const allPaths = new Set<string>([...existingPaths, ...newImportPaths]);
+                    const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths]);
                     const allImportsArray = Array.from(allPaths);
                     const groupedImports = this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping);
 
@@ -364,7 +389,7 @@ export class ImportDocumentEditor {
             }
         } else {
             // Consolidate all imports at the top
-            const allPaths = new Set<string>([...existingPaths, ...newImportPaths]);
+            const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths]);
             const allImportsArray = Array.from(allPaths);
 
             // Use the new grouping method for all imports
@@ -423,7 +448,14 @@ export class ImportDocumentEditor {
     ): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
         const lines = text.split(LINE_SPLIT);
-        const scannedImports = scanModuleImports(lines);
+        // An import anchored by a block-comment opener is neither hoisted nor
+        // removed from the body: its line stays exactly where it is, and the
+        // rest of the file is organized around it. It is still an import,
+        // though, so an additional path it already covers must not be written
+        // out a second time - that would duplicate it rather than move it.
+        const allImports = scanModuleImports(lines);
+        const scannedImports = rewritableImports(allImports);
+        const anchoredPaths = new Set(allImports.filter((imp) => imp.opensBlockComment).map((imp) => imp.path));
 
         const paths = scannedImports.map((imp) => imp.path);
         const importLines = new Set<number>();
@@ -434,7 +466,7 @@ export class ImportDocumentEditor {
         }
         const body = lines.filter((_, index) => !importLines.has(index));
 
-        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0);
+        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0 && !anchoredPaths.has(p));
         if (paths.length === 0 && extraPaths.length === 0) {
             return null;
         }
@@ -516,8 +548,11 @@ export class ImportDocumentEditor {
         const lines = text.split(LINE_SPLIT);
 
         // Find the last file-level import (module imports only: not local-scope
-        // using, and not module-scoped imports inside module bodies)
-        const scannedImports = scanModuleImports(lines);
+        // using, and not module-scoped imports inside module bodies). An import
+        // that opens a block comment is skipped as well: the lines after it are
+        // that comment's body, so adjusting spacing there would insert or remove
+        // lines inside the user's comment rather than after the import block.
+        const scannedImports = rewritableImports(scanModuleImports(lines));
         const lastImportLine = scannedImports.length > 0 ? scannedImports[scannedImports.length - 1].endLine : -1;
 
         // If no imports found or file only has imports, nothing to do

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -8,6 +8,18 @@ export interface ScannedImport {
     startLine: number;
     /** Last line of the statement: equal to startLine, or startLine + 1 for the indented pair. */
     endLine: number;
+    /**
+     * Whether the statement's own text leaves a `<#` block comment open, so
+     * the lines below it are that comment's body.
+     *
+     * Writers rebuild an import line from `path` alone, which discards
+     * everything trailing on it. For an ordinary trailing comment that only
+     * loses annotation text, but dropping a block-comment opener turns the
+     * commented-out region below it back into live code and orphans its `#>`.
+     * Such a statement cannot be rewritten or moved: it has to stay on its
+     * own line, with everything else organized around it.
+     */
+    opensBlockComment: boolean;
 }
 
 /**
@@ -104,11 +116,21 @@ function blockCommentMask(lines: string[]): boolean[] {
  *   a module import (a same-directory folder-module import): module `using`
  *   is only legal at file level or module-definition body level, so a bare
  *   `using` at column 0 can never be a legal local-scope using.
+ * - A collected import that itself opens a block comment spanning the lines
+ *   below it is flagged with `opensBlockComment`. It is a real import and
+ *   still counts as present, but no writer may rebuild its line, because the
+ *   opener lives in the trailing text a rebuild discards.
  */
 export function scanModuleImports(lines: string[]): ScannedImport[] {
     const formatter = new ImportFormatter();
     const imports: ScannedImport[] = [];
     const insideBlockComment = blockCommentMask(lines);
+
+    // A statement left a block comment open exactly when the line after it
+    // starts inside one: every candidate below begins at depth 0, so any depth
+    // the next line inherits was opened by the statement's own text. The mask
+    // already holds that answer, so nothing has to be re-scanned here.
+    const opensBlockComment = (endLine: number): boolean => endLine + 1 < lines.length && insideBlockComment[endLine + 1];
 
     let i = 0;
     while (i < lines.length) {
@@ -140,7 +162,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             if (nextLine !== undefined && /^\s+\S/.test(nextLine)) {
                 const indentedPath = ImportFormatter.stripTrailingComment(nextLine);
                 if (indentedPath) {
-                    imports.push({ path: indentedPath, startLine: i, endLine: i + 1 });
+                    imports.push({ path: indentedPath, startLine: i, endLine: i + 1, opensBlockComment: opensBlockComment(i + 1) });
                     i += 2;
                     continue;
                 }
@@ -152,7 +174,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
 
         const path = formatter.extractPathFromImport(trimmed);
         if (path) {
-            imports.push({ path, startLine: i, endLine: i });
+            imports.push({ path, startLine: i, endLine: i, opensBlockComment: opensBlockComment(i) });
         }
         i += 1;
     }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -73,6 +73,35 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent("<#\nusing { /Old/Path }\n#>\n\ncode()", [], curlyNoSort)).toBeNull();
     });
 
+    // Rebuilding an import line from its path alone drops everything trailing
+    // on it. Where that trailing text is a `<#` opening the block below, the
+    // drop turns a deliberately disabled import back into live code and leaves
+    // its `#>` orphaned, so the line has to be left alone and organized around.
+    it("leaves an import whose line opens a block comment where it is", () => {
+        const input = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "using { /B }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using { /A } <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n"));
+    });
+
+    it("reproduces a document with an anchored import exactly, so organize can skip the edit", () => {
+        const input = ["using { /B }", "", "using { /A } <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
+    });
+
+    it("returns null when the only import is anchored and nothing is added", () => {
+        const input = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    it("does not write a second copy of a path an anchored import already provides", () => {
+        const input = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/A"], curlySorted)).toBeNull();
+    });
+
+    it("keeps an anchored indented pair intact instead of normalizing it to one line", () => {
+        const input = ["using:", "    /A <# disabled below", "using { /Old/Path }", "#>", "using { /B }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using:", "    /A <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n"));
+    });
+
     it("writes the preferred dot syntax", () => {
         const input = "using { /A }\ncode()";
         expect(
@@ -254,6 +283,30 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(operations[0].kind).toBe("insert");
         expect(operations[0].position).toEqual({ line: 0, character: 0 });
         expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n\n");
+    });
+
+    it("adds a new import without rebuilding an import line that opens a block comment", async () => {
+        // Merging into that line would rewrite it from its path alone and drop
+        // the `<#`, making the disabled import below it live again.
+        const input = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("insert");
+        expect(operations[0].position).toEqual({ line: 0, character: 0 });
+        expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n\n");
+    });
+
+    it("still counts an import whose line opens a block comment as already present", async () => {
+        const input = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /A }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
     it("dedupes a bare folder import that already exists at column 0 and makes no edit", async () => {

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -2,21 +2,21 @@ import { scanModuleImports } from "../ImportScanner";
 
 describe("scanModuleImports", () => {
     it("collects a braced import at column 0 with a single-line span", () => {
-        expect(scanModuleImports(["using { /Verse.org/Simulation }", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0 }]);
+        expect(scanModuleImports(["using { /Verse.org/Simulation }", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
     });
 
     it("collects a dotted-style import", () => {
-        expect(scanModuleImports(["using. /Verse.org/Simulation"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0 }]);
+        expect(scanModuleImports(["using. /Verse.org/Simulation"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
     });
 
     it("consumes the indented using: pair as one two-line entry", () => {
-        expect(scanModuleImports(["using:", "    /Verse.org/Simulation", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 1 }]);
+        expect(scanModuleImports(["using:", "    /Verse.org/Simulation", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 1, opensBlockComment: false }]);
     });
 
     it("strips a trailing comment from a scanned import path, in all three styles", () => {
-        expect(scanModuleImports(["using { /Verse.org/Simulation } # keep me"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0 }]);
-        expect(scanModuleImports(["using. /Verse.org/Simulation # keep me"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0 }]);
-        expect(scanModuleImports(["using:", "    /Verse.org/Simulation # keep me", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 1 }]);
+        expect(scanModuleImports(["using { /Verse.org/Simulation } # keep me"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using. /Verse.org/Simulation # keep me"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using:", "    /Verse.org/Simulation # keep me", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 1, opensBlockComment: false }]);
     });
 
     it("skips a using: line whose indented next line is nothing but a comment", () => {
@@ -24,7 +24,7 @@ describe("scanModuleImports", () => {
     });
 
     it("collects dot-notation module references", () => {
-        expect(scanModuleImports(["using { Gadgets.Tools }"])).toEqual([{ path: "Gadgets.Tools", startLine: 0, endLine: 0 }]);
+        expect(scanModuleImports(["using { Gadgets.Tools }"])).toEqual([{ path: "Gadgets.Tools", startLine: 0, endLine: 0, opensBlockComment: false }]);
     });
 
     it("skips indented using lines (module-scoped imports)", () => {
@@ -37,7 +37,7 @@ describe("scanModuleImports", () => {
         // body level; local-scope `using{instance}` is only legal inside a
         // function body. So a bare `using { X }` at column 0 can only be a
         // same-directory folder-module import, never a local-scope using.
-        expect(scanModuleImports(["using { Features }"])).toEqual([{ path: "Features", startLine: 0, endLine: 0 }]);
+        expect(scanModuleImports(["using { Features }"])).toEqual([{ path: "Features", startLine: 0, endLine: 0, opensBlockComment: false }]);
     });
 
     it("skips local-scope using inside a function body", () => {
@@ -50,7 +50,7 @@ describe("scanModuleImports", () => {
     });
 
     it("handles CRLF line endings", () => {
-        expect(scanModuleImports(["using { /A }\r", "code()\r"])).toEqual([{ path: "/A", startLine: 0, endLine: 0 }]);
+        expect(scanModuleImports(["using { /A }\r", "code()\r"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: false }]);
     });
 
     it("skips an import commented out with a block comment", () => {
@@ -60,24 +60,63 @@ describe("scanModuleImports", () => {
 
     it("resumes scanning after a block comment closes", () => {
         const lines = ["<#", "using { /Old/Path }", "#>", "using { /Verse.org/Simulation }", "", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3 }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, opensBlockComment: false }]);
     });
 
     it("skips an import inside a block comment opened and closed on one line", () => {
-        expect(scanModuleImports(["<# using { /Old/Path } #>", "using { /A }"])).toEqual([{ path: "/A", startLine: 1, endLine: 1 }]);
+        expect(scanModuleImports(["<# using { /Old/Path } #>", "using { /A }"])).toEqual([{ path: "/A", startLine: 1, endLine: 1, opensBlockComment: false }]);
     });
 
-    it("keeps an import whose line opens a block comment after it", () => {
+    it("keeps an import whose line opens a block comment after it, and flags it", () => {
         const lines = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "using { /B }"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 0 },
-            { path: "/B", startLine: 3, endLine: 3 },
+            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: true },
+            { path: "/B", startLine: 3, endLine: 3, opensBlockComment: false },
         ]);
+    });
+
+    it("does not flag an import whose trailing block comment closes on the same line", () => {
+        // Nothing below the line is comment body, so rebuilding it only loses
+        // the annotation text - the documented behavior of stripTrailingComment.
+        expect(scanModuleImports(["using { /A } <# note #>", "using { /B }"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: false },
+            { path: "/B", startLine: 1, endLine: 1, opensBlockComment: false },
+        ]);
+    });
+
+    it("does not flag an import whose trailing line comment mentions <#", () => {
+        expect(scanModuleImports(["using { /A } # opens with <#", "using { /B }"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: false },
+            { path: "/B", startLine: 1, endLine: 1, opensBlockComment: false },
+        ]);
+    });
+
+    it("flags an indented pair whose path line opens a block comment", () => {
+        // The opener is on the second line of the statement, so the flag has to
+        // be read at endLine rather than startLine.
+        const lines = ["using:", "    /A <# disabled below", "using { /Old/Path }", "#>", "using { /B }"];
+        expect(scanModuleImports(lines)).toEqual([
+            { path: "/A", startLine: 0, endLine: 1, opensBlockComment: true },
+            { path: "/B", startLine: 4, endLine: 4, opensBlockComment: false },
+        ]);
+    });
+
+    it("does not flag an unclosed opener on the last line, which has nothing below it", () => {
+        // The flag exists to protect the lines a comment swallows. With no line
+        // after the statement there are none, so the import stays rewritable.
+        expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: false }]);
     });
 
     it("treats block comments as nesting, so an inner close does not resume scanning", () => {
         const lines = ["<#", "<#", "using { /Inner }", "#>", "using { /Outer }", "#>", "using { /Live }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Live", startLine: 6, endLine: 6 }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Live", startLine: 6, endLine: 6, opensBlockComment: false }]);
+    });
+
+    it("flags an import whose trailing opener is closed by a nested block below", () => {
+        // The outer `<#` is still open on the line after the statement, so the
+        // import stays anchored even though an inner `#>` appears first.
+        const lines = ["using { /A } <# outer", "<# inner #>", "using { /Old/Path }", "#>", "code()"];
+        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: true }]);
     });
 
     it("skips an indented using: pair commented out as a block", () => {
@@ -90,20 +129,20 @@ describe("scanModuleImports", () => {
         // below it, which are skipped anyway. Reading it as `<#` would open a
         // block that never closes and hide every import in the rest of the file.
         const lines = ["<#> disabled for now", "    using { /Old/Path }", "using { /Verse.org/Simulation }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 2, endLine: 2 }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 2, endLine: 2, opensBlockComment: false }]);
     });
 
     it("does not treat a <# inside a line comment as a block opener", () => {
         const lines = ["# a block comment opens with <#", "using { /Verse.org/Simulation }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 1, endLine: 1 }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 1, endLine: 1, opensBlockComment: false }]);
     });
 
     it("returns entries in document order with correct spans across mixed styles", () => {
         const lines = ["using { /A }", "using:", "    /B", "using. /C"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 0 },
-            { path: "/B", startLine: 1, endLine: 2 },
-            { path: "/C", startLine: 3, endLine: 3 },
+            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: false },
+            { path: "/B", startLine: 1, endLine: 2, opensBlockComment: false },
+            { path: "/C", startLine: 3, endLine: 3, opensBlockComment: false },
         ]);
     });
 });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -107,6 +107,13 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: false }]);
     });
 
+    it("flags that same opener once a trailing newline gives it a line below", () => {
+        // A real file ends with a newline, so splitting it yields a trailing
+        // empty element and the carve-out above stops applying. Both outcomes
+        // are safe, but which one a file gets turns on an invisible byte.
+        expect(scanModuleImports(["using { /A } <#", ""])).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: true }]);
+    });
+
     it("treats block comments as nesting, so an inner close does not resume scanning", () => {
         const lines = ["<#", "<#", "using { /Inner }", "#>", "using { /Outer }", "#>", "using { /Live }"];
         expect(scanModuleImports(lines)).toEqual([{ path: "/Live", startLine: 6, endLine: 6, opensBlockComment: false }]);


### PR DESCRIPTION
Closes #166

## The defect

The writers rebuild an import line from its path alone, discarding everything trailing on it. Where that trailing text is a `<#` opening the block below, dropping it turned a deliberately disabled import back into live code and left its `#>` orphaned.

## Approach

Direction 2 of the two the ticket offered: refuse to rebuild such a line, leave it where it is, and organize around it. Direction 1 (carry trailing trivia and re-emit it) is actively wrong for this case - once imports are sorted, re-emitting the opener at the import's new position makes the comment swallow different lines than the author wrote it around.

- `scanModuleImports` flags the statement with `opensBlockComment`, read from the block-comment mask it already computes: a statement left a comment open exactly when the line after it starts inside one. Nothing is re-scanned.
- The writers treat a flagged import as anchored. Its lines never enter a replacement range, and its path is never re-emitted elsewhere.
- It still counts as present for existence and deduplication, so nothing adds a second copy of the same path - including an `additionalPaths` entry that names it.

The four consumers of the scanner in `ImportDocumentEditor` now agree on that rule. `ensureEmptyLinesAfterImports` is included because, without it, an anchored import that is the last scanned import makes the spacing pass insert or delete lines at the first line of the user's comment body. It is behavior-neutral when no anchored import exists.

`extractExistingImports` is unchanged: it is read-only and reports the line faithfully.

## Verification

`npm run compile` - clean.

```
Test Suites: 16 passed, 16 total
Tests:       263 passed, 263 total
Snapshots:   0 total
Time:        9.08 s
```

`npm run format:check` - `All matched files use Prettier code style!`

The seven new tests were confirmed to catch the defect rather than pass vacuously: with the `rewritableImports` filter neutralized, exactly the six new behavioral tests fail and every pre-existing test still passes.

## Review gate

`PASS_WITH_SUGGESTIONS`, no Critical findings. Reviewer ran on a different model in a separate context. Its one Suggestion that was cheap to act on is applied (a test pinning the trailing-newline variant of the last-line edge). The other two are recorded below rather than fixed, as both are wider than this ticket.

## Follow-ups this does not fix

1. **A trailing `<#>` has the same failure mode and this rule misses it.** `<#>` is the indented-comment marker, whose body is the indented lines below it; it does not change block-comment depth, so the depth-based rule leaves the line rewritable. `using { /A } <#> disabled` followed by an indented `using { /Old }` still drops the marker and orphans the indented block. The ticket's closing note that "only the block-comment case changes what the code below it means" is what is incomplete here. Found independently by the implementation and the review gate; worth its own issue.
2. **Placement is blind to an anchored provider.** A new dependent import (`Economy.Shop`) added to a file whose only provider is an anchored `using { Features } <# ...` is inserted above it, which breaks Verse's top-down `using` resolution. Inherent to direction 2 - the comment's extent is not tracked - and a compile error is a better outcome than silently resurrecting disabled code, but it is a known limit.