### PR TITLE
fix(imports): keep the text trailing an import line through a rebuild

### DIFF
--- a/changelog.d/189.fixed.md
+++ b/changelog.d/189.fixed.md
@@ -1,0 +1,1 @@
+**Import comments**: the comment trailing a `using` statement is no longer deleted when imports are sorted or organized, and an import line carrying a `<#>` indented-comment marker is left where it is instead of being rebuilt without it.

--- a/changelog.d/189.fixed.md
+++ b/changelog.d/189.fixed.md
@@ -1,1 +1,1 @@
-**Import comments**: the comment trailing a `using` statement is no longer deleted when imports are sorted or organized, and an import line carrying a `<#>` indented-comment marker is left where it is instead of being rebuilt without it.
+**Import comments**: the comment trailing a `using` statement is no longer deleted when imports are sorted or organized. An import line carrying a `<#>` indented-comment marker, or an unclosed `<#` block opener, is now left where it was written rather than rebuilt without it, so the lines it comments out stay commented out.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -142,7 +142,13 @@ export class ImportDocumentEditor {
     private trailingCommentsByStatement(scannedImports: ScannedImport[], preferDotSyntax: boolean): Map<string, string> {
         const byStatement = new Map<string, string>();
         for (const imp of scannedImports) {
-            if (!imp.trailingComment) {
+            // An anchored import has a trailing comment like any other, and its
+            // is the marker that anchors it. Restoring that onto a rebuilt line
+            // is what puts the marker somewhere it was not written, so it is
+            // refused here rather than only by every caller passing a filtered
+            // list. Every caller does today; one that forgot would resurrect a
+            // defect this branch has already shipped once.
+            if (!imp.trailingComment || imp.anchorsCommentBelow) {
                 continue;
             }
             const statement = this.formatter.formatImportStatement(imp.path, preferDotSyntax);

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -126,6 +126,48 @@ export class ImportDocumentEditor {
     }
 
     /**
+     * The comment trailing each import, keyed on the statement a rebuild emits
+     * for its path.
+     *
+     * Keyed on the formatted statement rather than on a line, because that is
+     * the only handle a writer still has once it has sorted and grouped a list
+     * of paths - the same reason buildOrganizedContent keys the comments
+     * written *above* an import that way.
+     *
+     * Deduplication keeps one statement for a repeated path, so the comments of
+     * its several occurrences are concatenated rather than replaced: keeping
+     * only the last would delete text the author wrote. They stay on one line,
+     * which is where they were, and a `#` comment runs to the end of it.
+     */
+    private trailingCommentsByStatement(scannedImports: ScannedImport[], preferDotSyntax: boolean): Map<string, string> {
+        const byStatement = new Map<string, string>();
+        for (const imp of scannedImports) {
+            if (!imp.trailingComment) {
+                continue;
+            }
+            const statement = this.formatter.formatImportStatement(imp.path, preferDotSyntax);
+            const existing = byStatement.get(statement);
+            byStatement.set(statement, existing ? `${existing} ${imp.trailingComment}` : imp.trailingComment);
+        }
+        return byStatement;
+    }
+
+    /**
+     * Puts an import's trailing comment back on the statement rebuilt from its
+     * path. A group separator groupAndFormatImports emits is left alone: no
+     * path formats to one, so none is ever a key.
+     */
+    private withTrailingComment(statement: string, trailingByStatement: Map<string, string>): string {
+        const trailing = trailingByStatement.get(statement);
+        return trailing ? `${statement} ${trailing}` : statement;
+    }
+
+    /** withTrailingComment over a whole rebuilt block. */
+    private withTrailingComments(statements: string[], trailingByStatement: Map<string, string>): string[] {
+        return statements.map((statement) => this.withTrailingComment(statement, trailingByStatement));
+    }
+
+    /**
      * Creates an edit to replace an import block with combined and formatted imports.
      */
     private createBlockReplacementEdit(
@@ -145,8 +187,12 @@ export class ImportDocumentEditor {
             combinedPaths = this.formatter.sortImportsByRank(combinedPaths);
         }
 
-        // Format all imports for this block
-        const formattedImports = combinedPaths.map((path) => this.formatter.formatImportStatement(path, preferDotSyntax));
+        // Format all imports for this block, restoring the comment each
+        // existing one trailed its line with.
+        const formattedImports = this.withTrailingComments(
+            combinedPaths.map((path) => this.formatter.formatImportStatement(path, preferDotSyntax)),
+            this.trailingCommentsByStatement(block.imports, preferDotSyntax),
+        );
 
         // Replace the entire block
         edit.replace(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)), formattedImports.join(eol) + eol);
@@ -357,7 +403,10 @@ export class ImportDocumentEditor {
                     // We have existing imports but no grouping - reorganize everything into groups
                     const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths]);
                     const allImportsArray = Array.from(allPaths);
-                    const groupedImports = this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping);
+                    const groupedImports = this.withTrailingComments(
+                        this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping),
+                        this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
+                    );
 
                     if (importBlocks.length > 0) {
                         // Replace the first existing block in place so it stays at its
@@ -452,7 +501,10 @@ export class ImportDocumentEditor {
             const allImportsArray = Array.from(allPaths);
 
             // Use the new grouping method for all imports
-            const formattedImports = this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping);
+            const formattedImports = this.withTrailingComments(
+                this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping),
+                this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
+            );
 
             // Insert imports at top with minimal spacing (will be fixed by ensureEmptyLinesAfterImports)
             const importsText = formattedImports.join(eol) + eol;
@@ -512,14 +564,14 @@ export class ImportDocumentEditor {
     ): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
         const lines = text.split(LINE_SPLIT);
-        // An import anchored by a block-comment opener is neither hoisted nor
+        // An import anchored by a comment marker is neither hoisted nor
         // removed from the body: its line stays exactly where it is, and the
         // rest of the file is organized around it. It is still an import,
         // though, so an additional path it already covers must not be written
         // out a second time - that would duplicate it rather than move it.
         const allImports = scanModuleImports(lines);
         const scannedImports = rewritableImports(allImports);
-        const anchoredPaths = new Set(allImports.filter((imp) => imp.opensBlockComment).map((imp) => imp.path));
+        const anchoredPaths = new Set(allImports.filter((imp) => imp.anchorsCommentBelow).map((imp) => imp.path));
 
         const paths = scannedImports.map((imp) => imp.path);
         const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0 && !anchoredPaths.has(p));
@@ -568,9 +620,13 @@ export class ImportDocumentEditor {
         for (const [path, comments] of commentsByPath) {
             commentsByStatement.set(this.formatter.formatImportStatement(path, options.preferDotSyntax), comments);
         }
+        // Both lookups key on the bare statement, so the trailing comment goes
+        // on only once both have been read.
+        const trailingByStatement = this.trailingCommentsByStatement(scannedImports, options.preferDotSyntax);
         const block = formatted.flatMap((statement) => {
             const comments = commentsByStatement.get(statement);
-            return comments ? [...comments, statement] : [statement];
+            const line = this.withTrailingComment(statement, trailingByStatement);
+            return comments ? [...comments, line] : [line];
         });
 
         // Drop blank lines the removed imports left at the top; the gap after

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -308,7 +308,7 @@ export class ImportDocumentEditor {
         logger.debug("ImportDocumentEditor", `Found ${scannedImports.length} existing imports in ${importBlocks.length} blocks`);
 
         // Existence is judged from every import, including one anchored by a
-        // block-comment opener: it is imported, so nothing needs adding for it.
+        // comment marker: it is imported, so nothing needs adding for it.
         const existingPaths = new Set<string>(scannedImports.map((imp) => imp.path));
         // Relocation is judged only from the movable ones. Re-emitting an
         // anchored path at the top while its own line necessarily stays put
@@ -704,9 +704,10 @@ export class ImportDocumentEditor {
 
         // Find the last file-level import (module imports only: not local-scope
         // using, and not module-scoped imports inside module bodies). An import
-        // that opens a block comment is skipped as well: the lines after it are
-        // that comment's body, so adjusting spacing there would insert or remove
-        // lines inside the user's comment rather than after the import block.
+        // that opens a comment over the lines below it - a `<#` block opener or
+        // a `<#>` marker - is skipped as well: those lines are that comment's
+        // body, so adjusting spacing there would insert or remove lines inside
+        // the user's comment rather than after the import block.
         const scannedImports = rewritableImports(scanModuleImports(lines));
         const lastImportLine = scannedImports.length > 0 ? scannedImports[scannedImports.length - 1].endLine : -1;
 

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -30,13 +30,42 @@ export class ImportFormatter {
      * @returns The content with any trailing comment removed, trimmed
      */
     static stripTrailingComment(content: string): string {
+        const commentStart = ImportFormatter.commentStartIndex(content);
+        return commentStart === -1 ? content.trim() : content.slice(0, commentStart).trim();
+    }
+
+    /**
+     * The trailing Verse comment of a `using` statement, or "" when it has none.
+     *
+     * The inverse of stripTrailingComment, splitting at the same point so the
+     * two halves always recompose the original. A writer rebuilds an import
+     * line from its path alone, which discards everything after that split;
+     * this is what it needs to put back so the annotation survives.
+     *
+     * @param content A `using` statement, or the indented path line of one
+     * @returns The comment, trimmed, or "" when the content carries none
+     */
+    static extractTrailingComment(content: string): string {
+        const commentStart = ImportFormatter.commentStartIndex(content);
+        return commentStart === -1 ? "" : content.slice(commentStart).trim();
+    }
+
+    /**
+     * Where the trailing comment of a `using` statement begins, or -1 when it
+     * has none. One home for the rule, so the two halves of the split cannot
+     * drift apart.
+     *
+     * `#` opens a line comment and `<#` opens a block comment. Neither
+     * character is legal in a module path, so the first `#` is always the
+     * start of trivia rather than of the path.
+     */
+    private static commentStartIndex(content: string): number {
         const hashIndex = content.indexOf("#");
         if (hashIndex === -1) {
-            return content.trim();
+            return -1;
         }
         // For a `<#` block comment the `<` opens the comment, not the path.
-        const commentStart = hashIndex > 0 && content[hashIndex - 1] === "<" ? hashIndex - 1 : hashIndex;
-        return content.slice(0, commentStart).trim();
+        return hashIndex > 0 && content[hashIndex - 1] === "<" ? hashIndex - 1 : hashIndex;
     }
 
     /**

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -9,17 +9,36 @@ export interface ScannedImport {
     /** Last line of the statement: equal to startLine, or startLine + 1 for the indented pair. */
     endLine: number;
     /**
-     * Whether the statement's own text leaves a `<#` block comment open, so
-     * the lines below it are that comment's body.
+     * Whether the statement's own text opens a comment whose body is the lines
+     * below it, which pins the statement to the position it was written at.
      *
-     * Writers rebuild an import line from `path` alone, which discards
-     * everything trailing on it. For an ordinary trailing comment that only
-     * loses annotation text, but dropping a block-comment opener turns the
-     * commented-out region below it back into live code and orphans its `#>`.
-     * Such a statement cannot be rewritten or moved: it has to stay on its
-     * own line, with everything else organized around it.
+     * Two markers do this, and their consequences are identical, so they are
+     * one flag rather than two:
+     *
+     * - `<#` leaves a block comment open, making every line below it comment
+     *   body until a matching `#>`.
+     * - `<#>` opens an indented comment, making every line below it indented
+     *   past it comment body.
+     *
+     * Writers rebuild an import line from `path` alone, so trailing text is
+     * restored from `trailingComment` rather than preserved in place. That is
+     * enough for an annotation, but not for either marker: what a marker
+     * comments out is decided by where it sits, so re-emitting it at a
+     * different line makes it swallow lines the author never wrote it around.
+     * Such a statement cannot be rewritten or moved: it stays on its own line,
+     * with everything else organized around it.
      */
-    opensBlockComment: boolean;
+    anchorsCommentBelow: boolean;
+    /**
+     * The comment trailing the statement on its own line, or "" when it has
+     * none. For the indented pair this is the comment on the path line, the
+     * only one of the two lines that can carry a path and therefore a comment
+     * after it.
+     *
+     * Held here because a rebuild reconstructs the line from `path` and would
+     * otherwise discard it, deleting text the author wrote.
+     */
+    trailingComment: string;
 }
 
 /** What one line of a document leaves behind for the line below it. */
@@ -210,10 +229,12 @@ function blockCommentMask(lines: string[]): boolean[] {
  *   a module import (a same-directory folder-module import): module `using`
  *   is only legal at file level or module-definition body level, so a bare
  *   `using` at column 0 can never be a legal local-scope using.
- * - A collected import that itself opens a block comment spanning the lines
- *   below it is flagged with `opensBlockComment`. It is a real import and
- *   still counts as present, but no writer may rebuild its line, because the
- *   opener lives in the trailing text a rebuild discards.
+ * - A collected import that itself opens a comment over the lines below it is
+ *   flagged with `anchorsCommentBelow`. It is a real import and still counts
+ *   as present, but no writer may rebuild or move its line, because where the
+ *   marker sits is what decides which lines it comments out.
+ * - The comment trailing a statement is kept in `trailingComment` so a writer
+ *   that rebuilds the line from `path` can put it back rather than delete it.
  */
 export function scanModuleImports(lines: string[]): ScannedImport[] {
     const formatter = new ImportFormatter();
@@ -225,6 +246,26 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     // the next line inherits was opened by the statement's own text. The mask
     // already holds that answer, so nothing has to be re-scanned here.
     const opensBlockComment = (endLine: number): boolean => endLine + 1 < lines.length && insideBlockComment[endLine + 1];
+
+    // A `<#>` anchors its statement whether or not a body follows it today.
+    // The carve-out above - an unclosed `<#` on the last line anchors nothing,
+    // having no line below to swallow - cannot be extended to this marker: a
+    // `<#` on the last line of a file can never gain a body, while a `<#>`
+    // gains one the moment a rebuild moves it above an indented line.
+    //
+    // Every line of a statement's span starts at depth 0: lines inside a block
+    // comment are skipped above, and the `using:` opening an indented pair
+    // holds no `#` to open one on the path line.
+    const opensIndentedComment = (startLine: number, endLine: number): boolean => {
+        for (let line = startLine; line <= endLine; line++) {
+            if (scanLine(lines[line], 0).opensIndentedComment) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    const anchorsCommentBelow = (startLine: number, endLine: number): boolean => opensBlockComment(endLine) || opensIndentedComment(startLine, endLine);
 
     let i = 0;
     while (i < lines.length) {
@@ -256,7 +297,13 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             if (nextLine !== undefined && /^\s+\S/.test(nextLine)) {
                 const indentedPath = ImportFormatter.stripTrailingComment(nextLine);
                 if (indentedPath) {
-                    imports.push({ path: indentedPath, startLine: i, endLine: i + 1, opensBlockComment: opensBlockComment(i + 1) });
+                    imports.push({
+                        path: indentedPath,
+                        startLine: i,
+                        endLine: i + 1,
+                        anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                        trailingComment: ImportFormatter.extractTrailingComment(nextLine),
+                    });
                     i += 2;
                     continue;
                 }
@@ -268,7 +315,13 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
 
         const path = formatter.extractPathFromImport(trimmed);
         if (path) {
-            imports.push({ path, startLine: i, endLine: i, opensBlockComment: opensBlockComment(i) });
+            imports.push({
+                path,
+                startLine: i,
+                endLine: i,
+                anchorsCommentBelow: anchorsCommentBelow(i, i),
+                trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+            });
         }
         i += 1;
     }
@@ -280,19 +333,19 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
  * The subset of scanned imports a writer is allowed to rebuild or move.
  *
  * Every writer reconstructs an import line from its path alone, so an import
- * whose line also opens a block comment has to be excluded from both halves of
- * that: its lines never enter a range a writer replaces, and its path is never
- * re-emitted somewhere else. Anything else either drops the opener -
- * resurrecting the region below it - or relocates the opener so the comment
- * swallows different lines than the author wrote it around. See
- * ScannedImport.opensBlockComment.
+ * whose line also opens a comment over the lines below it has to be excluded
+ * from both halves of that: its lines never enter a range a writer replaces,
+ * and its path is never re-emitted somewhere else. Anything else relocates the
+ * marker so the comment swallows different lines than the author wrote it
+ * around, or - for a `<#` - drops it and resurrects the region below. See
+ * ScannedImport.anchorsCommentBelow.
  *
  * Such an import is still present for existence and deduplication purposes;
  * only rewriting is off limits. Callers wanting "is this path imported" must
  * read the unfiltered scan.
  */
 export function rewritableImports(scannedImports: ScannedImport[]): ScannedImport[] {
-    return scannedImports.filter((imp) => !imp.opensBlockComment);
+    return scannedImports.filter((imp) => !imp.anchorsCommentBelow);
 }
 
 /** An import statement a path conversion may act on, with the line it occupies. */
@@ -315,8 +368,9 @@ export interface ConvertibleImport {
  *   membership line by line instead is what let a lens appear on inert text and
  *   on a module-scoped import, and acting on that lens edited a line inside a
  *   comment.
- * - An import that opens a block comment is excluded: rebuilding its line drops
- *   the opener and resurrects the region below it.
+ * - An import that opens a comment over the lines below it is excluded:
+ *   rebuilding its line moves the marker away from the lines it was written
+ *   around, and for a `<#` drops the opener and resurrects the region below.
  * - The indented style (`using:` with the path on the following line) is
  *   excluded, because every conversion path identifies an import by a single
  *   line of statement text and replaces that one line.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -241,31 +241,31 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     const imports: ScannedImport[] = [];
     const insideBlockComment = blockCommentMask(lines);
 
-    // A statement left a block comment open exactly when the line after it
-    // starts inside one: every candidate below begins at depth 0, so any depth
-    // the next line inherits was opened by the statement's own text. The mask
-    // already holds that answer, so nothing has to be re-scanned here.
-    const opensBlockComment = (endLine: number): boolean => endLine + 1 < lines.length && insideBlockComment[endLine + 1];
-
-    // A `<#>` anchors its statement whether or not a body follows it today.
-    // The carve-out above - an unclosed `<#` on the last line anchors nothing,
-    // having no line below to swallow - cannot be extended to this marker: a
-    // `<#` on the last line of a file can never gain a body, while a `<#>`
-    // gains one the moment a rebuild moves it above an indented line.
+    // Whether the statement's own text opens a comment over the lines below it,
+    // read from that text alone rather than from what currently sits under it.
     //
-    // Every line of a statement's span starts at depth 0: lines inside a block
-    // comment are skipped above, and the `using:` opening an indented pair
-    // holds no `#` to open one on the path line.
-    const opensIndentedComment = (startLine: number, endLine: number): boolean => {
+    // Both markers are decided the same way: a `<#>` anywhere on the span, or a
+    // `<#` the span never closes. Neither depends on there being a body today,
+    // because a rebuild is free to move the line and hand it one - sorting an
+    // unclosed opener above another import makes it swallow that import, and
+    // moving a `<#>` above an indented line makes it swallow that line. The
+    // statement is what carries the marker, so the statement is what is asked.
+    //
+    // A span always starts at depth 0: lines inside a block comment are skipped
+    // below, and the `using:` opening an indented pair holds no `#` to open one
+    // on the path line. Only depth 0 yields opensIndentedComment, so a `<#>`
+    // inside a block comment on the same span cannot be mistaken for a marker.
+    const anchorsCommentBelow = (startLine: number, endLine: number): boolean => {
+        let depth = 0;
         for (let line = startLine; line <= endLine; line++) {
-            if (scanLine(lines[line], 0).opensIndentedComment) {
+            const scan = scanLine(lines[line], depth);
+            if (scan.opensIndentedComment) {
                 return true;
             }
+            depth = scan.depth;
         }
-        return false;
+        return depth > 0;
     };
-
-    const anchorsCommentBelow = (startLine: number, endLine: number): boolean => opensBlockComment(endLine) || opensIndentedComment(startLine, endLine);
 
     let i = 0;
     while (i < lines.length) {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -110,6 +110,56 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using:", "    /A <# disabled below", "using { /Old/Path }", "#>", "", "code()"].join("\n"));
     });
 
+    // A `<#>` marker is the same hazard with a different marker: its body is
+    // the lines below it indented past it, so a rebuild that moves the line
+    // strands that body as indented lines at file scope, where the file stops
+    // parsing.
+    it("leaves an import whose line carries an indented comment marker where it is", () => {
+        const input = ["using { /A } <#> why this is here", "    it brings the module into scope", "using { /B }", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using { /A } <#> why this is here", "    it brings the module into scope", "code()"].join("\n"));
+    });
+
+    it("returns null when the only import carries an indented comment marker", () => {
+        const input = ["using { /A } <#> why this is here", "    it brings the module into scope", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    // Excluding an import with an ordinary trailing comment from rewriting
+    // would stop it being sorted at all, so the comment travels through the
+    // rebuild instead.
+    it("keeps the comment trailing an import when the block is rebuilt around it", () => {
+        const input = ["using { /Zebra } # network only", "using { /Apple }", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /Apple }", "using { /Zebra } # network only", "", "code()"].join("\n"));
+    });
+
+    it("keeps the trailing comment of an import written in any of the three styles", () => {
+        expect(editor.buildOrganizedContent("using { /B } # braced\nusing { /A }\ncode()", [], curlySorted)).toBe(["using { /A }", "using { /B } # braced", "", "code()"].join("\n"));
+        expect(editor.buildOrganizedContent("using. /B # dotted\nusing { /A }\ncode()", [], curlySorted)).toBe(["using { /A }", "using { /B } # dotted", "", "code()"].join("\n"));
+        expect(editor.buildOrganizedContent("using:\n    /B # indented\nusing { /A }\ncode()", [], curlySorted)).toBe(["using { /A }", "using { /B } # indented", "", "code()"].join("\n"));
+    });
+
+    it("keeps a trailing block comment that closes on its own line", () => {
+        const input = ["using { /Zebra } <# network only #>", "using { /Apple }", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /Apple }", "using { /Zebra } <# network only #>", "", "code()"].join("\n"));
+    });
+
+    it("reproduces a document whose imports carry trailing comments, so organize can skip the edit", () => {
+        const input = ["using { /Apple }", "using { /Zebra } # network only", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
+    });
+
+    it("keeps the trailing comment with its own import when another is added above it", () => {
+        const input = ["using { /Zebra } # network only", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/Apple"], curlySorted)).toBe(["using { /Apple }", "using { /Zebra } # network only", "", "code()"].join("\n"));
+    });
+
+    it("keeps both comments when a duplicated path is deduplicated to one statement", () => {
+        // Dropping either would delete text the author wrote, and a `#` comment
+        // runs to the end of the line, so the pair still reads as one comment.
+        const input = ["using { /A } # first", "using { /A } # second", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A } # first # second", "", "code()"].join("\n"));
+    });
+
     // A rebuild that emits the import block at line 0 and everything else
     // under it moves the file's header into the middle of the file and tears
     // an explanatory comment off the import it explains. Both are text the

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -551,8 +551,14 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
         expect(success).toBe(true);
+        // Pinned to the exact edit rather than to "no `<#` anywhere": a delete
+        // operation carries no text, so an assertion over every operation's
+        // text passes vacuously and would hold for an edit that writes nothing.
         const operations = appliedOperations(0);
-        expect(operations.every((op) => !op.text?.includes("<#"))).toBe(true);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("insert");
+        expect(operations[0].text).toBe("using { /B }\n\n");
+        expect(operations[0].position!.line).toBe(0);
     });
 
     function mockConfig(overrides: Record<string, unknown>): void {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -160,6 +160,20 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A } # first # second", "", "code()"].join("\n"));
     });
 
+    // Restoring trailing text is what makes an unbalanced opener dangerous
+    // wherever it sits. On the last line of a buffer it swallowed nothing while
+    // a rebuild discarded it; carried through the rebuild and sorted upward, it
+    // swallows every import written below it.
+    it("does not sort an unclosed block opener up over the imports it would swallow", () => {
+        const input = ["using { /Zebra }", "using { /Apple } <#"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /Zebra }", "", "using { /Apple } <#"].join("\n"));
+    });
+
+    it("does not write a newly added import under an unclosed opener that ends the buffer", () => {
+        const input = ["code()", "using { /A } <#"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["using { /B }", "", "code()", "using { /A } <#"].join("\n"));
+    });
+
     // A rebuild that emits the import block at line 0 and everything else
     // under it moves the file's header into the middle of the file and tears
     // an explanatory comment off the import it explains. Both are text the
@@ -495,6 +509,50 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(deletes).toHaveLength(1);
         expect(deletes[0].range!.start.line).toBe(0);
         expect(deletes[0].range!.end.line).toBe(1);
+    });
+
+    // The auto-import path, which users reach without invoking a command. It
+    // rebuilds a block through createBlockReplacementEdit rather than through
+    // buildOrganizedContent, and reads trailing comments off that block alone.
+    it("keeps the comment trailing an existing import when a new one joins its block", async () => {
+        const input = ["using { /Zebra } # network only", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Apple }"]);
+
+        expect(success).toBe(true);
+        const replace = appliedOperations(0).find((op) => op.kind === "replace");
+        expect(replace!.text).toBe("using { /Apple }\nusing { /Zebra } # network only\n");
+    });
+
+    it("keeps that comment when consolidating every import at the top", async () => {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                if (key === "behavior.preserveImportLocations") {
+                    return false;
+                }
+                return defaultValue;
+            }),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+        const input = ["using { /Zebra } # network only", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Apple }"]);
+
+        expect(success).toBe(true);
+        const insert = appliedOperations(0).find((op) => op.kind === "insert");
+        expect(insert!.text).toContain("using { /Zebra } # network only");
+    });
+
+    it("does not add an import under an unclosed opener that ends the buffer", async () => {
+        // The opener is anchored, so the new import is written above it rather
+        // than into the comment it would otherwise open over that import.
+        const input = ["hello := 1", "using { /A } <#"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+        expect(operations.every((op) => !op.text?.includes("<#"))).toBe(true);
     });
 
     function mockConfig(overrides: Record<string, unknown>): void {

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -60,6 +60,29 @@ describe("ImportFormatter.stripTrailingComment", () => {
     });
 });
 
+describe("ImportFormatter.extractTrailingComment", () => {
+    it("returns a line comment without the whitespace ahead of it", () => {
+        expect(ImportFormatter.extractTrailingComment("using { /Verse.org/Simulation } # network only")).toBe("# network only");
+    });
+
+    it("returns a block comment from its opening angle bracket", () => {
+        expect(ImportFormatter.extractTrailingComment("using { /A } <# keep me #>")).toBe("<# keep me #>");
+    });
+
+    it("returns an indented comment marker with the text after it", () => {
+        expect(ImportFormatter.extractTrailingComment("using { /A } <#> why this is here")).toBe("<#> why this is here");
+    });
+
+    it("returns an empty string when there is no comment", () => {
+        expect(ImportFormatter.extractTrailingComment("using { /A }")).toBe("");
+    });
+
+    it("recomposes the original with stripTrailingComment, which splits at the same point", () => {
+        const content = "/Verse.org/Simulation # keep me";
+        expect(`${ImportFormatter.stripTrailingComment(content)} ${ImportFormatter.extractTrailingComment(content)}`).toBe(content);
+    });
+});
+
 describe("ImportFormatter trailing comments on import statements", () => {
     let formatter: ImportFormatter;
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -2,21 +2,34 @@ import { classifyLines, scanConvertibleImports, scanModuleImports } from "../Imp
 
 describe("scanModuleImports", () => {
     it("collects a braced import at column 0 with a single-line span", () => {
-        expect(scanModuleImports(["using { /Verse.org/Simulation }", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using { /Verse.org/Simulation }", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" },
+        ]);
     });
 
     it("collects a dotted-style import", () => {
-        expect(scanModuleImports(["using. /Verse.org/Simulation"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using. /Verse.org/Simulation"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("consumes the indented using: pair as one two-line entry", () => {
-        expect(scanModuleImports(["using:", "    /Verse.org/Simulation", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 1, opensBlockComment: false }]);
+        expect(scanModuleImports(["using:", "    /Verse.org/Simulation", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, trailingComment: "" },
+        ]);
     });
 
-    it("strips a trailing comment from a scanned import path, in all three styles", () => {
-        expect(scanModuleImports(["using { /Verse.org/Simulation } # keep me"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
-        expect(scanModuleImports(["using. /Verse.org/Simulation # keep me"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, opensBlockComment: false }]);
-        expect(scanModuleImports(["using:", "    /Verse.org/Simulation # keep me", "code()"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 1, opensBlockComment: false }]);
+    it("keeps a trailing comment out of the path but on the entry, in all three styles", () => {
+        // Out of `path`, which is re-emitted inside the braces and would be
+        // corrupted by it, and onto `trailingComment`, which is what a writer
+        // puts back after rebuilding the line.
+        expect(scanModuleImports(["using { /Verse.org/Simulation } # keep me"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "# keep me" },
+        ]);
+        expect(scanModuleImports(["using. /Verse.org/Simulation # keep me"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "# keep me" },
+        ]);
+        expect(scanModuleImports(["using:", "    /Verse.org/Simulation # keep me", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, trailingComment: "# keep me" },
+        ]);
     });
 
     it("skips a using: line whose indented next line is nothing but a comment", () => {
@@ -24,7 +37,7 @@ describe("scanModuleImports", () => {
     });
 
     it("collects dot-notation module references", () => {
-        expect(scanModuleImports(["using { Gadgets.Tools }"])).toEqual([{ path: "Gadgets.Tools", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using { Gadgets.Tools }"])).toEqual([{ path: "Gadgets.Tools", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("skips indented using lines (module-scoped imports)", () => {
@@ -37,7 +50,7 @@ describe("scanModuleImports", () => {
         // body level; local-scope `using{instance}` is only legal inside a
         // function body. So a bare `using { X }` at column 0 can only be a
         // same-directory folder-module import, never a local-scope using.
-        expect(scanModuleImports(["using { Features }"])).toEqual([{ path: "Features", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using { Features }"])).toEqual([{ path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("skips local-scope using inside a function body", () => {
@@ -50,7 +63,7 @@ describe("scanModuleImports", () => {
     });
 
     it("handles CRLF line endings", () => {
-        expect(scanModuleImports(["using { /A }\r", "code()\r"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using { /A }\r", "code()\r"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("skips an import commented out with a block comment", () => {
@@ -60,18 +73,18 @@ describe("scanModuleImports", () => {
 
     it("resumes scanning after a block comment closes", () => {
         const lines = ["<#", "using { /Old/Path }", "#>", "using { /Verse.org/Simulation }", "", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, opensBlockComment: false }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("skips an import inside a block comment opened and closed on one line", () => {
-        expect(scanModuleImports(["<# using { /Old/Path } #>", "using { /A }"])).toEqual([{ path: "/A", startLine: 1, endLine: 1, opensBlockComment: false }]);
+        expect(scanModuleImports(["<# using { /Old/Path } #>", "using { /A }"])).toEqual([{ path: "/A", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("keeps an import whose line opens a block comment after it, and flags it", () => {
         const lines = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "using { /B }"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: true },
-            { path: "/B", startLine: 3, endLine: 3, opensBlockComment: false },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<# disabled below" },
+            { path: "/B", startLine: 3, endLine: 3, anchorsCommentBelow: false, trailingComment: "" },
         ]);
     });
 
@@ -79,15 +92,15 @@ describe("scanModuleImports", () => {
         // Nothing below the line is comment body, so rebuilding it only loses
         // the annotation text - the documented behavior of stripTrailingComment.
         expect(scanModuleImports(["using { /A } <# note #>", "using { /B }"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: false },
-            { path: "/B", startLine: 1, endLine: 1, opensBlockComment: false },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "<# note #>" },
+            { path: "/B", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" },
         ]);
     });
 
     it("does not flag an import whose trailing line comment mentions <#", () => {
         expect(scanModuleImports(["using { /A } # opens with <#", "using { /B }"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: false },
-            { path: "/B", startLine: 1, endLine: 1, opensBlockComment: false },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "# opens with <#" },
+            { path: "/B", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" },
         ]);
     });
 
@@ -96,34 +109,54 @@ describe("scanModuleImports", () => {
         // be read at endLine rather than startLine.
         const lines = ["using:", "    /A <# disabled below", "using { /Old/Path }", "#>", "using { /B }"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 1, opensBlockComment: true },
-            { path: "/B", startLine: 4, endLine: 4, opensBlockComment: false },
+            { path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, trailingComment: "<# disabled below" },
+            { path: "/B", startLine: 4, endLine: 4, anchorsCommentBelow: false, trailingComment: "" },
         ]);
     });
 
     it("does not flag an unclosed opener on the last line, which has nothing below it", () => {
         // The flag exists to protect the lines a comment swallows. With no line
         // after the statement there are none, so the import stays rewritable.
-        expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: false }]);
+        expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "<#" }]);
     });
 
     it("flags that same opener once a trailing newline gives it a line below", () => {
         // A real file ends with a newline, so splitting it yields a trailing
         // empty element and the carve-out above stops applying. Both outcomes
         // are safe, but which one a file gets turns on an invisible byte.
-        expect(scanModuleImports(["using { /A } <#", ""])).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: true }]);
+        expect(scanModuleImports(["using { /A } <#", ""])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#" }]);
+    });
+
+    it("flags an import whose line carries an indented comment marker", () => {
+        // `<#>` opens a comment whose body is the lines below it indented past
+        // it. Rebuilding the line moves the marker away from that body, and
+        // leaves the body behind as indented lines at file scope.
+        const lines = ["using { /A } <#> why this is here", "    it brings the module into scope", "code()"];
+        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#> why this is here" }]);
+    });
+
+    it("flags an indented pair whose path line carries an indented comment marker", () => {
+        const lines = ["using:", "    /A <#> why", "        the body of the marker's comment", "code()"];
+        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, trailingComment: "<#> why" }]);
+    });
+
+    it("flags a marker with no body below it, unlike an unclosed block opener", () => {
+        // The `<#` carve-out above is safe because a file ending at that line
+        // can never grow a body. A marker's body is whatever sits indented
+        // below it, so a rebuild that moves the line hands it one it never had.
+        expect(scanModuleImports(["using { /A } <#> note", "code()"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#> note" }]);
     });
 
     it("treats block comments as nesting, so an inner close does not resume scanning", () => {
         const lines = ["<#", "<#", "using { /Inner }", "#>", "using { /Outer }", "#>", "using { /Live }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Live", startLine: 6, endLine: 6, opensBlockComment: false }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Live", startLine: 6, endLine: 6, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("flags an import whose trailing opener is closed by a nested block below", () => {
         // The outer `<#` is still open on the line after the statement, so the
         // import stays anchored even though an inner `#>` appears first.
         const lines = ["using { /A } <# outer", "<# inner #>", "using { /Old/Path }", "#>", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, opensBlockComment: true }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<# outer" }]);
     });
 
     it("skips an indented using: pair commented out as a block", () => {
@@ -136,20 +169,20 @@ describe("scanModuleImports", () => {
         // below it, which are skipped anyway. Reading it as `<#` would open a
         // block that never closes and hide every import in the rest of the file.
         const lines = ["<#> disabled for now", "    using { /Old/Path }", "using { /Verse.org/Simulation }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 2, endLine: 2, opensBlockComment: false }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 2, endLine: 2, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("does not treat a <# inside a line comment as a block opener", () => {
         const lines = ["# a block comment opens with <#", "using { /Verse.org/Simulation }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 1, endLine: 1, opensBlockComment: false }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" }]);
     });
 
     it("returns entries in document order with correct spans across mixed styles", () => {
         const lines = ["using { /A }", "using:", "    /B", "using. /C"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, opensBlockComment: false },
-            { path: "/B", startLine: 1, endLine: 2, opensBlockComment: false },
-            { path: "/C", startLine: 3, endLine: 3, opensBlockComment: false },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/B", startLine: 1, endLine: 2, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/C", startLine: 3, endLine: 3, anchorsCommentBelow: false, trailingComment: "" },
         ]);
     });
 });
@@ -186,6 +219,14 @@ describe("scanConvertibleImports", () => {
         // Rebuilding the line from its path alone would drop the opener and
         // resurrect the region below it.
         const lines = ["using { /A } <#", "using { /Old/Path }", "#>", "code()"];
+        expect(scanConvertibleImports(lines)).toEqual([]);
+    });
+
+    it("excludes an import whose own line carries an indented comment marker", () => {
+        // Conversion replaces the whole line, so the marker would land at
+        // whatever the converted statement is and the body below it would be
+        // read against a marker that is no longer above it.
+        const lines = ["using { /A } <#> why", "    the body", "code()"];
         expect(scanConvertibleImports(lines)).toEqual([]);
     });
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -114,17 +114,20 @@ describe("scanModuleImports", () => {
         ]);
     });
 
-    it("does not flag an unclosed opener on the last line, which has nothing below it", () => {
-        // The flag exists to protect the lines a comment swallows. With no line
-        // after the statement there are none, so the import stays rewritable.
-        expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "<#" }]);
+    it("flags an unclosed opener whether or not a line sits below it today", () => {
+        // The flag used to be read off the line below, so an opener ending the
+        // buffer was left rewritable as swallowing nothing - and which a file
+        // got turned on whether it ended with a newline. Now that a rebuild
+        // carries the opener through rather than dropping it, "swallows nothing
+        // today" stops being safe: sorted above another import, it swallows it.
+        expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#" }]);
+        expect(scanModuleImports(["using { /A } <#", ""])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#" }]);
     });
 
-    it("flags that same opener once a trailing newline gives it a line below", () => {
-        // A real file ends with a newline, so splitting it yields a trailing
-        // empty element and the carve-out above stops applying. Both outcomes
-        // are safe, but which one a file gets turns on an invisible byte.
-        expect(scanModuleImports(["using { /A } <#", ""])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#" }]);
+    it("does not flag a statement whose own text closes every block it opens", () => {
+        // Depth returns to 0 on the line, so nothing below it is comment body
+        // and the trailing text travels with the statement safely.
+        expect(scanModuleImports(["using { /A } <# note #>", "code()"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "<# note #>" }]);
     });
 
     it("flags an import whose line carries an indented comment marker", () => {


### PR DESCRIPTION
Closes #189

Every writer rebuilt an import line from its path alone, so whatever trailed the statement on that line was discarded. Two symptoms, one root cause: `ScannedImport` carried nothing for a writer to put back.

## What changed

**A trailing comment now survives a rebuild.** `ScannedImport.trailingComment` holds it, extracted by a new `ImportFormatter.extractTrailingComment` that shares its split point with the existing `stripTrailingComment` (one private `commentStartIndex`, so the two halves cannot drift apart and always recompose the original). The four rebuild sites re-attach it, keyed on the formatted statement — the same handle `buildOrganizedContent` already uses to re-attach the comments written *above* an import, and the only one still available after a list of paths has been sorted and grouped.

**A line carrying a comment marker is left where it was written.** `opensBlockComment` becomes `anchorsCommentBelow` and covers the `<#>` indented-comment marker as well as the `<#` block opener it already covered. Renamed rather than extended in place: every consumer wanted the union and nothing told the two apart, and a field named "block" over a marker that the file's own doc comment insists is *not* a block opener would have been wrong.

The flag is read from the statement's own text — a `<#>` anywhere on its span, or a `<#` the span never closes — rather than from what happens to sit under it.

## The `<#>` semantics

The Book of Verse prose (`00_overview.md:653`) says a `<#>` sits "on its own line", which would make the trailing case in the ticket dubious. The compiler's own round-trip tests overrule it: `Tests/Roundtrip/Comments.versetest:309-320` asserts `a<#>` with `b<#>` indented below it round-trips, and `:227` has `<#>hey` mid-body. A `<#>` after code does open an indented comment.

## A defect the review caught

The first commit kept the pre-existing carve-out that left an unclosed `<#` on the buffer's last line rewritable, on the reasoning that it had no line below to swallow. That held only while a rebuild *discarded* the opener. Carrying it through and sorting it upward made it swallow the imports below:

```
in : "using { /Zebra }\nusing { /Apple } <#"
out: "using { /Apple } <#\nusing { /Zebra }\n"     <- /Zebra is now comment text
```

and through `addImportsToDocument` the newly added import landed under the opener, leaving it inert so auto-import re-fired on it forever. Both were reproduced as failing tests before the fix. Removing the carve-out also drops the wart where the outcome turned on whether the file ended with a newline.

## Tests

Each new test was proven to detect its own defect: the fix was reverted one behaviour at a time and the failures were disjoint — six for the marker anchoring, six for the comment preservation, no others in either run.

Coverage spans `scanModuleImports`, `scanConvertibleImports`, `extractTrailingComment`, `buildOrganizedContent` (all three import styles, dedup, idempotence, CRLF) and `addImportsToDocument` (both the block-replacement and consolidate writers, which the ticket's acceptance reaches and which had no trailing-comment coverage).

## Verification

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 20 passed, 20 total
Tests:       365 passed, 365 total
Snapshots:   0 total
Time:        9.73 s
Ran all test suites.

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

Round 1 FAIL (1 Critical, 1 Important, 6 Suggestions) — the Critical above. Round 2 PASS_WITH_SUGGESTIONS after the fix; both remaining Suggestions were applied (the trailing-comment helper now refuses an anchored import itself rather than relying on all four callers to pass a filtered list, and the regression test for the Critical was pinned to the exact edit instead of a vacuous "no `<#` anywhere" assertion).

## Out of scope, worth filing separately

- `ImportPathConverter.applyConversion` replaces the whole line with `originalIndent + finalImport`, so a path conversion still deletes a trailing comment. A different writer from the ones the ticket names; `ScannedImport.trailingComment` now carries what a fix would need.
- `buildOrganizedContent`'s `anchoredPaths` filters only `additionalPaths`, so a path imported both by an anchored line and a live one is emitted twice. Pre-existing for `<#`, newly reachable for `<#>`.
