### PR TITLE
fix(imports): place a new import below the anchored import that provides it

### DIFF
--- a/changelog.d/196.fixed.md
+++ b/changelog.d/196.fixed.md
@@ -1,0 +1,1 @@
+**Import placement around an anchored import**: a new import is no longer written above the import that brings its first segment into scope when that import is anchored by a `<#` or `<#>` comment marker. Such an import belongs to no import block, so every placement decision was blind to it and the "Unknown identifier" the new import was added to resolve could survive.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -328,9 +328,11 @@ export class ImportDocumentEditor {
      * above it rather than merely preferring it there.
      *
      * Only a dotted path needs something in scope above it - its first segment.
-     * An absolute path needs nothing, and a bare reference names a module
-     * beside the file rather than something an earlier import brought in, so
-     * neither can be depending on an import added below it.
+     * An absolute path needs nothing at all. A bare reference can need another
+     * bare one, a nested child its parent, but a newly added import has no
+     * claim to be that parent: belongsAbove already keeps a new bare import
+     * below the existing ones, so raising an upper bound from a bare import
+     * would only contradict the lower bound it raises anyway.
      *
      * Narrower than belongsBelow on purpose. Preference is the right strength
      * in selectTargetBlockIndex, where the consequence of an upper bound is
@@ -365,20 +367,6 @@ export class ImportDocumentEditor {
         return { floor, ceiling };
     }
 
-    /** The bounds of a run of paths written together: the tightest of each. */
-    private combinedAnchoredBounds(anchoredImports: ScannedImport[], classifications: LineClassification[], paths: string[]): AnchoredBounds {
-        return paths.reduce<AnchoredBounds>(
-            (combined, path) => {
-                const bounds = this.anchoredBounds(anchoredImports, classifications, path);
-                return {
-                    floor: Math.max(combined.floor, bounds.floor),
-                    ceiling: combined.ceiling === -1 ? bounds.ceiling : bounds.ceiling === -1 ? combined.ceiling : Math.min(combined.ceiling, bounds.ceiling),
-                };
-            },
-            { floor: -1, ceiling: -1 },
-        );
-    }
-
     /**
      * The line a run of new import statements is written on: `desired`, moved
      * below the floor, and directly above the ceiling wherever there is one.
@@ -389,15 +377,21 @@ export class ImportDocumentEditor {
      * - The ceiling wins over the floor. Only couldResolveAgainst raises one,
      *   so a ceiling is always a scope requirement - an anchored dotted import
      *   whose first segment this new import is being added to provide. A floor
-     *   that disagrees with it can only come from an anchored absolute path,
-     *   which is ordering preference. Honouring the preference and breaking the
-     *   requirement writes the provider below its consumer, which is the defect
-     *   this whole path exists to prevent.
-     * - Taken exactly, so the import lands directly above the statement that
-     *   needs it rather than at `desired`. Anywhere higher is equally legal and
-     *   strictly worse: it opens a third import region, and from `desired` 0 it
-     *   would sit above the file header, which headerLineCount calls the one
-     *   place a header must never be.
+     *   disagreeing with it is usually the rank-0-before-rank-1 preference,
+     *   raised by an anchored absolute path that brings nothing into scope, and
+     *   honouring a preference over a requirement writes the provider below its
+     *   consumer: the defect this whole path exists to prevent. The one
+     *   disagreement that is not a preference - an anchored bare parent below
+     *   an anchored dotted consumer - is a file where the consumer already sits
+     *   above the chain it resolves through, so no line satisfies both and
+     *   neither choice makes it compile.
+     * - Taken exactly, because the ceiling is the *lowest* legal line: the new
+     *   import must precede that statement, so everything below the ceiling is
+     *   ruled out and everything above it is merely further away. Landing
+     *   directly above the statement that needs it keeps it beside its
+     *   consumer, and keeps it off line 0, where a `desired` of 0 would put it
+     *   above the file header - which headerLineCount calls the one place a
+     *   header must never be.
      */
     private placementLine(desired: number, bounds: AnchoredBounds): number {
         if (bounds.ceiling !== -1) {
@@ -662,10 +656,22 @@ export class ImportDocumentEditor {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, false);
                         }
                     } else {
-                        // No existing block - insert the grouped imports at the
-                        // top, or below an anchored import that has to precede
-                        // one of them.
-                        this.insertImportLines(edit, document, this.placementLine(0, this.combinedAnchoredBounds(anchoredImports, classifications, allImportsArray)), groupedImports, eol, true);
+                        // No existing block - write the imports at the top, or
+                        // below an anchored import that has to precede one of
+                        // them. Split by line like every other site rather than
+                        // written as one run under a merged bound: paths of
+                        // different ranks take their bounds from different
+                        // anchored imports, and one path's floor can sit below
+                        // another's ceiling, leaving the group no line it can
+                        // legally occupy at all.
+                        //
+                        // A relocated path is never among these. Every
+                        // rewritable import opens or extends a block, so no
+                        // block means none of them, which is also why the
+                        // trailing comments here are always empty.
+                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, 0, anchoredImports, classifications)) {
+                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, true);
+                        }
                     }
                 } else {
                     // No grouping or no existing imports - use original behavior
@@ -722,12 +728,21 @@ export class ImportDocumentEditor {
                         }
 
                         // Blocks are disjoint, so the replacements never overlap.
-                        // Neither can a standalone line below collide with one:
-                        // placementLine returns either a ceiling, which is an
-                        // anchored import's own line and so in no block, or
-                        // floor + 1 - and a path reaching that had every block
-                        // refused, which for a path with no ceiling means every
-                        // block starts at or above the floor.
+                        // Neither can a standalone line below collide with one.
+                        // placementLine returns one of two things, and an
+                        // anchored import's span holds no block line either way:
+                        // its own line breaks the contiguity a block is built
+                        // from, and the comment body below it is comment, so no
+                        // column-0 import the scanner would collect can be in
+                        // it.
+                        //
+                        // - A ceiling, which is an anchored import's own line.
+                        // - floor + 1, reached only when every block was
+                        //   refused, which for a path with no ceiling means
+                        //   every block starts at or below the floor. The floor
+                        //   is the end of an anchored span, so a block starting
+                        //   at or below it ends before that span begins, and
+                        //   floor + 1 is past the end of the block.
                         for (const index of [...pathsByBlock.keys()].sort((a, b) => a - b)) {
                             this.createBlockReplacementEdit(edit, document, importBlocks[index], pathsByBlock.get(index)!, preferDotSyntax, true, eol);
                         }

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -144,14 +144,18 @@ function anchoredCommentEnd(imp: ScannedImport, classifications: LineClassificat
  * real import that a `using` below it resolves against, so it constrains where
  * a new one may go exactly as the imports inside a block do.
  *
- * Both bounds read the same ranks selectTargetBlockIndex compares, with the
- * same two predicates, so anchored and blocked imports cannot disagree about
- * what must precede what:
+ * Both bounds read the ranks selectTargetBlockIndex compares, so anchored and
+ * blocked imports cannot disagree about what precedes what:
  *
  * - `floor` - the last line owned by the lowest anchored import that belongs
- *   above the new one. The new import goes below it.
- * - `ceiling` - the first line of the highest anchored import the new one
- *   belongs above. The new import goes above it.
+ *   above the new one (belongsAbove). The new import goes below it.
+ * - `ceiling` - the first line of the highest anchored import that could be
+ *   resolving against the new one (couldResolveAgainst). The new import goes
+ *   directly above it.
+ *
+ * The two predicates are deliberately not mirror images: see
+ * couldResolveAgainst for why an upper bound here has to be a scope
+ * requirement rather than the ordering preference belongsBelow also captures.
  *
  * `-1` means unconstrained in that direction.
  */
@@ -319,6 +323,27 @@ export class ImportDocumentEditor {
     }
 
     /**
+     * Whether an existing import of rank `existing` could be resolving against
+     * a newly added import of rank `rank`, which is what forces the new one
+     * above it rather than merely preferring it there.
+     *
+     * Only a dotted path needs something in scope above it - its first segment.
+     * An absolute path needs nothing, and a bare reference names a module
+     * beside the file rather than something an earlier import brought in, so
+     * neither can be depending on an import added below it.
+     *
+     * Narrower than belongsBelow on purpose. Preference is the right strength
+     * in selectTargetBlockIndex, where the consequence of an upper bound is
+     * merging into an earlier block - always a legal place for the import.
+     * Here the consequence is refusing every block and writing a standalone
+     * line, so applying a preference at that strength fragments a file into
+     * import regions to satisfy nothing.
+     */
+    private couldResolveAgainst(existing: number, rank: number): boolean {
+        return existing === 2 && rank < 2;
+    }
+
+    /**
      * Where the imports anchored by a comment marker allow a new `path` to be
      * written. See AnchoredBounds.
      */
@@ -332,7 +357,7 @@ export class ImportDocumentEditor {
             if (this.belongsAbove(existing, rank)) {
                 floor = Math.max(floor, anchoredCommentEnd(imp, classifications));
             }
-            if (this.belongsBelow(existing, rank)) {
+            if (this.couldResolveAgainst(existing, rank)) {
                 ceiling = ceiling === -1 ? imp.startLine : Math.min(ceiling, imp.startLine);
             }
         }
@@ -356,22 +381,29 @@ export class ImportDocumentEditor {
 
     /**
      * The line a run of new import statements is written on: `desired`, moved
-     * below the floor and then above the ceiling.
+     * below the floor, and directly above the ceiling wherever there is one.
      *
-     * The floor wins where the two disagree. That disagreement is never a real
-     * provider-consumer cycle: one would need an anchored dotted consumer
-     * already sitting above the anchored bare provider it depends on, which is
-     * a file that does not compile as written. What it can be is an anchored
-     * absolute path below an anchored dotted one, and an absolute path brings
-     * nothing into scope, so that floor is ordering preference rather than a
-     * scope requirement - honouring it costs nothing that compiles.
+     * A ceiling is always honoured, and taken exactly rather than as a cap.
+     * Both halves matter:
+     *
+     * - The ceiling wins over the floor. Only couldResolveAgainst raises one,
+     *   so a ceiling is always a scope requirement - an anchored dotted import
+     *   whose first segment this new import is being added to provide. A floor
+     *   that disagrees with it can only come from an anchored absolute path,
+     *   which is ordering preference. Honouring the preference and breaking the
+     *   requirement writes the provider below its consumer, which is the defect
+     *   this whole path exists to prevent.
+     * - Taken exactly, so the import lands directly above the statement that
+     *   needs it rather than at `desired`. Anywhere higher is equally legal and
+     *   strictly worse: it opens a third import region, and from `desired` 0 it
+     *   would sit above the file header, which headerLineCount calls the one
+     *   place a header must never be.
      */
     private placementLine(desired: number, bounds: AnchoredBounds): number {
-        const belowFloor = Math.max(desired, bounds.floor + 1);
-        if (bounds.ceiling === -1 || bounds.ceiling > bounds.floor) {
-            return bounds.ceiling === -1 ? belowFloor : Math.min(belowFloor, bounds.ceiling);
+        if (bounds.ceiling !== -1) {
+            return bounds.ceiling;
         }
-        return belowFloor;
+        return Math.max(desired, bounds.floor + 1);
     }
 
     /** Whether a block sits entirely inside the space the anchored imports leave for `path`. */
@@ -551,25 +583,37 @@ export class ImportDocumentEditor {
                 // statement at that block's lines, so which block absorbs a
                 // path is a placement decision like any other, and a block
                 // sitting above an anchored provider cannot make one.
-                const blockCanTake = (blockIndex: number, path: string): boolean =>
-                    blockIndex >= 0 && this.blockIsWithin(importBlocks[blockIndex], this.anchoredBounds(anchoredImports, classifications, path));
+                //
+                // Partitioned in one pass rather than filtered twice, so taken
+                // and unhandled are complements by construction: two filters
+                // that have to stay each other's negation write a path into
+                // both lists, or into neither, as soon as one is edited alone.
+                const splitForBlock = (blockIndex: number, paths: string[]): { taken: string[]; unhandled: string[] } => {
+                    const taken: string[] = [];
+                    const unhandled: string[] = [];
+                    for (const path of paths) {
+                        const canTake = blockIndex >= 0 && this.blockIsWithin(importBlocks[blockIndex], this.anchoredBounds(anchoredImports, classifications, path));
+                        (canTake ? taken : unhandled).push(path);
+                    }
+                    return { taken, unhandled };
+                };
 
-                const digestForBlock = newDigestPaths.filter((path) => blockCanTake(digestBlockIndex, path));
-                const localForBlock = newLocalPaths.filter((path) => blockCanTake(localBlockIndex, path));
+                const digest = splitForBlock(digestBlockIndex, newDigestPaths);
+                const local = splitForBlock(localBlockIndex, newLocalPaths);
 
                 // Add digest imports to digest block
-                if (digestForBlock.length > 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], digestForBlock, preferDotSyntax, sortAlphabetically, eol);
+                if (digest.taken.length > 0) {
+                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], digest.taken, preferDotSyntax, sortAlphabetically, eol);
                 }
 
                 // Add local imports to local block
-                if (localForBlock.length > 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], localForBlock, preferDotSyntax, sortAlphabetically, eol);
+                if (local.taken.length > 0) {
+                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], local.taken, preferDotSyntax, sortAlphabetically, eol);
                 }
 
                 // Imports no block took: one with no matching block, and one an
                 // anchored import keeps out of the block it would have matched.
-                const unhandledPaths = [...newDigestPaths.filter((path) => !blockCanTake(digestBlockIndex, path)), ...newLocalPaths.filter((path) => !blockCanTake(localBlockIndex, path))];
+                const unhandledPaths = [...digest.unhandled, ...local.unhandled];
 
                 if (unhandledPaths.length > 0) {
                     // Add unhandled imports at the appropriate position
@@ -678,6 +722,12 @@ export class ImportDocumentEditor {
                         }
 
                         // Blocks are disjoint, so the replacements never overlap.
+                        // Neither can a standalone line below collide with one:
+                        // placementLine returns either a ceiling, which is an
+                        // anchored import's own line and so in no block, or
+                        // floor + 1 - and a path reaching that had every block
+                        // refused, which for a path with no ceiling means every
+                        // block starts at or above the floor.
                         for (const index of [...pathsByBlock.keys()].sort((a, b) => a - b)) {
                             this.createBlockReplacementEdit(edit, document, importBlocks[index], pathsByBlock.get(index)!, preferDotSyntax, true, eol);
                         }

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -113,6 +113,54 @@ function attachedCommentStart(importStartLine: number, classifications: LineClas
 }
 
 /**
+ * The last line an import anchored by a comment marker owns: its own statement,
+ * plus the body of the comment it opens below it.
+ *
+ * Placement needs the whole span rather than the statement, because the line
+ * directly below the marker is comment text. A `<#>` marker's body is the lines
+ * indented past it, and a `<#` leaves every line comment until a matching `#>`,
+ * so writing a new import at column 0 on the line after the statement lands it
+ * inside the author's comment - which for `<#>` also truncates that comment at
+ * the new line, silently discarding the rest of what they wrote.
+ *
+ * `continuesCommentAbove` is exactly this question already answered: it marks a
+ * line whose comment was opened above it, under either marker. So the span ends
+ * at the last line still carrying it.
+ */
+function anchoredCommentEnd(imp: ScannedImport, classifications: LineClassification[]): number {
+    let end = imp.endLine;
+    while (end + 1 < classifications.length && classifications[end + 1].continuesCommentAbove) {
+        end++;
+    }
+    return end;
+}
+
+/**
+ * The lines an anchored import forbids a newly added `path` from crossing.
+ *
+ * An anchored import is in no ImportBlock - blocks are built from the movable
+ * imports alone, since a writer may not rebuild an anchored line - so every
+ * placement decision that reads `importBlocks` is blind to it. It is still a
+ * real import that a `using` below it resolves against, so it constrains where
+ * a new one may go exactly as the imports inside a block do.
+ *
+ * Both bounds read the same ranks selectTargetBlockIndex compares, with the
+ * same two predicates, so anchored and blocked imports cannot disagree about
+ * what must precede what:
+ *
+ * - `floor` - the last line owned by the lowest anchored import that belongs
+ *   above the new one. The new import goes below it.
+ * - `ceiling` - the first line of the highest anchored import the new one
+ *   belongs above. The new import goes above it.
+ *
+ * `-1` means unconstrained in that direction.
+ */
+interface AnchoredBounds {
+    floor: number;
+    ceiling: number;
+}
+
+/**
  * Handles all document modifications for imports.
  */
 export class ImportDocumentEditor {
@@ -238,10 +286,10 @@ export class ImportDocumentEditor {
         let upperBound = -1;
         importBlocks.forEach((block, index) => {
             const ranks = block.imports.map((imp) => this.formatter.importRank(imp.path));
-            if (ranks.some((existing) => existing < rank || (existing === rank && rank === 1))) {
+            if (ranks.some((existing) => this.belongsAbove(existing, rank))) {
                 lowerBound = index;
             }
-            if (upperBound === -1 && ranks.some((existing) => existing > rank)) {
+            if (upperBound === -1 && ranks.some((existing) => this.belongsBelow(existing, rank))) {
                 upperBound = index;
             }
         });
@@ -250,6 +298,119 @@ export class ImportDocumentEditor {
             return 0;
         }
         return upperBound !== -1 && upperBound < lowerBound ? upperBound : lowerBound;
+    }
+
+    /**
+     * Whether an existing import of rank `existing` belongs above a newly added
+     * import of rank `rank`.
+     *
+     * A lower rank always precedes a higher one, and two bare references keep
+     * their written order because it is semantic - a nested child must follow
+     * the parent providing it, and a newly added one has no claim to go first.
+     * See ImportFormatter.sortImportsByRank.
+     */
+    private belongsAbove(existing: number, rank: number): boolean {
+        return existing < rank || (existing === rank && rank === 1);
+    }
+
+    /** Whether an existing import of rank `existing` belongs below a newly added one of rank `rank`. */
+    private belongsBelow(existing: number, rank: number): boolean {
+        return existing > rank;
+    }
+
+    /**
+     * Where the imports anchored by a comment marker allow a new `path` to be
+     * written. See AnchoredBounds.
+     */
+    private anchoredBounds(anchoredImports: ScannedImport[], classifications: LineClassification[], path: string): AnchoredBounds {
+        const rank = this.formatter.importRank(path);
+
+        let floor = -1;
+        let ceiling = -1;
+        for (const imp of anchoredImports) {
+            const existing = this.formatter.importRank(imp.path);
+            if (this.belongsAbove(existing, rank)) {
+                floor = Math.max(floor, anchoredCommentEnd(imp, classifications));
+            }
+            if (this.belongsBelow(existing, rank)) {
+                ceiling = ceiling === -1 ? imp.startLine : Math.min(ceiling, imp.startLine);
+            }
+        }
+
+        return { floor, ceiling };
+    }
+
+    /** The bounds of a run of paths written together: the tightest of each. */
+    private combinedAnchoredBounds(anchoredImports: ScannedImport[], classifications: LineClassification[], paths: string[]): AnchoredBounds {
+        return paths.reduce<AnchoredBounds>(
+            (combined, path) => {
+                const bounds = this.anchoredBounds(anchoredImports, classifications, path);
+                return {
+                    floor: Math.max(combined.floor, bounds.floor),
+                    ceiling: combined.ceiling === -1 ? bounds.ceiling : bounds.ceiling === -1 ? combined.ceiling : Math.min(combined.ceiling, bounds.ceiling),
+                };
+            },
+            { floor: -1, ceiling: -1 },
+        );
+    }
+
+    /**
+     * The line a run of new import statements is written on: `desired`, moved
+     * below the floor and then above the ceiling.
+     *
+     * The floor wins where the two disagree. That disagreement is never a real
+     * provider-consumer cycle: one would need an anchored dotted consumer
+     * already sitting above the anchored bare provider it depends on, which is
+     * a file that does not compile as written. What it can be is an anchored
+     * absolute path below an anchored dotted one, and an absolute path brings
+     * nothing into scope, so that floor is ordering preference rather than a
+     * scope requirement - honouring it costs nothing that compiles.
+     */
+    private placementLine(desired: number, bounds: AnchoredBounds): number {
+        const belowFloor = Math.max(desired, bounds.floor + 1);
+        if (bounds.ceiling === -1 || bounds.ceiling > bounds.floor) {
+            return bounds.ceiling === -1 ? belowFloor : Math.min(belowFloor, bounds.ceiling);
+        }
+        return belowFloor;
+    }
+
+    /** Whether a block sits entirely inside the space the anchored imports leave for `path`. */
+    private blockIsWithin(block: ImportBlock, bounds: AnchoredBounds): boolean {
+        return block.start > bounds.floor && (bounds.ceiling === -1 || block.end < bounds.ceiling);
+    }
+
+    /**
+     * Writes a run of import statements on their own lines at `line`.
+     *
+     * One home for the end-of-document case, which every caller has to handle
+     * the same way: the line after the last one does not exist in a document
+     * with no trailing newline, and VS Code clamps a position past the end onto
+     * the end of the last line - splicing the first statement onto whatever is
+     * already there and leaving one unreadable line where two belong.
+     */
+    private insertImportLines(edit: vscode.WorkspaceEdit, document: vscode.TextDocument, line: number, statements: string[], eol: LineEnding, blankLineAfter: boolean): void {
+        const text = statements.join(eol);
+
+        if (line < document.lineCount) {
+            edit.insert(document.uri, new vscode.Position(line, 0), text + eol + (blankLineAfter ? eol : ""));
+            return;
+        }
+
+        edit.insert(document.uri, document.lineAt(document.lineCount - 1).range.end, eol + text);
+    }
+
+    /**
+     * Groups paths no block can take by the line each has to be written on,
+     * starting from the line the site would have used had no import been
+     * anchored. Paths wanting the same line are written together.
+     */
+    private groupByPlacementLine(paths: string[], desired: number, anchoredImports: ScannedImport[], classifications: LineClassification[]): Map<number, string[]> {
+        const byLine = new Map<number, string[]>();
+        for (const path of paths) {
+            const line = this.placementLine(desired, this.anchoredBounds(anchoredImports, classifications, path));
+            byLine.set(line, [...(byLine.get(line) ?? []), path]);
+        }
+        return new Map([...byLine].sort(([a], [b]) => a - b));
     }
 
     /**
@@ -295,6 +456,13 @@ export class ImportDocumentEditor {
         const eol = resolveEol(document, text);
         const lines = text.split(LINE_SPLIT);
         const scannedImports = scanModuleImports(lines);
+
+        // Blocks are built from the movable imports below, so an anchored one
+        // is in none of them and no placement decision can see it. Kept here,
+        // with the comment structure a placement needs to read its span, so
+        // every site can bound itself against them. See AnchoredBounds.
+        const classifications = classifyLines(lines);
+        const anchoredImports = scannedImports.filter((imp) => imp.anchorsCommentBelow);
 
         const importBlocks: ImportBlock[] = [];
         for (const imp of rewritableImports(scannedImports)) {
@@ -378,36 +546,54 @@ export class ImportDocumentEditor {
                     }
                 }
 
+                // A block can only take a new import where the anchored imports
+                // leave room for it. Rebuilding a block writes the new
+                // statement at that block's lines, so which block absorbs a
+                // path is a placement decision like any other, and a block
+                // sitting above an anchored provider cannot make one.
+                const blockCanTake = (blockIndex: number, path: string): boolean =>
+                    blockIndex >= 0 && this.blockIsWithin(importBlocks[blockIndex], this.anchoredBounds(anchoredImports, classifications, path));
+
+                const digestForBlock = newDigestPaths.filter((path) => blockCanTake(digestBlockIndex, path));
+                const localForBlock = newLocalPaths.filter((path) => blockCanTake(localBlockIndex, path));
+
                 // Add digest imports to digest block
-                if (newDigestPaths.length > 0 && digestBlockIndex >= 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], newDigestPaths, preferDotSyntax, sortAlphabetically, eol);
+                if (digestForBlock.length > 0) {
+                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], digestForBlock, preferDotSyntax, sortAlphabetically, eol);
                 }
 
                 // Add local imports to local block
-                if (newLocalPaths.length > 0 && localBlockIndex >= 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], newLocalPaths, preferDotSyntax, sortAlphabetically, eol);
+                if (localForBlock.length > 0) {
+                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], localForBlock, preferDotSyntax, sortAlphabetically, eol);
                 }
 
-                // Handle imports that don't have a matching block
-                const unhandledDigest = digestBlockIndex < 0 ? newDigestPaths : [];
-                const unhandledLocal = localBlockIndex < 0 ? newLocalPaths : [];
-                const unhandledPaths = [...unhandledDigest, ...unhandledLocal];
+                // Imports no block took: one with no matching block, and one an
+                // anchored import keeps out of the block it would have matched.
+                const unhandledPaths = [...newDigestPaths.filter((path) => !blockCanTake(digestBlockIndex, path)), ...newLocalPaths.filter((path) => !blockCanTake(localBlockIndex, path))];
 
                 if (unhandledPaths.length > 0) {
-                    const unhandledImports = this.formatter.groupAndFormatImports(unhandledPaths, preferDotSyntax, sortAlphabetically, importGrouping);
-
                     // Add unhandled imports at the appropriate position
-                    if (importBlocks.length > 0) {
-                        edit.insert(document.uri, new vscode.Position(importBlocks[importBlocks.length - 1].end + 1, 0), unhandledImports.join(eol) + eol);
-                    } else {
-                        edit.insert(document.uri, new vscode.Position(0, 0), unhandledImports.join(eol) + eol + eol);
+                    const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;
+                    for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, anchoredImports, classifications)) {
+                        this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, importBlocks.length === 0);
                     }
                 }
             } else {
                 // Either no existing grouping or need to create initial groups
                 if (importGrouping !== "none" && existingPaths.size > 0) {
-                    // We have existing imports but no grouping - reorganize everything into groups
-                    const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths]);
+                    // We have existing imports but no grouping - reorganize
+                    // everything into groups. A new path an anchored import
+                    // keeps out of the rebuilt block is written on its own line
+                    // below that import instead, rather than into a group that
+                    // sits above it. Only the new paths are asked: this branch
+                    // sees at most one block (2+ gapped blocks reach the
+                    // hasGrouping branch above), so every relocated path is
+                    // already inside the block being rebuilt in place.
+                    const displacedPaths =
+                        importBlocks.length > 0 ? Array.from(newImportPaths).filter((path) => !this.blockIsWithin(importBlocks[0], this.anchoredBounds(anchoredImports, classifications, path))) : [];
+                    const displaced = new Set(displacedPaths);
+
+                    const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths].filter((path) => !displaced.has(path)));
                     const allImportsArray = Array.from(allPaths);
                     const groupedImports = this.withTrailingComments(
                         this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping),
@@ -427,9 +613,15 @@ export class ImportDocumentEditor {
                             const block = importBlocks[i];
                             edit.delete(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)));
                         }
+
+                        for (const [line, paths] of this.groupByPlacementLine(displacedPaths, firstBlock.end + 1, anchoredImports, classifications)) {
+                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, false);
+                        }
                     } else {
-                        // No existing imports - insert grouped imports at the top
-                        edit.insert(document.uri, new vscode.Position(0, 0), groupedImports.join(eol) + eol + eol);
+                        // No existing block - insert the grouped imports at the
+                        // top, or below an anchored import that has to precede
+                        // one of them.
+                        this.insertImportLines(edit, document, this.placementLine(0, this.combinedAnchoredBounds(anchoredImports, classifications, allImportsArray)), groupedImports, eol, true);
                     }
                 } else {
                     // No grouping or no existing imports - use original behavior
@@ -450,9 +642,33 @@ export class ImportDocumentEditor {
                         // block orders the new import against that block alone,
                         // which is how a consumer ended up above its provider in
                         // another block (see selectTargetBlockIndex).
+                        //
+                        // Only a block inside the space the anchored imports
+                        // leave is eligible, and the selector chooses among
+                        // those. An anchored import is in no block, so offering
+                        // it every block is what let a new import be merged into
+                        // one above the anchored provider it needs.
                         const pathsByBlock = new Map<number, string[]>();
+                        const unblockedPaths: string[] = [];
                         for (const path of newImportPathsArray) {
-                            const index = this.selectTargetBlockIndex(importBlocks, path);
+                            const bounds = this.anchoredBounds(anchoredImports, classifications, path);
+                            const eligible = importBlocks.map((block, index) => ({ block, index })).filter(({ block }) => this.blockIsWithin(block, bounds));
+
+                            if (eligible.length === 0) {
+                                // No block sits where this import may go, so it
+                                // is written on its own line there instead.
+                                unblockedPaths.push(path);
+                                continue;
+                            }
+
+                            // The selector reports a position in the list it was
+                            // given, so its answer is read back through that
+                            // list to reach the real block.
+                            const chosen = this.selectTargetBlockIndex(
+                                eligible.map(({ block }) => block),
+                                path,
+                            );
+                            const index = eligible[chosen].index;
                             const targetPaths = pathsByBlock.get(index);
                             if (targetPaths) {
                                 targetPaths.push(path);
@@ -465,38 +681,36 @@ export class ImportDocumentEditor {
                         for (const index of [...pathsByBlock.keys()].sort((a, b) => a - b)) {
                             this.createBlockReplacementEdit(edit, document, importBlocks[index], pathsByBlock.get(index)!, preferDotSyntax, true, eol);
                         }
+
+                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, 0, anchoredImports, classifications)) {
+                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), eol, true);
+                        }
                     } else {
                         // Sorting off or no existing block: keep the original
                         // append-in-place behavior and leave existing lines
                         // untouched.
-                        const newImports = this.formatter.groupAndFormatImports(newImportPathsArray, preferDotSyntax, sortAlphabetically, importGrouping);
+                        // After the last import block, not the first: with
+                        // sorting off nothing reorders a block afterwards, so
+                        // any earlier position could leave a new import above
+                        // one that has to stay above it.
+                        //
+                        // Wherever that block sits, not only when it starts at
+                        // line 0. A file whose imports open below a licence
+                        // header has its first block at a later line, and
+                        // inserting at line 0 there put the new import above the
+                        // header and left two disconnected import regions
+                        // behind.
+                        //
+                        // With no block at all the top of the file is where a
+                        // new import goes - unless an anchored import that has
+                        // to precede it sits there, which is the one case a file
+                        // whose only import is anchored always reaches. That is
+                        // what groupByPlacementLine answers, from either start.
+                        const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;
+                        const blankLineAfter = importBlocks.length === 0;
 
-                        if (importBlocks.length > 0) {
-                            // After the last import block, not the first: with
-                            // sorting off nothing reorders a block afterwards,
-                            // so any earlier position could leave a new import
-                            // above one that has to stay above it.
-                            //
-                            // Wherever that block sits, not only when it starts
-                            // at line 0. A file whose imports open below a
-                            // licence header has its first block at a later
-                            // line, and inserting at line 0 there put the new
-                            // import above the header and left two disconnected
-                            // import regions behind.
-                            const lastBlock = importBlocks[importBlocks.length - 1];
-                            if (lastBlock.end + 1 < document.lineCount) {
-                                edit.insert(document.uri, new vscode.Position(lastBlock.end + 1, 0), newImports.join(eol) + eol);
-                            } else {
-                                // The block ends a document with no trailing
-                                // newline, so the line after it does not exist.
-                                // VS Code clamps a position past the end onto
-                                // the end of the last line, which would splice
-                                // the new statement onto the last import and
-                                // leave one unreadable line where two belong.
-                                edit.insert(document.uri, document.lineAt(lastBlock.end).range.end, eol + newImports.join(eol));
-                            }
-                        } else {
-                            edit.insert(document.uri, new vscode.Position(0, 0), newImports.join(eol) + eol + eol);
+                        for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, anchoredImports, classifications)) {
+                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, blankLineAfter);
                         }
                     }
                 }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1210,6 +1210,61 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(insert!.text).toBe("using { Economy.Shop }\n");
         });
 
+        // Two new paths of different ranks take their bounds from different
+        // anchored imports, and one path's floor can sit below another's
+        // ceiling. Written as one run under a merged bound there is no line the
+        // group can legally occupy, and the consumer went above its provider.
+        it("digestFirst: splits new imports whose bounds want different lines", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "digestFirst",
+            });
+            const input = ["using { Economy.Shop } <#> note", "    body", "using { Features } <#> why", "    body", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }", "using { Zone.Area }"]);
+
+            expect(success).toBe(true);
+            const inserts = appliedOperations(0).filter((op) => op.kind === "insert");
+            expect(inserts).toHaveLength(2);
+
+            // The absolute path is only needed above the anchored consumer.
+            expect(inserts[0].position!.line).toBe(0);
+            expect(inserts[0].text).toBe("using { /Fortnite.com/Devices }\n\n");
+
+            // The dotted one needs `Features` above it, so it goes below.
+            expect(inserts[1].position!.line).toBe(4);
+            expect(inserts[1].text).toBe("using { Zone.Area }\n\n");
+        });
+
+        // The one branch that rewrites a block in place and inserts on its own
+        // line in the same edit: the group is rebuilt where it stands, and the
+        // path the anchored import keeps out of it is written separately.
+        it("digestFirst: writes a displaced path on its own line while rebuilding the group in place", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "digestFirst",
+            });
+            const input = ["using { Economy.Shop } <#> note", "    body", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+
+            // The existing block is rebuilt where it stands, without the
+            // displaced path in it.
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(2);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\n");
+
+            // The provider goes above the anchored consumer that needs it.
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n");
+        });
+
         it("digestFirst: writes the new group below the anchored provider, not at the top", async () => {
             mockConfig({
                 "behavior.preserveImportLocations": true,

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -994,6 +994,150 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(operations.some((op) => op.kind === "replace")).toBe(false);
         expect(operations.some((op) => op.kind === "delete")).toBe(false);
     });
+
+    // An import anchored by a comment marker belongs to no import block, so
+    // every placement decision - all of which read the blocks - was blind to
+    // it, and a new import could be written above the anchored import that
+    // brings its first segment into scope. Verse resolves `using` sequentially,
+    // so the "Unknown identifier" the import was added to fix survived it.
+    describe("placement against an import anchored by a comment marker", () => {
+        it("writes a new consumer below an anchored provider, past the indented comment it opens", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Features } <#> why this is here", "    it brings Economy into scope", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations).toHaveLength(1);
+            expect(operations[0].kind).toBe("insert");
+            // Line 2, not line 1: the line below the marker is the comment's
+            // own body, and an import at column 0 there both lands inside the
+            // comment and truncates the rest of what the author wrote.
+            expect(operations[0].position).toEqual({ line: 2, character: 0 });
+            expect(operations[0].text).toBe("using { Economy.Shop }\n\n");
+        });
+
+        it("writes a new consumer below an anchored provider, past the block comment it leaves open", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Features } <# why this is here", "it brings Economy into scope", "#>", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations).toHaveLength(1);
+            expect(operations[0].kind).toBe("insert");
+            expect(operations[0].position).toEqual({ line: 3, character: 0 });
+            expect(operations[0].text).toBe("using { Economy.Shop }\n\n");
+        });
+
+        it("keeps a new consumer out of a block that sits above the anchored provider it needs", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { /Verse.org/Simulation }", "", "using { Features } <#> note", "    body", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // The block at line 0 would have taken it, above the provider.
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(4);
+            expect(insert!.text).toBe("using { Economy.Shop }\n\n");
+        });
+
+        it("still merges a new consumer into a block that sits below the anchored provider", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Features } <#> note", "    body", "", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // Nothing forbids that block, so the ordinary merge still happens
+            // rather than a standalone line.
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(3);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Economy.Shop }\n");
+        });
+
+        it("writes a new provider above the anchored consumer that depends on it", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Economy.Shop } <#> note", "    body", "", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // Merging into the block below would put the provider under the
+            // anchored consumer, which is the same breakage the other way up.
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        it("sort OFF: appends below the anchored provider rather than after the last block", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": false,
+            });
+            const input = ["using { /Verse.org/Simulation }", "", "using { Features } <#> note", "    body", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(4);
+            expect(insert!.text).toBe("using { Economy.Shop }\n");
+        });
+
+        it("digestFirst: writes the new group below the anchored provider, not at the top", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "digestFirst",
+            });
+            const input = ["using { Features } <#> note", "    body", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(2);
+            expect(insert!.text).toBe("using { Economy.Shop }\n\n");
+        });
+    });
 });
 
 describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1122,6 +1122,94 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(insert!.text).toBe("using { Economy.Shop }\n");
         });
 
+        // The provider has to clear the anchored consumer, and an anchored
+        // absolute path below that consumer says only that absolute paths are
+        // written first. Honouring the preference over the requirement is how
+        // the provider ended up under its consumer again, one bound further on.
+        it("writes a new provider above the anchored consumer even when an anchored absolute path sits below it", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Economy.Shop } <#> note", "    body", "using { /A } <#> note", "    body", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // Directly above the statement that needs it, which is not the same
+        // line as the top of the file - and only a fixture with something above
+        // the anchored import can tell the two apart. Everything higher is
+        // equally legal and strictly worse: it opens a third import region, and
+        // at line 0 it puts the import above the file header.
+        it("writes a new provider directly above the anchored consumer, not above the file header", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["# Copyright 2026 MyGame", "", "using { Economy.Shop } <#> note", "    body", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(2);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // An anchored bare import does not constrain a new absolute one: an
+        // absolute path needs nothing in scope, and a bare reference names a
+        // module beside the file rather than anything an import provides. So
+        // neither needs the other above it, and treating the rank order as a
+        // requirement would refuse the block and fragment the file for nothing.
+        it("still merges a new absolute import into a block below an anchored bare import", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Features } <#> why", "    body", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(2);
+            expect(replace!.text).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n");
+        });
+
+        it("digestFirst with two existing groups: keeps a new consumer out of the group above the anchored provider", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "digestFirst",
+            });
+            const input = ["using { /Verse.org/Simulation }", "", "using { Other }", "", "using { Features } <#> note", "    body", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // The local group at line 2 would have taken it, above the provider.
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(6);
+            expect(insert!.text).toBe("using { Economy.Shop }\n");
+        });
+
         it("digestFirst: writes the new group below the anchored provider, not at the top", async () => {
             mockConfig({
                 "behavior.preserveImportLocations": true,


### PR DESCRIPTION
Closes #196

An import whose own line opens a comment over the lines below it is *anchored*: `rewritableImports` drops it, because rebuilding the line from its path alone would move the marker away from the lines the author wrote it around. `addImportsToDocument` builds `importBlocks` from that filtered list, so an anchored import belongs to no block - and every placement decision in that method reads the blocks.

A new import could therefore be written above the anchored import that brings its first segment into scope. Verse resolves `using` sequentially (Book of Verse, `docs/16_modules.md`: "importing the parent before the child always works, while the reverse order fails"), so the "Unknown identifier" the import was added to fix survived it.

## What changed

Placement now bounds itself against the anchored imports, reading the same ranks `selectTargetBlockIndex` already compares:

- **floor** - the last line owned by an anchored import that belongs above the new one (`belongsAbove`, the predicate `selectTargetBlockIndex` uses for its lower bound). The new import goes below it.
- **ceiling** - the first line of an anchored import that could be resolving against the new one (`couldResolveAgainst`). The new import goes directly above it.

The span a floor reads is the statement **plus the comment body it opens**, walked through `LineClassification.continuesCommentAbove`. This is load-bearing: the line directly below a `<#>` marker is comment text, and an import written at column 0 there lands inside the comment and truncates the rest of what the author wrote.

The two predicates are deliberately not mirror images. `belongsBelow` - which `selectTargetBlockIndex` still uses unchanged - also captures the rank-0-before-rank-1 ordering preference. That is the right strength for choosing between blocks, where an upper bound only sends the import to an earlier block, always a legal place. It is the wrong strength for an anchored import, where the fallback is refusing every block and writing a standalone line: applying a preference there fragments a file into import regions to satisfy nothing. So only a dotted path - the one rank that needs something in scope above it - raises a ceiling.

Where a floor and a ceiling disagree, the **ceiling wins**, and it is taken exactly rather than as a cap. A ceiling is always a scope requirement; a floor contradicting one is normally the ordering preference, raised by an anchored absolute path that brings nothing into scope. Taken exactly because the ceiling is the *lowest* legal line - everything below it is ruled out, everything above merely further away - which keeps the import beside the consumer that needs it and off line 0, where it would sit above the file header.

Each new path is placed on its own, never as a group under a merged bound: paths of different ranks take their bounds from different anchored imports, and one path's floor can sit below another's ceiling, describing a line no group can legally occupy.

Applied at every placement site under `behavior.preserveImportLocations: true` (the default): the block merge, the append-after-block and top inserts, and both grouping branches. The end-of-document clamp that two of those sites duplicated is now one method.

## Scope

The consolidate-at-top branch (`preserveImportLocations: false`) and `buildOrganizedContent` behind the organize command are untouched. Both hoist to line 0 by contract and have the same exposure, but that is a question of what the contract becomes rather than a missing bound, and changing one without the other would make them disagree about where the block goes. Filed as #221.

Two notes on the ticket, both confirmed against the code:

- Its Confidence section says `addImportsToDocument` has "no cheap unit path" and asks for a new seam. That is not true today - a `fakeDocument` plus recorded-`WorkspaceEdit` harness already exists in the test file and already covers two anchored cases. No seam was built; the existing one is reused, which satisfies the third acceptance criterion.
- The defect is not confined to the two sites the ticket names. The ticket's own general claim - "every placement decision downstream reads `importBlocks`" - is the accurate one, and the fix follows it. This wider scope was agreed with the maintainer before implementing.

## Tests

Thirteen new cases in `ImportDocumentEditor.addImportsToDocument`, covering both markers, an empty `importBlocks`, both bound directions, sort on and off, and both grouping branches.

Against `origin/main`'s `ImportDocumentEditor.ts`, **10 of the 13 fail**. The 3 that pass are deliberate no-over-correction guards: a consumer still merging into a block that sits below the anchored provider, an absolute import still merging into a block below an anchored bare import, and the branch that rebuilds a group in place while writing a displaced path separately.

## Review

Two rounds, fresh context each time.

**Round 1 - FAIL:** 1 Critical, 2 Important, 3 Suggestion. The Critical was real and mine: `placementLine` preferred the ordering preference over the scope requirement, so a new provider was written below the anchored consumer it was added to serve - the branch's own defect, one bound further on, and a regression against `origin/main` rather than an incomplete fix. All six findings acted on.

**Round 2 - PASS_WITH_SUGGESTIONS:** 1 Important, 4 Suggestion, no Critical. The Important was the merged-bound site described above - not a regression, since `origin/main` misplaces that fixture too, but inside the agreed scope, so it is fixed here. Three of the suggestions were comments asserting things the code does not support - the same shape as the round-1 Critical - and are corrected. The fourth was the one untested new branch, now covered.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 25 passed, 25 total
Tests:       505 passed, 505 total
Snapshots:   0 total
Time:        9.869 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
