### PR TITLE
fix(imports): land a path conversion on the line the lens was on

### DIFF
--- a/changelog.d/183.fixed.md
+++ b/changelog.d/183.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: Using a path conversion on an import whose statement also appears elsewhere in the file - commented out above it, say - now rewrites the line the CodeLens sits on instead of the first line reading the same.

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -25,6 +25,7 @@ interface PathConversionResult {
     moduleName: string;
     isAmbiguous: boolean;
     possiblePaths?: string[];
+    line?: number;
 }
 
 /**
@@ -421,11 +422,13 @@ export class CommandsHandler {
     /**
      * Converts a single import to absolute path format.
      */
-    async convertToFullPath(document: vscode.TextDocument, importStatement: string, _lineNumber: number): Promise<void> {
+    async convertToFullPath(document: vscode.TextDocument, importStatement: string, lineNumber: number): Promise<void> {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);
 
-        const result = (await this.deps.importPathConverter.convertToFullPath(importStatement, document.uri)) as PathConversionResult | null;
+        // The line the lens was clicked on travels with the conversion, so the
+        // edit lands there rather than on the first line reading the same.
+        const result = (await this.deps.importPathConverter.convertToFullPath(importStatement, document.uri, lineNumber)) as PathConversionResult | null;
 
         if (!result) {
             vscode.window.showInformationMessage("Import is already in absolute path format or could not be converted.");
@@ -489,11 +492,11 @@ export class CommandsHandler {
     /**
      * Converts a single import to relative path format.
      */
-    async convertToRelativePath(document: vscode.TextDocument, importStatement: string, _lineNumber: number): Promise<void> {
+    async convertToRelativePath(document: vscode.TextDocument, importStatement: string, lineNumber: number): Promise<void> {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);
 
-        const result = (await this.deps.importPathConverter.convertFromFullPath(importStatement)) as PathConversionResult | null;
+        const result = (await this.deps.importPathConverter.convertFromFullPath(importStatement, lineNumber)) as PathConversionResult | null;
 
         if (!result) {
             vscode.window.showInformationMessage("Import cannot be converted to relative path.");

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -534,9 +534,13 @@ export class ImportPathConverter {
      * match is then the wrong line. Only that recorded line is checked against
      * the statement, never searched for, so a duplicate above it cannot win.
      *
-     * The text search remains for a caller with no line to give, and for a line
-     * that no longer holds the statement because the document changed while the
-     * conversion was being resolved.
+     * A search remains for a caller with no line to give, and for a line that no
+     * longer holds the statement because the document changed while the
+     * conversion was being resolved - resolving one spans a workspace scan, and
+     * an ambiguous one also spans a quick pick. That search goes through the
+     * shared scanner rather than every line, so a fallback cannot land somewhere
+     * a lens would never have appeared: searching the raw lines is what let the
+     * commented-out copy absorb the edit in the first place.
      *
      * Comparison is by trimmed text, which also absorbs the trailing `\r` a CRLF
      * document leaves on every element of a `"\n"` split.
@@ -549,7 +553,7 @@ export class ImportPathConverter {
             return recorded;
         }
 
-        return lines.findIndex((line) => line.trim() === original);
+        return scanConvertibleImports(lines).find(({ statement }) => statement === original)?.line ?? -1;
     }
 
     /**

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -12,6 +12,12 @@ interface ImportConversionResult {
     moduleName: string;
     isAmbiguous: boolean;
     possiblePaths?: string[];
+    /**
+     * The line the conversion acts on, where the caller knows it. Statement text
+     * is not unique in a document, so this is what keeps the edit on the line the
+     * user chose rather than on the first line that reads the same.
+     */
+    line?: number;
 }
 
 /** Content folder name constant */
@@ -360,7 +366,7 @@ export class ImportPathConverter {
     /**
      * Converts a full path import to a relative import
      */
-    async convertFromFullPath(importStatement: string): Promise<ImportConversionResult | null> {
+    async convertFromFullPath(importStatement: string, line?: number): Promise<ImportConversionResult | null> {
         if (this.isBuiltinModule(importStatement)) {
             logger.debug("ImportPathConverter", "Cannot convert built-in module to relative path");
             return null;
@@ -408,6 +414,7 @@ export class ImportPathConverter {
             fullPathImport: relativeImport, // In this case, it's actually the relative import
             moduleName: modulePathSegments[modulePathSegments.length - 1] || relativeImportPath,
             isAmbiguous: false,
+            line,
         };
     }
 
@@ -419,9 +426,9 @@ export class ImportPathConverter {
         const text = document.getText();
         const lines = text.split("\n");
 
-        for (const { statement } of scanConvertibleImports(lines)) {
+        for (const { statement, line } of scanConvertibleImports(lines)) {
             if (this.isFullPathImport(statement) && !this.isBuiltinModule(statement)) {
-                const result = await this.convertFromFullPath(statement);
+                const result = await this.convertFromFullPath(statement, line);
                 if (result) {
                     results.push(result);
                 }
@@ -434,7 +441,7 @@ export class ImportPathConverter {
     /**
      * Converts a relative import to a full path import
      */
-    async convertToFullPath(importStatement: string, documentUri: vscode.Uri): Promise<ImportConversionResult | null> {
+    async convertToFullPath(importStatement: string, documentUri: vscode.Uri, line?: number): Promise<ImportConversionResult | null> {
         if (this.isFullPathImport(importStatement)) {
             if (this.isBuiltinModule(importStatement)) {
                 logger.debug("ImportPathConverter", "Import is a built-in module and should not be converted");
@@ -484,6 +491,7 @@ export class ImportPathConverter {
                 fullPathImport,
                 moduleName,
                 isAmbiguous: false,
+                line,
             };
         } else {
             const possiblePaths = possibleLocations.map((location) => ImportPathConverter.buildFullVersePath(projectVersePath, location, modulePath));
@@ -494,6 +502,7 @@ export class ImportPathConverter {
                 moduleName,
                 isAmbiguous: true,
                 possiblePaths,
+                line,
             };
         }
     }
@@ -506,8 +515,8 @@ export class ImportPathConverter {
         const text = document.getText();
         const lines = text.split("\n");
 
-        for (const { statement } of scanConvertibleImports(lines)) {
-            const result = await this.convertToFullPath(statement, document.uri);
+        for (const { statement, line } of scanConvertibleImports(lines)) {
+            const result = await this.convertToFullPath(statement, document.uri, line);
             if (result) {
                 results.push(result);
             }
@@ -517,18 +526,39 @@ export class ImportPathConverter {
     }
 
     /**
+     * The line a conversion must land on.
+     *
+     * The line the caller recorded wins, because statement text is not unique in
+     * a document: an identical `using` can sit in a `<# ... #>` block comment or
+     * be plainly repeated above the one the user acted on, and the first textual
+     * match is then the wrong line. Only that recorded line is checked against
+     * the statement, never searched for, so a duplicate above it cannot win.
+     *
+     * The text search remains for a caller with no line to give, and for a line
+     * that no longer holds the statement because the document changed while the
+     * conversion was being resolved.
+     *
+     * Comparison is by trimmed text, which also absorbs the trailing `\r` a CRLF
+     * document leaves on every element of a `"\n"` split.
+     */
+    private static findConversionLine(lines: string[], conversion: ImportConversionResult): number {
+        const original = conversion.originalImport.trim();
+        const recorded = conversion.line;
+
+        if (recorded !== undefined && recorded >= 0 && recorded < lines.length && lines[recorded].trim() === original) {
+            return recorded;
+        }
+
+        return lines.findIndex((line) => line.trim() === original);
+    }
+
+    /**
      * Applies a conversion result to the document
      */
     async applyConversion(document: vscode.TextDocument, conversion: ImportConversionResult, selectedPath?: string): Promise<boolean> {
         const text = document.getText();
         const lines = text.split("\n");
-        let lineIndex = -1;
-        for (let i = 0; i < lines.length; i++) {
-            if (lines[i].trim() === conversion.originalImport.trim()) {
-                lineIndex = i;
-                break;
-            }
-        }
+        const lineIndex = ImportPathConverter.findConversionLine(lines, conversion);
 
         if (lineIndex === -1) {
             logger.debug("ImportPathConverter", `Could not find import line: ${conversion.originalImport}`);

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -118,15 +118,7 @@ describe("ImportPathConverter.applyConversion", () => {
         expect(replacedOperation().range!.start.line).toBe(1);
     });
 
-    it("keeps the indentation of the named line, not of the first match", async () => {
-        const document = fakeDocument(["using { Gadgets.Tools }", "    using { Gadgets.Tools }", "", "code()"]);
-
-        expect(await converter.applyConversion(document, conversion(1))).toBe(true);
-
-        expect(replacedOperation().text).toBe("    using { /mygame@fortnite.com/mygame/Gadgets/Tools }");
-    });
-
-    it("falls back to the first textual match when the conversion names no line", async () => {
+    it("falls back to the first convertible import when the conversion names no line", async () => {
         const document = fakeDocument(["", "using { Gadgets.Tools }", "", "code()"]);
 
         expect(await converter.applyConversion(document, conversion())).toBe(true);
@@ -134,13 +126,23 @@ describe("ImportPathConverter.applyConversion", () => {
         expect(replacedOperation().range!.start.line).toBe(1);
     });
 
-    it("falls back to the first textual match when the named line no longer holds the statement", async () => {
+    it("falls back to the first convertible import when the named line no longer holds the statement", async () => {
         // The document changed while the conversion was being resolved.
         const document = fakeDocument(["using { Gadgets.Tools }", "", "code()"]);
 
         expect(await converter.applyConversion(document, conversion(7))).toBe(true);
 
         expect(replacedOperation().range!.start.line).toBe(0);
+    });
+
+    it("does not fall back onto a commented-out copy when the named line has moved", async () => {
+        // Resolving a conversion spans a workspace scan, and an ambiguous one a
+        // quick pick, so the document can change under a recorded line. The
+        // fallback must still refuse the lines a lens would never appear on.
+        const document = fakeDocument(["<#", "using { Gadgets.Tools }", "#>", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion(9))).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
     it("reports failure when the statement is nowhere in the document", async () => {

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -118,6 +118,17 @@ describe("ImportPathConverter.applyConversion", () => {
         expect(replacedOperation().range!.start.line).toBe(1);
     });
 
+    it("keeps the indentation of the line it edits", async () => {
+        // The named line wins on trimmed text, so it survives the user indenting
+        // the import while the conversion resolves - and the rewrite has to keep
+        // that indent rather than flatten the line.
+        const document = fakeDocument(["    using { Gadgets.Tools }", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion(0))).toBe(true);
+
+        expect(replacedOperation().text).toBe("    using { /mygame@fortnite.com/mygame/Gadgets/Tools }");
+    });
+
     it("falls back to the first convertible import when the conversion names no line", async () => {
         const document = fakeDocument(["", "using { Gadgets.Tools }", "", "code()"]);
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode";
 import { ImportPathConverter } from "../ImportPathConverter";
 
 describe("ImportPathConverter.buildFullVersePath", () => {
@@ -55,5 +56,97 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
         const re = ImportPathConverter.buildModuleDefinitionRegex("a.b");
         expect(re.test("a.b := module:")).toBe(true);
         expect(re.test("axb := module:")).toBe(false);
+    });
+});
+
+interface RecordedOperation {
+    kind: "insert" | "delete" | "replace";
+    range?: { start: { line: number; character: number }; end: { line: number; character: number } };
+    text?: string;
+}
+
+function fakeDocument(lines: string[]): vscode.TextDocument {
+    const text = lines.join("\n");
+    return {
+        uri: vscode.Uri.file("C:/project/test.verse"),
+        getText: () => text,
+    } as unknown as vscode.TextDocument;
+}
+
+describe("ImportPathConverter.applyConversion", () => {
+    let converter: ImportPathConverter;
+    const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
+
+    const replacedOperation = (): RecordedOperation => {
+        const edit = applyEditMock().mock.calls[0][0] as { operations: RecordedOperation[] };
+        return edit.operations[0];
+    };
+
+    /** A resolved relative-to-absolute conversion of `using { Gadgets.Tools }`. */
+    const conversion = (line?: number) => ({
+        originalImport: "using { Gadgets.Tools }",
+        fullPathImport: "using { /mygame@fortnite.com/mygame/Gadgets/Tools }",
+        moduleName: "Tools",
+        isAmbiguous: false,
+        line,
+    });
+
+    beforeEach(() => {
+        converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
+        applyEditMock().mockClear();
+    });
+
+    it("edits the line the conversion names, not an identical statement commented out above it", async () => {
+        // The commented copy carries no CodeLens after the scanner change, but a
+        // search from the top of the document still reaches it first.
+        const document = fakeDocument(["<#", "using { Gadgets.Tools }", "#>", "", "using { Gadgets.Tools }", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion(4))).toBe(true);
+
+        const replaced = replacedOperation();
+        expect(replaced.kind).toBe("replace");
+        expect(replaced.range!.start.line).toBe(4);
+        expect(replaced.range!.end.line).toBe(4);
+        expect(replaced.text).toBe("using { /mygame@fortnite.com/mygame/Gadgets/Tools }");
+    });
+
+    it("edits the named one of two identical imports rather than the first", async () => {
+        const document = fakeDocument(["using { Gadgets.Tools }", "using { Gadgets.Tools }", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion(1))).toBe(true);
+
+        expect(replacedOperation().range!.start.line).toBe(1);
+    });
+
+    it("keeps the indentation of the named line, not of the first match", async () => {
+        const document = fakeDocument(["using { Gadgets.Tools }", "    using { Gadgets.Tools }", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion(1))).toBe(true);
+
+        expect(replacedOperation().text).toBe("    using { /mygame@fortnite.com/mygame/Gadgets/Tools }");
+    });
+
+    it("falls back to the first textual match when the conversion names no line", async () => {
+        const document = fakeDocument(["", "using { Gadgets.Tools }", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion())).toBe(true);
+
+        expect(replacedOperation().range!.start.line).toBe(1);
+    });
+
+    it("falls back to the first textual match when the named line no longer holds the statement", async () => {
+        // The document changed while the conversion was being resolved.
+        const document = fakeDocument(["using { Gadgets.Tools }", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion(7))).toBe(true);
+
+        expect(replacedOperation().range!.start.line).toBe(0);
+    });
+
+    it("reports failure when the statement is nowhere in the document", async () => {
+        const document = fakeDocument(["using { Other.Module }", "", "code()"]);
+
+        expect(await converter.applyConversion(document, conversion(0))).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Closes #183
Closes #141

`applyConversion` found the line to rewrite by scanning from the top of the document for the first line whose trimmed text equalled the statement it was given. Statement text is not unique, so an identical `using` sitting in a `<# ... #>` block comment or plainly repeated above the clicked one absorbed the edit, and the line the user acted on was left untouched. #167 fixed which lines *offer* a conversion; this is which line one *lands on*.

#141 is the same defect reported from a `module:` body reproduction, so it closes with this.

## What changed

The line index was already threaded from `ImportCodeLensProvider` to the command handlers and dropped there as `_lineNumber`. It now travels on `ImportConversionResult` to `applyConversion`:

- `convertToFullPath` and `convertFromFullPath` take an optional line and record it on the result.
- `convertAllImportsInDocument` and `convertAllImportsFromFullPath` pass the line `scanConvertibleImports` already gives them, so the batch paths disambiguate too. A conversion replaces one line with one line, so an earlier apply never shifts a later recorded line.
- `applyConversion` resolves its target through `findConversionLine`, which takes the recorded line when that line still holds the statement, and otherwise searches.

The search is still needed: resolving a conversion spans a workspace scan, and an ambiguous one also spans a quick pick, so the document can change under a recorded line. It now searches the convertible imports the shared scanner reports rather than every line in the file — searching raw lines is what let the commented-out copy absorb the edit, and a fallback must not be able to land where a lens would never have appeared.

The CRLF concern the issue raises is handled: both sides of the comparison are trimmed, which absorbs the trailing `\r` a `"\n"` split leaves. `findConversionLine` now says so, since it was load-bearing and undocumented.

## Tests

Seven cases over `applyConversion` in `src/imports/__tests__/ImportPathConverter.test.ts`: the commented-out duplicate, two identical imports, indentation preserved on the named line, the two fallback paths, a fallback that must refuse a commented-out copy, and a statement absent from the document.

Proven to detect the defect. Against the parent commit, the three cases pinning the recorded line fail:

```
● ImportPathConverter.applyConversion › edits the line the conversion names, not an identical statement commented out above it
● ImportPathConverter.applyConversion › edits the named one of two identical imports rather than the first
Tests: 3 failed, 11 passed, 14 total
```

With the scanner-aware fallback removed, the sixth fails:

```
● ImportPathConverter.applyConversion › does not fall back onto a commented-out copy when the named line has moved
    Expected: false
    Received: true
Tests: 1 failed, 13 passed, 14 total
```

## Verification

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 20 passed, 20 total
Tests:       303 passed, 303 total
Snapshots:   0 total
Time:        6.328 s
Ran all test suites.

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

Two rounds with a fresh reviewer, no Critical in either.

Round 1, `PASS_WITH_SUGGESTIONS`: the changelog fragment was uncommitted, and the stale-line fallback was still the raw top-down search, so it could still land inside a commented-out copy. Both fixed in `22153f6`.

Round 2, `PASS_WITH_SUGGESTIONS`: the reviewer enumerated what the scanner-aware fallback now refuses that the old one accepted — copies inside `<# ... #>` comments, indented module-scoped copies, and lines whose text would not have matched anyway — and confirmed no legitimate edit is lost, since every reachable `originalImport` comes from `scanConvertibleImports` to begin with. Its remaining suggestion, restoring the indentation assertion in a reachable form, is `69fb940`.

## Noted, not changed

- `CommandsHandler.convertToFullPath` and `convertToRelativePath` ignore `applyConversion`'s return value and show a success status-bar message either way, so a refused edit still reads as "Using absolute path: ...". Pre-existing — the old `-1` path had it too — and the same class #180 fixed for `addSingleImport` and `optimizeImports`, left unfixed here. Worth a follow-up issue.
- `applyConversion` builds its replacement range as `[0, lines[i].length]` over a `"\n"` split, so on a CRLF document the range covers the trailing `\r` and the replacement drops it, leaving that one line LF-terminated. Pre-existing, separate from line selection, and out of scope here.
- `CommandsHandler` keeps a hand-mirrored `PathConversionResult` alongside the converter's own `ImportConversionResult`, with casts between them. Exporting the real interface would remove both, but that is a wider change than this ticket.
- The first commit on this branch carries a stray `@` in its subject, from a here-string that was written in the wrong shell dialect. The squash merge sets its subject explicitly, so it does not reach `main`.
