### PR TITLE
test(integration): locate a T6 import by its line, not by any line

### DIFF
--- a/src/test-integration/suite/importStyles.itest.ts
+++ b/src/test-integration/suite/importStyles.itest.ts
@@ -15,8 +15,25 @@ describe("import styles matrix (playbook T6)", () => {
         await settings.restoreAll();
     });
 
-    function lineIndexContaining(text: string, fragment: string): number {
-        return text.split("\n").findIndex((line) => line.includes(fragment));
+    /**
+     * Where the import statement naming `fragment` sits, which is what every
+     * assertion below is really asking about.
+     *
+     * Import lines only. Matching any line that merely contains the fragment
+     * found the fixture's own header comment, which names `Gadgets.Tools` in
+     * prose to say which import is the local one: that comment sits above the
+     * block, so `digestFirst` read as violated while the output was correctly
+     * grouped. The collision was invisible until the header stopped being
+     * pushed below the imports, and any future fixture whose prose names a
+     * path would hit it again.
+     *
+     * Covers the braced and dotted styles, both of which this suite flips
+     * between. Not the indented `using:` pair, whose path is on the next line -
+     * nothing here writes one, and a test that needs it should locate it
+     * deliberately rather than lean on a substring match.
+     */
+    function importLineIndex(text: string, fragment: string): number {
+        return text.split("\n").findIndex((line) => line.startsWith("using") && line.includes(fragment));
     }
 
     it("importSyntax dot rewrites the block; flipping back restores curly", async () => {
@@ -34,15 +51,15 @@ describe("import styles matrix (playbook T6)", () => {
     it("importGrouping digestFirst puts digest imports before local ones; localFirst reverses", async () => {
         await settings.set("behavior.importGrouping", "digestFirst");
         let text = await runOptimizeImports(document);
-        let digestIndex = lineIndexContaining(text, "/Fortnite.com/Devices");
-        let localIndex = lineIndexContaining(text, "Gadgets.Tools");
+        let digestIndex = importLineIndex(text, "/Fortnite.com/Devices");
+        let localIndex = importLineIndex(text, "Gadgets.Tools");
         assert.ok(digestIndex !== -1 && localIndex !== -1, `imports missing after optimize:\n${text}`);
         assert.ok(digestIndex < localIndex, `digestFirst violated:\n${text}`);
 
         await settings.set("behavior.importGrouping", "localFirst");
         text = await runOptimizeImports(document);
-        digestIndex = lineIndexContaining(text, "/Fortnite.com/Devices");
-        localIndex = lineIndexContaining(text, "Gadgets.Tools");
+        digestIndex = importLineIndex(text, "/Fortnite.com/Devices");
+        localIndex = importLineIndex(text, "Gadgets.Tools");
         assert.ok(digestIndex !== -1 && localIndex !== -1, `imports missing after optimize:\n${text}`);
         assert.ok(localIndex < digestIndex, `localFirst violated:\n${text}`);
 
@@ -52,8 +69,8 @@ describe("import styles matrix (playbook T6)", () => {
     it("sortImportsAlphabetically orders the block", async () => {
         await settings.set("behavior.sortImportsAlphabetically", true);
         const text = await runOptimizeImports(document);
-        const devices = lineIndexContaining(text, "/Fortnite.com/Devices");
-        const simulation = lineIndexContaining(text, "/Verse.org/Simulation");
+        const devices = importLineIndex(text, "/Fortnite.com/Devices");
+        const simulation = importLineIndex(text, "/Verse.org/Simulation");
         assert.ok(devices !== -1 && simulation !== -1, `imports missing after optimize:\n${text}`);
         assert.ok(devices < simulation, `alphabetical sort violated (/Fortnite.com/Devices must precede /Verse.org/Simulation):\n${text}`);
     });

--- a/src/test-integration/suite/importStyles.itest.ts
+++ b/src/test-integration/suite/importStyles.itest.ts
@@ -31,9 +31,13 @@ describe("import styles matrix (playbook T6)", () => {
      * between. Not the indented `using:` pair, whose path is on the next line -
      * nothing here writes one, and a test that needs it should locate it
      * deliberately rather than lean on a substring match.
+     *
+     * The character after `using` has to be one that can follow the keyword, so
+     * an identifier merely beginning with it - `usingCount := 0` - is not read
+     * as an import.
      */
     function importLineIndex(text: string, fragment: string): number {
-        return text.split("\n").findIndex((line) => line.startsWith("using") && line.includes(fragment));
+        return text.split("\n").findIndex((line) => /^using[\s.{:]/.test(line) && line.includes(fragment));
     }
 
     it("importSyntax dot rewrites the block; flipping back restores curly", async () => {


### PR DESCRIPTION
Closes #193

`test-integration` has been red on `main` since #188. This turns it green. The extension was never wrong — the test was locating the wrong line.

## What was happening

`lineIndexContaining` substring-matched every line of the document, and the `t6_styles.verse` fixture's header comment names the import in prose:

```
# Gadgets.Tools import is the local (non-digest) member of the block.
```

So `lineIndexContaining(text, "Gadgets.Tools")` returned that comment's index, above the import block, rather than the import's. `digestFirst violated` fired against output that was correctly grouped:

```
# Playbook T6: styles matrix. …
# … The
# Gadgets.Tools import is the local (non-digest) member of the block.   <- matched this

using { /Fortnite.com/Devices }
using { /Verse.org/Simulation }

using { Gadgets.Tools }                                                 <- meant this
```

Only `Gadgets.Tools` collides; the other two call sites look for `/Fortnite.com/Devices` and `/Verse.org/Simulation`, neither of which appears in the prose, which is why the sibling assertions kept passing.

It became reachable at #188, which made the file's opening comment run stay above the import block. Before that, organize hoisted the imports to line 0 and pushed the header down — the defect #188 exists to fix — so the first line containing `Gadgets.Tools` happened to be the import. The test was passing on the old, wrong behaviour.

## The change

The helper now matches import lines only, and is renamed to say what it returns. That is what all three call sites are asking about, and it will not collide with a future fixture whose prose names a path — which fixing the fixture's wording alone would leave possible.

Covers the braced and dotted styles, both of which this suite flips between. Not the indented `using:` pair, whose path sits on the following line; nothing in T6 writes one, and a test that needs it should locate it deliberately rather than lean on a substring match. That is stated in the helper's doc comment.

## Verification

Integration suite, locally, on this branch:

```
> verse-auto-imports@0.9.0 test:integration

  25 passing (25s)

Exit code:   0
```

The assertion still detects a genuine break. Flipping the expected order to `digestIndex > localIndex` fails it, so it is not passing vacuously:

```
  24 passing (23s)
  1 failing

  1) import styles matrix (playbook T6)
       importGrouping digestFirst puts digest imports before local ones; localFirst reverses:
      AssertionError [ERR_ASSERTION]: digestFirst violated:

Exit code:   1
```

Unit suite and formatting:

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 20 passed, 20 total
Tests:       343 passed, 343 total
Snapshots:   0 total
Time:        9.046 s
Ran all test suites.

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Why this is its own PR

#190 (issue #189) is blocked on this check and inherits the failure. Landing the repair separately keeps that PR's diff to what its ticket asked for, and fixes `main` for every branch rather than only under one.
