### PR TITLE
fix(imports): judge conversion syntax style on the path, not the comment

### DIFF
--- a/changelog.d/204.fixed.md
+++ b/changelog.d/204.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: a brace inside the comment trailing an import no longer flips the `using` syntax style the conversion emits. The style now follows the statement the author wrote, dotted or braced, with comment text excluded from the decision.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -96,6 +96,19 @@ export class ImportPathConverter {
         return ImportFormatter.stripTrailingComment(captured);
     }
 
+    /**
+     * Whether the author wrote the braced style rather than the dotted one.
+     *
+     * Judged on the statement minus any trailing comment: a `{` is legal in
+     * comment prose but not in a module path, so testing the raw line lets a
+     * comment decide the syntax the conversion emits. Every other reader in
+     * this class strips the comment first, via extractPathFromImport; this is
+     * the one that reads the statement rather than the path.
+     */
+    private static usesBracedStyle(importStatement: string): boolean {
+        return ImportFormatter.stripTrailingComment(importStatement).includes("{");
+    }
+
     /** Checks if an import is already in full path format */
     isFullPathImport(importStatement: string): boolean {
         const path = this.extractPathFromImport(importStatement);
@@ -410,7 +423,7 @@ export class ImportPathConverter {
             return null;
         }
 
-        const usesCurlyBraces = importStatement.includes("{");
+        const usesCurlyBraces = ImportPathConverter.usesBracedStyle(importStatement);
         const relativeImport = usesCurlyBraces ? `using { ${relativeImportPath} }` : `using. ${relativeImportPath}`;
 
         return {
@@ -475,7 +488,7 @@ export class ImportPathConverter {
         logger.debug("ImportPathConverter", `findModuleLocations returned ${possibleLocations.length} location(s)`);
         possibleLocations.forEach((loc, idx) => logger.debug("ImportPathConverter", `  Location ${idx}: '${loc}'`));
 
-        const usesCurlyBraces = importStatement.includes("{");
+        const usesCurlyBraces = ImportPathConverter.usesBracedStyle(importStatement);
 
         if (possibleLocations.length === 0) {
             logger.debug("ImportPathConverter", `No locations found for ${modulePath}`);
@@ -575,7 +588,7 @@ export class ImportPathConverter {
 
         let finalImport = conversion.fullPathImport;
         if (conversion.isAmbiguous && selectedPath) {
-            const usesCurlyBraces = conversion.originalImport.includes("{");
+            const usesCurlyBraces = ImportPathConverter.usesBracedStyle(conversion.originalImport);
             finalImport = usesCurlyBraces ? `using { ${selectedPath} }` : `using. ${selectedPath}`;
         }
 

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -101,9 +101,9 @@ export class ImportPathConverter {
      *
      * Judged on the statement minus any trailing comment: a `{` is legal in
      * comment prose but not in a module path, so testing the raw line lets a
-     * comment decide the syntax the conversion emits. Every other reader in
-     * this class strips the comment first, via extractPathFromImport; this is
-     * the one that reads the statement rather than the path.
+     * comment decide the syntax the conversion emits. This is the one reader
+     * that looks at the whole statement rather than at a capture taken from
+     * it, which is why it needs its own strip.
      */
     private static usesBracedStyle(importStatement: string): boolean {
         return ImportFormatter.stripTrailingComment(importStatement).includes("{");

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -274,10 +274,12 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         expect(result?.fullPathImport).toBe("using. Economy.Shop");
     });
 
-    it("keeps the braced style when the trailing comment contains no brace", async () => {
+    it("keeps the braced style when the trailing comment also contains a brace", async () => {
+        // The other half of the same rule: stripping the comment must not cost
+        // a braced import its braces, whatever the comment happens to hold.
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # the shop", 0);
+        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # see {Vendor}", 0);
 
         expect(result?.fullPathImport).toBe("using { Economy.Shop }");
     });
@@ -316,10 +318,10 @@ describe("ImportPathConverter.convertToFullPath", () => {
         expect(result?.fullPathImport).toBe("using. /mygame@fortnite.com/mygame/Economy/Shop");
     });
 
-    it("keeps the braced style when the trailing comment contains no brace", async () => {
+    it("keeps the braced style when the trailing comment also contains a brace", async () => {
         const converter = converterWithLocation("/Economy");
 
-        const result = await converter.convertToFullPath("using { Shop } # the shop", vscode.Uri.file("C:/project/test.verse"), 0);
+        const result = await converter.convertToFullPath("using { Shop } # see {Vendor}", vscode.Uri.file("C:/project/test.verse"), 0);
 
         expect(result?.fullPathImport).toBe("using { /mygame@fortnite.com/mygame/Economy/Shop }");
     });

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -196,6 +196,26 @@ describe("ImportPathConverter.applyConversion", () => {
         expect(replacedOperation().text).toBe("    using { /mygame@fortnite.com/mygame/Gadgets/Tools } # kept");
     });
 
+    it("keeps the dotted style when the trailing comment of an ambiguous import contains a brace", async () => {
+        // The user picks the path from a quick pick, and the style comes from
+        // the statement the pick was offered against. A `{` in the comment is
+        // prose, not syntax, so it must not turn a dotted import braced.
+        const line = "using. Gadgets.Tools # prefer {Tools} over {Gadgets}";
+        const document = fakeDocument([line, "", "code()"]);
+        const ambiguous = {
+            originalImport: line,
+            fullPathImport: "",
+            moduleName: "Tools",
+            isAmbiguous: true,
+            possiblePaths: ["/mygame@fortnite.com/mygame/Gadgets/Tools", "/mygame@fortnite.com/mygame/UI/Gadgets/Tools"],
+            line: 0,
+        };
+
+        expect(await converter.applyConversion(document, ambiguous, "/mygame@fortnite.com/mygame/Gadgets/Tools")).toBe(true);
+
+        expect(replacedOperation().text).toBe("using. /mygame@fortnite.com/mygame/Gadgets/Tools # prefer {Tools} over {Gadgets}");
+    });
+
     it("does not carry the carriage return of a CRLF line into the comment it restores", async () => {
         // The document is split on "\n", so every line of a CRLF file ends in a
         // `\r` and the comment is read out of text carrying one. Writing that
@@ -243,6 +263,25 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         expect(result?.fullPathImport).toBe("using { Economy.Shop }");
     });
 
+    it("keeps the dotted style when the trailing comment contains a brace", async () => {
+        // The style test reads the statement, not the path, so it is the one
+        // reader a comment can still reach. A `{` in comment prose is not the
+        // author asking for braced syntax.
+        const converter = converterWithProjectPath(projectVersePath);
+
+        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # use {braces} here", 0);
+
+        expect(result?.fullPathImport).toBe("using. Economy.Shop");
+    });
+
+    it("keeps the braced style when the trailing comment contains no brace", async () => {
+        const converter = converterWithProjectPath(projectVersePath);
+
+        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # the shop", 0);
+
+        expect(result?.fullPathImport).toBe("using { Economy.Shop }");
+    });
+
     it("writes the comment once, and unaltered, when the conversion is applied", async () => {
         // The two halves have to agree on who owns the comment: the converted
         // statement leaves it out and applyConversion puts it back. The `/` in
@@ -256,5 +295,32 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         expect(await converter.applyConversion(document, result!)).toBe(true);
 
         expect(replacedOperation().text).toBe("using. Economy.Shop # see Economy/Vendor");
+    });
+});
+
+describe("ImportPathConverter.convertToFullPath", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+
+    /** A converter that resolves every module to one fixed location, so conversion is pure string work. */
+    function converterWithLocation(location: string): ImportPathConverter {
+        const converter = converterWithProjectPath(projectVersePath);
+        converter.findModuleLocations = async () => [location];
+        return converter;
+    }
+
+    it("keeps the dotted style when the trailing comment contains a brace", async () => {
+        const converter = converterWithLocation("/Economy");
+
+        const result = await converter.convertToFullPath("using. Shop # use {braces} here", vscode.Uri.file("C:/project/test.verse"), 0);
+
+        expect(result?.fullPathImport).toBe("using. /mygame@fortnite.com/mygame/Economy/Shop");
+    });
+
+    it("keeps the braced style when the trailing comment contains no brace", async () => {
+        const converter = converterWithLocation("/Economy");
+
+        const result = await converter.convertToFullPath("using { Shop } # the shop", vscode.Uri.file("C:/project/test.verse"), 0);
+
+        expect(result?.fullPathImport).toBe("using { /mygame@fortnite.com/mygame/Economy/Shop }");
     });
 });


### PR DESCRIPTION
Closes #204

Path conversion picked between the dotted and braced `using` styles by testing the raw statement for a `{`. The statement is the whole trimmed line, so a brace anywhere in the trailing comment read as a braced import and the conversion silently rewrote the author's style:

```
in : using. /mygame@fortnite.com/mygame/Economy/Shop # use {braces} here
out: using { Economy.Shop } # use {braces} here
```

The style test was the one reader in `ImportPathConverter` that looked at the statement rather than at a capture taken from it, so it was the one place a comment could still reach. It now routes through `ImportFormatter.stripTrailingComment`, behind a single `usesBracedStyle` helper shared by the three sites that made the decision: `convertFromFullPath`, `convertToFullPath`, and the ambiguous branch of `applyConversion`.

## Tests

Five cases in `src/imports/__tests__/`, covering both halves of the rule at all three sites: a brace in the comment does not turn a dotted import braced, and stripping the comment does not cost a braced import its braces. The three brace-in-comment cases were each proven to fail against the unfixed code — stashing `ImportPathConverter.ts` gives 3 failed / 24 passed.

Edge cases checked and unaffected: inline `<# ... #>` (`commentStartIndex` backs up over the `<`), the indented `using:` style and comment-anchoring imports (both excluded by `scanConvertibleImports`), and local-scope `using{X}`.

## Verification

```
$ npm run compile
> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 21 passed, 21 total
Tests:       422 passed, 422 total
Snapshots:   0 total
Time:        12.078 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

`PASS_WITH_SUGGESTIONS` — no Critical or Important findings. Three suggestions; the two that concerned this diff are applied in 8a3c4d0. The third, folding the triplicated `usesCurlyBraces ? ... : ...` emit ternary into `ImportFormatter.formatImportStatement`, is left alone as out of scope here.

The gate also surfaced a separate pre-existing defect, out of scope for this ticket and untouched by it: `extractPathFromImport` matches before it strips, so the curly regex can match inside a comment — `using. Economy.Shop # was using { Inventory }` extracts the path `Inventory`. The same ordering is in `ImportFormatter`.
