### PR TITLE
fix(config): make every declared setting real

### DIFF
--- a/changelog.d/135.fixed.md
+++ b/changelog.d/135.fixed.md
@@ -1,0 +1,1 @@
+**Settings**: `cache.watcherDebounceMs` and `cache.autoRebuildOnStartup` now take effect; both were declared and documented but read by no code path.

--- a/changelog.d/135.removed.md
+++ b/changelog.d/135.removed.md
@@ -1,0 +1,1 @@
+**Settings**: `pathConversion.scanDepth` and `experimental.unknownIdentifierResolution` are gone; neither was ever consulted, and `experimental.useDigestFiles` already covers digest lookup.

--- a/package.json
+++ b/package.json
@@ -288,28 +288,11 @@
           "description": "Milliseconds to wait before hiding CodeLens after cursor leaves import (only applies when visibility is 'hover')",
           "order": 32
         },
-        "verseAutoImports.pathConversion.scanDepth": {
-          "type": "number",
-          "default": 5,
-          "description": "Maximum directory depth to scan when searching for module locations (used for ambiguity detection)",
-          "order": 33
-        },
         "verseAutoImports.experimental.useDigestFiles": {
           "type": "boolean",
           "default": false,
           "description": "⚠️ Enable lookup of unknown identifiers in Verse digest files for intelligent import suggestions",
           "order": 40
-        },
-        "verseAutoImports.experimental.unknownIdentifierResolution": {
-          "type": "string",
-          "enum": [
-            "digest_only",
-            "digest_and_inference",
-            "disabled"
-          ],
-          "default": "disabled",
-          "description": "⚠️ Strategy for resolving unknown identifiers: 'digest_only' uses only digest files, 'digest_and_inference' adds pattern-based guessing, 'disabled' turns off unknown identifier resolution",
-          "order": 41
         },
         "verseAutoImports.cache.enableProjectCache": {
           "type": "boolean",

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -351,6 +351,33 @@ const EndOfLine = {
 };
 
 /**
+ * A code action kind, as vscode.CodeActionKind models one: a dotted string
+ * that append() extends. Only the value matters to the providers; nothing
+ * dispatches on identity, so plain string comparison is enough.
+ */
+class CodeActionKind {
+    static readonly QuickFix = new CodeActionKind("quickfix");
+
+    constructor(public readonly value: string) {}
+
+    append(parts: string): CodeActionKind {
+        return new CodeActionKind(`${this.value}.${parts}`);
+    }
+}
+
+class CodeAction {
+    isPreferred?: boolean;
+    diagnostics?: unknown[];
+    command?: Command;
+    edit?: WorkspaceEdit;
+
+    constructor(
+        public title: string,
+        public kind?: CodeActionKind,
+    ) {}
+}
+
+/**
  * The host version, as vscode.version reports it. A fixed value: tests assert
  * that it reaches the log, never what it happens to be.
  */
@@ -376,5 +403,7 @@ export {
     Disposable,
     FileSystemWatcher,
     CodeLens,
+    CodeAction,
+    CodeActionKind,
     EventEmitter,
 };

--- a/src/__tests__/configurationDefaults.test.ts
+++ b/src/__tests__/configurationDefaults.test.ts
@@ -1,0 +1,108 @@
+import * as fs from "fs";
+import * as path from "path";
+import { DEFAULT_AMBIGUOUS_IMPORTS } from "../imports/ImportSuggestionExtractor";
+
+/**
+ * Guard for issue #135's defect class: a code-side fallback that disagrees with
+ * the default package.json registers.
+ *
+ * config.get returns the registered default for a registered setting, so a
+ * disagreeing fallback is dead in production - but src/__mocks__/vscode.ts
+ * returns the passed fallback, so the suite runs against the fallback instead.
+ * A divergence therefore changes nothing a user sees and everything the tests
+ * see, which is why two of them survived a release each.
+ *
+ * This walks the real call sites rather than a hand-kept list: a new
+ * config.get with a wrong fallback fails here without anyone remembering to
+ * update a table.
+ */
+describe("code-side configuration fallbacks", () => {
+    const srcRoot = path.join(__dirname, "..");
+    const manifest = JSON.parse(fs.readFileSync(path.join(srcRoot, "..", "package.json"), "utf8"));
+    const registered: Record<string, { default?: unknown }> = manifest.contributes.configuration.properties;
+
+    /** One `config.get<T>("key", fallback)` call found in the source. */
+    interface CallSite {
+        file: string;
+        key: string;
+        /** The fallback's source text, before any attempt to resolve it. */
+        fallbackSource: string;
+    }
+
+    /** Every .ts file under src/, excluding tests, mocks and the integration suite. */
+    const sourceFiles = (dir: string): string[] =>
+        fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                return ["__tests__", "__mocks__", "test-integration"].includes(entry.name) ? [] : sourceFiles(full);
+            }
+            return entry.isFile() && entry.name.endsWith(".ts") ? [full] : [];
+        });
+
+    /**
+     * Matches `.get<T>("key", fallback)` where the fallback is a single
+     * argument with no nested parentheses or commas - a literal, or an
+     * identifier naming one. Object and call-expression fallbacks are left to
+     * UNRESOLVED below rather than parsed badly.
+     */
+    const GET_WITH_FALLBACK = /\.get<[^>]+>\(\s*"([^"]+)"\s*,\s*([^(),]+?)\s*\)/g;
+
+    /** `const NAME = <literal>` or `static readonly NAME = <literal>` in the same file. */
+    const literalConstant = (source: string, name: string): string | undefined => {
+        const declaration = new RegExp(`(?:const|static readonly)\\s+${name}\\s*(?::[^=]+)?=\\s*([^;\\n]+);`).exec(source);
+        return declaration?.[1].trim();
+    };
+
+    /**
+     * Fallbacks this scan cannot read statically. Each needs its own assertion
+     * below; listing them here means a NEW unreadable site fails the scan
+     * rather than being skipped in silence.
+     */
+    const UNRESOLVED = new Set(["behavior.ambiguousImports"]);
+
+    const callSites: CallSite[] = [];
+    for (const file of sourceFiles(srcRoot)) {
+        const source = fs.readFileSync(file, "utf8");
+        for (const match of source.matchAll(GET_WITH_FALLBACK)) {
+            const [, key, fallbackSource] = match;
+            const resolved = /^[A-Za-z_$][\w$.]*$/.test(fallbackSource) ? literalConstant(source, fallbackSource.split(".").pop() as string) : fallbackSource;
+            callSites.push({ file: path.relative(srcRoot, file), key, fallbackSource: resolved ?? fallbackSource });
+        }
+    }
+
+    it("finds the call sites at all, so a broken scan cannot pass vacuously", () => {
+        expect(callSites.length).toBeGreaterThan(5);
+    });
+
+    it("reads only settings package.json contributes", () => {
+        for (const site of callSites) {
+            expect({ site: `${site.file}:${site.key}`, contributed: `verseAutoImports.${site.key}` in registered }).toEqual({
+                site: `${site.file}:${site.key}`,
+                contributed: true,
+            });
+        }
+    });
+
+    it("passes the registered default as the fallback at every call site", () => {
+        for (const site of callSites) {
+            if (UNRESOLVED.has(site.key)) {
+                continue;
+            }
+
+            const expected = registered[`verseAutoImports.${site.key}`]?.default;
+            // The fallback's source text, compared as JSON so "curly", false
+            // and 500 each match the manifest value they stand for.
+            expect({ site: `${site.file}:${site.key}`, fallback: site.fallbackSource }).toEqual({
+                site: `${site.file}:${site.key}`,
+                fallback: JSON.stringify(expected),
+            });
+        }
+    });
+
+    it("has an assertion for every fallback the scan could not read", () => {
+        // behavior.ambiguousImports: an object literal, compared by value.
+        expect(DEFAULT_AMBIGUOUS_IMPORTS).toEqual(registered["verseAutoImports.behavior.ambiguousImports"].default);
+
+        expect([...UNRESOLVED]).toEqual(["behavior.ambiguousImports"]);
+    });
+});

--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -13,7 +13,10 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
         const codeActions: vscode.CodeAction[] = [];
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const sortAlphabetically = config.get<boolean>("quickFix.sortAlphabetically", false);
-        const showDescriptions = config.get<boolean>("quickFix.showDescriptions", true);
+        // false is what package.json registers, and config.get returns the
+        // registered default for a registered setting - so a fallback of true
+        // never reached production and only ever changed what the tests saw.
+        const showDescriptions = config.get<boolean>("quickFix.showDescriptions", false);
 
         for (const diagnostic of context.diagnostics) {
             const suggestions = await this.importHandler.extractImportSuggestions(diagnostic.message);

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -322,7 +322,7 @@ export class ImportPathConverter {
     }
 
     /** Scans the workspace for possible locations of a module */
-    async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri, _maxDepth: number = 5): Promise<string[]> {
+    async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<string[]> {
         const locations: string[] = [];
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) return locations;

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -33,6 +33,18 @@ const PATTERNS = {
  */
 const QUALIFIED_NAME = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 
+/**
+ * Fallback for behavior.ambiguousImports. package.json is the source of truth
+ * and registers exactly these three mappings; config.get returns the registered
+ * default for a registered setting, so an empty fallback never reached
+ * production and only ever changed what the tests saw. Keep the two in step.
+ */
+const DEFAULT_AMBIGUOUS_IMPORTS: Record<string, string> = {
+    vector3: "/UnrealEngine.com/Temporary/SpatialMath",
+    vector2: "/UnrealEngine.com/Temporary/SpatialMath",
+    rotation: "/UnrealEngine.com/Temporary/SpatialMath",
+};
+
 /** A resolvable import extracted from a compiler message. */
 interface ImportCandidate {
     path: string;
@@ -347,7 +359,7 @@ export class ImportSuggestionExtractor {
 
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
-        const ambiguousImportMappings = config.get<Record<string, string>>("behavior.ambiguousImports", {});
+        const ambiguousImportMappings = config.get<Record<string, string>>("behavior.ambiguousImports", DEFAULT_AMBIGUOUS_IMPORTS);
 
         const classification = this.classifyMessage(errorMessage);
 

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -39,7 +39,7 @@ const QUALIFIED_NAME = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
  * default for a registered setting, so an empty fallback never reached
  * production and only ever changed what the tests saw. Keep the two in step.
  */
-const DEFAULT_AMBIGUOUS_IMPORTS: Record<string, string> = {
+export const DEFAULT_AMBIGUOUS_IMPORTS: Record<string, string> = {
     vector3: "/UnrealEngine.com/Temporary/SpatialMath",
     vector2: "/UnrealEngine.com/Temporary/SpatialMath",
     rotation: "/UnrealEngine.com/Temporary/SpatialMath",

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -1,0 +1,62 @@
+import * as vscode from "vscode";
+import { ImportCodeActionProvider } from "../ImportCodeActionProvider";
+import { ImportHandler } from "../ImportHandler";
+import { ImportSuggestion } from "../../types";
+
+/**
+ * Regression for issue #135: the provider read quickFix.showDescriptions with a
+ * fallback of true where package.json registers false. config.get returns the
+ * registered default for a registered setting, so the fallback never reached
+ * production - but the vscode mock returns the passed fallback, so the suite
+ * exercised descriptions-on while every user saw them off.
+ */
+describe("ImportCodeActionProvider quick fix titles", () => {
+    const suggestion = (overrides: Partial<ImportSuggestion> = {}): ImportSuggestion => ({
+        importStatement: "using { /Fortnite.com/Devices }",
+        source: "error_message",
+        confidence: "high",
+        description: "class from /Fortnite.com/Devices",
+        ...overrides,
+    });
+
+    /** Drives the provider over one diagnostic and returns the action titles. */
+    const titlesFor = async (suggestions: ImportSuggestion[]): Promise<string[]> => {
+        const importHandler = { extractImportSuggestions: jest.fn().mockResolvedValue(suggestions) } as unknown as ImportHandler;
+        const provider = new ImportCodeActionProvider({ appendLine: jest.fn() } as unknown as vscode.OutputChannel, importHandler);
+
+        const actions = await provider.provideCodeActions(
+            { uri: { toString: () => "file:///Project/Content/Scripts/device.verse" } } as unknown as vscode.TextDocument,
+            {} as unknown as vscode.Range,
+            { diagnostics: [{ message: "Unknown identifier `button_device`" }] } as unknown as vscode.CodeActionContext,
+            {} as unknown as vscode.CancellationToken,
+        );
+
+        return (actions ?? []).map((action) => action.title);
+    };
+
+    it("omits the description, matching the default package.json registers", async () => {
+        expect(await titlesFor([suggestion()])).toEqual(["Add import: using { /Fortnite.com/Devices }"]);
+    });
+
+    it("omits the confidence indicator too", async () => {
+        expect(await titlesFor([suggestion({ confidence: "low" })])).toEqual(["Add import: using { /Fortnite.com/Devices }"]);
+    });
+
+    it("shows both once the user turns descriptions on", async () => {
+        const getConfiguration = vscode.workspace.getConfiguration as unknown as jest.Mock;
+        const original = getConfiguration.getMockImplementation();
+        getConfiguration.mockReturnValue({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key === "quickFix.showDescriptions" ? true : defaultValue)),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+
+        try {
+            expect(await titlesFor([suggestion({ confidence: "medium" })])).toEqual(["[medium confidence] Add import: using { /Fortnite.com/Devices } (class from /Fortnite.com/Devices)"]);
+        } finally {
+            getConfiguration.mockReset();
+            if (original) {
+                getConfiguration.mockImplementation(original);
+            }
+        }
+    });
+});

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -123,6 +123,19 @@ describe("ImportSuggestionExtractor", () => {
             expect(suggestions[0].description).toBe("Configured import for player");
         });
 
+        // Regression for #135: the fallback passed for behavior.ambiguousImports
+        // was {} where package.json registers three mappings. config.get returns
+        // the registered default for a registered setting, so production always
+        // had them - but the vscode mock returns the passed fallback, so the
+        // suite ran against no mappings at all.
+        it("should apply the registered ambiguous mappings when the user has set none", async () => {
+            const suggestions = await extractor.extractImportSuggestions("Unknown identifier `vector3`");
+
+            expect(suggestions).toHaveLength(1);
+            expect(suggestions[0].importStatement).toBe("using { /UnrealEngine.com/Temporary/SpatialMath }");
+            expect(suggestions[0].description).toBe("Configured import for vector3");
+        });
+
         it("should return nothing for messages without import-related content", async () => {
             const suggestions = await extractor.extractImportSuggestions("Expected expression after operator");
 

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -22,7 +22,14 @@ export class ProjectPathCache {
     private static readonly CACHE_KEY = "projectPathTree";
     /** Storage key of the pre-2 metadata payload; cleared on save. */
     private static readonly LEGACY_METADATA_KEY = "projectPathTreeMeta";
+    /**
+     * Fallbacks for the two settings this class reads. Each must equal the
+     * default package.json registers for the same key: config.get returns the
+     * registered default for a registered setting, so a fallback that disagrees
+     * is dead in production and live only under the test mock.
+     */
     private static readonly DEBOUNCE_MS = 500;
+    private static readonly AUTO_REBUILD_ON_STARTUP = false;
 
     constructor(
         private context: vscode.ExtensionContext,
@@ -31,7 +38,22 @@ export class ProjectPathCache {
     ) {}
 
     /**
+     * The watcher debounce delay, in milliseconds. Read where the timer is
+     * armed rather than at construction, so changing the setting applies to the
+     * next file change instead of waiting for a window reload.
+     */
+    private getDebounceMs(): number {
+        return vscode.workspace.getConfiguration("verseAutoImports").get<number>("cache.watcherDebounceMs", ProjectPathCache.DEBOUNCE_MS);
+    }
+
+    /**
      * Initialize the cache - load from storage or build fresh.
+     *
+     * cache.autoRebuildOnStartup skips the stored payload entirely and scans
+     * the project instead. The stored cache is only as fresh as the watchers
+     * that maintained it, so a project edited outside this window - a UEFN
+     * build, a branch switch - starts stale; rebuilding trades startup time for
+     * that certainty.
      */
     async initialize(): Promise<void> {
         if (this.initialized) {
@@ -42,13 +64,20 @@ export class ProjectPathCache {
         logger.info("ProjectPathCache", "Initializing project path cache...");
 
         try {
-            const loaded = await this.loadFromStorage();
+            const autoRebuild = vscode.workspace.getConfiguration("verseAutoImports").get<boolean>("cache.autoRebuildOnStartup", ProjectPathCache.AUTO_REBUILD_ON_STARTUP);
 
-            if (loaded) {
-                logger.info("ProjectPathCache", `Loaded cache from storage in ${Date.now() - startTime}ms`);
-            } else {
-                logger.info("ProjectPathCache", "No valid cache found, building fresh...");
+            if (autoRebuild) {
+                logger.info("ProjectPathCache", "cache.autoRebuildOnStartup is on, rebuilding instead of loading the stored cache...");
                 await this.rebuildCache();
+            } else {
+                const loaded = await this.loadFromStorage();
+
+                if (loaded) {
+                    logger.info("ProjectPathCache", `Loaded cache from storage in ${Date.now() - startTime}ms`);
+                } else {
+                    logger.info("ProjectPathCache", "No valid cache found, building fresh...");
+                    await this.rebuildCache();
+                }
             }
 
             // Latch only once the cache actually holds data. A build that found
@@ -414,7 +443,7 @@ export class ProjectPathCache {
             this.invalidateFiles(filesToUpdate).catch((error) => {
                 logger.error("ProjectPathCache", "Failed to invalidate changed files", error);
             });
-        }, ProjectPathCache.DEBOUNCE_MS);
+        }, this.getDebounceMs());
     }
 
     /**

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -69,6 +69,14 @@ export class ProjectPathCache {
             if (autoRebuild) {
                 logger.info("ProjectPathCache", "cache.autoRebuildOnStartup is on, rebuilding instead of loading the stored cache...");
                 await this.rebuildCache();
+
+                // A rebuild that found no UEFN project leaves the cache empty.
+                // Preferring a fresh scan must not be worse than not asking for
+                // one, so fall back to whatever storage holds: stale
+                // declarations still serve lookups the empty cache would miss.
+                if (!this.data && (await this.loadFromStorage())) {
+                    logger.info("ProjectPathCache", "Rebuild found no project; kept the stored cache rather than starting empty");
+                }
             } else {
                 const loaded = await this.loadFromStorage();
 

--- a/src/services/__tests__/ProjectPathCache.settings.test.ts
+++ b/src/services/__tests__/ProjectPathCache.settings.test.ts
@@ -200,6 +200,22 @@ describe("ProjectPathCache settings", () => {
             expect(cache.getStats().files).toBe(1);
         });
 
+        it("keeps the stored cache when the rebuild finds no project", async () => {
+            stubSettings({ "cache.autoRebuildOnStartup": true });
+            findFiles.mockResolvedValue([]);
+
+            const cache = makeCache({ [CACHE_KEY]: STORED_CACHE });
+            // No project name is what scanProject reports when the workspace
+            // holds no .uefnproject yet, and it returns null rather than empty
+            // data - so the rebuild leaves the cache untouched.
+            jest.spyOn(cache, "rebuildCache").mockResolvedValue(undefined);
+            await cache.initialize();
+
+            // Asking for a fresh scan must not leave the session worse off than
+            // not asking: the stored declarations still answer lookups.
+            expect(cache.getStats().files).toBe(1);
+        });
+
         it("still builds fresh when it is off and storage holds nothing", async () => {
             stubSettings({ "cache.autoRebuildOnStartup": false });
             findFiles.mockResolvedValue([]);

--- a/src/services/__tests__/ProjectPathCache.settings.test.ts
+++ b/src/services/__tests__/ProjectPathCache.settings.test.ts
@@ -1,0 +1,213 @@
+import * as vscode from "vscode";
+import { ProjectPathCache } from "../ProjectPathCache";
+import { PROJECT_CACHE_VERSION, SerializedProjectPathCache } from "../../types";
+
+/**
+ * Regression tests for issue #135: cache.watcherDebounceMs and
+ * cache.autoRebuildOnStartup were declared in package.json, validated by the
+ * settings UI and announced in the 0.7.0 changelog, but no code path read
+ * either. The watcher debounce was a hardcoded 500ms constant, and initialize()
+ * always preferred the stored payload, so a user tuning the debounce or asking
+ * for a fresh cache at startup got nothing.
+ *
+ * These drive the cache against stub VS Code workspace APIs, so no extension
+ * host is needed.
+ */
+describe("ProjectPathCache settings", () => {
+    /** The subset of the mock watcher these tests drive. */
+    interface FakeWatcher {
+        globPattern: unknown;
+        fireChange(fsPath: string): void;
+    }
+
+    type CacheParams = ConstructorParameters<typeof ProjectPathCache>;
+
+    /** ProjectPathCache's own storage key; kept in sync with its private static. */
+    const CACHE_KEY = "projectPathTree";
+
+    const getConfiguration = vscode.workspace.getConfiguration as unknown as jest.Mock;
+    const createFileSystemWatcher = vscode.workspace.createFileSystemWatcher as unknown as jest.Mock;
+    const findFiles = vscode.workspace.findFiles as unknown as jest.Mock;
+
+    /** Minimal in-memory stand-in for vscode.Memento (workspaceState). */
+    class FakeMemento {
+        constructor(private readonly store: Map<string, unknown> = new Map()) {}
+
+        get<T>(key: string): T | undefined {
+            return this.store.get(key) as T | undefined;
+        }
+
+        async update(key: string, value: unknown): Promise<void> {
+            if (value === undefined) {
+                this.store.delete(key);
+            } else {
+                this.store.set(key, value);
+            }
+        }
+    }
+
+    /** Stands in for ProjectPathHandler; a name is all the scan needs to succeed. */
+    class FakeProjectPathHandler {
+        async getProjectName(): Promise<string | null> {
+            return "MyGame";
+        }
+
+        async getProjectVersePath(): Promise<string | null> {
+            return "/mygame@fortnite.com/mygame";
+        }
+    }
+
+    /** A stored payload holding one declaration, so a load is visible in the stats. */
+    const STORED_CACHE: SerializedProjectPathCache = {
+        version: PROJECT_CACHE_VERSION,
+        projectName: "MyGame",
+        projectVersePath: "/mygame@fortnite.com/mygame",
+        generatedAt: 0,
+        nodes: [{ name: "device_module", fullPath: "device_module", type: "module", isPublic: true, sourceFile: "Scripts/device.verse", sourceLine: 1 }],
+    };
+
+    /** The shared configuration stub, restored after every test. */
+    const originalConfiguration = getConfiguration.getMockImplementation();
+
+    /**
+     * Answers the named settings explicitly and falls through to the passed
+     * fallback for everything else, the way the shared mock does.
+     */
+    const stubSettings = (settings: Record<string, unknown>): void => {
+        getConfiguration.mockReturnValue({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key in settings ? settings[key] : defaultValue)),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+    };
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    const makeCache = (stored: Record<string, unknown> = {}): ProjectPathCache =>
+        new ProjectPathCache(
+            { workspaceState: new FakeMemento(new Map(Object.entries(stored))) } as unknown as CacheParams[0],
+            { appendLine: jest.fn() } as unknown as CacheParams[1],
+            new FakeProjectPathHandler() as unknown as CacheParams[2],
+        );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        setWorkspaceFolders([{ uri: { fsPath: "C:\\Project\\Content" }, name: "Content", index: 0 }]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        getConfiguration.mockReset();
+        if (originalConfiguration) {
+            getConfiguration.mockImplementation(originalConfiguration);
+        }
+        jest.useRealTimers();
+    });
+
+    describe("cache.watcherDebounceMs", () => {
+        /**
+         * Arms the watcher debounce on a file change and reports when the
+         * invalidation it guards actually runs.
+         */
+        const armDebounce = (cache: ProjectPathCache): jest.SpyInstance => {
+            const invalidateFiles = jest.spyOn(cache, "invalidateFiles").mockResolvedValue(undefined);
+            cache.setupFileWatchers();
+
+            // Watchers are created in order: **/*.verse first, then **/*.uefnproject.
+            const verseWatcher = createFileSystemWatcher.mock.results.map((result) => result.value as FakeWatcher)[0];
+            expect(verseWatcher.globPattern).toBe("**/*.verse");
+            verseWatcher.fireChange("C:\\Project\\Content\\Scripts\\device.verse");
+
+            return invalidateFiles;
+        };
+
+        it("waits the configured delay rather than the built-in 500ms", async () => {
+            jest.useFakeTimers();
+            stubSettings({ "cache.watcherDebounceMs": 2000 });
+
+            const invalidateFiles = armDebounce(makeCache());
+
+            jest.advanceTimersByTime(500);
+            expect(invalidateFiles).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1500);
+            expect(invalidateFiles).toHaveBeenCalledWith(["Scripts/device.verse"]);
+        });
+
+        it("falls back to 500ms, the default package.json registers", async () => {
+            jest.useFakeTimers();
+            stubSettings({});
+
+            const invalidateFiles = armDebounce(makeCache());
+
+            jest.advanceTimersByTime(499);
+            expect(invalidateFiles).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1);
+            expect(invalidateFiles).toHaveBeenCalledWith(["Scripts/device.verse"]);
+        });
+
+        it("re-reads the setting for each change, so a new value needs no window reload", async () => {
+            jest.useFakeTimers();
+            const settings: Record<string, unknown> = { "cache.watcherDebounceMs": 500 };
+            getConfiguration.mockReturnValue({
+                get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key in settings ? settings[key] : defaultValue)),
+                update: jest.fn().mockResolvedValue(undefined),
+            });
+
+            const cache = makeCache();
+            const invalidateFiles = armDebounce(cache);
+            jest.advanceTimersByTime(500);
+            expect(invalidateFiles).toHaveBeenCalledTimes(1);
+
+            // The user raises the delay; the next change must honour it.
+            settings["cache.watcherDebounceMs"] = 3000;
+            const verseWatcher = createFileSystemWatcher.mock.results.map((result) => result.value as FakeWatcher)[0];
+            verseWatcher.fireChange("C:\\Project\\Content\\Scripts\\other.verse");
+
+            jest.advanceTimersByTime(500);
+            expect(invalidateFiles).toHaveBeenCalledTimes(1);
+
+            jest.advanceTimersByTime(2500);
+            expect(invalidateFiles).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("cache.autoRebuildOnStartup", () => {
+        it("scans the project instead of loading the stored cache when on", async () => {
+            stubSettings({ "cache.autoRebuildOnStartup": true });
+            findFiles.mockResolvedValue([]);
+
+            const cache = makeCache({ [CACHE_KEY]: STORED_CACHE });
+            await cache.initialize();
+
+            expect(findFiles).toHaveBeenCalled();
+            // The scan found no files, so the stored declaration is gone: what
+            // the cache holds came from the rebuild, not from storage.
+            expect(cache.getStats().files).toBe(0);
+        });
+
+        it("loads the stored cache when off", async () => {
+            stubSettings({ "cache.autoRebuildOnStartup": false });
+            findFiles.mockResolvedValue([]);
+
+            const cache = makeCache({ [CACHE_KEY]: STORED_CACHE });
+            await cache.initialize();
+
+            expect(findFiles).not.toHaveBeenCalled();
+            expect(cache.getStats().files).toBe(1);
+        });
+
+        it("still builds fresh when it is off and storage holds nothing", async () => {
+            stubSettings({ "cache.autoRebuildOnStartup": false });
+            findFiles.mockResolvedValue([]);
+
+            const cache = makeCache();
+            await cache.initialize();
+
+            expect(findFiles).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -36,12 +36,10 @@ export interface PathConversionConfig {
     enableCodeLens: boolean;
     codeLensVisibility: "hover" | "always";
     codeLensHideDelay: number;
-    scanDepth: number;
 }
 
 export interface ExperimentalConfig {
     useDigestFiles: boolean;
-    unknownIdentifierResolution: "digest_only" | "digest_and_inference" | "disabled";
 }
 
 export interface VerseAutoImportsConfig {

--- a/test-fixtures/corpus/41.10/diagnostics.json
+++ b/test-fixtures/corpus/41.10/diagnostics.json
@@ -106,10 +106,10 @@
         {
             "id": "unknown-identifier-bare-ambiguous",
             "source": "synthetic",
-            "context": "bare unknown identifier with no inline suggestion; pure extraction yields nothing (expected below), but in a real host the registered behavior.ambiguousImports default maps vector3 to /UnrealEngine.com/Temporary/SpatialMath - the integration suite asserts that mapped import (issue #77 regression)",
+            "context": "bare unknown identifier with no inline suggestion; the registered behavior.ambiguousImports default maps vector3 to /UnrealEngine.com/Temporary/SpatialMath, so extraction resolves it without any inline hint (issue #77 regression, also asserted by the integration suite). Before issue #135 this entry expected nothing, because the extractor's code-side fallback was {} and the test mock returned that fallback rather than the registered default.",
             "message": "Unknown identifier `vector3`.\nUsed inside module /vukefn@fortnite.com/VerseAutoImports/Scripts.",
             "expected": {
-                "suggestions": [],
+                "suggestions": ["using { /UnrealEngine.com/Temporary/SpatialMath }"],
                 "optimizePaths": []
             }
         }


### PR DESCRIPTION
Closes #135

Four settings were registered in `package.json`, shown and validated by the settings UI, and read by no code path. Two of them were announced in the 0.7.0 changelog as working features. Two further settings had code-side fallbacks contradicting their registered defaults.

## What changed

**Implemented, per the decision on the ticket:**

- `cache.watcherDebounceMs` — read where the debounce timer is armed rather than at construction, so a new value applies to the next file change instead of waiting for a window reload. Replaces the hardcoded `DEBOUNCE_MS = 500`.
- `cache.autoRebuildOnStartup` — `initialize()` now scans the project instead of loading the stored payload when it is on. If that rebuild resolves no project, it falls back to storage: asking for a fresh scan must not leave a session worse off than not asking.

**Removed:**

- `pathConversion.scanDepth` and `experimental.unknownIdentifierResolution`, with their `configuration.ts` type fields and `findModuleLocations`' unused `_maxDepth` parameter.

Neither could be implemented without inventing behaviour. `searchImplicitModules` tests sibling and parent candidate paths derived from the current file's directory segments — there is no depth-limited recursion for `scanDepth` to bound. `experimental.useDigestFiles` is already the digest on/off axis and is fully consumed, and `digest_and_inference` names a pattern-guessing feature that does not exist.

**Aligned with their registered defaults:**

- `quickFix.showDescriptions` — fallback `true` became `false`.
- `behavior.ambiguousImports` — fallback `{}` became the three registered mappings.

Both were inert in production, because `config.get` returns the registered default for a registered setting. They were live under the test mock, which returns the passed fallback — so the suite exercised the opposite of what every user saw. `test-fixtures/corpus/41.10/diagnostics.json` recorded that divergence in its own `context` note; it now states production behaviour.

## Tests

Six regression tests, each proven to fail against the unfixed code before being kept. Plus `src/__tests__/configurationDefaults.test.ts`, a guard for the defect class itself: it walks every `config.get` call site in `src/` and asserts the fallback equals the default `package.json` registers, so a new divergence fails without anyone maintaining a list. Verified it detects a reintroduced `showDescriptions: true`.

`src/__mocks__/vscode.ts` gained `CodeAction` and `CodeActionKind`, which it did not have before. Purely additive — no pre-existing test could have constructed either. The mock's pass-through `get` is deliberately untouched; see the follow-up below.

## Verification

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       511 passed, 511 total
Snapshots:   0 total
Time:        11.705 s
Ran all test suites.
```

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

Fresh reviewer, opus, one round: `PASS_WITH_SUGGESTIONS`, 0 Critical, 2 Important, 6 Suggestion.

Both Important findings are addressed or surfaced:

- The startup-rebuild path could leave a session with no cache where the stored payload would have served. Fixed in `39acb87`, with a regression test.
- No guard against the divergence recurring. Added as `configurationDefaults.test.ts`.

## For the maintainer

**Two things this PR deliberately leaves to you:**

1. **Historical changelog sections.** The ticket asked to "correct the changelog". The forward-looking half is done via the two fragments. The 0.7.0 entries still describe the two cache settings as working in *that* release, and the 0.6.0 rename table still lists the two removed settings. Rewriting released sections cuts against Keep a Changelog practice, so it is your call rather than something to do quietly here.

2. **Follow-up issue worth filing:** `src/__mocks__/vscode.ts` returns the passed fallback from `config.get`, where real VS Code returns the registered default. That is the general mechanism which hid both divergences for a release each. `configurationDefaults.test.ts` now catches the consequence, but the mock still models the wrong thing. Changing it alters what every existing test sees, so it wants its own ticket.
