### PR TITLE
refactor(imports): derive the conversion range from the real line length

### DIFF
--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
 import { ImportFormatter } from "./ImportFormatter";
-import { allUsingPaths, classifyLines, LineClassification, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
+import { allUsingPaths, classifyLines, LINE_SPLIT, LineClassification, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
 
 /** Represents a contiguous block of import statements in the document. */
 interface ImportBlock {
@@ -12,9 +12,6 @@ interface ImportBlock {
 
 /** The line ending a document is written with. */
 export type LineEnding = "\r\n" | "\n";
-
-/** Splits text into lines without keeping the carriage return of a CRLF pair. */
-const LINE_SPLIT = /\r?\n/;
 
 /**
  * Detects the dominant line ending of a text, or null when it has no line

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -4,7 +4,7 @@ import { logger } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathCache } from "../services";
 import { ImportFormatter } from "./ImportFormatter";
-import { scanConvertibleImports } from "./ImportScanner";
+import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
 interface ImportConversionResult {
     originalImport: string;
@@ -450,7 +450,7 @@ export class ImportPathConverter {
     async convertAllImportsFromFullPath(document: vscode.TextDocument): Promise<ImportConversionResult[]> {
         const results: ImportConversionResult[] = [];
         const text = document.getText();
-        const lines = text.split("\n");
+        const lines = text.split(LINE_SPLIT);
 
         for (const { statement, line } of scanConvertibleImports(lines)) {
             if (this.isFullPathImport(statement) && !this.isBuiltinModule(statement)) {
@@ -539,7 +539,7 @@ export class ImportPathConverter {
     async convertAllImportsInDocument(document: vscode.TextDocument): Promise<ImportConversionResult[]> {
         const results: ImportConversionResult[] = [];
         const text = document.getText();
-        const lines = text.split("\n");
+        const lines = text.split(LINE_SPLIT);
 
         for (const { statement, line } of scanConvertibleImports(lines)) {
             const result = await this.convertToFullPath(statement, document.uri, line);
@@ -568,8 +568,8 @@ export class ImportPathConverter {
      * a lens would never have appeared: searching the raw lines is what let the
      * commented-out copy absorb the edit in the first place.
      *
-     * Comparison is by trimmed text, which also absorbs the trailing `\r` a CRLF
-     * document leaves on every element of a `"\n"` split.
+     * Comparison is by trimmed text, so the recorded line still matches after
+     * the user indents or outdents the import while the conversion resolves.
      */
     private static findConversionLine(lines: string[], conversion: ImportConversionResult): number {
         const original = conversion.originalImport.trim();
@@ -587,7 +587,7 @@ export class ImportPathConverter {
      */
     async applyConversion(document: vscode.TextDocument, conversion: ImportConversionResult, selectedPath?: string): Promise<boolean> {
         const text = document.getText();
-        const lines = text.split("\n");
+        const lines = text.split(LINE_SPLIT);
         const lineIndex = ImportPathConverter.findConversionLine(lines, conversion);
 
         if (lineIndex === -1) {

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -1,5 +1,15 @@
 import { ImportFormatter } from "./ImportFormatter";
 
+/**
+ * Splits text into lines without keeping the carriage return of a CRLF pair.
+ *
+ * Every `lines: string[]` this module consumes is expected to have been split
+ * this way. A `"\n"` split leaves a trailing `\r` on every line of a CRLF
+ * document, and a caller that derives a column from `line.length` then points
+ * one past the end of the line.
+ */
+export const LINE_SPLIT = /\r?\n/;
+
 /** A module import found in a document, with the line span it occupies. */
 export interface ScannedImport {
     /** The module path, e.g. "/Verse.org/Simulation" or "Gadgets.Tools". */

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -3,10 +3,9 @@ import { ImportFormatter } from "./ImportFormatter";
 /**
  * Splits text into lines without keeping the carriage return of a CRLF pair.
  *
- * Every `lines: string[]` this module consumes is expected to have been split
- * this way. A `"\n"` split leaves a trailing `\r` on every line of a CRLF
- * document, and a caller that derives a column from `line.length` then points
- * one past the end of the line.
+ * Split with this wherever a column is later derived from `line.length`: a
+ * `"\n"` split leaves a trailing `\r` on every line of a CRLF document, which
+ * puts that column one past the end of the line.
  */
 export const LINE_SPLIT = /\r?\n/;
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -65,8 +65,8 @@ interface RecordedOperation {
     text?: string;
 }
 
-function fakeDocument(lines: string[]): vscode.TextDocument {
-    const text = lines.join("\n");
+function fakeDocument(lines: string[], eol: "\n" | "\r\n" = "\n"): vscode.TextDocument {
+    const text = lines.join(eol);
     return {
         uri: vscode.Uri.file("C:/project/test.verse"),
         getText: () => text,
@@ -217,17 +217,56 @@ describe("ImportPathConverter.applyConversion", () => {
     });
 
     it("does not carry the carriage return of a CRLF line into the comment it restores", async () => {
-        // The document is split on "\n", so every line of a CRLF file ends in a
-        // `\r` and the comment is read out of text carrying one. Writing that
-        // `\r` back mid-line would split the line where the comment starts.
-        const document = fakeDocument(["using { Gadgets.Tools } # kept\r", "\r", "code()\r"]);
+        // The comment is read back out of the line about to be replaced, so a
+        // `\r` left on that line would be written into the middle of the
+        // rebuilt one - splitting it where the comment starts.
+        const document = fakeDocument(["using { Gadgets.Tools } # kept", "", "code()"], "\r\n");
         const annotated = { ...conversion(0), originalImport: "using { Gadgets.Tools } # kept" };
 
         expect(await converter.applyConversion(document, annotated)).toBe(true);
 
         expect(replacedOperation().text).toBe("using { /mygame@fortnite.com/mygame/Gadgets/Tools } # kept");
     });
+
+    it("ends the replace range at the true end of a CRLF line", async () => {
+        // The end column comes from the split line's length, so splitting on
+        // "\n" makes it one past the end of the line on every CRLF document.
+        // Real VS Code clamps the overshoot, which is exactly why nothing here
+        // can be left resting on it.
+        const document = fakeDocument(["using { Gadgets.Tools }", "", "code()"], "\r\n");
+
+        expect(await converter.applyConversion(document, conversion(0))).toBe(true);
+
+        const range = replacedOperation().range!;
+        expect(range.start).toEqual({ line: 0, character: 0 });
+        expect(range.end).toEqual({ line: 0, character: "using { Gadgets.Tools }".length });
+    });
+
+    it("leaves every other line of a CRLF document byte-identical", async () => {
+        const lines = ["using { Gadgets.Tools }", "", "code()"];
+        const document = fakeDocument(lines, "\r\n");
+
+        expect(await converter.applyConversion(document, conversion(0))).toBe(true);
+
+        const replaced = replacedOperation();
+        expect(applyOperation(document.getText(), replaced, "\r\n")).toBe(["using { /mygame@fortnite.com/mygame/Gadgets/Tools }", "", "code()"].join("\r\n"));
+    });
 });
+
+/**
+ * Applies a recorded replace operation to `text`, resolving its positions the
+ * way VS Code does: against lines that exclude the terminator.
+ *
+ * The mock's Range does not clamp an out-of-range column, which is what lets a
+ * test see the range the code actually built rather than the one the host
+ * would have salvaged from it.
+ */
+function applyOperation(text: string, operation: RecordedOperation, eol: "\n" | "\r\n"): string {
+    const lines = text.split(eol);
+    const offsetOf = (position: { line: number; character: number }) => lines.slice(0, position.line).reduce((total, line) => total + line.length + eol.length, 0) + position.character;
+
+    return text.slice(0, offsetOf(operation.range!.start)) + operation.text + text.slice(offsetOf(operation.range!.end));
+}
 
 /** A converter with project path resolution pinned, so conversion is pure string work. */
 function converterWithProjectPath(projectVersePath: string): ImportPathConverter {


### PR DESCRIPTION
Closes #150

`ImportPathConverter` split the document on a bare `"\n"` at three sites, so on a CRLF file every line kept its carriage return. The third of those feeds a write: `applyConversion` derives its replace range from the split line's length, which put the end column one past the true end of the line.

This is not a defect today, and that still holds against code added since the issue was filed — VS Code clamps the out-of-range column, and `ImportFormatter.extractTrailingComment` ends in `.trim()`, so the stray `\r` never reaches the rebuilt line either. What it cost is that the range was correct only because the host salvaged it, and the file contradicted the convention #139 established next door.

## Changes

- `LINE_SPLIT` moves from `ImportDocumentEditor.ts`, where it was unexported, to `ImportScanner.ts`, where it is exported. That is the line-level module both writers already import from, and every function it exports takes `lines: string[]` — the constant that produces them belongs beside them. Exporting from `ImportDocumentEditor` would instead have made the converter depend on a sibling writer. The regex carries no `g` flag, so it holds no `lastIndex` state and is safe to share.
- The converter's three sites split on it.
- The `findConversionLine` doc comment claimed the trimmed comparison "absorbs the trailing `\r` a CRLF document leaves on every element of a `"\n"` split" — no longer true, so it now says what trimming is still for.

## Tests

Two regression tests, both proven to fail against the unfixed code by stashing the source and running them. The vscode mock's `Range`/`Position` do not clamp, which is what makes the defect observable where real VS Code hides it:

- the replace range ends at column 23 rather than 24 on a CRLF line — the acceptance criterion's "end column equals the line length without the carriage return";
- applying the recorded operation to the CRLF text leaves every other line byte-identical. Unfixed, the overshooting range eats the `\r` and leaves a lone `\n`.

`fakeDocument` gained an optional line-ending argument to build them, and the existing `"does not carry the carriage return..."` test now constructs its CRLF document that way instead of hand-writing `\r` into each line — its comment described the `"\n"` split this change removes.

No changelog fragment: there is no user-visible effect.

## Out of scope

Which line the conversion targets (#141, already landed) and EOL detection, both excluded by the ticket.

The review gate flagged that `ImportCodeLensProvider.ts:164` splits on `"\n"` and builds a range from `lines[i].length` at `:178` — the same shape, in a lens range rather than a write. Confirmed and left alone as outside this ticket; it deserves its own issue.

## Verification

```
$ npm run compile
> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       538 passed, 538 total
Snapshots:   0 total
Time:        9.323 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Review gate: PASS_WITH_SUGGESTIONS, 0 Critical, 0 Important, 2 Suggestions. The first is addressed in `58d2ff4` — the new `LINE_SPLIT` doc asserted a module-wide precondition the code lens provider violates, so it now claims only what it can vouch for. The second is informational: the pre-existing trailing-comment test is protected by `.trim()` rather than by the split, so it is not coverage of this change.
