### PR TITLE
fix(imports): read a using: pair opened after a semicolon

### DIFF
--- a/changelog.d/216.fixed.md
+++ b/changelog.d/216.fixed.md
@@ -1,0 +1,1 @@
+**Organize imports**: an indented `using:` pair written after a `;` on the same line no longer reads as absent, so organizing keeps an import the pair resolves against instead of dropping it.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -444,8 +444,10 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
  * A `;` also means a line can carry more than one statement, so a line
  * contributes every `using` statement usingPathsOnLine finds on it, in written
  * order, rather than the first. Reporting the first was the same error under
- * another name - see that function. The indented `using:` pair is the one shape
- * still counted once, because its path is read here from the line below.
+ * another name - see that function. For the same reason a `using:` opening an
+ * indented pair is recognised at the end of its line rather than as the whole
+ * of it: a statement can precede it there too. The pair is the one shape still
+ * counted once, because its path is read here from the line below.
  *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */
@@ -460,20 +462,36 @@ export function allUsingPaths(lines: string[]): string[] {
             continue;
         }
 
-        // The indented half of a `using:` pair is read here from nextLine, and
-        // holds no `using` of its own, so the loop reaching it finds nothing and
-        // the pair is counted once - as scanModuleImports consumes both at once.
         const trimmed = code.trim();
-        const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
-        if (/^using\s*:\s*$/.test(trimmed)) {
-            const indentedPath = nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "";
-            if (indentedPath) {
-                paths.push(indentedPath);
-            }
+        paths.push(...usingPathsOnLine(formatter, trimmed));
+
+        // A `using:` opening an indented pair carries no path of its own -
+        // extractPathFromImport reads neither pattern out of it - so the path
+        // below it is read here instead, and the line above contributes it
+        // nothing.
+        //
+        // The opener is matched as the tail of the line rather than as the
+        // whole of it, because `;` separates statements exactly as a newline
+        // does and one can therefore precede it. Whatever precedes it is
+        // already reported above, so requiring the line to hold nothing else
+        // dropped the path below a pair written that way, and a line reporting
+        // only its absolute statements is read by the caller as permission to
+        // remove an import. The tail is all that has to match: a `using:`
+        // anywhere but the end opens no block, since the path would have to
+        // follow it on the line.
+        //
+        // The indented half holds no `using` of its own, so the loop reaching
+        // it finds nothing and the pair is still counted once - as
+        // scanModuleImports consumes both at once.
+        if (!/\busing\s*:\s*$/.test(trimmed)) {
             continue;
         }
 
-        paths.push(...usingPathsOnLine(formatter, trimmed));
+        const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
+        const indentedPath = nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "";
+        if (indentedPath) {
+            paths.push(indentedPath);
+        }
     }
 
     return paths;

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -467,22 +467,18 @@ export function allUsingPaths(lines: string[]): string[] {
 
         // A `using:` opening an indented pair carries no path of its own -
         // extractPathFromImport reads neither pattern out of it - so the path
-        // below it is read here instead, and the line above contributes it
-        // nothing.
+        // below it is read here instead.
         //
-        // The opener is matched as the tail of the line rather than as the
-        // whole of it, because `;` separates statements exactly as a newline
-        // does and one can therefore precede it. Whatever precedes it is
-        // already reported above, so requiring the line to hold nothing else
-        // dropped the path below a pair written that way, and a line reporting
-        // only its absolute statements is read by the caller as permission to
-        // remove an import. The tail is all that has to match: a `using:`
-        // anywhere but the end opens no block, since the path would have to
-        // follow it on the line.
+        // Only the tail of the line has to match. Requiring the whole of it
+        // dropped the path below a pair opened after a `;`, and a line left
+        // reporting nothing but its absolute statements is read by the caller
+        // as permission to remove an import. Matching the tail alone errs the
+        // other way: a line merely ending in `using:` contributes the text
+        // below it as a path, which can only make the caller decline to tidy.
         //
-        // The indented half holds no `using` of its own, so the loop reaching
-        // it finds nothing and the pair is still counted once - as
-        // scanModuleImports consumes both at once.
+        // The indented half holds no `using` statement of its own, so the loop
+        // reaching it adds no second copy of the path - as scanModuleImports
+        // consumes both lines at once.
         if (!/\busing\s*:\s*$/.test(trimmed)) {
             continue;
         }

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -89,6 +89,26 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using { /A }", "MyModule := module:", "    using { /X }; using { Economy.Shop }", "code()"])).toEqual(["/A", "/X", "Economy.Shop"]);
     });
 
+    // The one shape whose second half lives on the next line. Requiring the
+    // `using:` to be the whole of its line dropped the path below it, leaving a
+    // line of nothing but absolute paths - which the caller reads as permission
+    // to withhold an import the pair was resolving against.
+    it("collects the path below a using: opened after a semicolon", () => {
+        expect(allUsingPaths(["using { /X }; using:", "    Economy.Shop", "code()"])).toEqual(["/X", "Economy.Shop"]);
+    });
+
+    it("collects the path below a using: opened after a semicolon in a module body", () => {
+        expect(allUsingPaths(["using { /A }", "MyModule := module:", "    using { /X }; using:", "        Economy.Shop", "code()"])).toEqual(["/A", "/X", "Economy.Shop"]);
+    });
+
+    it("reports the statements on the line when a using: opens no indented path", () => {
+        expect(allUsingPaths(["using { /X }; using:", "code()"])).toEqual(["/X"]);
+    });
+
+    it("does not read an identifier that merely ends with using: as an opener", () => {
+        expect(allUsingPaths(["Xusing:", "    Economy.Shop", "using { /A }"])).toEqual(["/A"]);
+    });
+
     it("does not read a second statement out of a comment sharing the line", () => {
         expect(allUsingPaths(["using { /X } # see using { Economy.Shop }", "code()"])).toEqual(["/X"]);
     });


### PR DESCRIPTION
`allUsingPaths` recognised the `using:` that opens an indented pair only when it was the whole of its line, so a pair written after a `;` lost the path on the line below it:

```
in : ["using { /X }; using:", "    Economy.Shop"]
out: ["/X"]                                   (expected ["/X", "Economy.Shop"])
```

The line then reported nothing but its own absolute statements, and `withholdIsSafe` reads an all-absolute answer as permission to withhold an import an anchored one duplicates - so the file lost a provider the pair was resolving against.

## The change

The opener is matched as the tail of the line rather than as the whole of it, and `usingPathsOnLine` now runs on every line unconditionally, reporting whatever precedes the opener.

A `using:` carries no path of its own - `extractPathFromImport` matches neither the dotted (`^using\.`) nor the braced (`^using\s*\{`) pattern against it - so running it through that helper first contributes nothing, and the pair is still counted once, from its path line.

Output is a superset of the old output for every input: `^using\s*:\s*$` is a strict subset of `\busing\s*:\s*$` on a trimmed string, and `usingPathsOnLine` now runs on a superset of lines. That direction matters, because the caller reads a missing path as permission to delete an import.

`\b` keeps the match off an identifier ending in the same letters (`Xusing:`, `My_using:`), which is pinned by a test.

## On the ticket's open question

Whether a block-opening `using:` after a `;` is legal Verse is left unanswered, and the fix does not depend on it. The Book of Verse treats `using` as a statement-level declaration and never writes the indented form; the compiler corpus attests `using{...}; <definition>` on one line and a block opener after a `;` mid-line separately, but not the combination. The fix errs towards reporting either way, which the ticket explicitly permits.

## Scope

`scanModuleImports` still decides the indented pair with the old whole-line test, so the two functions in this file now disagree about whether a `using:` may follow a `;`. That is pre-existing and out of scope here; noted for a follow-up rather than widened into this PR.

## Verification

`npm run compile`

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./

```

`npm test`

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 25 passed, 25 total
Tests:       496 passed, 496 total
Snapshots:   0 total
Time:        9.311 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The two behavioural regression tests were confirmed to fail against the unfixed scanner - stashing `ImportScanner.ts` and re-running the suite reproduced the issue's symptom exactly, `Economy.Shop` missing from both:

```
Tests:       2 failed, 77 passed, 79 total
```

Review gate: PASS_WITH_SUGGESTIONS, 0 Critical. The suggestions taken were comment accuracy and length in the hunk itself.

Closes #216
