### PR TITLE
fix(imports): apply import spacing during the save, not after it

### DIFF
--- a/changelog.d/144.fixed.md
+++ b/changelog.d/144.fixed.md
@@ -1,0 +1,1 @@
+**Saving no longer re-dirties the file**: the import spacing pass now runs as part of the save rather than editing the file once the save has finished, so the tab no longer shows unsaved changes the moment you press Ctrl+S. A hand-edited negative `behavior.emptyLinesAfterImports` is ignored instead of removing a line of code.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -98,11 +98,16 @@ class WorkspaceEdit {
 
     /**
      * Real VS Code stores TextEdits whichever method built them, so each one is
-     * recorded as the operation it is equivalent to. That keeps a set() and the
-     * insert()/delete() calls it replaces indistinguishable to a test, which is
-     * what they are to the editor.
+     * recorded as the operation it is equivalent to - which keeps a set() and
+     * the insert()/delete() calls it replaces indistinguishable to a test, as
+     * they are to the editor. set() also *replaces* whatever was recorded for
+     * that uri rather than adding to it, so an empty array clears it.
      */
     set(uri: unknown, edits: TextEdit[]): void {
+        const remaining = this.operations.filter((operation) => String(operation.uri) !== String(uri));
+        this.operations.length = 0;
+        this.operations.push(...remaining);
+
         for (const edit of edits) {
             if (edit.newText.length === 0) {
                 this.delete(uri, edit.range);

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -10,6 +10,29 @@ class Range {
         public readonly start: Position,
         public readonly end: Position,
     ) {}
+
+    get isEmpty(): boolean {
+        return this.start.line === this.end.line && this.start.character === this.end.character;
+    }
+}
+
+class TextEdit {
+    constructor(
+        public readonly range: Range,
+        public readonly newText: string,
+    ) {}
+
+    static insert(position: Position, newText: string): TextEdit {
+        return new TextEdit(new Range(position, position), newText);
+    }
+
+    static delete(range: Range): TextEdit {
+        return new TextEdit(range, "");
+    }
+
+    static replace(range: Range, newText: string): TextEdit {
+        return new TextEdit(range, newText);
+    }
 }
 
 interface Command {
@@ -71,6 +94,24 @@ class WorkspaceEdit {
 
     replace(uri: unknown, range: Range, text: string): void {
         this.operations.push({ kind: "replace", uri, range, text });
+    }
+
+    /**
+     * Real VS Code stores TextEdits whichever method built them, so each one is
+     * recorded as the operation it is equivalent to. That keeps a set() and the
+     * insert()/delete() calls it replaces indistinguishable to a test, which is
+     * what they are to the editor.
+     */
+    set(uri: unknown, edits: TextEdit[]): void {
+        for (const edit of edits) {
+            if (edit.newText.length === 0) {
+                this.delete(uri, edit.range);
+            } else if (edit.range.isEmpty) {
+                this.insert(uri, edit.range.start, edit.newText);
+            } else {
+                this.replace(uri, edit.range, edit.newText);
+            }
+        }
     }
 }
 
@@ -193,6 +234,7 @@ const workspace = {
     onDidChangeConfiguration: jest.fn().mockImplementation(() => ({ dispose: jest.fn() })),
     onDidChangeTextDocument: jest.fn().mockImplementation(() => ({ dispose: jest.fn() })),
     onDidSaveTextDocument: jest.fn().mockImplementation(() => ({ dispose: jest.fn() })),
+    onWillSaveTextDocument: jest.fn().mockImplementation(() => ({ dispose: jest.fn() })),
     applyEdit: jest.fn().mockResolvedValue(true),
     workspaceFolders: undefined as { uri: { fsPath: string }; name: string; index: number }[] | undefined,
     findFiles: jest.fn().mockResolvedValue([]),
@@ -312,6 +354,7 @@ export {
     EndOfLine,
     Position,
     Range,
+    TextEdit,
     WorkspaceEdit,
     Uri,
     RelativePattern,

--- a/src/__tests__/extension.saveSpacing.test.ts
+++ b/src/__tests__/extension.saveSpacing.test.ts
@@ -1,0 +1,140 @@
+import * as vscode from "vscode";
+import { activate } from "../extension";
+
+/**
+ * Regression for #144: the import-spacing pass ran on onDidSaveTextDocument and
+ * applied a WorkspaceEdit, so a file whose import block did not already carry
+ * behavior.emptyLinesAfterImports blank lines was edited *after* its own save
+ * completed. The tab went dirty the instant the user saved it, and only a
+ * second save converged.
+ *
+ * The pass is a save participant now: it hands VS Code the edits through
+ * waitUntil, which applies them before the file is written. So the assertion
+ * that matters is the pair - edits offered to the save, and no applyEdit
+ * anywhere near it.
+ */
+
+/** The subset of ExtensionContext activate() touches. */
+interface FakeContext {
+    subscriptions: { dispose(): unknown }[];
+    workspaceState: { get: jest.Mock; update: jest.Mock; keys: jest.Mock };
+}
+
+/** A will-save event, with waitUntil recorded the way VS Code offers it. */
+interface FakeWillSaveEvent {
+    document: vscode.TextDocument;
+    reason: number;
+    waitUntil: jest.Mock;
+}
+
+function makeContext(): FakeContext {
+    return {
+        subscriptions: [],
+        workspaceState: {
+            get: jest.fn().mockReturnValue(undefined),
+            update: jest.fn().mockResolvedValue(undefined),
+            keys: jest.fn().mockReturnValue([]),
+        },
+    };
+}
+
+/**
+ * Answers every setting with its default - which is what these tests want for
+ * emptyLinesAfterImports, whose default of 1 is the case the bug was reported
+ * against. inspect() is part of the contract: the debounce delay is read
+ * through it and activation throws without it.
+ */
+function stubConfiguration(): void {
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+        get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+        inspect: jest.fn().mockReturnValue(undefined),
+        update: jest.fn().mockResolvedValue(undefined),
+    });
+}
+
+function fakeDocument(text: string, languageId: string = "verse"): vscode.TextDocument {
+    const lines = text.split(/\r?\n/);
+    return {
+        uri: { toString: () => "file:///test.verse" },
+        languageId,
+        getText: () => text,
+        eol: vscode.EndOfLine.LF,
+        lineCount: lines.length,
+        lineAt: (index: number) => ({ range: { end: new vscode.Position(index, lines[index].length) } }),
+    } as unknown as vscode.TextDocument;
+}
+
+/** The listener activate() registered, which is the only handle on it. */
+function willSaveListener(): (event: FakeWillSaveEvent) => void {
+    const calls = (vscode.workspace.onWillSaveTextDocument as jest.Mock).mock.calls;
+    if (calls.length === 0) {
+        throw new Error("No onWillSaveTextDocument listener was registered");
+    }
+    return calls[0][0];
+}
+
+function fireWillSave(document: vscode.TextDocument): FakeWillSaveEvent {
+    const event: FakeWillSaveEvent = { document, reason: 1, waitUntil: jest.fn() };
+    willSaveListener()(event);
+    return event;
+}
+
+/** The edits the participant offered to the save. */
+async function offeredEdits(event: FakeWillSaveEvent): Promise<vscode.TextEdit[]> {
+    expect(event.waitUntil).toHaveBeenCalledTimes(1);
+    return await event.waitUntil.mock.calls[0][0];
+}
+
+const NEEDS_A_BLANK_LINE = ["using { /Fortnite.com/Devices }", "code()"].join("\n");
+const ALREADY_SPACED = ["using { /Fortnite.com/Devices }", "", "code()"].join("\n");
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    stubConfiguration();
+    activate(makeContext() as unknown as vscode.ExtensionContext);
+});
+
+describe("import spacing on save", () => {
+    it("offers the spacing edit to the save instead of applying it afterwards", async () => {
+        const event = fireWillSave(fakeDocument(NEEDS_A_BLANK_LINE));
+
+        const edits = await offeredEdits(event);
+        expect(edits).toHaveLength(1);
+        expect(edits[0].newText).toBe("\n");
+        expect(edits[0].range.start.line).toBe(1);
+        // The re-dirty itself: any edit applied around a save is one the save
+        // did not write, which is what left the tab modified.
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+    });
+
+    it("does not run after the save at all", () => {
+        expect(vscode.workspace.onDidSaveTextDocument).not.toHaveBeenCalled();
+    });
+
+    it("stays out of the save when the spacing already matches", () => {
+        const event = fireWillSave(fakeDocument(ALREADY_SPACED));
+
+        expect(event.waitUntil).not.toHaveBeenCalled();
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+    });
+
+    it("ignores a document that is not Verse", () => {
+        const event = fireWillSave(fakeDocument(NEEDS_A_BLANK_LINE, "typescript"));
+
+        expect(event.waitUntil).not.toHaveBeenCalled();
+    });
+
+    // The old handler was async with no try/catch, so a throw became an
+    // unhandled rejection. A save participant that throws blocks the save.
+    it("does not throw out of the save when the spacing pass fails", () => {
+        const document = fakeDocument(NEEDS_A_BLANK_LINE);
+        (document as { getText: () => string }).getText = () => {
+            throw new Error("document read failed");
+        };
+
+        const event: FakeWillSaveEvent = { document, reason: 1, waitUntil: jest.fn() };
+
+        expect(() => willSaveListener()(event)).not.toThrow();
+        expect(event.waitUntil).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/extension.saveSpacing.test.ts
+++ b/src/__tests__/extension.saveSpacing.test.ts
@@ -107,7 +107,9 @@ describe("import spacing on save", () => {
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
     });
 
-    it("does not run after the save at all", () => {
+    // The spacing pass was the only post-save listener, so its registration is
+    // the whole of what activate() must no longer do.
+    it("registers nothing to run after a save", () => {
         expect(vscode.workspace.onDidSaveTextDocument).not.toHaveBeenCalled();
     });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,15 +205,26 @@ export function activate(context: vscode.ExtensionContext) {
         }),
     );
 
-    // Document save listener for import spacing
+    // Save participant for import spacing. This has to run *during* the save,
+    // not after it: an edit applied once the save has completed makes the tab
+    // dirty again the instant the user saves, and only a second save converges.
+    // waitUntil hands the edits to VS Code, which applies them before writing
+    // the file, so the saved content is already correct.
     context.subscriptions.push(
-        vscode.workspace.onDidSaveTextDocument(async (document) => {
-            if (document.languageId === "verse") {
-                const config = vscode.workspace.getConfiguration("verseAutoImports");
-                const emptyLinesAfterImports = config.get<number>("behavior.emptyLinesAfterImports", 1);
-                if (emptyLinesAfterImports >= 0) {
-                    await importHandler.ensureEmptyLinesAfterImports(document);
+        vscode.workspace.onWillSaveTextDocument((event) => {
+            if (event.document.languageId !== "verse") {
+                return;
+            }
+            // waitUntil is only accepted while the listener is on the stack, so
+            // the edits are computed synchronously. Nothing here may throw
+            // either: a save participant that throws blocks the save.
+            try {
+                const edits = importHandler.computeEmptyLinesAfterImportsEdits(event.document);
+                if (edits.length > 0) {
+                    event.waitUntil(Promise.resolve(edits));
                 }
+            } catch (error) {
+                logger.error("Extension", `Error computing import spacing on save: ${error}`, error);
             }
         }),
     );

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -754,12 +754,21 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * Ensures the proper number of empty lines exists after the last import statement.
-     * This method is called when saving files, adding imports, or optimizing imports.
+     * The edits that would give the file the configured number of empty lines
+     * after its import block, or an empty array when it already has them.
+     *
+     * Kept separate from applying them because the save path participates in
+     * the save with these edits (see the onWillSaveTextDocument listener in
+     * extension.ts) rather than editing the document afterwards, which is what
+     * used to leave the tab dirty the moment it was saved.
      */
-    async ensureEmptyLinesAfterImports(document: vscode.TextDocument): Promise<boolean> {
+    computeEmptyLinesAfterImportsEdits(document: vscode.TextDocument): vscode.TextEdit[] {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
-        const emptyLinesAfterImports = config.get<number>("behavior.emptyLinesAfterImports", 1);
+        // Clamped because a negative value reaches the delete branch below,
+        // where it would take real code rather than blank lines. package.json
+        // declares a minimum of 0, but a hand-edited settings.json does not
+        // have to honour it.
+        const emptyLinesAfterImports = Math.max(0, config.get<number>("behavior.emptyLinesAfterImports", 1));
 
         logger.debug("ImportDocumentEditor", `Ensuring ${emptyLinesAfterImports} empty lines after imports`);
 
@@ -779,7 +788,7 @@ export class ImportDocumentEditor {
         // If no imports found or file only has imports, nothing to do
         if (lastImportLine === -1 || lastImportLine === lines.length - 1) {
             logger.debug("ImportDocumentEditor", "No imports found or file ends with imports, skipping spacing adjustment");
-            return true;
+            return [];
         }
 
         // Count existing empty lines after the last import
@@ -804,7 +813,7 @@ export class ImportDocumentEditor {
         // Only adjust if there's content after imports
         if (!hasContentAfterImports) {
             logger.debug("ImportDocumentEditor", "No content after imports, skipping spacing adjustment");
-            return true;
+            return [];
         }
 
         // Calculate adjustment needed
@@ -812,26 +821,40 @@ export class ImportDocumentEditor {
 
         if (lineDifference === 0) {
             logger.debug("ImportDocumentEditor", `Already has ${emptyLinesAfterImports} empty lines after imports`);
-            return true;
+            return [];
         }
-
-        const edit = new vscode.WorkspaceEdit();
 
         if (lineDifference > 0) {
             // Need to add empty lines
             const newLines = eol.repeat(lineDifference);
             const insertPosition = new vscode.Position(lastImportLine + 1, 0);
-            edit.insert(document.uri, insertPosition, newLines);
             logger.info("ImportDocumentEditor", `Adding ${lineDifference} empty lines after imports`);
-        } else {
-            // Need to remove empty lines
-            const linesToRemove = Math.abs(lineDifference);
-            const startLine = lastImportLine + 1;
-            const endLine = Math.min(startLine + linesToRemove, lines.length);
-            const range = new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(endLine, 0));
-            edit.delete(document.uri, range);
-            logger.info("ImportDocumentEditor", `Removing ${linesToRemove} empty lines after imports`);
+            return [vscode.TextEdit.insert(insertPosition, newLines)];
         }
+
+        // Need to remove empty lines
+        const linesToRemove = Math.abs(lineDifference);
+        const startLine = lastImportLine + 1;
+        const endLine = Math.min(startLine + linesToRemove, lines.length);
+        const range = new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(endLine, 0));
+        logger.info("ImportDocumentEditor", `Removing ${linesToRemove} empty lines after imports`);
+        return [vscode.TextEdit.delete(range)];
+    }
+
+    /**
+     * Applies the spacing edits to the document. Used by the paths that already
+     * hold the document open and edit it - adding imports and organizing them.
+     * The save path uses computeEmptyLinesAfterImportsEdits instead.
+     */
+    async ensureEmptyLinesAfterImports(document: vscode.TextDocument): Promise<boolean> {
+        const edits = this.computeEmptyLinesAfterImportsEdits(document);
+
+        if (edits.length === 0) {
+            return true;
+        }
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.set(document.uri, edits);
 
         try {
             const success = await vscode.workspace.applyEdit(edit);

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -764,11 +764,15 @@ export class ImportDocumentEditor {
      */
     computeEmptyLinesAfterImportsEdits(document: vscode.TextDocument): vscode.TextEdit[] {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
-        // Clamped because a negative value reaches the delete branch below,
-        // where it would take real code rather than blank lines. package.json
-        // declares a minimum of 0, but a hand-edited settings.json does not
-        // have to honour it.
-        const emptyLinesAfterImports = Math.max(0, config.get<number>("behavior.emptyLinesAfterImports", 1));
+        const emptyLinesAfterImports = config.get<number>("behavior.emptyLinesAfterImports", 1);
+
+        // package.json declares a minimum of 0, but a hand-edited settings.json
+        // does not have to honour it, and a negative value reaches the delete
+        // branch below, where it would take real code rather than blank lines.
+        if (emptyLinesAfterImports < 0) {
+            logger.debug("ImportDocumentEditor", `Ignoring a negative emptyLinesAfterImports (${emptyLinesAfterImports})`);
+            return [];
+        }
 
         logger.debug("ImportDocumentEditor", `Ensuring ${emptyLinesAfterImports} empty lines after imports`);
 

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -62,16 +62,13 @@ export class ImportHandler {
     }
 
     /**
-     * Ensures the proper number of empty lines exists after the last import statement.
-     */
-    async ensureEmptyLinesAfterImports(document: vscode.TextDocument): Promise<boolean> {
-        return this.documentEditor.ensureEmptyLinesAfterImports(document);
-    }
-
-    /**
      * The edits that would give the file the configured number of empty lines
      * after its import block, without applying them. For the save participant,
      * which hands them to VS Code so they land as part of the save.
+     *
+     * There is no applying counterpart on the facade: the only callers that
+     * apply the spacing themselves are inside ImportDocumentEditor, at the end
+     * of adding and organizing imports.
      */
     computeEmptyLinesAfterImportsEdits(document: vscode.TextDocument): vscode.TextEdit[] {
         return this.documentEditor.computeEmptyLinesAfterImportsEdits(document);

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -67,4 +67,13 @@ export class ImportHandler {
     async ensureEmptyLinesAfterImports(document: vscode.TextDocument): Promise<boolean> {
         return this.documentEditor.ensureEmptyLinesAfterImports(document);
     }
+
+    /**
+     * The edits that would give the file the configured number of empty lines
+     * after its import block, without applying them. For the save participant,
+     * which hands them to VS Code so they land as part of the save.
+     */
+    computeEmptyLinesAfterImportsEdits(document: vscode.TextDocument): vscode.TextEdit[] {
+        return this.documentEditor.computeEmptyLinesAfterImportsEdits(document);
+    }
 }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1048,3 +1048,81 @@ describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {
         expect(operations[0].text).toBe("\r\n");
     });
 });
+
+/**
+ * The save participant asks for the edits and hands them to VS Code instead of
+ * applying them itself (#144), so the spacing decisions have to be answerable
+ * without touching the document.
+ */
+describe("ImportDocumentEditor.computeEmptyLinesAfterImportsEdits", () => {
+    let editor: ImportDocumentEditor;
+
+    /** Answers emptyLinesAfterImports with `value`, defaults for everything else. */
+    function mockEmptyLines(value: number): void {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key === "behavior.emptyLinesAfterImports" ? value : defaultValue)),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+    }
+
+    beforeEach(() => {
+        const outputChannel = vscode.window.createOutputChannel("test");
+        editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
+        (vscode.workspace.applyEdit as unknown as jest.Mock).mockClear();
+    });
+
+    it("asks for an inserted blank line when the import block has none", () => {
+        const edits = editor.computeEmptyLinesAfterImportsEdits(fakeDocument(["using { /Top }", "code()"].join("\n")));
+
+        expect(edits).toHaveLength(1);
+        expect(edits[0].range.start.line).toBe(1);
+        expect(edits[0].range.isEmpty).toBe(true);
+        expect(edits[0].newText).toBe("\n");
+    });
+
+    it("asks for a deletion when the import block has too many blank lines", () => {
+        const edits = editor.computeEmptyLinesAfterImportsEdits(fakeDocument(["using { /Top }", "", "", "code()"].join("\n")));
+
+        expect(edits).toHaveLength(1);
+        expect(edits[0].newText).toBe("");
+        expect(edits[0].range.start.line).toBe(1);
+        expect(edits[0].range.end.line).toBe(2);
+    });
+
+    it("asks for nothing when the spacing already matches", () => {
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(["using { /Top }", "", "code()"].join("\n")))).toEqual([]);
+    });
+
+    it("asks for nothing after a module-scoped using", () => {
+        const input = ["using { /Top }", "", "M := module:", "    using { /Verse.org/Random }", "    F():void = {}", ""].join("\n");
+
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(input))).toEqual([]);
+    });
+
+    it("asks for nothing after an import inside a block comment", () => {
+        const input = ["<#", "using { /Fortnite.com/Devices }", "#>", "", "code()"].join("\n");
+
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(input))).toEqual([]);
+    });
+
+    it("writes a CRLF blank line into a CRLF document", () => {
+        const edits = editor.computeEmptyLinesAfterImportsEdits(fakeDocument("using { /Top }\r\ncode()\r\n", vscode.EndOfLine.CRLF));
+
+        expect(edits[0].newText).toBe("\r\n");
+    });
+
+    // package.json declares minimum 0, but settings.json can be hand-edited
+    // past it. Unclamped, the negative difference reaches the delete branch and
+    // takes the first line of real code with it.
+    it("deletes nothing when the setting is negative", () => {
+        mockEmptyLines(-1);
+
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(["using { /Top }", "code()"].join("\n")))).toEqual([]);
+    });
+
+    it("never edits the document itself", () => {
+        editor.computeEmptyLinesAfterImportsEdits(fakeDocument(["using { /Top }", "code()"].join("\n")));
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+    });
+});

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1112,7 +1112,7 @@ describe("ImportDocumentEditor.computeEmptyLinesAfterImportsEdits", () => {
     });
 
     // package.json declares minimum 0, but settings.json can be hand-edited
-    // past it. Unclamped, the negative difference reaches the delete branch and
+    // past it. Unguarded, the negative difference reaches the delete branch and
     // takes the first line of real code with it.
     it("deletes nothing when the setting is negative", () => {
         mockEmptyLines(-1);

--- a/src/test-integration/suite/regressions144.itest.ts
+++ b/src/test-integration/suite/regressions144.itest.ts
@@ -13,35 +13,23 @@ import { docText, openFixture, sleep } from "./helpers";
  * reported, which is only observable with a real editor doing a real save.
  */
 describe("issue #144: saving must not re-dirty the document", () => {
-    /** Rewrites the whole document and saves, so the fixture survives the run. */
-    async function restore(document: vscode.TextDocument, text: string): Promise<void> {
-        const edit = new vscode.WorkspaceEdit();
-        const end = document.lineAt(document.lineCount - 1).range.end;
-        edit.replace(document.uri, new vscode.Range(new vscode.Position(0, 0), end), text);
-        await vscode.workspace.applyEdit(edit);
-        await document.save();
-    }
-
+    // The fixture is saved here. runTests.ts runs the suite against a scratch
+    // copy of the workspace for exactly this reason, so nothing is restored.
     it("applies the import spacing as part of the save and leaves the tab clean", async () => {
         const document = await openFixture("r144_save_spacing.verse");
-        const original = document.getText();
 
-        try {
-            // Dirty the document away from the imports so the save actually
-            // runs; a clean document does not go through the save at all.
-            const probe = new vscode.WorkspaceEdit();
-            probe.insert(document.uri, new vscode.Position(document.lineCount, 0), "\n# save probe\n");
-            assert.ok(await vscode.workspace.applyEdit(probe), "probe edit failed");
+        // Dirty the document away from the imports so the save actually runs;
+        // a clean document does not go through the save at all.
+        const probe = new vscode.WorkspaceEdit();
+        probe.insert(document.uri, new vscode.Position(document.lineCount, 0), "\n# save probe\n");
+        assert.ok(await vscode.workspace.applyEdit(probe), "probe edit failed");
 
-            assert.ok(await document.save(), "save failed");
-            // The pre-fix edit landed just after the save resolved, so the
-            // dirty assertion below needs to give it the chance to.
-            await sleep(500);
+        assert.ok(await document.save(), "save failed");
+        // The pre-fix edit landed just after the save resolved, so the dirty
+        // assertion below needs to give it the chance to.
+        await sleep(500);
 
-            assert.strictEqual(document.isDirty, false, "the document must not be modified again by its own save");
-            assert.ok(docText(document).includes("using { /Fortnite.com/Devices }\n\nr144_save_spacing"), `the blank line after the import block is missing, got:\n${docText(document)}`);
-        } finally {
-            await restore(document, original);
-        }
+        assert.strictEqual(document.isDirty, false, "the document must not be modified again by its own save");
+        assert.ok(docText(document).includes("using { /Fortnite.com/Devices }\n\nr144_save_spacing"), `the blank line after the import block is missing, got:\n${docText(document)}`);
     });
 });

--- a/src/test-integration/suite/regressions144.itest.ts
+++ b/src/test-integration/suite/regressions144.itest.ts
@@ -1,0 +1,47 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { docText, openFixture, sleep } from "./helpers";
+
+/**
+ * Regression for #144. The import-spacing pass used to run on
+ * onDidSaveTextDocument and apply a WorkspaceEdit, so a file whose import block
+ * did not already carry the configured blank lines was edited after its own
+ * save had completed - the tab went straight back to dirty and only a second
+ * save converged.
+ *
+ * The unit tests pin the participant's contract; this pins the symptom the user
+ * reported, which is only observable with a real editor doing a real save.
+ */
+describe("issue #144: saving must not re-dirty the document", () => {
+    /** Rewrites the whole document and saves, so the fixture survives the run. */
+    async function restore(document: vscode.TextDocument, text: string): Promise<void> {
+        const edit = new vscode.WorkspaceEdit();
+        const end = document.lineAt(document.lineCount - 1).range.end;
+        edit.replace(document.uri, new vscode.Range(new vscode.Position(0, 0), end), text);
+        await vscode.workspace.applyEdit(edit);
+        await document.save();
+    }
+
+    it("applies the import spacing as part of the save and leaves the tab clean", async () => {
+        const document = await openFixture("r144_save_spacing.verse");
+        const original = document.getText();
+
+        try {
+            // Dirty the document away from the imports so the save actually
+            // runs; a clean document does not go through the save at all.
+            const probe = new vscode.WorkspaceEdit();
+            probe.insert(document.uri, new vscode.Position(document.lineCount, 0), "\n# save probe\n");
+            assert.ok(await vscode.workspace.applyEdit(probe), "probe edit failed");
+
+            assert.ok(await document.save(), "save failed");
+            // The pre-fix edit landed just after the save resolved, so the
+            // dirty assertion below needs to give it the chance to.
+            await sleep(500);
+
+            assert.strictEqual(document.isDirty, false, "the document must not be modified again by its own save");
+            assert.ok(docText(document).includes("using { /Fortnite.com/Devices }\n\nr144_save_spacing"), `the blank line after the import block is missing, got:\n${docText(document)}`);
+        } finally {
+            await restore(document, original);
+        }
+    });
+});

--- a/test-fixtures/integration-workspace/Project/Content/r144_save_spacing.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r144_save_spacing.verse
@@ -1,0 +1,8 @@
+# Regression #144: the file-top import block is deliberately NOT followed by a
+# blank line, so the on-save spacing pass always has an edit to make. The
+# pre-fix code made that edit after the save had already completed, which left
+# the tab dirty the instant the user saved it.
+
+using { /Fortnite.com/Devices }
+r144_save_spacing := class:
+    var MaybeButton:?button_device = false


### PR DESCRIPTION
Closes #144

## The defect

The import-spacing pass ran on `onDidSaveTextDocument` and applied a `WorkspaceEdit`, so a file whose import block did not already carry `behavior.emptyLinesAfterImports` blank lines was edited *after* its own save had completed. The tab went dirty the instant the user pressed Ctrl+S, and only a second save converged. Confirmed still present at v0.9.0; the issue's line numbers have since shifted but the code is the same.

## The fix

The spacing pass is a save participant now. `ImportDocumentEditor.computeEmptyLinesAfterImportsEdits` answers what edits the file needs without touching it, and the listener hands those to VS Code through `event.waitUntil`, which applies them before the file is written — so the saved content is already correct and the document is never re-modified. `ensureEmptyLinesAfterImports` keeps applying the edits itself for its two remaining callers, adding and organizing imports, which are not save-driven.

The two smaller items in the same handler:

- The listener is synchronous and wrapped in try/catch. `onDidSaveTextDocument` does not await listener promises, so the old `async` handler turned a throw into an unhandled rejection; there is no promise to reject now, and a save participant that throws would block the save.
- The dead `emptyLinesAfterImports >= 0` check is gone. Its intent moved into the pass itself, where it is live: a hand-edited negative value (`package.json` declares `"minimum": 0`, `settings.json` need not honour it) reached the delete branch and took a line of real code rather than blank lines. That is now ignored rather than clamped to 0 — clamping would strip the blank lines after the import block, an edit nobody asked for.

`ImportHandler.ensureEmptyLinesAfterImports` is dropped: the save listener was its only caller, and the two remaining call sites are inside `ImportDocumentEditor` itself.

## Tests

- `src/__tests__/extension.saveSpacing.test.ts` — the participant offers the edit to the save and `workspace.applyEdit` is never called, which is the re-dirty itself; nothing is registered to run after a save; a non-Verse document and already-correct spacing stay out of the save; a throwing pass does not throw out of the listener.
- `src/imports/__tests__/ImportDocumentEditor.test.ts` — the compute's answers: insert, delete, no-op, module-scoped `using`, block comment, CRLF, and the negative setting.
- `src/test-integration/suite/regressions144.itest.ts` — the reported symptom in a real editor: dirty the fixture away from the imports, save, and assert both that the blank line landed and that `document.isDirty` is `false`.

Both unit regressions were checked against the unfixed code (`git stash push` on the three source files): they fail without the fix and pass with it.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 23 passed, 23 total
Tests:       456 passed, 456 total
Snapshots:   0 total
Time:        9.48 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

`npm run test:integration` (extension host, VS Code 1.132.0):

```
  issue #144: saving must not re-dirty the document
    ✔ applies the import spacing as part of the save and leaves the tab clean

  30 passing (36s)
```
