### PR TITLE
fix(imports): pin a using: pair opened after a semicolon

### DIFF
--- a/changelog.d/219.fixed.md
+++ b/changelog.d/219.fixed.md
@@ -1,0 +1,1 @@
+**Import organizing**: a `using:` block opened after a semicolon keeps both its lines, instead of losing the opener and leaving its path stranded in the file body.

--- a/changelog.d/219.fixed.md
+++ b/changelog.d/219.fixed.md
@@ -1,1 +1,1 @@
-**Import organizing**: a `using:` block opened after a semicolon keeps both its lines, instead of losing the opener and leaving its path stranded in the file body.
+**Organize imports**: a `using:` pair opened after a `;` keeps both of its lines, instead of losing the opener and leaving its path stranded in the file body.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -147,8 +147,10 @@ export class ImportDocumentEditor {
             // is what puts the marker somewhere it was not written, so it is
             // refused here rather than only by every caller passing a filtered
             // list. Every caller does today; one that forgot would resurrect a
-            // defect this branch has already shipped once.
-            if (!imp.trailingComment || imp.anchorsCommentBelow) {
+            // defect this branch has already shipped once. A statement sharing
+            // its span is refused for the same reason: what trails it is the
+            // rest of the span, not an annotation to re-emit.
+            if (!imp.trailingComment || imp.anchorsCommentBelow || imp.rebuildLosesText) {
                 continue;
             }
             const statement = this.formatter.formatImportStatement(imp.path, preferDotSyntax);

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -579,16 +579,19 @@ export class ImportDocumentEditor {
     ): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
         const lines = text.split(LINE_SPLIT);
-        // An import anchored by a comment marker is neither hoisted nor
-        // removed from the body: its line stays exactly where it is, and the
-        // rest of the file is organized around it. It is still an import,
-        // though, so an additional path it already covers must not be written
-        // out a second time - that would duplicate it rather than move it.
+        // A pinned import - one anchored by a comment marker, or one sharing its
+        // span with another statement - is neither hoisted nor removed from the
+        // body: its line stays exactly where it is, and the rest of the file is
+        // organized around it. It is still an import, though, so an additional
+        // path it already covers must not be written out a second time - that
+        // would duplicate it rather than move it. Both reasons answer that the
+        // same way, so the set is keyed on the line staying put rather than on
+        // why it does; see ScannedImport.rebuildLosesText.
         const allImports = scanModuleImports(lines);
         const movableImports = rewritableImports(allImports);
-        const anchoredPaths = new Set(allImports.filter((imp) => imp.anchorsCommentBelow).map((imp) => imp.path));
+        const pinnedPaths = new Set(allImports.filter((imp) => imp.anchorsCommentBelow || imp.rebuildLosesText).map((imp) => imp.path));
 
-        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0 && !anchoredPaths.has(p));
+        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0 && !pinnedPaths.has(p));
 
         // Module imports have file scope, so the names an anchored import brings
         // in are available to code anywhere in the file, however far down its
@@ -627,7 +630,7 @@ export class ImportDocumentEditor {
         // direction: the duplicate left behind is legal Verse, and a stranded
         // provider is a file that stops compiling.
         const withholdIsSafe = [...allUsingPaths(lines), ...extraPaths].every((path) => this.formatter.importRank(path) === 0);
-        const blockImports = withholdIsSafe ? movableImports.filter((imp) => !anchoredPaths.has(imp.path)) : movableImports;
+        const blockImports = withholdIsSafe ? movableImports.filter((imp) => !pinnedPaths.has(imp.path)) : movableImports;
 
         const paths = blockImports.map((imp) => imp.path);
         // Keyed on the unfiltered set: a file whose only rewritable import is

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -30,6 +30,31 @@ export interface ScannedImport {
      */
     anchorsCommentBelow: boolean;
     /**
+     * Whether rebuilding this statement's lines from `path` would delete text
+     * the author wrote, because the span carries a statement `path` cannot
+     * reproduce.
+     *
+     * Every writer reconstructs a span from `path` and `trailingComment`, which
+     * is faithful only while the statement is the whole of what its lines say.
+     * A `using:` opening an indented pair after a `;` breaks that: the span
+     * holds the statement before the `;` as well, and a rebuild from either
+     * path alone deletes the other. Such a statement is still a real import and
+     * still counts as present - only rewriting is off limits, exactly as for
+     * anchorsCommentBelow, and rewritableImports filters on both.
+     *
+     * `false` is "no loss known", not "provably none". Two shapes carry the
+     * same hazard undetected:
+     *
+     * - a line writing two complete statements, `using { /X }; using { /Y }`,
+     *   which reads as its first path alone and drops the second silently
+     *   (#223)
+     * - `using. /X; using:`, where the dotted statement has no closing
+     *   delimiter and swallows the rest of the line into its path, so the pair
+     *   is pinned under a path that is not `/X` and `/X` itself goes
+     *   unreported - the same weakness usingPathsOnLine documents
+     */
+    rebuildLosesText: boolean;
+    /**
      * The comment trailing the statement on its own line, or "" when it has
      * none. For the indented pair this is the comment on the path line, the
      * only one of the two lines that can carry a path and therefore a comment
@@ -224,15 +249,6 @@ export function classifyLines(lines: string[]): LineClassification[] {
 }
 
 /**
- * Marks, for each line, whether it begins inside a block comment. Computed in
- * one pass up front because a block comment is a property of everything above
- * a line, which the scanner's main loop cannot see once it starts skipping.
- */
-function blockCommentMask(lines: string[]): boolean[] {
-    return classifyLines(lines).map((classification) => classification.insideBlockComment);
-}
-
-/**
  * Scans document lines for module imports. This is the single scanner behind
  * every import-editing operation so they all agree on what counts as an
  * import:
@@ -247,7 +263,11 @@ function blockCommentMask(lines: string[]): boolean[] {
  *   deliberately disabled import back into force.
  * - The indented style (`using:` with the path on the following line) is
  *   consumed as one two-line entry so editing operations never orphan the
- *   path line or lose its path.
+ *   path line or lose its path. A pair opened after a `using` statement and a
+ *   `;` is consumed as well, but pinned rather than rewritable: its span says
+ *   more than any one path can, so a writer rebuilding it deletes what it did
+ *   not read. A `using:` following anything that is not itself a `using` is
+ *   not an import line at all and is skipped whole, as it always was.
  * - Content classification (module import vs local-scope using) is delegated
  *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
  *   every candidate here already sits at column 0. This means a bare
@@ -265,7 +285,12 @@ function blockCommentMask(lines: string[]): boolean[] {
 export function scanModuleImports(lines: string[]): ScannedImport[] {
     const formatter = new ImportFormatter();
     const imports: ScannedImport[] = [];
-    const insideBlockComment = blockCommentMask(lines);
+    // Computed in one pass up front because comment structure is a property of
+    // everything above a line, which the main loop cannot see once it starts
+    // skipping. `insideBlockComment` decides whether a line may be read as an
+    // import at all, and `code` is what a test searching a line rather than
+    // prefix-testing it has to search - see the tail test below.
+    const classifications = classifyLines(lines);
 
     // Whether the statement's own text opens a comment over the lines below it,
     // read from that text alone rather than from what currently sits under it.
@@ -297,7 +322,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     while (i < lines.length) {
         const line = lines[i];
 
-        if (insideBlockComment[i]) {
+        if (classifications[i].insideBlockComment) {
             i += 1;
             continue;
         }
@@ -310,6 +335,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         }
 
         const trimmed = line.trim();
+        const code = classifications[i].code.trim();
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
 
         if (!ImportFormatter.isModuleImport(trimmed, nextLine, { atFileScope: true })) {
@@ -328,6 +354,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                         startLine: i,
                         endLine: i + 1,
                         anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                        rebuildLosesText: false,
                         trailingComment: ImportFormatter.extractTrailingComment(nextLine),
                     });
                     i += 2;
@@ -339,6 +366,75 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             continue;
         }
 
+        // The same pair, opened after a `;` rather than at the head of its line.
+        // `;` separates definitions in a scope exactly as a newline does, so a
+        // statement can precede the `using:` - which is why allUsingPaths tests
+        // the tail of the line rather than the whole of it (#218). Read whole,
+        // the line is not a pair at all: it falls through to the single-statement
+        // branch below, which reports the path before the `;` and a span of one
+        // line, and a writer then rebuilds that line from that path alone -
+        // deleting the `; using:` and leaving its path stranded in the body.
+        //
+        // Tested against the line's code rather than its raw text, for the same
+        // reason allUsingPaths is: a `$` anchored on the raw line is defeated by
+        // any comment after the `using:`, which puts the line straight back on
+        // the mangling path this branch exists to keep it off. Searching the raw
+        // text has the mirror failure - `using { /A } <# note about using:` ends
+        // in `using:` inside a comment, and reading it as an opener records the
+        // comment text below as an import path.
+        //
+        // Order is load-bearing. A whole-line `using:` matches this tail test
+        // too, so the branch above has to keep first refusal or the plain pair
+        // changes shape. It tests the raw line on purpose: promoting
+        // `using: # note` to a rewritable pair would rebuild that line and
+        // delete the comment, which is the loss this branch pins lines to avoid.
+        //
+        // Every path the line writes is recorded, because each is imported and
+        // none may be written again, and all are pinned, because no writer can
+        // reproduce this span from any one of them. Their spans overlap, which
+        // is harmless precisely because being pinned keeps them away from every
+        // writer.
+        if (/\busing\s*:\s*$/.test(code)) {
+            // The statement before the `;`, when the line writes one. A line
+            // whose `using:` follows something that is not a `using` at all
+            // never reaches here: isModuleImport rejects it above, so the line
+            // is skipped whole and left alone, which is the same outcome by a
+            // different route.
+            const precedingPath = formatter.extractPathFromImport(code);
+            if (precedingPath) {
+                imports.push({
+                    path: precedingPath,
+                    startLine: i,
+                    endLine: i,
+                    anchorsCommentBelow: anchorsCommentBelow(i, i),
+                    rebuildLosesText: true,
+                    trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                });
+            }
+
+            const indentedPath = nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "";
+            if (!indentedPath) {
+                // The `using:` opens nothing usable, exactly as in the branch
+                // above - but the line still carries a statement this scanner
+                // cannot reproduce, so it is pinned rather than handed to the
+                // single-statement branch, which would rebuild it and delete the
+                // `; using:`.
+                i += 1;
+                continue;
+            }
+
+            imports.push({
+                path: indentedPath,
+                startLine: i,
+                endLine: i + 1,
+                anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                rebuildLosesText: true,
+                trailingComment: ImportFormatter.extractTrailingComment(nextLine),
+            });
+            i += 2;
+            continue;
+        }
+
         const path = formatter.extractPathFromImport(trimmed);
         if (path) {
             imports.push({
@@ -346,6 +442,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 startLine: i,
                 endLine: i,
                 anchorsCommentBelow: anchorsCommentBelow(i, i),
+                rebuildLosesText: false,
                 trailingComment: ImportFormatter.extractTrailingComment(trimmed),
             });
         }
@@ -366,12 +463,16 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
  * around, or - for a `<#` - drops it and resurrects the region below. See
  * ScannedImport.anchorsCommentBelow.
  *
+ * A statement sharing its span with another one is excluded for the same
+ * reason, arrived at from the other direction: there the rebuild is faithful to
+ * the path and deletes the rest of the span. See ScannedImport.rebuildLosesText.
+ *
  * Such an import is still present for existence and deduplication purposes;
  * only rewriting is off limits. Callers wanting "is this path imported" must
  * read the unfiltered scan.
  */
 export function rewritableImports(scannedImports: ScannedImport[]): ScannedImport[] {
-    return scannedImports.filter((imp) => !imp.anchorsCommentBelow);
+    return scannedImports.filter((imp) => !imp.anchorsCommentBelow && !imp.rebuildLosesText);
 }
 
 /**

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -385,15 +385,21 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         //
         // Order is load-bearing. A whole-line `using:` matches this tail test
         // too, so the branch above has to keep first refusal or the plain pair
-        // changes shape. It tests the raw line on purpose: promoting
-        // `using: # note` to a rewritable pair would rebuild that line and
-        // delete the comment, which is the loss this branch pins lines to avoid.
+        // changes shape.
+        //
+        // That branch still tests the raw line, and the two inputs cannot
+        // disagree where it runs: isModuleImport gates this loop on the raw text
+        // as well, and a line whose raw text is not exactly `using:` matches
+        // none of its three patterns - so `using: # note` is refused above and
+        // never reaches either branch. The gate is what protects it, not the
+        // input choice. Relaxing the gate is what would make the choice matter.
         //
         // Every path the line writes is recorded, because each is imported and
         // none may be written again, and all are pinned, because no writer can
-        // reproduce this span from any one of them. Their spans overlap, which
-        // is harmless precisely because being pinned keeps them away from every
-        // writer.
+        // reproduce this span from any one of them. Their spans overlap. No
+        // writer sees that, because all of them read rewritableImports, which
+        // excludes a pinned entry; a reader of the unfiltered scan does, and
+        // gets the region reported once per path it carries.
         if (/\busing\s*:\s*$/.test(code)) {
             // The statement before the `;`, when the line writes one. A line
             // whose `using:` follows something that is not a `using` at all
@@ -408,6 +414,12 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     endLine: i,
                     anchorsCommentBelow: anchorsCommentBelow(i, i),
                     rebuildLosesText: true,
+                    // Read from the raw line, so on a line whose comment sits
+                    // mid-statement this holds the `; using:` after it as well
+                    // as the comment. Nothing re-emits it - that is what being
+                    // pinned means - and the alternative is worse: the code has
+                    // its comments already removed, so it can only ever answer
+                    // "none".
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
                 });
             }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -125,6 +125,45 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using { /A } <#> why this is here", "    it brings the module into scope", "code()"].join("\n"));
     });
 
+    // A `using:` opening an indented pair after a `;` carries two paths across
+    // two lines, which no rebuild from a single path can reproduce. The line
+    // used to read as the path before the `;` alone, so organizing rewrote it as
+    // `using { /X }` - deleting the `; using:` that opened the pair and leaving
+    // Economy.Shop below as a bare indented expression that imports nothing.
+    // Null is what leaves the document untouched: organizeImports skips the edit
+    // entirely (#219).
+    it("leaves a using: pair opened after a semicolon alone", () => {
+        const input = ["using { /X }; using:", "    Economy.Shop", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    it("organizes the other imports around a using: pair opened after a semicolon", () => {
+        const input = ["using { /X }; using:", "    Economy.Shop", "using { /B }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using { /X }; using:", "    Economy.Shop", "", "code()"].join("\n"));
+    });
+
+    it("does not write a second copy of a path such a pair already provides", () => {
+        const input = ["using { /X }; using:", "    Economy.Shop", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/X"], curlySorted)).toBeNull();
+        expect(editor.buildOrganizedContent(input, ["Economy.Shop"], curlySorted)).toBeNull();
+    });
+
+    // A comment after the `using:` defeats a `$` anchored on the raw line, which
+    // put the line straight back on the mangling path: rebuilt as
+    // `using { /X } # note`, with Economy.Shop stranded below it.
+    it("leaves a using: pair alone when a comment trails the opener", () => {
+        const input = ["using { /X }; using: # note", "    Economy.Shop", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    // The `using:` opens nothing here, so there is no pair to read - but the
+    // line is still not reproducible from the path before the `;`, and
+    // rebuilding it deletes the `; using:` the author wrote.
+    it("leaves the line alone when such a using: opens no indented path", () => {
+        const input = ["using { /X }; using:", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
     // The anchored line ends up below the rebuilt block, so dropping the copy
     // above it can leave a `using` without the import that brings its first
     // segment into scope - the ordering #91 and #129 fixed. Only an absolute

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1,4 +1,4 @@
-import { allUsingPaths, classifyLines, scanConvertibleImports, scanModuleImports } from "../ImportScanner";
+import { allUsingPaths, classifyLines, rewritableImports, scanConvertibleImports, scanModuleImports } from "../ImportScanner";
 
 describe("allUsingPaths", () => {
     it("collects a file-scope import the same way scanModuleImports does", () => {
@@ -147,18 +147,85 @@ describe("allUsingPaths", () => {
 describe("scanModuleImports", () => {
     it("collects a braced import at column 0 with a single-line span", () => {
         expect(scanModuleImports(["using { /Verse.org/Simulation }", "code()"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 
     it("collects a dotted-style import", () => {
-        expect(scanModuleImports(["using. /Verse.org/Simulation"])).toEqual([{ path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(["using. /Verse.org/Simulation"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
     });
 
     it("consumes the indented using: pair as one two-line entry", () => {
         expect(scanModuleImports(["using:", "    /Verse.org/Simulation", "code()"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
+    });
+
+    // Read as a whole line the tail is not a `using:` at all, so the line used
+    // to fall through to the single-statement branch: one entry for the path
+    // before the `;`, spanning one line, and rewritable. Organizing then rebuilt
+    // that line from that path alone, deleting the `; using:` and leaving
+    // Economy.Shop stranded in the body as a bare indented expression.
+    it("consumes a using: pair opened after a semicolon, pinning both paths", () => {
+        expect(scanModuleImports(["using { /X }; using:", "    Economy.Shop", "", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // Both paths still count as imported - that is what stops a writer adding
+    // either one a second time - but neither may be rebuilt or moved, because
+    // no writer can reproduce the span from one path.
+    it("offers no rewritable import for a pair opened after a semicolon", () => {
+        expect(rewritableImports(scanModuleImports(["using { /X }; using:", "    Economy.Shop", "", "code()"]))).toEqual([]);
+    });
+
+    // The line the fix keys on has to keep meaning what it did: a pair opening
+    // its own line is one entry spanning both lines, and still rewritable.
+    it("leaves the plain indented pair rewritable", () => {
+        expect(rewritableImports(scanModuleImports(["using:", "    Economy.Shop", "code()"]))).toEqual([
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+    });
+
+    // The tail is tested against the line's code, not its raw text. A `$`
+    // anchored on the raw line is defeated by any comment after the `using:`,
+    // which puts the line straight back on the branch that rebuilds it from the
+    // path before the `;`.
+    it("consumes a pair opened after a semicolon when a comment trails the opener", () => {
+        expect(scanModuleImports(["using { /X }; using: # note", "    Economy.Shop", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "# note" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The mirror error of searching the raw line: this one ends in `using:`
+    // inside a comment, and reading that as an opener records the comment text
+    // below it as an import path.
+    it("does not read a using: written inside a comment as opening a pair", () => {
+        expect(scanModuleImports(["using { /A } <# note about using:", "    still comment", "#>", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<# note about using:" },
+        ]);
+    });
+
+    // The `using:` opens nothing usable, but the line still writes a statement
+    // no rebuild can reproduce, so it is pinned rather than handed to the
+    // single-statement branch - which would rebuild it and delete the
+    // `; using:`.
+    it("pins a pair opened after a semicolon whose using: opens no indented path", () => {
+        expect(scanModuleImports(["using { /X }; using:", "code()"])).toEqual([{ path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" }]);
+        expect(scanModuleImports(["using { /X }; using:", "    # just a note", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // A `using:` following something that is not a `using` writes no import
+    // this scanner may touch: isModuleImport rejects the line, so it is skipped
+    // whole and left exactly as written.
+    it("skips a using: opened after a statement that is not a using", () => {
+        expect(scanModuleImports(["X := 1; using:", "    Economy.Shop", "code()"])).toEqual([]);
     });
 
     it("keeps a trailing comment out of the path but on the entry, in all three styles", () => {
@@ -166,13 +233,13 @@ describe("scanModuleImports", () => {
         // corrupted by it, and onto `trailingComment`, which is what a writer
         // puts back after rebuilding the line.
         expect(scanModuleImports(["using { /Verse.org/Simulation } # keep me"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "# keep me" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# keep me" },
         ]);
         expect(scanModuleImports(["using. /Verse.org/Simulation # keep me"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "# keep me" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# keep me" },
         ]);
         expect(scanModuleImports(["using:", "    /Verse.org/Simulation # keep me", "code()"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, trailingComment: "# keep me" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# keep me" },
         ]);
     });
 
@@ -181,7 +248,7 @@ describe("scanModuleImports", () => {
     });
 
     it("collects dot-notation module references", () => {
-        expect(scanModuleImports(["using { Gadgets.Tools }"])).toEqual([{ path: "Gadgets.Tools", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(["using { Gadgets.Tools }"])).toEqual([{ path: "Gadgets.Tools", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("skips indented using lines (module-scoped imports)", () => {
@@ -194,7 +261,7 @@ describe("scanModuleImports", () => {
         // body level; local-scope `using{instance}` is only legal inside a
         // function body. So a bare `using { X }` at column 0 can only be a
         // same-directory folder-module import, never a local-scope using.
-        expect(scanModuleImports(["using { Features }"])).toEqual([{ path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(["using { Features }"])).toEqual([{ path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("skips local-scope using inside a function body", () => {
@@ -207,7 +274,7 @@ describe("scanModuleImports", () => {
     });
 
     it("handles CRLF line endings", () => {
-        expect(scanModuleImports(["using { /A }\r", "code()\r"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(["using { /A }\r", "code()\r"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("skips an import commented out with a block comment", () => {
@@ -217,18 +284,20 @@ describe("scanModuleImports", () => {
 
     it("resumes scanning after a block comment closes", () => {
         const lines = ["<#", "using { /Old/Path }", "#>", "using { /Verse.org/Simulation }", "", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("skips an import inside a block comment opened and closed on one line", () => {
-        expect(scanModuleImports(["<# using { /Old/Path } #>", "using { /A }"])).toEqual([{ path: "/A", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(["<# using { /Old/Path } #>", "using { /A }"])).toEqual([
+            { path: "/A", startLine: 1, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
     });
 
     it("keeps an import whose line opens a block comment after it, and flags it", () => {
         const lines = ["using { /A } <# disabled below", "using { /Old/Path }", "#>", "using { /B }"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<# disabled below" },
-            { path: "/B", startLine: 3, endLine: 3, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<# disabled below" },
+            { path: "/B", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 
@@ -236,15 +305,15 @@ describe("scanModuleImports", () => {
         // Nothing below the line is comment body, so rebuilding it only loses
         // the annotation text - the documented behavior of stripTrailingComment.
         expect(scanModuleImports(["using { /A } <# note #>", "using { /B }"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "<# note #>" },
-            { path: "/B", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "<# note #>" },
+            { path: "/B", startLine: 1, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 
     it("does not flag an import whose trailing line comment mentions <#", () => {
         expect(scanModuleImports(["using { /A } # opens with <#", "using { /B }"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "# opens with <#" },
-            { path: "/B", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# opens with <#" },
+            { path: "/B", startLine: 1, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 
@@ -253,8 +322,8 @@ describe("scanModuleImports", () => {
         // be read at endLine rather than startLine.
         const lines = ["using:", "    /A <# disabled below", "using { /Old/Path }", "#>", "using { /B }"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, trailingComment: "<# disabled below" },
-            { path: "/B", startLine: 4, endLine: 4, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<# disabled below" },
+            { path: "/B", startLine: 4, endLine: 4, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 
@@ -264,14 +333,16 @@ describe("scanModuleImports", () => {
         // got turned on whether it ended with a newline. Now that a rebuild
         // carries the opener through rather than dropping it, "swallows nothing
         // today" stops being safe: sorted above another import, it swallows it.
-        expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#" }]);
-        expect(scanModuleImports(["using { /A } <#", ""])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#" }]);
+        expect(scanModuleImports(["using { /A } <#"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<#" }]);
+        expect(scanModuleImports(["using { /A } <#", ""])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<#" }]);
     });
 
     it("does not flag a statement whose own text closes every block it opens", () => {
         // Depth returns to 0 on the line, so nothing below it is comment body
         // and the trailing text travels with the statement safely.
-        expect(scanModuleImports(["using { /A } <# note #>", "code()"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "<# note #>" }]);
+        expect(scanModuleImports(["using { /A } <# note #>", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "<# note #>" },
+        ]);
     });
 
     it("flags an import whose line carries an indented comment marker", () => {
@@ -279,31 +350,33 @@ describe("scanModuleImports", () => {
         // it. Rebuilding the line moves the marker away from that body, and
         // leaves the body behind as indented lines at file scope.
         const lines = ["using { /A } <#> why this is here", "    it brings the module into scope", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#> why this is here" }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<#> why this is here" }]);
     });
 
     it("flags an indented pair whose path line carries an indented comment marker", () => {
         const lines = ["using:", "    /A <#> why", "        the body of the marker's comment", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, trailingComment: "<#> why" }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<#> why" }]);
     });
 
     it("flags a marker with no body below it, unlike an unclosed block opener", () => {
         // The `<#` carve-out above is safe because a file ending at that line
         // can never grow a body. A marker's body is whatever sits indented
         // below it, so a rebuild that moves the line hands it one it never had.
-        expect(scanModuleImports(["using { /A } <#> note", "code()"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<#> note" }]);
+        expect(scanModuleImports(["using { /A } <#> note", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<#> note" },
+        ]);
     });
 
     it("treats block comments as nesting, so an inner close does not resume scanning", () => {
         const lines = ["<#", "<#", "using { /Inner }", "#>", "using { /Outer }", "#>", "using { /Live }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Live", startLine: 6, endLine: 6, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Live", startLine: 6, endLine: 6, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("flags an import whose trailing opener is closed by a nested block below", () => {
         // The outer `<#` is still open on the line after the statement, so the
         // import stays anchored even though an inner `#>` appears first.
         const lines = ["using { /A } <# outer", "<# inner #>", "using { /Old/Path }", "#>", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, trailingComment: "<# outer" }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<# outer" }]);
     });
 
     it("skips an indented using: pair commented out as a block", () => {
@@ -316,20 +389,20 @@ describe("scanModuleImports", () => {
         // below it, which are skipped anyway. Reading it as `<#` would open a
         // block that never closes and hide every import in the rest of the file.
         const lines = ["<#> disabled for now", "    using { /Old/Path }", "using { /Verse.org/Simulation }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 2, endLine: 2, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 2, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("does not treat a <# inside a line comment as a block opener", () => {
         const lines = ["# a block comment opens with <#", "using { /Verse.org/Simulation }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 1, endLine: 1, anchorsCommentBelow: false, trailingComment: "" }]);
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 1, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("returns entries in document order with correct spans across mixed styles", () => {
         const lines = ["using { /A }", "using:", "    /B", "using. /C"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, trailingComment: "" },
-            { path: "/B", startLine: 1, endLine: 2, anchorsCommentBelow: false, trailingComment: "" },
-            { path: "/C", startLine: 3, endLine: 3, anchorsCommentBelow: false, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+            { path: "/B", startLine: 1, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+            { path: "/C", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 });


### PR DESCRIPTION
Closes #219

`scanModuleImports` decided the indented pair with a whole-line test, so `using { /X }; using:` read as a plain one-line import of `/X`. Organizing rebuilt that line from the path alone - deleting the `; using:` that opened the pair and leaving `Economy.Shop` below it as a bare indented expression that imports nothing.

## The fix

The invariant the scanner owes every writer is that a recorded import's span is reproducible from its `path`, because that is all a writer rebuilds from. A pair opened after a `;` breaks it: the span says more than any one path can.

So the scanner now reads that shape, and records **every path such a line writes as pinned** - present for existence and deduplication, never rebuilt or moved. That reuses the mechanism `anchorsCommentBelow` already has: a new `ScannedImport.rebuildLosesText`, filtered by `rewritableImports` alongside it. `ImportDocumentEditor` keys its suppression set on the line staying put rather than on why it does, so a path a pinned line already provides is still never written a second time.

The tail is tested against the line's **code** rather than its raw text, as `allUsingPaths` already is. A `$` anchored on the raw line is defeated by any comment after the `using:`, which puts the line straight back on the mangling path; searching the raw text has the mirror failure, reading a `using:` written inside a comment as an opener and recording the comment text below it as an import path. Both were caught by the review gate, with reproductions.

This also makes the two functions agree, which is what #219 opens with: #218 fixed the same whole-line test in `allUsingPaths` and deliberately did not widen into the writer.

## Behaviour

| input | before | after |
| --- | --- | --- |
| `using { /X }; using:` + `    Economy.Shop` | `using { /X }`, path stranded below | both lines intact, both paths counted as imported |
| `using { /X }; using: # note` + path line | same corruption, plus `# note` | both lines intact |
| `using { /X }; using:` opening nothing usable | `using { /X }`, `; using:` deleted | line intact, `/X` still counted |
| `using:` + `    Economy.Shop` (plain pair) | one rewritable entry | unchanged |
| `X := 1; using:` + path line | skipped whole | unchanged |

## Not in this PR

- **#223**, filed from this work: `using { /X }; using { /Y }` organizes to `using { /X }`, deleting `/Y` outright with nothing left behind to signal the loss. Same root assumption, different symptom, no acceptance criterion in #219. `rebuildLosesText` is documented as "no loss known" rather than "provably none" and points at it.
- **A pre-existing ordering hole, not introduced here and not fixed here.** A pinned line stays where it is, so a consumer can still be hoisted above the provider it resolves against: `["using { Features }; using:", "    Economy.Shop", "using { Economy.Other }"]` puts `Economy.Other` on top, above the line bringing `Economy` into scope. The identical shape with an anchored import produces the identical ordering today, so this is the `anchorsCommentBelow` hole reachable through a second pin reason rather than a regression. Say the word and I will file it.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 25 passed, 25 total
Tests:       508 passed, 508 total
Snapshots:   0 total
Time:        11.828 s, estimated 12 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

**Regression proof.** With `src/imports/ImportScanner.ts` and `src/imports/ImportDocumentEditor.ts` stashed and the tests left in place, exactly the five new `ImportDocumentEditor` tests fail and the other 115 pass:

```
  ● ImportDocumentEditor.buildOrganizedContent › leaves a using: pair opened after a semicolon alone
  ● ImportDocumentEditor.buildOrganizedContent › organizes the other imports around a using: pair opened after a semicolon
  ● ImportDocumentEditor.buildOrganizedContent › does not write a second copy of a path such a pair already provides
  ● ImportDocumentEditor.buildOrganizedContent › leaves a using: pair alone when a comment trails the opener
  ● ImportDocumentEditor.buildOrganizedContent › leaves the line alone when such a using: opens no indented path
Tests:       5 failed, 115 passed, 120 total
```

## Review gate

Two rounds, fresh context each time.

- **Round 1: FAIL** - 1 Critical (a trailing comment on the opener defeated the fix entirely and restored the reported corruption), 4 Important, 3 Suggestion. The Critical, and two of the Importants that shared its root cause, are fixed here with tests; the changelog fragment it flagged as missing was added.
- **Round 2: PASS_WITH_SUGGESTIONS** - all round-1 findings verified closed, no new defect. Six suggestions; five applied. The declined one is collapsing the two `using:` branches into one, which is a refactor of code this ticket did not ask about.

The gate also corrected my reasoning on one point: I had justified testing the whole-line branch against the raw line by a case that `isModuleImport` already rejects at the gate. That comment now states the real reason.
