### PR TITLE
docs: record the Epic account placeholder convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ Read the code for structure. These are the things reading one file won't tell yo
 
 Jest + ts-jest; `vscode` is mocked at `src/__mocks__/vscode.ts`. Tests live in `__tests__/` beside the code. Add a regression test for any bug fix in pure logic (extractors, formatters, parsers) — those run without the VS Code runtime.
 
+Epic account placeholders have one spelling per context: `/mygame@fortnite.com/mygame` in unit tests under `src/**/__tests__/`, and `/vukefn@fortnite.com` in the integration harness, the smoke fixtures under `test-fixtures/`, and prose examples such as JSDoc. Use the one the context calls for rather than inventing a third.
+
 ## Git workflow
 
 GitHub Flow: `main` is the only long-lived branch and the default branch. There is no `develop`.


### PR DESCRIPTION
Closes #201

Adds one paragraph to `CLAUDE.md` under Testing recording which Epic account placeholder belongs in which context. #177 settled the convention and #200 applied it to the unit tests, but nothing in the tree stated it, so the next test or example added had no in-repo source to follow.

The convention as written matches the tree exactly — verified by sweeping tracked files for both spellings:

- `/mygame@fortnite.com/mygame` appears only under `src/**/__tests__/`
- `/vukefn@fortnite.com` appears only in `src/project/ProjectPathHandler.ts` (JSDoc), `test-fixtures/integration-workspace/`, `test-fixtures/uefn-smoke/` and `test-fixtures/corpus/`

No third spelling exists, and neither spelling crosses into the other's context.

`test-fixtures/corpus/**` gets no rule of its own, per the issue: its `README` already contracts those entries as verbatim compiler output regenerated by the Capture Diagnostics Corpus command, which is a stronger reason not to hand-edit them.

No changelog fragment: this is contributor-facing documentation, not a user-facing change. `changelog.d/` holds no fragment for the sibling docs and test-data issues #175, #176, #177 or #200 either.

## Verification

`npm run compile`

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 21 passed, 21 total
Tests:       417 passed, 417 total
Snapshots:   0 total
Time:        9.961 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

Verdict `PASS_WITH_SUGGESTIONS` — no Critical or Important findings. Three suggestions, none applied, all recorded here as maintainer calls:

1. The rule sits under Testing, but one context it governs is JSDoc in production source, which is Code style territory. The issue named Testing explicitly, so the section stays where it was asked for.
2. "the smoke fixtures under `test-fixtures/`" names the parent rather than `test-fixtures/uefn-smoke/`. The wording is verbatim from the issue and is accurate today, since all of `test-fixtures/` uses the same spelling.
3. The repo copy is now the source of truth for this convention; any private or external copy should defer to it.
