### PR TITLE
fix(ui): hide argument-requiring commands from the Command Palette

### DIFF
--- a/changelog.d/136.fixed.md
+++ b/changelog.d/136.fixed.md
@@ -1,0 +1,1 @@
+**Command Palette**: five commands that only the quick fix and the CodeLens are meant to invoke - Add Import, Use Absolute Path, Use Absolute Paths for All, Use Relative Path and Use Relative Paths for All - no longer appear in the Command Palette, where running them raised a raw "Running the contributed command failed" error.

--- a/package.json
+++ b/package.json
@@ -120,6 +120,30 @@
         "category": "Verse Auto Imports"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "verseAutoImports.addSingleImport",
+          "when": "false"
+        },
+        {
+          "command": "verseAutoImports.convertToFullPath",
+          "when": "false"
+        },
+        {
+          "command": "verseAutoImports.convertAllToFullPath",
+          "when": "false"
+        },
+        {
+          "command": "verseAutoImports.convertToRelativePath",
+          "when": "false"
+        },
+        {
+          "command": "verseAutoImports.convertAllToRelativePath",
+          "when": "false"
+        }
+      ]
+    },
     "configuration": {
       "title": "Verse Auto Imports",
       "properties": {

--- a/src/commands/__tests__/commandManifest.test.ts
+++ b/src/commands/__tests__/commandManifest.test.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// Regression for #136: five commands need caller-supplied arguments - the quick
+// fix passes them to addSingleImport, the CodeLens passes them to the four
+// conversion commands. Without a commandPalette entry hiding them, every
+// declared command is palette-visible, and invoking one of these from the
+// palette dereferences an undefined document.
+
+interface CommandContribution {
+    command: string;
+    title: string;
+}
+
+interface MenuContribution {
+    command: string;
+    when?: string;
+}
+
+interface Manifest {
+    contributes: {
+        commands: CommandContribution[];
+        menus?: { commandPalette?: MenuContribution[] };
+    };
+}
+
+const ARGUMENT_REQUIRING_COMMANDS = [
+    "verseAutoImports.addSingleImport",
+    "verseAutoImports.convertToFullPath",
+    "verseAutoImports.convertAllToFullPath",
+    "verseAutoImports.convertToRelativePath",
+    "verseAutoImports.convertAllToRelativePath",
+];
+
+const manifest: Manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json"), "utf8"));
+
+const commandPalette = manifest.contributes.menus?.commandPalette ?? [];
+
+/** A palette entry hides its command only with a "when" that never holds. */
+function isHiddenFromPalette(command: string): boolean {
+    return commandPalette.some((entry) => entry.command === command && entry.when === "false");
+}
+
+describe("package.json commandPalette contributions", () => {
+    it.each(ARGUMENT_REQUIRING_COMMANDS)("hides %s from the Command Palette", (command) => {
+        expect(isHiddenFromPalette(command)).toBe(true);
+    });
+
+    it("hides no other command from the Command Palette", () => {
+        const visible = manifest.contributes.commands.map((entry) => entry.command).filter((command) => !ARGUMENT_REQUIRING_COMMANDS.includes(command));
+
+        for (const command of visible) {
+            expect(isHiddenFromPalette(command)).toBe(false);
+        }
+    });
+
+    it("declares no palette entry for a command that does not exist", () => {
+        const declared = manifest.contributes.commands.map((entry) => entry.command);
+
+        for (const entry of commandPalette) {
+            expect(declared).toContain(entry.command);
+        }
+    });
+});

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -119,8 +119,9 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 3. [ ] Case C `Economy.Shop` (explicit module declared in two files): both
        locations detected (Systems and Features). This exercises the cache
        lookup path and the #43 regex fix across multiple files.
-4. [ ] Bulk command "Verse Auto Imports: Use Absolute Paths for All" handles
-       all three lines coherently in one pass.
+4. [ ] The "Use absolute paths for all" CodeLens handles all three lines
+       coherently in one pass. It is not in the Command Palette (#136): it
+       needs the document as an argument, so only the lens invokes it.
 5. [ ] Cache off/on: set `cache.enabled` false, reload, repeat case C
        (pure filesystem path), then re-enable, rebuild cache, repeat again.
        Same results both ways; Debug log shows cache hits when enabled.


### PR DESCRIPTION
Closes #136

## What

`package.json` declared no `contributes.menus.commandPalette`, so all 19 commands were palette-visible. Five of them take caller-supplied arguments and are invoked only internally:

| Command | Only caller |
|---|---|
| `addSingleImport` | quick fix, `ImportCodeActionProvider.ts:79-80` |
| `convertToFullPath` | CodeLens, `ImportCodeLensProvider.ts:191` |
| `convertAllToFullPath` | CodeLens, `:201` |
| `convertToRelativePath` | CodeLens, `:217` |
| `convertAllToRelativePath` | CodeLens, `:227` |

Selecting one from the palette called the handler with no arguments, which dereferenced an undefined `document` and surfaced as a raw "Running the contributed command failed" notification.

This adds a `commandPalette` block gating exactly those five on `"when": "false"`. A `commandPalette` menu entry governs palette listing only, so the quick fix, the CodeLens, and any `executeCommand` path are unaffected — the integration suite's `getCommands()` registration check still sees all 19.

The remaining 14 commands take no arguments and each guards its own preconditions (`optimizeImports` checks `activeTextEditor`, the cache commands check the path cache), so they stay visible.

## Also in this diff

The smoke playbook's T4 step 4 named the palette form of the bulk conversion command, which this change removes from the palette. It now names the "Use absolute paths for all" CodeLens that actually invokes it. There is no automated e2e suite, so that playbook is the human release gate; leaving the step as written would have read as a regression.

## Test

New `src/commands/__tests__/commandManifest.test.ts` asserts the five are hidden, that no other command is, and that no palette entry names a command that is not declared.

Proven to detect the defect — with the `package.json` change stashed, the five hiding cases fail:

```
Test Suites: 1 failed, 1 total
Tests:       5 failed, 2 passed, 7 total
```

## Verification

`npm run compile`:

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 21 passed, 21 total
Tests:       402 passed, 402 total
Snapshots:   0 total
Time:        8.78 s, estimated 13 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

Fresh-context review gate, opus, round 1: `PASS_WITH_SUGGESTIONS` — 0 Critical, 1 Important, 3 Suggestions. The Important finding was the stale playbook step, fixed above; one Suggestion (an overstated test name) was taken. Two were left, deliberately:

- **The test pins today's five rather than deriving them from handler arity.** A sixth argument-taking command added later would pass every assertion. Closing that means a shared command-to-handler table keyed on `Function.length`, which is a wider change than this ticket asks for.
- **Palette hiding is not every path.** VS Code still lists palette-hidden commands in the Keyboard Shortcuts editor, so a user-assigned keybinding, or another extension's `executeCommand`, still reaches these handlers with no arguments. #136 scoped the fix to the manifest and noted the missing `try`/`catch` only as an aggravating factor. Worth a follow-up issue if you want the handlers to guard their own arguments.
