### PR TITLE
docs(readme): sync Key Features list with the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Stop manually managing imports in your Verse code. This extension automatically 
 - **Multi-Option Quick Fixes** - Choose from multiple import options when VS Code finds ambiguous identifiers
 - **Full Path Conversion** - Convert relative imports to full path format with CodeLens
 - **Smart Error Recognition** - Enhanced pattern matching for various Verse compiler errors
+- **Path Tree Caching** - Fast identifier resolution with automatic cache updates
 - **Zero Configuration** - Works perfectly out of the box with sensible defaults
-- **Import Organization** - Automatically sorts and consolidates imports with proper spacing
+- **Import Organization** - Sorts and consolidates imports with proper spacing, in an order Verse can actually resolve
+- **Comment-Aware** - Imports inside block comments stay commented out, and files keep their own line endings
 - **Flexible Configuration** - Customize behavior to match your coding style
 
 ## Quick Start


### PR DESCRIPTION
Closes #175

The README **Key Features** list had drifted from the wiki's Home page. The wiki is current as of v0.9.0, so its list is copied verbatim rather than the other way round.

Three changes, all inside the Key Features block:

- Added **Path Tree Caching** (`src/services/ProjectPathCache.ts`, shipped 0.7.0 via #41, kept fresh by the watchers from #131 and #146).
- Added **Comment-Aware**, covering #127, #166 and the line-ending preservation from #139.
- Reworded **Import Organization** to the wiki's post-#91 phrasing. The old line said imports are "Automatically sorts and consolidates imports with proper spacing", which predates rank-based ordering.

No changelog fragment: `changelog.d/README` scopes fragments to "what changed in the editor experience", and this changes documentation only. Past README-only commits carry none either.

### Verification

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 17 passed, 17 total
Tests:       268 passed, 268 total
Snapshots:   0 total
Time:        8.933 s
Ran all test suites.
```

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

### Review gate

Independent reviewer on a different model: **PASS**, no findings. It confirmed the resulting list matches the wiki's nine bullets verbatim, that both newly claimed features trace to shipped changes, and that the diff touches nothing outside the Key Features block.