### PR TITLE
fix(imports): read an import path from the statement, not from its comment

### DIFF
--- a/changelog.d/207.fixed.md
+++ b/changelog.d/207.fixed.md
@@ -1,0 +1,1 @@
+**Import paths read from the statement, not its comment**: a `using` import whose trailing comment mentioned another import in braces, such as `using. Economy.Shop # was using { Inventory }`, had that other path read as its own - converting the wrong module and misclassifying the import as a full path or a built-in one.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -165,8 +165,8 @@ export class ImportFormatter {
      * A trailing comment is stripped, so the returned path never carries trivia
      * that would corrupt the statement when it is re-emitted.
      *
-     * Anchored on the trimmed statement, and dotted before braced, exactly as
-     * isModuleImport does it. Unanchored, the braced pattern is free to match
+     * Anchored on the trimmed statement, and dotted before braced, following
+     * isModuleImport. Unanchored, the braced pattern is free to match
      * inside the trailing comment of a dotted statement and win the path -
      * `using. Economy.Shop # was using { Inventory }` read as `Inventory`,
      * because the comment is only stripped afterwards, from that capture.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -164,19 +164,28 @@ export class ImportFormatter {
      * Handles both curly syntax (using { /path }) and dot syntax (using. /path).
      * A trailing comment is stripped, so the returned path never carries trivia
      * that would corrupt the statement when it is re-emitted.
+     *
+     * Anchored on the trimmed statement, and dotted before braced, exactly as
+     * isModuleImport does it. Unanchored, the braced pattern is free to match
+     * inside the trailing comment of a dotted statement and win the path -
+     * `using. Economy.Shop # was using { Inventory }` read as `Inventory`,
+     * because the comment is only stripped afterwards, from that capture.
+     *
      * @param importStatement The full import statement
      * @returns The extracted path, or null if there is none (including a
      *   statement whose content is nothing but a comment)
      */
     extractPathFromImport(importStatement: string): string | null {
-        const curlyMatch = importStatement.match(/using\s*\{\s*([^}]+)\s*\}/);
-        if (curlyMatch) {
-            return ImportFormatter.stripTrailingComment(curlyMatch[1]) || null;
-        }
+        const trimmed = importStatement.trim();
 
-        const dotMatch = importStatement.match(/using\.\s*(.+)/);
+        const dotMatch = trimmed.match(/^using\.\s*(.+)/);
         if (dotMatch) {
             return ImportFormatter.stripTrailingComment(dotMatch[1]) || null;
+        }
+
+        const curlyMatch = trimmed.match(/^using\s*\{\s*([^}]+)\s*\}/);
+        if (curlyMatch) {
+            return ImportFormatter.stripTrailingComment(curlyMatch[1]) || null;
         }
 
         return null;

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -88,11 +88,20 @@ export class ImportPathConverter {
         return new RegExp(`\\b${escaped}(?:'[^']*')?\\s*(?:<\\s*(?:public|private|internal|protected)\\s*>)?\\s*:=\\s*module\\s*[:>]`, "m");
     }
 
-    /** Extracts the path string from an import statement, minus any trailing comment */
+    /**
+     * Extracts the path string from an import statement, minus any trailing comment.
+     *
+     * Anchored on the trimmed statement, and dotted before braced, to match
+     * ImportFormatter. Unanchored, the braced pattern is free to match inside
+     * the trailing comment of a dotted statement and win the path - which
+     * misclassifies the import through isFullPathImport and isBuiltinModule as
+     * well as converting the wrong module.
+     */
     private extractPathFromImport(importStatement: string): string {
-        const curlyMatch = importStatement.match(/using\s*\{\s*([^}]+)\s*\}/);
-        const dotMatch = importStatement.match(/using\.\s*(.+)/);
-        const captured = curlyMatch ? curlyMatch[1] : dotMatch ? dotMatch[1] : "";
+        const trimmed = importStatement.trim();
+        const dotMatch = trimmed.match(/^using\.\s*(.+)/);
+        const curlyMatch = dotMatch ? null : trimmed.match(/^using\s*\{\s*([^}]+)\s*\}/);
+        const captured = dotMatch ? dotMatch[1] : curlyMatch ? curlyMatch[1] : "";
         return ImportFormatter.stripTrailingComment(captured);
     }
 

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -48,6 +48,14 @@ interface LineScan {
     /** Whether the line carries any text outside a comment. */
     hasCode: boolean;
     /**
+     * Index of the first character of that text, or -1 when the line carries
+     * none. A statement is not required to open its line - a line closing a
+     * block comment can carry a live one after the `#>` - so a reader that does
+     * not prefix-test needs to be told where the code starts rather than
+     * searching the whole line and finding a `using` written in the trivia.
+     */
+    codeStart: number;
+    /**
      * Whether the line holds a `<#>` marker, which makes every line below it
      * indented past it part of the comment it opens.
      */
@@ -75,6 +83,7 @@ interface LineScan {
 function scanLine(line: string, depth: number): LineScan {
     let nesting = depth;
     let hasCode = false;
+    let codeStart = -1;
     let i = 0;
 
     while (i < line.length) {
@@ -94,13 +103,13 @@ function scanLine(line: string, depth: number): LineScan {
         if (line.startsWith("<#>", i)) {
             // Indented comment: the rest of this line is comment text, and so
             // is everything below indented past this line.
-            return { depth: nesting, hasCode, opensIndentedComment: true };
+            return { depth: nesting, hasCode, codeStart, opensIndentedComment: true };
         }
 
         if (line[i] === "#") {
             // Line comment: the rest of the line is comment text and cannot
             // open a block.
-            return { depth: nesting, hasCode, opensIndentedComment: false };
+            return { depth: nesting, hasCode, codeStart, opensIndentedComment: false };
         }
 
         if (line.startsWith("<#", i)) {
@@ -110,12 +119,15 @@ function scanLine(line: string, depth: number): LineScan {
         }
 
         if (!/\s/.test(line[i])) {
+            if (!hasCode) {
+                codeStart = i;
+            }
             hasCode = true;
         }
         i += 1;
     }
 
-    return { depth: nesting, hasCode, opensIndentedComment: false };
+    return { depth: nesting, hasCode, codeStart, opensIndentedComment: false };
 }
 
 /** The width of a line's leading whitespace, which is its indentation. */
@@ -143,6 +155,12 @@ export interface LineClassification {
      * below the opener or strands lines that no longer read as comment text.
      */
     continuesCommentAbove: boolean;
+    /**
+     * Where the line's live code begins, or -1 when it has none. A reader that
+     * searches the line rather than prefix-testing it needs this: without it a
+     * `using` written in the line's trivia reads as the line's own statement.
+     */
+    codeStart: number;
 }
 
 /**
@@ -186,6 +204,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
             kind,
             insideBlockComment,
             continuesCommentAbove: insideBlockComment || insideIndentedComment,
+            codeStart: scan.codeStart,
         };
 
         if (!insideBlockComment && !insideIndentedComment && scan.opensIndentedComment) {
@@ -375,10 +394,11 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
  * error this must not make: the caller reads an empty answer as permission to
  * remove an import, so anything unrecognised has to fail towards reporting a
  * path rather than away from it. That is also why the statement is not required
- * to open its line, and why extractPathFromImport decides rather than a prefix
- * test - a line closing a block comment can carry a live `using` after the `#>`.
- * The cost is that trivia naming a path, such as a trailing `# see using { /B }`,
- * reports it; that only makes the caller more cautious.
+ * to open its line: a line closing a block comment can carry a live `using`
+ * after the `#>`, and so can one behind closed inline trivia. Where that live
+ * code begins is the classifier's answer, not a search - reading from the start
+ * of the line instead let a `using { X }` written in the trivia stand in for the
+ * line's own statement, which is the same defect the readers below it had.
  *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */
@@ -388,14 +408,15 @@ export function allUsingPaths(lines: string[]): string[] {
     const paths: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
-        if (classifications[i].kind === "comment") {
+        const { kind, codeStart } = classifications[i];
+        if (kind === "comment") {
             continue;
         }
 
         // The indented half of a `using:` pair is read here from nextLine, and
         // holds no `using` of its own, so the loop reaching it finds nothing and
         // the pair is counted once - as scanModuleImports consumes both at once.
-        const trimmed = lines[i].trim();
+        const trimmed = (codeStart === -1 ? lines[i] : lines[i].slice(codeStart)).trim();
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
         const path = /^using\s*:\s*$/.test(trimmed)
             ? nextLine !== undefined && /^\s+\S/.test(nextLine)

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -48,13 +48,14 @@ interface LineScan {
     /** Whether the line carries any text outside a comment. */
     hasCode: boolean;
     /**
-     * Index of the first character of that text, or -1 when the line carries
-     * none. A statement is not required to open its line - a line closing a
-     * block comment can carry a live one after the `#>` - so a reader that does
-     * not prefix-test needs to be told where the code starts rather than
-     * searching the whole line and finding a `using` written in the trivia.
+     * The line with its comments removed, each replaced by a space so text on
+     * either side cannot join into a token the author did not write. A reader
+     * searching a line for a statement it cannot prefix-test needs this: a
+     * statement is not required to open its line - one can follow a `;`, or the
+     * `#>` that closes a block comment - so the search has to cover the whole
+     * line, and searching the raw line finds a `using` written in the trivia.
      */
-    codeStart: number;
+    code: string;
     /**
      * Whether the line holds a `<#>` marker, which makes every line below it
      * indented past it part of the comment it opens.
@@ -83,7 +84,7 @@ interface LineScan {
 function scanLine(line: string, depth: number): LineScan {
     let nesting = depth;
     let hasCode = false;
-    let codeStart = -1;
+    let code = "";
     let i = 0;
 
     while (i < line.length) {
@@ -94,6 +95,9 @@ function scanLine(line: string, depth: number): LineScan {
             } else if (line.startsWith("#>", i)) {
                 nesting -= 1;
                 i += 2;
+                if (nesting === 0) {
+                    code += " ";
+                }
             } else {
                 i += 1;
             }
@@ -103,31 +107,30 @@ function scanLine(line: string, depth: number): LineScan {
         if (line.startsWith("<#>", i)) {
             // Indented comment: the rest of this line is comment text, and so
             // is everything below indented past this line.
-            return { depth: nesting, hasCode, codeStart, opensIndentedComment: true };
+            return { depth: nesting, hasCode, code, opensIndentedComment: true };
         }
 
         if (line[i] === "#") {
             // Line comment: the rest of the line is comment text and cannot
             // open a block.
-            return { depth: nesting, hasCode, codeStart, opensIndentedComment: false };
+            return { depth: nesting, hasCode, code, opensIndentedComment: false };
         }
 
         if (line.startsWith("<#", i)) {
             nesting += 1;
             i += 2;
+            code += " ";
             continue;
         }
 
         if (!/\s/.test(line[i])) {
-            if (!hasCode) {
-                codeStart = i;
-            }
             hasCode = true;
         }
+        code += line[i];
         i += 1;
     }
 
-    return { depth: nesting, hasCode, codeStart, opensIndentedComment: false };
+    return { depth: nesting, hasCode, code, opensIndentedComment: false };
 }
 
 /** The width of a line's leading whitespace, which is its indentation. */
@@ -156,11 +159,12 @@ export interface LineClassification {
      */
     continuesCommentAbove: boolean;
     /**
-     * Where the line's live code begins, or -1 when it has none. A reader that
-     * searches the line rather than prefix-testing it needs this: without it a
-     * `using` written in the line's trivia reads as the line's own statement.
+     * The line with its comments removed, each replaced by a space. A reader
+     * that searches a line rather than prefix-testing it needs this: search the
+     * raw line and a `using` written in its trivia reads as the line's own
+     * statement.
      */
-    codeStart: number;
+    code: string;
 }
 
 /**
@@ -204,7 +208,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
             kind,
             insideBlockComment,
             continuesCommentAbove: insideBlockComment || insideIndentedComment,
-            codeStart: scan.codeStart,
+            code: scan.code,
         };
 
         if (!insideBlockComment && !insideIndentedComment && scan.opensIndentedComment) {
@@ -368,6 +372,26 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
 }
 
 /**
+ * The path of the first `using` written anywhere in a line of live code, or ""
+ * when it writes none.
+ *
+ * extractPathFromImport reads a statement from the head of what it is given, so
+ * a statement that does not open the line has to be handed its own head rather
+ * than the line. Every `using` on the line is offered in turn, which keeps one
+ * copy of the two patterns instead of a looser second copy that searches - the
+ * looser copy is what read a comment as the statement in the first place.
+ */
+function firstImportPath(formatter: ImportFormatter, code: string): string {
+    for (let at = code.indexOf("using"); at !== -1; at = code.indexOf("using", at + 1)) {
+        const path = formatter.extractPathFromImport(code.slice(at));
+        if (path) {
+            return path;
+        }
+    }
+    return "";
+}
+
+/**
  * The path of every `using` the file writes, at any indentation, module import
  * and local-scope using alike.
  *
@@ -394,11 +418,12 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
  * error this must not make: the caller reads an empty answer as permission to
  * remove an import, so anything unrecognised has to fail towards reporting a
  * path rather than away from it. That is also why the statement is not required
- * to open its line: a line closing a block comment can carry a live `using`
- * after the `#>`, and so can one behind closed inline trivia. Where that live
- * code begins is the classifier's answer, not a search - reading from the start
- * of the line instead let a `using { X }` written in the trivia stand in for the
- * line's own statement, which is the same defect the readers below it had.
+ * to open its line: it can follow a `;`, the `#>` that closes a block comment,
+ * or closed inline trivia. So the whole line is searched - but the line with its
+ * comments already removed, which is the classifier's answer rather than
+ * anything read off the raw text. Searching the raw text is what let a
+ * `using { X }` written in a comment stand in for the line's own statement,
+ * the same defect extractPathFromImport itself had.
  *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */
@@ -408,7 +433,7 @@ export function allUsingPaths(lines: string[]): string[] {
     const paths: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
-        const { kind, codeStart } = classifications[i];
+        const { kind, code } = classifications[i];
         if (kind === "comment") {
             continue;
         }
@@ -416,13 +441,9 @@ export function allUsingPaths(lines: string[]): string[] {
         // The indented half of a `using:` pair is read here from nextLine, and
         // holds no `using` of its own, so the loop reaching it finds nothing and
         // the pair is counted once - as scanModuleImports consumes both at once.
-        const trimmed = (codeStart === -1 ? lines[i] : lines[i].slice(codeStart)).trim();
+        const trimmed = code.trim();
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
-        const path = /^using\s*:\s*$/.test(trimmed)
-            ? nextLine !== undefined && /^\s+\S/.test(nextLine)
-                ? ImportFormatter.stripTrailingComment(nextLine)
-                : ""
-            : formatter.extractPathFromImport(trimmed);
+        const path = /^using\s*:\s*$/.test(trimmed) ? (nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "") : firstImportPath(formatter, trimmed);
         if (path) {
             paths.push(path);
         }

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -48,12 +48,20 @@ interface LineScan {
     /** Whether the line carries any text outside a comment. */
     hasCode: boolean;
     /**
-     * The line with its comments removed, each replaced by a space so text on
-     * either side cannot join into a token the author did not write. A reader
-     * searching a line for a statement it cannot prefix-test needs this: a
-     * statement is not required to open its line - one can follow a `;`, or the
-     * `#>` that closes a block comment - so the search has to cover the whole
-     * line, and searching the raw line finds a `using` written in the trivia.
+     * The line with its comments removed. A reader searching a line for a
+     * statement it cannot prefix-test needs this: a statement is not required
+     * to open its line - one can follow a `;`, or the `#>` that closes a block
+     * comment - so the search has to cover the whole line, and searching the
+     * raw line finds a `using` written in the trivia.
+     *
+     * Nothing is put in a removed comment's place, so text on either side of
+     * one joins. Whether Verse splits a token there is not something its test
+     * corpus settles: comments appear only between tokens throughout
+     * Tests/Roundtrip/Comments.versetest, and the one splicing case,
+     * `"abc<#def#>ghi" = "abcghi"` in Tests/Literals/String.versetest, is
+     * string contents rather than an identifier. Joining is the side to be
+     * wrong on: it can only report a `using` this reader would otherwise miss,
+     * and missing one is the error its caller cannot survive.
      */
     code: string;
     /**
@@ -95,9 +103,6 @@ function scanLine(line: string, depth: number): LineScan {
             } else if (line.startsWith("#>", i)) {
                 nesting -= 1;
                 i += 2;
-                if (nesting === 0) {
-                    code += " ";
-                }
             } else {
                 i += 1;
             }
@@ -119,7 +124,6 @@ function scanLine(line: string, depth: number): LineScan {
         if (line.startsWith("<#", i)) {
             nesting += 1;
             i += 2;
-            code += " ";
             continue;
         }
 
@@ -159,10 +163,9 @@ export interface LineClassification {
      */
     continuesCommentAbove: boolean;
     /**
-     * The line with its comments removed, each replaced by a space. A reader
-     * that searches a line rather than prefix-testing it needs this: search the
-     * raw line and a `using` written in its trivia reads as the line's own
-     * statement.
+     * The line with its comments removed. A reader that searches a line rather
+     * than prefix-testing it needs this: search the raw line and a `using`
+     * written in its trivia reads as the line's own statement.
      */
     code: string;
 }

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -119,6 +119,25 @@ describe("ImportFormatter trailing comments on import statements", () => {
         expect(formatter.groupAndFormatImports([path as string], false, true, "none")).toEqual(["using { /Verse.org/Simulation }"]);
     });
 
+    // The braced pattern used to be tried first and unanchored, so on a dotted
+    // statement it matched inside the trailing comment and won the path - the
+    // comment being stripped only afterwards, from that wrong capture.
+    it("dot syntax: a trailing comment holding `using { X }` does not hijack the path", () => {
+        expect(formatter.extractPathFromImport("using. Economy.Shop # was using { Inventory }")).toBe("Economy.Shop");
+    });
+
+    it("dot syntax: a full path survives a trailing comment holding `using { X }`", () => {
+        expect(formatter.extractPathFromImport("using. /mygame@fortnite.com/mygame/Economy/Shop # see using { Vendor }")).toBe("/mygame@fortnite.com/mygame/Economy/Shop");
+    });
+
+    // isDigestImport routes anything containing "using" through here, which a
+    // bare path can satisfy as a substring - "Housing" ends in one. Anchoring
+    // means no match, so its `|| importPath` fallback keeps the real path
+    // instead of the tail the unanchored dotted pattern used to capture.
+    it("a bare path whose segment ends in `using` is not read as a dotted statement", () => {
+        expect(formatter.extractPathFromImport("/mygame@fortnite.com/mygame/Housing.Shop")).toBeNull();
+    });
+
     it("a trailing comment does not change module-import classification", () => {
         // Without stripping, the `.` in a comment such as `# see Foo.Bar` made a
         // bare local-scope using look like a dotted module import.

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -236,6 +236,21 @@ function converterWithProjectPath(projectVersePath: string): ImportPathConverter
     return converter;
 }
 
+describe("ImportPathConverter import classification", () => {
+    // Both classifiers read the path through extractPathFromImport, where the
+    // braced pattern used to be tried first and unanchored - so a comment
+    // cross-referencing another import handed them its path instead of the
+    // statement's own, and a relative import answered as full-path and built-in.
+    it("judges a dotted import on its own path, not on a `using { X }` in its comment", () => {
+        const converter = converterWithProjectPath("/mygame@fortnite.com/mygame");
+        const statement = "using. Economy.Shop # was using { /Verse.org/Simulation }";
+
+        expect(converter.isFullPathImport(statement)).toBe(false);
+        expect(converter.isBuiltinModule(statement)).toBe(false);
+        expect(converter.extractModuleFromImport(statement)?.moduleName).toBe("Shop");
+    });
+});
+
 describe("ImportPathConverter.convertFromFullPath", () => {
     const projectVersePath = "/mygame@fortnite.com/mygame";
 
@@ -324,5 +339,17 @@ describe("ImportPathConverter.convertToFullPath", () => {
         const result = await converter.convertToFullPath("using { Shop } # see {Vendor}", vscode.Uri.file("C:/project/test.verse"), 0);
 
         expect(result?.fullPathImport).toBe("using { /mygame@fortnite.com/mygame/Economy/Shop }");
+    });
+
+    // A brace in comment prose costs the statement its style; a whole
+    // `using { X }` in there used to cost it its module, converting the
+    // cross-referenced import rather than the one on the line.
+    it("converts the module on the line, not one named in its trailing comment", async () => {
+        const converter = converterWithLocation("/Economy");
+
+        const result = await converter.convertToFullPath("using. Shop # was using { Inventory }", vscode.Uri.file("C:/project/test.verse"), 0);
+
+        expect(result?.fullPathImport).toBe("using. /mygame@fortnite.com/mygame/Economy/Shop");
+        expect(result?.moduleName).toBe("Shop");
     });
 });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -71,11 +71,27 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using { /A } # why", "code()"])).toEqual(["/A"]);
     });
 
-    // The other half of reading from where the code starts: a line that carries
-    // code and then names a using in its trivia writes no import, so the trivia
-    // must not report one.
+    // The other half of searching the line's code: a line that carries code and
+    // then names a using in its trivia writes no import, so the trivia must not
+    // report one.
     it("does not read a using named in the trivia of a code line", () => {
         expect(allUsingPaths(["code() # see using { /B }", "using { /A }"])).toEqual(["/A"]);
+    });
+
+    // The statement need not be the first thing on its line either. Reporting
+    // only a statement that opens the line is the miss this must never make.
+    it("collects a using written after other code on the same line", () => {
+        expect(allUsingPaths(["F():void =", "    Foo(); using { LocalVar }", "using { /A }"])).toEqual(["LocalVar", "/A"]);
+    });
+
+    it("collects a using written after code and a closed inline comment", () => {
+        expect(allUsingPaths(["X := 1 <# note #> using { Economy.Shop }", "using { /A }"])).toEqual(["Economy.Shop", "/A"]);
+    });
+
+    // Removing a comment must not splice its neighbours into a token the author
+    // never wrote - `us<# c #>ing` is `us` then `ing`, not a using.
+    it("does not join text across a removed comment into a using", () => {
+        expect(allUsingPaths(["us<# c #>ing { /B }", "using { /A }"])).toEqual(["/A"]);
     });
 });
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -70,6 +70,13 @@ describe("allUsingPaths", () => {
     it("strips a trailing comment from the path", () => {
         expect(allUsingPaths(["using { /A } # why", "code()"])).toEqual(["/A"]);
     });
+
+    // The other half of reading from where the code starts: a line that carries
+    // code and then names a using in its trivia writes no import, so the trivia
+    // must not report one.
+    it("does not read a using named in the trivia of a code line", () => {
+        expect(allUsingPaths(["code() # see using { /B }", "using { /A }"])).toEqual(["/A"]);
+    });
 });
 
 describe("scanModuleImports", () => {

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -88,10 +88,13 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["X := 1 <# note #> using { Economy.Shop }", "using { /A }"])).toEqual(["Economy.Shop", "/A"]);
     });
 
-    // Removing a comment must not splice its neighbours into a token the author
-    // never wrote - `us<# c #>ing` is `us` then `ing`, not a using.
-    it("does not join text across a removed comment into a using", () => {
-        expect(allUsingPaths(["us<# c #>ing { /B }", "using { /A }"])).toEqual(["/A"]);
+    // Whether Verse reads `us<# c #>ing` as one token is not settled by its test
+    // corpus - comments sit between tokens throughout Roundtrip/Comments, and
+    // the one splicing case is string contents. Reporting is the side to be
+    // wrong on: a false path only makes the caller more cautious, where a missed
+    // one is the error it cannot survive.
+    it("reports a using whose token a comment splits, rather than risking a miss", () => {
+        expect(allUsingPaths(["us<# c #>ing { /B }", "using { /A }"])).toEqual(["/B", "/A"]);
     });
 });
 


### PR DESCRIPTION
Both copies of `extractPathFromImport` tried the braced pattern first and neither anchored it, so on a dotted statement the braced regex was free to match inside the trailing comment and win the path. The comment was only stripped afterwards, from that wrong capture.

```
in : using. Economy.Shop # was using { Inventory }
out: "Inventory"                      (expected "Economy.Shop")
```

Both now trim, anchor, and try dotted before braced, following `ImportFormatter.isModuleImport`, which already reads a dotted statement by its own head rather than by its comment.

## What that cost, and what it bought

Anchoring means a statement has to open the text it is read from. `allUsingPaths` deliberately required no such thing: a live `using` can follow the `#>` that closes a block comment, closed inline trivia, or a `;`. Three existing tests caught this immediately, and the review gate then caught a subtler miss in the first correction — reading from a single "where the code starts" index still lost `Foo(); using { LocalVar }`, which under the old unanchored search was reported. That is the one error the function must not make: its caller reads an empty answer as permission to withhold an import.

So `scanLine` now reports the line **with its comments removed** rather than where its code starts, and `allUsingPaths` offers each `using` in that text to `extractPathFromImport` in turn. The whole line is searched, as before; comment text simply is not part of what is searched, which is what the anchoring was for.

Nothing replaces a removed comment, so text on either side joins. Whether Verse splits a token there is not settled by its test corpus — comments sit between tokens throughout `Tests/Roundtrip/Comments.versetest` and never inside an identifier, and the one splicing case, `"abc<#def#>ghi" = "abcghi"`, is string contents rather than code. With the rule undecided the direction is what matters, and this reader has one safe direction: an invented path makes its caller more cautious, a missed one is read as permission to withhold an import.

Reading from where the code starts also stops a code line's trivia reporting a path — `code() # see using { /B }` used to report `/B`. The old doc comment called that over-reporting an acceptable cost; it is the same defect one level up, and it is now gone.

## Files

- `src/imports/ImportFormatter.ts` — anchored, dotted-first.
- `src/imports/ImportPathConverter.ts` — the same, keeping its `""`-on-no-match contract, which `isFullPathImport` and `isBuiltinModule` call `.startsWith` on unguarded.
- `src/imports/ImportScanner.ts` — `LineScan.code` / `LineClassification.code`, and `firstImportPath`.

`isDigestImport` improves as a side effect: it routes anything containing the substring `using` through the extractor, which a bare path can satisfy (`/mygame@fortnite.com/mygame/Housing.Shop` — "Ho**using**."). It used to return `Shop`; it now falls through to its `|| importPath` fallback and keeps the real path.

## Not done here

Two things, both pre-existing and both deliberately left:

- The two `extractPathFromImport` bodies remain two copies rather than one shared helper. Folding them together changes `ImportFormatter`'s public shape, which is wider than this fix; the ticket asks for the pair to be made consistent, and they now are.
- `allUsingPaths` still reports one path per line, so `using { /X }; using { Economy.Shop }` reports only `/X`. The unanchored search it replaced stopped at its first match too, so this is not a regression, but the function's doc promises the path of *every* `using`. Worth its own issue.

## Tests

Nine added, across `ImportFormatter.test.ts`, `ImportPathConverter.test.ts` and `ImportScanner.test.ts`. Six were proved against the unfixed sources — stash the fix, watch them fail, restore — and two of the three scanner guards were proved against the interim version the review rejected. The ninth pins the comment-splice direction, which is a choice rather than a defect, so it has no pre-fix failure to demonstrate.

## Verification

```
$ npm run compile
> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 22 passed, 22 total
Tests:       452 passed, 452 total
Snapshots:   0 total
Time:        5.781 s, estimated 7 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Reviewed in a fresh context over two rounds: round 1 `FAIL` on one Critical — the miss described above — plus three Suggestions; round 2 `PASS_WITH_SUGGESTIONS` after the fix, with the reviewer re-implementing the pre-fix `allUsingPaths` and diffing it against this branch across 21 line shapes to confirm no real path is lost.

Closes #207
