### PR TITLE
fix(imports): report refused path conversions instead of success

### DIFF
--- a/changelog.d/185.fixed.md
+++ b/changelog.d/185.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: converting an import to an absolute or relative path now warns when the edit could not be applied, instead of reporting the new path over an unchanged document. A whole-document conversion says how many imports it could not convert rather than only counting the ones it did.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -239,6 +239,7 @@ const window = {
     showInformationMessage: jest.fn(),
     showWarningMessage: jest.fn(),
     showErrorMessage: jest.fn(),
+    showQuickPick: jest.fn(),
     setStatusBarMessage: jest.fn(),
 };
 

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -400,6 +400,34 @@ export class CommandsHandler {
     }
 
     /**
+     * Reports a conversion the document refused. applyConversion returns false
+     * when it cannot find the line to rewrite, when applyEdit is rejected, or
+     * when the edit throws, and the document is unchanged in all three cases -
+     * reporting the new path would leave the only trace in the output channel.
+     */
+    private reportRefusedConversion(originalImport: string): void {
+        logger.warn("CommandsHandler", `Failed to convert import: ${originalImport}`);
+        vscode.window.showWarningMessage(`Could not convert import: ${originalImport}. The document may have changed or be read-only.`);
+    }
+
+    /**
+     * Reports the outcome of a whole-document conversion. A count alone does
+     * not read as a failure: a run where every edit was refused still reports
+     * a number, so any failure has to say so in its own words.
+     */
+    private reportConversionTotals(pathKind: string, convertedCount: number, failedCount: number): void {
+        const summary = `Using ${pathKind} paths for ${convertedCount} import${convertedCount !== 1 ? "s" : ""}.`;
+
+        if (failedCount === 0) {
+            vscode.window.showInformationMessage(summary);
+            return;
+        }
+
+        logger.warn("CommandsHandler", `${failedCount} conversion(s) were not applied to the document`);
+        vscode.window.showWarningMessage(`${summary} ${failedCount} could not be converted. The document may have changed or be read-only.`);
+    }
+
+    /**
      * Shows a quick pick for selecting an ambiguous path.
      */
     private async selectAmbiguousPath(result: PathConversionResult): Promise<string | undefined> {
@@ -438,12 +466,22 @@ export class CommandsHandler {
         if (result.isAmbiguous && result.possiblePaths) {
             const selectedPath = await this.selectAmbiguousPath(result);
             if (selectedPath) {
-                await this.deps.importPathConverter.applyConversion(document, result, selectedPath);
+                const applied = await this.deps.importPathConverter.applyConversion(document, result, selectedPath);
+                if (!applied) {
+                    this.reportRefusedConversion(result.originalImport);
+                    return;
+                }
+
                 vscode.window.setStatusBarMessage(`Using absolute path: ${selectedPath}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
                 this.finalizeConversion(documentUri);
             }
         } else {
-            await this.deps.importPathConverter.applyConversion(document, result);
+            const applied = await this.deps.importPathConverter.applyConversion(document, result);
+            if (!applied) {
+                this.reportRefusedConversion(result.originalImport);
+                return;
+            }
+
             vscode.window.setStatusBarMessage(`Using absolute path: ${result.fullPathImport}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
             this.finalizeConversion(documentUri);
         }
@@ -464,6 +502,7 @@ export class CommandsHandler {
         }
 
         let convertedCount = 0;
+        let failedCount = 0;
         const ambiguousImports: PathConversionResult[] = [];
 
         // First pass: handle non-ambiguous imports
@@ -471,21 +510,24 @@ export class CommandsHandler {
             if (!result.isAmbiguous) {
                 const success = await this.deps.importPathConverter.applyConversion(document, result);
                 if (success) convertedCount++;
+                else failedCount++;
             } else {
                 ambiguousImports.push(result);
             }
         }
 
-        // Second pass: handle ambiguous imports interactively
+        // Second pass: handle ambiguous imports interactively. A cancelled quick
+        // pick is a decline rather than a failure, so it counts as neither.
         for (const result of ambiguousImports) {
             const selectedPath = await this.selectAmbiguousPath(result);
             if (selectedPath) {
                 const success = await this.deps.importPathConverter.applyConversion(document, result, selectedPath);
                 if (success) convertedCount++;
+                else failedCount++;
             }
         }
 
-        vscode.window.showInformationMessage(`Using absolute paths for ${convertedCount} import${convertedCount !== 1 ? "s" : ""}.`);
+        this.reportConversionTotals("absolute", convertedCount, failedCount);
         this.finalizeConversion(documentUri);
     }
 
@@ -503,7 +545,12 @@ export class CommandsHandler {
             return;
         }
 
-        await this.deps.importPathConverter.applyConversion(document, result);
+        const applied = await this.deps.importPathConverter.applyConversion(document, result);
+        if (!applied) {
+            this.reportRefusedConversion(result.originalImport);
+            return;
+        }
+
         vscode.window.setStatusBarMessage(`Using relative path: ${result.fullPathImport}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
         this.finalizeConversion(documentUri);
     }
@@ -523,12 +570,14 @@ export class CommandsHandler {
         }
 
         let convertedCount = 0;
+        let failedCount = 0;
         for (const result of results) {
             const success = await this.deps.importPathConverter.applyConversion(document, result);
             if (success) convertedCount++;
+            else failedCount++;
         }
 
-        vscode.window.showInformationMessage(`Using relative paths for ${convertedCount} import${convertedCount !== 1 ? "s" : ""}.`);
+        this.reportConversionTotals("relative", convertedCount, failedCount);
         this.finalizeConversion(documentUri);
     }
 }

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -415,7 +415,7 @@ export class CommandsHandler {
      * not read as a failure: a run where every edit was refused still reports
      * a number, so any failure has to say so in its own words.
      */
-    private reportConversionTotals(pathKind: string, convertedCount: number, failedCount: number): void {
+    private reportConversionTotals(pathKind: "absolute" | "relative", convertedCount: number, failedCount: number): void {
         const summary = `Using ${pathKind} paths for ${convertedCount} import${convertedCount !== 1 ? "s" : ""}.`;
 
         if (failedCount === 0) {

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -106,7 +106,20 @@ describe("CommandsHandler.optimizeImports", () => {
 const RELATIVE_MODULE = "Gadgets/Tools";
 const ABSOLUTE_PATH = `/mygame@fortnite.com/mygame/${RELATIVE_MODULE}`;
 
-function makeConversion(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+/**
+ * The shape CommandsHandler reads off a conversion. Declared here because both
+ * PathConversionResult and ImportConversionResult are module-private, and an
+ * untyped fixture lets a mistyped key through to an assertion that still passes.
+ */
+interface ConversionFixture {
+    originalImport: string;
+    fullPathImport: string;
+    moduleName: string;
+    isAmbiguous: boolean;
+    possiblePaths?: string[];
+}
+
+function makeConversion(overrides: Partial<ConversionFixture> = {}): ConversionFixture {
     return {
         originalImport: `using { ${RELATIVE_MODULE} }`,
         fullPathImport: `using { ${ABSOLUTE_PATH} }`,
@@ -141,6 +154,12 @@ function makeConversionHandler(converterOverrides: Record<string, jest.Mock>): {
 
     return { handler, codeLensProvider };
 }
+
+// clearAllMocks clears calls but not implementations, so a quick pick stubbed in
+// one test would otherwise survive into every test declared after it.
+afterEach(() => {
+    (vscode.window.showQuickPick as jest.Mock).mockReset();
+});
 
 describe("CommandsHandler.convertToFullPath", () => {
     it("warns and reports no path when the edit is refused", async () => {

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { CommandsHandler, CommandsDependencies } from "../CommandsHandler";
-import { ImportHandler } from "../../imports";
+import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../../imports";
 
 // Regression for #133: addImportsToDocument and organizeImports return false
 // when applyEdit is rejected - a stale document version, or a read-only file -
@@ -92,6 +92,167 @@ describe("CommandsHandler.optimizeImports", () => {
 
         expect(document.save).toHaveBeenCalledTimes(1);
         expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("Imports optimized successfully");
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+});
+
+// Regression for #185: the same class as #133, for the four path conversion
+// commands. applyConversion returns false when it cannot find the line to
+// rewrite, when applyEdit is rejected, or when the edit throws; the single
+// conversions discarded the boolean and reported the new path anyway, and the
+// bulk conversions only counted it, so a run where every edit was refused
+// reported "Using absolute paths for 0 imports".
+
+const RELATIVE_MODULE = "Gadgets/Tools";
+const ABSOLUTE_PATH = `/mygame@fortnite.com/mygame/${RELATIVE_MODULE}`;
+
+function makeConversion(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        originalImport: `using { ${RELATIVE_MODULE} }`,
+        fullPathImport: `using { ${ABSOLUTE_PATH} }`,
+        moduleName: RELATIVE_MODULE,
+        isAmbiguous: false,
+        ...overrides,
+    };
+}
+
+function makeConversionHandler(converterOverrides: Record<string, jest.Mock>): {
+    handler: CommandsHandler;
+    codeLensProvider: { forceRefreshAfterConversion: jest.Mock };
+} {
+    const importPathConverter = {
+        convertToFullPath: jest.fn().mockResolvedValue(null),
+        convertFromFullPath: jest.fn().mockResolvedValue(null),
+        convertAllImportsInDocument: jest.fn().mockResolvedValue([]),
+        convertAllImportsFromFullPath: jest.fn().mockResolvedValue([]),
+        applyConversion: jest.fn().mockResolvedValue(true),
+        ...converterOverrides,
+    } as unknown as ImportPathConverter;
+
+    const codeLensProvider = {
+        keepHoverStateActive: jest.fn(),
+        forceRefreshAfterConversion: jest.fn(),
+    };
+
+    const handler = new CommandsHandler({
+        importPathConverter,
+        importCodeLensProvider: codeLensProvider as unknown as ImportCodeLensProvider,
+    } as unknown as CommandsDependencies);
+
+    return { handler, codeLensProvider };
+}
+
+describe("CommandsHandler.convertToFullPath", () => {
+    it("warns and reports no path when the edit is refused", async () => {
+        const { handler, codeLensProvider } = makeConversionHandler({
+            convertToFullPath: jest.fn().mockResolvedValue(makeConversion()),
+            applyConversion: jest.fn().mockResolvedValue(false),
+        });
+
+        await handler.convertToFullPath(makeDocument(), `using { ${RELATIVE_MODULE} }`, 4);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showWarningMessage as jest.Mock).mock.calls[0][0]).toMatch(/Could not convert import/);
+        expect(vscode.window.setStatusBarMessage).not.toHaveBeenCalled();
+        // The document is unchanged, so the lenses on it are still accurate.
+        expect(codeLensProvider.forceRefreshAfterConversion).not.toHaveBeenCalled();
+    });
+
+    it("reports the new path when the edit applies", async () => {
+        const { handler, codeLensProvider } = makeConversionHandler({
+            convertToFullPath: jest.fn().mockResolvedValue(makeConversion()),
+            applyConversion: jest.fn().mockResolvedValue(true),
+        });
+
+        await handler.convertToFullPath(makeDocument(), `using { ${RELATIVE_MODULE} }`, 4);
+
+        expect(vscode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.setStatusBarMessage as jest.Mock).mock.calls[0][0]).toBe(`Using absolute path: using { ${ABSOLUTE_PATH} }`);
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+        expect(codeLensProvider.forceRefreshAfterConversion).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns when the edit is refused after an ambiguous path was picked", async () => {
+        (vscode.window.showQuickPick as jest.Mock).mockImplementation(async (items: Array<{ path: string }>) => items[0]);
+        const { handler } = makeConversionHandler({
+            convertToFullPath: jest.fn().mockResolvedValue(makeConversion({ isAmbiguous: true, possiblePaths: [ABSOLUTE_PATH] })),
+            applyConversion: jest.fn().mockResolvedValue(false),
+        });
+
+        await handler.convertToFullPath(makeDocument(), `using { ${RELATIVE_MODULE} }`, 4);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showWarningMessage as jest.Mock).mock.calls[0][0]).toMatch(/Could not convert import/);
+        expect(vscode.window.setStatusBarMessage).not.toHaveBeenCalled();
+    });
+});
+
+describe("CommandsHandler.convertToRelativePath", () => {
+    it("warns and reports no path when the edit is refused", async () => {
+        const { handler } = makeConversionHandler({
+            convertFromFullPath: jest.fn().mockResolvedValue(makeConversion({ fullPathImport: `using { ${RELATIVE_MODULE} }` })),
+            applyConversion: jest.fn().mockResolvedValue(false),
+        });
+
+        await handler.convertToRelativePath(makeDocument(), `using { ${ABSOLUTE_PATH} }`, 4);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showWarningMessage as jest.Mock).mock.calls[0][0]).toMatch(/Could not convert import/);
+        expect(vscode.window.setStatusBarMessage).not.toHaveBeenCalled();
+    });
+});
+
+describe("CommandsHandler.convertAllToFullPath", () => {
+    it("warns rather than reporting a count when every edit is refused", async () => {
+        const { handler } = makeConversionHandler({
+            convertAllImportsInDocument: jest.fn().mockResolvedValue([makeConversion(), makeConversion()]),
+            applyConversion: jest.fn().mockResolvedValue(false),
+        });
+
+        await handler.convertAllToFullPath(makeDocument());
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showWarningMessage as jest.Mock).mock.calls[0][0]).toMatch(/2 could not be converted/);
+        expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it("counts a cancelled ambiguous pick as neither converted nor failed", async () => {
+        (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+        const { handler } = makeConversionHandler({
+            convertAllImportsInDocument: jest.fn().mockResolvedValue([makeConversion({ isAmbiguous: true, possiblePaths: [ABSOLUTE_PATH] })]),
+            applyConversion: jest.fn().mockResolvedValue(true),
+        });
+
+        await handler.convertAllToFullPath(makeDocument());
+
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("Using absolute paths for 0 imports.");
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+});
+
+describe("CommandsHandler.convertAllToRelativePath", () => {
+    it("names the failures alongside the count when only some edits are refused", async () => {
+        const { handler } = makeConversionHandler({
+            convertAllImportsFromFullPath: jest.fn().mockResolvedValue([makeConversion(), makeConversion()]),
+            applyConversion: jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
+        });
+
+        await handler.convertAllToRelativePath(makeDocument());
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showWarningMessage as jest.Mock).mock.calls[0][0]).toMatch(/Using relative paths for 1 import\. 1 could not be converted/);
+        expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it("reports the count as before when every edit applies", async () => {
+        const { handler } = makeConversionHandler({
+            convertAllImportsFromFullPath: jest.fn().mockResolvedValue([makeConversion(), makeConversion()]),
+            applyConversion: jest.fn().mockResolvedValue(true),
+        });
+
+        await handler.convertAllToRelativePath(makeDocument());
+
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("Using relative paths for 2 imports.");
         expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Closes #185

## What was wrong

All four path conversion commands treated `ImportPathConverter.applyConversion` as though it could not fail. `convertToFullPath` and `convertToRelativePath` discarded the boolean and reported the new path over a document that never changed; `convertAllToFullPath` and `convertAllToRelativePath` read it only to count, so a run where every edit was refused still reported "Using absolute paths for 0 imports".

`applyConversion` returns `false` on three paths: it cannot find the line to rewrite, `applyEdit` resolves false, or the edit throws. Each logged to the debug channel and nothing else. #183 made the line lookup refuse rather than guess when the document moves under an async conversion, which is exactly the case that now needs reporting.

## What changed

The signal is the one `a3292dc` settled on for #180, not a second one: `logger.warn`, one `showWarningMessage`, and no success message.

- Single conversions read the boolean and return before the status bar message. `finalizeConversion` is skipped there, as on the pre-existing `!result` path: the document is unchanged, so its lenses are still accurate.
- Bulk conversions count failures separately and replace the info message with a warning naming both counts when any edit was refused. A cancelled ambiguous quick pick never reaches `applyConversion`, so it stays a decline and counts as neither.

`showQuickPick` was absent from the `vscode` mock and the ambiguous-path tests need it.

## Verification

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./

Test Suites: 20 passed, 20 total
Tests:       403 passed, 403 total
Snapshots:   0 total
Time:        6.375 s, estimated 8 s
Ran all test suites.

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The five failure-signal tests were confirmed to detect the defect, by swapping in `origin/main`'s `CommandsHandler.ts` and re-running:

```
  ● CommandsHandler.convertToFullPath › warns and reports no path when the edit is refused
  ● CommandsHandler.convertToFullPath › warns when the edit is refused after an ambiguous path was picked
  ● CommandsHandler.convertToRelativePath › warns and reports no path when the edit is refused
  ● CommandsHandler.convertAllToFullPath › warns rather than reporting a count when every edit is refused
  ● CommandsHandler.convertAllToRelativePath › names the failures alongside the count when only some edits are refused
Tests:       5 failed, 7 passed, 12 total
```

The other three new tests pin the success paths and pass either way by design.

## Review gate

`PASS_WITH_SUGGESTIONS` on round 1, no Critical and no Important findings. Three of the four suggestions are applied in the second commit. The fourth is not, because it reaches outside this ticket: the sentence "The document may have changed or be read-only." is now hard-coded at four sites in `CommandsHandler`, two of them #180's, and extracting it to a constant would edit code this issue does not own. Worth a follow-up.
