### PR TITLE
chore(tests): use one Epic account placeholder in unit tests

### DIFF
--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -160,7 +160,7 @@ describe("ImportSuggestionExtractor", () => {
 
         it("should drop prose lines trailing a 'Did you mean any of' option list", async () => {
             // Regression #130: the trailing sentence used to become an option
-            const errorMessage = "Unknown identifier `Combat`. Did you mean any of: \nSystems.Combat\nFeatures.Combat\nUsed inside module /mygame@fortnite.com/MyGame/Scripts.";
+            const errorMessage = "Unknown identifier `Combat`. Did you mean any of: \nSystems.Combat\nFeatures.Combat\nUsed inside module /mygame@fortnite.com/mygame/Scripts.";
 
             const suggestions = await extractor.extractImportSuggestions(errorMessage);
 

--- a/src/services/__tests__/AssetsDigestParser.test.ts
+++ b/src/services/__tests__/AssetsDigestParser.test.ts
@@ -8,14 +8,15 @@ import { AssetsDigestParser } from "../AssetsDigestParser";
  */
 describe("AssetsDigestParser.parseDigestContent", () => {
     describe("41.10 declaration shapes", () => {
-        // Recorded verbatim from a live 41.10 Assets.digest.verse (issue #63).
+        // Recorded from a live 41.10 Assets.digest.verse (issue #63). The
+        // declaration shapes are verbatim; only the project path is a placeholder.
         const digest = [
-            "image1<scoped {/vuke@fortnite.com/VerseAutoImports}>:texture = external {}",
-            "TestSphere_asset<scoped {/vuke@fortnite.com/VerseAutoImports}>:mesh = external {}",
-            "TestVFX_asset<scoped {/vuke@fortnite.com/VerseAutoImports}>:particle_system = external {}",
-            "TestMaterial<scoped {/vuke@fortnite.com/VerseAutoImports}> := class<scoped {/vuke@fortnite.com/VerseAutoImports}>(material):",
-            "TestSphere<scoped {/vuke@fortnite.com/VerseAutoImports}> := class<final><scoped {/vuke@fortnite.com/VerseAutoImports}>(mesh_component):",
-            "TestVFX<scoped {/vuke@fortnite.com/VerseAutoImports}> := class<public>(particle_system_component):",
+            "image1<scoped {/mygame@fortnite.com/mygame}>:texture = external {}",
+            "TestSphere_asset<scoped {/mygame@fortnite.com/mygame}>:mesh = external {}",
+            "TestVFX_asset<scoped {/mygame@fortnite.com/mygame}>:particle_system = external {}",
+            "TestMaterial<scoped {/mygame@fortnite.com/mygame}> := class<scoped {/mygame@fortnite.com/mygame}>(material):",
+            "TestSphere<scoped {/mygame@fortnite.com/mygame}> := class<final><scoped {/mygame@fortnite.com/mygame}>(mesh_component):",
+            "TestVFX<scoped {/mygame@fortnite.com/mygame}> := class<public>(particle_system_component):",
         ].join("\n");
 
         it("parses every recorded 41.10 asset name", () => {
@@ -25,15 +26,13 @@ describe("AssetsDigestParser.parseDigestContent", () => {
         });
 
         it("parses the material class with a scoped specifier on the class keyword", () => {
-            const names = AssetsDigestParser.parseDigestContent("TestMaterial<scoped {/vuke@fortnite.com/VerseAutoImports}> := class<scoped {/vuke@fortnite.com/VerseAutoImports}>(material):");
+            const names = AssetsDigestParser.parseDigestContent("TestMaterial<scoped {/mygame@fortnite.com/mygame}> := class<scoped {/mygame@fortnite.com/mygame}>(material):");
 
             expect(names).toContain("TestMaterial");
         });
 
         it("parses a class with stacked specifiers on the class keyword (<final><scoped {...}>)", () => {
-            const names = AssetsDigestParser.parseDigestContent(
-                "TestSphere<scoped {/vuke@fortnite.com/VerseAutoImports}> := class<final><scoped {/vuke@fortnite.com/VerseAutoImports}>(mesh_component):",
-            );
+            const names = AssetsDigestParser.parseDigestContent("TestSphere<scoped {/mygame@fortnite.com/mygame}> := class<final><scoped {/mygame@fortnite.com/mygame}>(mesh_component):");
 
             expect(names).toEqual(["TestSphere"]);
         });
@@ -41,9 +40,9 @@ describe("AssetsDigestParser.parseDigestContent", () => {
         it("parses texture, mesh, and niagara instance declarations", () => {
             const names = AssetsDigestParser.parseDigestContent(
                 [
-                    "image1<scoped {/vuke@fortnite.com/VerseAutoImports}>:texture = external {}",
-                    "TestSphere_asset<scoped {/vuke@fortnite.com/VerseAutoImports}>:mesh = external {}",
-                    "TestVFX_asset<scoped {/vuke@fortnite.com/VerseAutoImports}>:particle_system = external {}",
+                    "image1<scoped {/mygame@fortnite.com/mygame}>:texture = external {}",
+                    "TestSphere_asset<scoped {/mygame@fortnite.com/mygame}>:mesh = external {}",
+                    "TestVFX_asset<scoped {/mygame@fortnite.com/mygame}>:particle_system = external {}",
                 ].join("\n"),
             );
 


### PR DESCRIPTION
Closes #177

Unit tests carried three spellings of the Epic account segment in Verse paths. This settles them on `/mygame@fortnite.com/mygame` and retires `/vuke@fortnite.com` entirely, leaving two placeholders in the tree, each in the context the issue assigns it.

## Changed

- `src/services/__tests__/AssetsDigestParser.test.ts` — the only remaining `/vuke@fortnite.com` in the repo.
- `src/imports/__tests__/ImportSuggestionExtractor.test.ts` — second segment was `MyGame` rather than `mygame`.

The `// Recorded verbatim` comment above the 41.10 fixture is amended in the same hunk: with the project path substituted, the declaration shapes are still verbatim but the strings as a whole are not, and the comment now says which is which.

## Deliberately not changed

Each of these already carries `/vukefn@fortnite.com`, which is the value the issue assigns its context:

- `test-fixtures/corpus/41.10/diagnostics.json` — `test-fixtures/corpus/README.md` contracts these as verbatim compiler messages regenerated by the Capture Diagnostics Corpus command, so a hand-edited account segment would be reverted on the next capture.
- `test-fixtures/uefn-smoke/**` and the integration harness `.uefnproject`, the latter being functional data the harness reads.
- `src/project/ProjectPathHandler.ts:115` — JSDoc prose example.

`CHANGELOG.md` is named in the issue but holds no occurrence today.

## On the issue's occurrence table

Re-measured on `main` as match counts: `/vuke@fortnite.com` 15, `/vukefn@fortnite.com` 14, `/mygame@fortnite.com` 13. The first two match the issue; the `/mygame@` row was understated at 7. On this branch `/vuke@fortnite.com` is 0.

## No changelog fragment

`changelog.d/README` scopes fragments to user-facing changes, "written for end users - what changed in the editor experience, not internal refactor details". This diff touches test data only and changes no behavior.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 20 passed, 20 total
Tests:       395 passed, 395 total
Snapshots:   0 total
Time:        6.728 s, estimated 12 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No regression test accompanies this change: it substitutes inert string content, and the existing suite passing is what demonstrates the substitution stayed inert. The account segment is never read — `AssetsDigestParser` consumes the specifier block as `(?:<[^>]*>)*` and neither placeholder contains `>`, and in the extractor test the path sits on a prose line the test asserts is dropped.

## Review

Reviewed by a separate agent against the issue and the repo's smell baseline: PASS_WITH_SUGGESTIONS, 0 Critical, 0 Important, 1 Suggestion.

The suggestion is out of this issue's scope and left for the maintainer to rule on: the placeholder convention itself is written down only in the issue, not in any committed repo doc, so nothing in the tree tells the next contributor which placeholder to use. A line in `CLAUDE.md` under Testing would close that loop; happy to file it separately.
