### PR TITLE
fix(imports): keep the comment trailing a converted import line

### DIFF
--- a/changelog.d/191.fixed.md
+++ b/changelog.d/191.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: converting an import path keeps the comment trailing that line instead of deleting it, in both directions and in both the braced and dotted styles. A comment on a dotted absolute import is also no longer carried into the converted path, which previously rewrote any `/` inside it as a `.`.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -377,9 +377,13 @@ export class ImportPathConverter {
             return null;
         }
 
-        const curlyMatch = importStatement.match(/using\s*\{\s*([^}]+)\s*\}/);
-        const dotMatch = importStatement.match(/using\.\s*(.+)/);
-        const fullPath = curlyMatch ? curlyMatch[1].trim() : dotMatch ? dotMatch[1].trim() : null;
+        // Read through extractPathFromImport rather than a second copy of its
+        // regexes, because that copy skipped the trailing-comment strip: the
+        // dotted capture runs to end of line, so `using. /A/B # note` yielded the
+        // path `/A/B # note` and re-emitted the comment inside the converted
+        // statement - which applyConversion, restoring the comment itself, would
+        // then write a second time.
+        const fullPath = this.extractPathFromImport(importStatement);
 
         if (!fullPath || !fullPath.startsWith("/")) {
             return null;
@@ -578,8 +582,21 @@ export class ImportPathConverter {
         const edit = new vscode.WorkspaceEdit();
         const range = new vscode.Range(new vscode.Position(lineIndex, 0), new vscode.Position(lineIndex, lines[lineIndex].length));
 
+        // The replacement is built from the statement alone, so everything else
+        // the line carried is dropped unless it is put back. The comment comes
+        // from the line about to be replaced rather than from the conversion:
+        // that line is what the edit overwrites, and resolving a conversion spans
+        // a workspace scan and, when ambiguous, a quick pick - long enough for
+        // the document to change under a recorded line and for findConversionLine
+        // to land on a different one than the comment was read from.
+        //
+        // Only the annotation is at stake here. An import whose line opens a
+        // comment over the lines below it never reaches this point, because
+        // scanConvertibleImports excludes it; see ScannedImport.anchorsCommentBelow.
         const originalIndent = lines[lineIndex].match(/^\s*/)?.[0] || "";
-        edit.replace(document.uri, range, originalIndent + finalImport);
+        const trailingComment = ImportFormatter.extractTrailingComment(lines[lineIndex]);
+        const rebuiltLine = trailingComment ? `${finalImport} ${trailingComment}` : finalImport;
+        edit.replace(document.uri, range, originalIndent + rebuiltLine);
 
         try {
             const success = await vscode.workspace.applyEdit(edit);

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -583,12 +583,12 @@ export class ImportPathConverter {
         const range = new vscode.Range(new vscode.Position(lineIndex, 0), new vscode.Position(lineIndex, lines[lineIndex].length));
 
         // The replacement is built from the statement alone, so everything else
-        // the line carried is dropped unless it is put back. The comment comes
-        // from the line about to be replaced rather than from the conversion:
-        // that line is what the edit overwrites, and resolving a conversion spans
-        // a workspace scan and, when ambiguous, a quick pick - long enough for
-        // the document to change under a recorded line and for findConversionLine
-        // to land on a different one than the comment was read from.
+        // the line carried is dropped unless it is put back. The comment is read
+        // from the line about to be replaced, which is the text this edit
+        // overwrites - the conversion carries the same comment, since
+        // findConversionLine matches on the whole trimmed line, so reading it
+        // here is the one that needs no field threaded through ConvertibleImport
+        // and ImportConversionResult to reach this point.
         //
         // Only the annotation is at stake here. An import whose line opens a
         // comment over the lines below it never reaches this point, because

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -195,6 +195,18 @@ describe("ImportPathConverter.applyConversion", () => {
 
         expect(replacedOperation().text).toBe("    using { /mygame@fortnite.com/mygame/Gadgets/Tools } # kept");
     });
+
+    it("does not carry the carriage return of a CRLF line into the comment it restores", async () => {
+        // The document is split on "\n", so every line of a CRLF file ends in a
+        // `\r` and the comment is read out of text carrying one. Writing that
+        // `\r` back mid-line would split the line where the comment starts.
+        const document = fakeDocument(["using { Gadgets.Tools } # kept\r", "\r", "code()\r"]);
+        const annotated = { ...conversion(0), originalImport: "using { Gadgets.Tools } # kept" };
+
+        expect(await converter.applyConversion(document, annotated)).toBe(true);
+
+        expect(replacedOperation().text).toBe("using { /mygame@fortnite.com/mygame/Gadgets/Tools } # kept");
+    });
 });
 
 /** A converter with project path resolution pinned, so conversion is pure string work. */

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -73,14 +73,15 @@ function fakeDocument(lines: string[]): vscode.TextDocument {
     } as unknown as vscode.TextDocument;
 }
 
+const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
+
+const replacedOperation = (): RecordedOperation => {
+    const edit = applyEditMock().mock.calls[0][0] as { operations: RecordedOperation[] };
+    return edit.operations[0];
+};
+
 describe("ImportPathConverter.applyConversion", () => {
     let converter: ImportPathConverter;
-    const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
-
-    const replacedOperation = (): RecordedOperation => {
-        const edit = applyEditMock().mock.calls[0][0] as { operations: RecordedOperation[] };
-        return edit.operations[0];
-    };
 
     /** A resolved relative-to-absolute conversion of `using { Gadgets.Tools }`. */
     const conversion = (line?: number) => ({
@@ -161,5 +162,87 @@ describe("ImportPathConverter.applyConversion", () => {
 
         expect(await converter.applyConversion(document, conversion(0))).toBe(false);
         expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("keeps the comment trailing the line it converts", async () => {
+        // The replacement is built from the statement alone, so the annotation
+        // the author wrote beside the import has to be put back onto it.
+        const document = fakeDocument(["using { Gadgets.Tools } # only the tools, not the gadgets", "", "code()"]);
+        const annotated = { ...conversion(0), originalImport: "using { Gadgets.Tools } # only the tools, not the gadgets" };
+
+        expect(await converter.applyConversion(document, annotated)).toBe(true);
+
+        expect(replacedOperation().text).toBe("using { /mygame@fortnite.com/mygame/Gadgets/Tools } # only the tools, not the gadgets");
+    });
+
+    it("keeps an inline block comment trailing the line it converts", async () => {
+        // `<# ... #>` closes on the same line, so it annotates that line only.
+        // An opener the line never closes anchors the lines below it instead,
+        // and scanConvertibleImports keeps that one away from the converter.
+        const document = fakeDocument(["using { Gadgets.Tools } <# tools only #>", "", "code()"]);
+        const annotated = { ...conversion(0), originalImport: "using { Gadgets.Tools } <# tools only #>" };
+
+        expect(await converter.applyConversion(document, annotated)).toBe(true);
+
+        expect(replacedOperation().text).toBe("using { /mygame@fortnite.com/mygame/Gadgets/Tools } <# tools only #>");
+    });
+
+    it("keeps indentation and a trailing comment together", async () => {
+        const document = fakeDocument(["    using { Gadgets.Tools } # kept", "", "code()"]);
+        const annotated = { ...conversion(0), originalImport: "using { Gadgets.Tools } # kept" };
+
+        expect(await converter.applyConversion(document, annotated)).toBe(true);
+
+        expect(replacedOperation().text).toBe("    using { /mygame@fortnite.com/mygame/Gadgets/Tools } # kept");
+    });
+});
+
+/** A converter with project path resolution pinned, so conversion is pure string work. */
+function converterWithProjectPath(projectVersePath: string): ImportPathConverter {
+    const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
+    (converter as unknown as { projectPathHandler: { getProjectVersePath: () => Promise<string> } }).projectPathHandler.getProjectVersePath = async () => projectVersePath;
+    return converter;
+}
+
+describe("ImportPathConverter.convertFromFullPath", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+
+    beforeEach(() => {
+        applyEditMock().mockClear();
+    });
+
+    it("leaves the comment trailing a dotted import out of the converted path", async () => {
+        // The dotted capture runs to end of line, so reading the path without
+        // stripping the comment first builds the comment into the relative
+        // import - where applyConversion, which restores it, writes it twice.
+        const converter = converterWithProjectPath(projectVersePath);
+
+        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # only the shop, not the vendor", 0);
+
+        expect(result?.fullPathImport).toBe("using. Economy.Shop");
+        expect(result?.moduleName).toBe("Shop");
+    });
+
+    it("leaves the comment trailing a braced import out of the converted path", async () => {
+        const converter = converterWithProjectPath(projectVersePath);
+
+        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # only the shop", 0);
+
+        expect(result?.fullPathImport).toBe("using { Economy.Shop }");
+    });
+
+    it("writes the comment once, and unaltered, when the conversion is applied", async () => {
+        // The two halves have to agree on who owns the comment: the converted
+        // statement leaves it out and applyConversion puts it back. The `/` in
+        // this comment is what carrying it through the path damaged - the path
+        // splits on "/" and rejoins on ".", so it came back as `Economy.Vendor`.
+        const line = "using. /mygame@fortnite.com/mygame/Economy/Shop # see Economy/Vendor";
+        const document = fakeDocument([line, "", "code()"]);
+        const converter = converterWithProjectPath(projectVersePath);
+
+        const result = await converter.convertFromFullPath(line, 0);
+        expect(await converter.applyConversion(document, result!)).toBe(true);
+
+        expect(replacedOperation().text).toBe("using. Economy.Shop # see Economy/Vendor");
     });
 });


### PR DESCRIPTION
Closes #191

`ImportPathConverter.applyConversion` rebuilt the line from indent plus statement, so a comment trailing a `using` was deleted when its path was converted.

## What changed

**`applyConversion` restores the comment.** It is read with `ImportFormatter.extractTrailingComment` from the line the edit is about to overwrite, and joined with a single space — the same recomposition `ImportDocumentEditor.withTrailingComment` uses, so the two writers agree on separation.

The ticket offered a choice: grow `ConvertibleImport` with `trailingComment`, or re-extract in `applyConversion`. Re-extraction, because the comment then needs no field threaded through `ConvertibleImport` and `ImportConversionResult` to reach the one place that writes it.

**`convertFromFullPath` no longer bakes the comment into the path.** It held a third copy of the path regexes that skipped the trailing-comment strip. The dotted capture `/using\.\s*(.+)/` runs to end of line, so `using. /mygame@fortnite.com/mygame/Economy/Shop # see Economy/Vendor` produced the path `/…/Economy/Shop # see Economy/Vendor`, and the `split("/")` / `join(".")` emitted `using. Economy.Shop # see Economy.Vendor` — the `/` inside the comment rewritten as a `.`.

This is required by the ticket's acceptance rather than adjacent tidying: without it, restoring the comment would write it twice on every dotted conversion. It now reads through `extractPathFromImport` like its siblings. Behaviour is otherwise identical — same regexes, same curly-before-dot precedence, and the `null` vs `""` difference is absorbed by the guard on the next line.

## Scope

Structure was already safe and stays untouched: `scanConvertibleImports` excludes `anchorsCommentBelow`, so a line carrying an unclosed `<#` or a `<#>` marker never reaches the converter. Only annotation text was at stake.

Not fixed here, and filed separately: `usesCurlyBraces = originalImport.includes("{")` reads the raw statement including its comment at three sites, so a comment containing `{` flips the emitted syntax style. Pre-existing, a different symptom, and outside this ticket's acceptance.

## Tests

Six new cases in `src/imports/__tests__/ImportPathConverter.test.ts`, all without the VS Code runtime. Five fail against the unfixed converter — verified by stashing it: the braced `#` case, the `<# ... #>` inline block, indent-plus-comment, the dotted path staying clean, and the end-to-end no-duplication case. A CRLF case pins that the `\r` a `"\n"` split leaves behind does not ride into the restored comment. The braced-path case passes either way and pins the contract rather than catching the defect.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 20 passed, 20 total
Tests:       402 passed, 402 total
Snapshots:   0 total
Time:        6.347 s, estimated 10 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Review gate: PASS_WITH_SUGGESTIONS, no Critical or Important findings. Two suggestions applied — the missing CRLF case, and a comment whose stated rationale described a `findConversionLine` divergence its matching rule cannot produce.
