### PR TITLE
fix(imports): report every using a line writes, not just its first

### DIFF
--- a/changelog.d/214.fixed.md
+++ b/changelog.d/214.fixed.md
@@ -1,0 +1,1 @@
+**Optimize Imports**: a file that writes two `using` statements on one line no longer loses an import the code below it needs.

--- a/changelog.d/214.fixed.md
+++ b/changelog.d/214.fixed.md
@@ -1,1 +1,1 @@
-**Optimize Imports**: a file that writes two `using` statements on one line no longer loses an import the code below it needs.
+**Optimize Imports**: a file holding both a comment-anchored import and an ordinary import of the same path no longer removes the ordinary one when two `using` statements share a line and something below still needs one of them.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -375,23 +375,36 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
 }
 
 /**
- * The path of the first `using` written anywhere in a line of live code, or ""
- * when it writes none.
+ * The path of every `using` written anywhere in a line of live code, in written
+ * order, or [] when it writes none.
  *
  * extractPathFromImport reads a statement from the head of what it is given, so
  * a statement that does not open the line has to be handed its own head rather
  * than the line. Every `using` on the line is offered in turn, which keeps one
  * copy of the two patterns instead of a looser second copy that searches - the
  * looser copy is what read a comment as the statement in the first place.
+ *
+ * All of them are collected rather than the first, because a line can carry more
+ * than one live statement - `;` separates definitions in a scope exactly as a
+ * newline does. Stopping at the first is how a rank-0 path written before a
+ * rank-1 or rank-2 one on the same line hid it from the caller, which reads an
+ * all-absolute answer as permission to remove an import.
+ *
+ * A dotted statement has no closing delimiter, so one sharing a line swallows
+ * what follows it into its path. The next iteration still finds the statement
+ * after it and reports that path on its own, so nothing is missed - which is the
+ * guarantee this owes its caller. The swallowed copy only adds a path the caller
+ * weighs too, and a path that is not absolute weighs towards keeping an import.
  */
-function firstImportPath(formatter: ImportFormatter, code: string): string {
+function allImportPaths(formatter: ImportFormatter, code: string): string[] {
+    const paths: string[] = [];
     for (let at = code.indexOf("using"); at !== -1; at = code.indexOf("using", at + 1)) {
         const path = formatter.extractPathFromImport(code.slice(at));
         if (path) {
-            return path;
+            paths.push(path);
         }
     }
-    return "";
+    return paths;
 }
 
 /**
@@ -428,6 +441,13 @@ function firstImportPath(formatter: ImportFormatter, code: string): string {
  * `using { X }` written in a comment stand in for the line's own statement,
  * the same defect extractPathFromImport itself had.
  *
+ * A `;` also means a line can carry more than one statement, so every one it
+ * writes is reported rather than the first. Reporting one was the same error
+ * under another name: a rank-0 path written first reads as safe and hides the
+ * rank-1 or rank-2 path beside it, which is exactly the answer the caller acts
+ * on. Two statements on one line therefore contribute two paths, in written
+ * order, and only the indented `using:` pair is still counted once.
+ *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */
 export function allUsingPaths(lines: string[]): string[] {
@@ -446,10 +466,15 @@ export function allUsingPaths(lines: string[]): string[] {
         // the pair is counted once - as scanModuleImports consumes both at once.
         const trimmed = code.trim();
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
-        const path = /^using\s*:\s*$/.test(trimmed) ? (nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "") : firstImportPath(formatter, trimmed);
-        if (path) {
-            paths.push(path);
+        if (/^using\s*:\s*$/.test(trimmed)) {
+            const indentedPath = nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "";
+            if (indentedPath) {
+                paths.push(indentedPath);
+            }
+            continue;
         }
+
+        paths.push(...allImportPaths(formatter, trimmed));
     }
 
     return paths;

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -391,12 +391,12 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
  * all-absolute answer as permission to remove an import.
  *
  * A dotted statement has no closing delimiter, so one sharing a line swallows
- * what follows it into its path. The next iteration still finds the statement
- * after it and reports that path on its own, so nothing is missed - which is the
- * guarantee this owes its caller. The swallowed copy only adds a path the caller
- * weighs too, and a path that is not absolute weighs towards keeping an import.
+ * what follows it into its path. That malformed path is reported as well, but
+ * the next iteration finds the statement after it and reports that path on its
+ * own - which is the guarantee this owes its caller. Reading the swallowed copy
+ * is not what makes the line safe; finding the statement inside it again is.
  */
-function allImportPaths(formatter: ImportFormatter, code: string): string[] {
+function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
     const paths: string[] = [];
     for (let at = code.indexOf("using"); at !== -1; at = code.indexOf("using", at + 1)) {
         const path = formatter.extractPathFromImport(code.slice(at));
@@ -441,12 +441,11 @@ function allImportPaths(formatter: ImportFormatter, code: string): string[] {
  * `using { X }` written in a comment stand in for the line's own statement,
  * the same defect extractPathFromImport itself had.
  *
- * A `;` also means a line can carry more than one statement, so every one it
- * writes is reported rather than the first. Reporting one was the same error
- * under another name: a rank-0 path written first reads as safe and hides the
- * rank-1 or rank-2 path beside it, which is exactly the answer the caller acts
- * on. Two statements on one line therefore contribute two paths, in written
- * order, and only the indented `using:` pair is still counted once.
+ * A `;` also means a line can carry more than one statement, so a line
+ * contributes every `using` statement usingPathsOnLine finds on it, in written
+ * order, rather than the first. Reporting the first was the same error under
+ * another name - see that function. The indented `using:` pair is the one shape
+ * still counted once, because its path is read here from the line below.
  *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */
@@ -474,7 +473,7 @@ export function allUsingPaths(lines: string[]): string[] {
             continue;
         }
 
-        paths.push(...allImportPaths(formatter, trimmed));
+        paths.push(...usingPathsOnLine(formatter, trimmed));
     }
 
     return paths;

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -67,6 +67,32 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using. /A", "code()"])).toEqual(["/A"]);
     });
 
+    // `;` separates definitions in a scope exactly as a newline does, so a line
+    // can write two statements. Reporting only the first is what let an
+    // absolute path hide a dotted one beside it and read as safe to withhold.
+    it("collects both statements a line separated by a semicolon writes", () => {
+        expect(allUsingPaths(["using { /X }; using { Economy.Shop }", "code()"])).toEqual(["/X", "Economy.Shop"]);
+    });
+
+    it("collects three statements sharing a line, in written order", () => {
+        expect(allUsingPaths(["using { /X }; using { Features }; using { Economy.Shop }", "code()"])).toEqual(["/X", "Features", "Economy.Shop"]);
+    });
+
+    // A dotted statement has no closing delimiter, so it swallows what follows
+    // it into its path. The statement after it is still found and reported on
+    // its own, which is the guarantee that matters: nothing is missed.
+    it("still reports a statement written after a dotted one on the same line", () => {
+        expect(allUsingPaths(["using. /X; using { Economy.Shop }", "code()"])).toEqual(["/X; using { Economy.Shop }", "Economy.Shop"]);
+    });
+
+    it("collects a second statement written after a braced one in a module body", () => {
+        expect(allUsingPaths(["using { /A }", "MyModule := module:", "    using { /X }; using { Economy.Shop }", "code()"])).toEqual(["/A", "/X", "Economy.Shop"]);
+    });
+
+    it("does not read a second statement out of a comment sharing the line", () => {
+        expect(allUsingPaths(["using { /X } # see using { Economy.Shop }", "code()"])).toEqual(["/X"]);
+    });
+
     it("strips a trailing comment from the path", () => {
         expect(allUsingPaths(["using { /A } # why", "code()"])).toEqual(["/A"]);
     });


### PR DESCRIPTION
Closes #214

`allUsingPaths` promised the path of every `using` the file writes but read at most one per line: the loop behind it returned on the first statement that yielded a path. A `;` separates definitions in a scope exactly as a newline does, so a line can carry two live statements, and a rank-0 path written before a rank-1 or rank-2 one hid the second from `withholdIsSafe` - whose all-absolute answer is what permits an import to be withheld. The stranded provider is a file that stops compiling.

The loop that collects them all was already written; only the `return` was early.

## What changed

- `firstImportPath` becomes `usingPathsOnLine`, returning every path the line writes in written order instead of the first. Named for its scope, since the file-level `allUsingPaths` sits beside it.
- `allUsingPaths` spreads that result. The indented `using:` pair keeps its own branch and is still counted once, from its path line.
- Five tests in `src/imports/__tests__/ImportScanner.test.ts`, which run without the VS Code runtime.

Nothing else moved. `extractPathFromImport` is untouched, so its four other callers are unaffected.

## The dotted statement

A dotted `using` has no closing delimiter, so one sharing a line swallows what follows it into its path: `using. /X; using { Economy.Shop }` reports `/X; using { Economy.Shop }` as well as `Economy.Shop`. The malformed entry is reported rather than suppressed, and the statement after it is found by the next iteration and reported on its own - which is the guarantee the function owes its caller. Bounding the dotted capture at `;` would mean changing `extractPathFromImport`, shared by four other call sites, to fix cosmetics in the one output that is never re-emitted: `allUsingPaths` has a single caller and it only ranks these paths.

The change is one-directional by construction. Every path the old code returned is still returned, in the same position, with more appended - so `.every(rank === 0)` can only go true to false, never false to true. No input flips a judgement towards "safe".

## Verification

`npm run compile`

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 23 passed, 23 total
Tests:       470 passed, 470 total
Snapshots:   0 total
Time:        9.053 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The new tests were proved to detect the defect: stashing only `src/imports/ImportScanner.ts` and re-running the file fails 4 of the 5. The fifth, "does not read a second statement out of a comment sharing the line", is a guard that must pass both ways.

## Known hole, not this ticket

An indented pair opened after a `;` still under-reports: `["using { /X }; using:", "    Economy.Shop"]` returns `["/X"]`, verified by running it. The `using:` branch tests the whole trimmed line, so the shape misses it. Behaviour is identical before and after this diff and outside the ticket's acceptance, so it is left for a separate issue rather than widening this one.
