### PR TITLE
test(imports): cover per-document uri keying for hover state and conversions

### DIFF
--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -10,10 +10,6 @@ import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../.
 
 const IMPORT_STATEMENT = "using { /Fortnite.com/Devices }";
 
-/**
- * @param fsPath distinguishes documents within one test; the conversion keying
- * tests rely on two documents differing only in their folder.
- */
 function makeDocument(fsPath = "C:\\Project\\Content\\device.verse"): vscode.TextDocument & { save: jest.Mock } {
     return {
         uri: vscode.Uri.file(fsPath),
@@ -324,11 +320,13 @@ describe("CommandsHandler per-document conversion keying", () => {
         await run(handler, weapons);
         await run(handler, ui);
 
-        const forwarded = codeLensProvider.forceRefreshAfterConversion.mock.calls.map(([documentUri]) => documentUri);
-        expect(forwarded).toEqual([weapons.uri.toString(), ui.uri.toString()]);
-        // Both sides of that comparison run through the same toString(), so it
-        // would still hold if the key itself collapsed onto one value. This is
-        // the half that fails when it does.
-        expect(new Set(forwarded).size).toBe(2);
+        for (const forwarding of [codeLensProvider.keepHoverStateActive, codeLensProvider.forceRefreshAfterConversion]) {
+            const forwarded = forwarding.mock.calls.map(([documentUri]) => documentUri);
+            expect(forwarded).toEqual([weapons.uri.toString(), ui.uri.toString()]);
+            // Both sides of that comparison run through the same toString(), so
+            // it would still hold if the key itself collapsed onto one value.
+            // This is the half that fails when it does.
+            expect(new Set(forwarded).size).toBe(2);
+        }
     });
 });

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -10,9 +10,13 @@ import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../.
 
 const IMPORT_STATEMENT = "using { /Fortnite.com/Devices }";
 
-function makeDocument(): vscode.TextDocument & { save: jest.Mock } {
+/**
+ * @param fsPath distinguishes documents within one test; the conversion keying
+ * tests rely on two documents differing only in their folder.
+ */
+function makeDocument(fsPath = "C:\\Project\\Content\\device.verse"): vscode.TextDocument & { save: jest.Mock } {
     return {
-        uri: vscode.Uri.file("C:\\Project\\Content\\device.verse"),
+        uri: vscode.Uri.file(fsPath),
         languageId: "verse",
         save: jest.fn().mockResolvedValue(true),
     } as unknown as vscode.TextDocument & { save: jest.Mock };
@@ -131,7 +135,7 @@ function makeConversion(overrides: Partial<ConversionFixture> = {}): ConversionF
 
 function makeConversionHandler(converterOverrides: Record<string, jest.Mock>): {
     handler: CommandsHandler;
-    codeLensProvider: { forceRefreshAfterConversion: jest.Mock };
+    codeLensProvider: { keepHoverStateActive: jest.Mock; forceRefreshAfterConversion: jest.Mock };
 } {
     const importPathConverter = {
         convertToFullPath: jest.fn().mockResolvedValue(null),
@@ -273,5 +277,58 @@ describe("CommandsHandler.convertAllToRelativePath", () => {
 
         expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("Using relative paths for 2 imports.");
         expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * A conversion command, the converter result that carries it through to a
+ * finalized conversion, and how to invoke it. The overrides are built per case
+ * rather than shared, so one case's call counts cannot leak into another's.
+ */
+type ConversionCommandCase = [name: string, converterOverrides: () => Record<string, jest.Mock>, run: (handler: CommandsHandler, document: vscode.TextDocument) => Promise<void>];
+
+const CONVERSION_COMMANDS: ConversionCommandCase[] = [
+    ["convertToFullPath", () => ({ convertToFullPath: jest.fn().mockResolvedValue(makeConversion()) }), (handler, document) => handler.convertToFullPath(document, `using { ${RELATIVE_MODULE} }`, 4)],
+    [
+        "convertToRelativePath",
+        () => ({ convertFromFullPath: jest.fn().mockResolvedValue(makeConversion()) }),
+        (handler, document) => handler.convertToRelativePath(document, `using { ${ABSOLUTE_PATH} }`, 4),
+    ],
+    ["convertAllToFullPath", () => ({ convertAllImportsInDocument: jest.fn().mockResolvedValue([makeConversion()]) }), (handler, document) => handler.convertAllToFullPath(document)],
+    ["convertAllToRelativePath", () => ({ convertAllImportsFromFullPath: jest.fn().mockResolvedValue([makeConversion()]) }), (handler, document) => handler.convertAllToRelativePath(document)],
+];
+
+// The provider keys its hover state on the string these commands hand it, so
+// the commands are half of that keying. One that forwarded a basename, or a
+// stale document's uri, would collide two same-named files without the provider
+// changing at all.
+describe("CommandsHandler per-document conversion keying", () => {
+    const WEAPONS_UTILS = "C:\\Project\\Content\\Weapons\\utils.verse";
+    const UI_UTILS = "C:\\Project\\Content\\UI\\utils.verse";
+
+    it.each(CONVERSION_COMMANDS)("%s forwards the acting document's own uri", async (_name, converterOverrides, run) => {
+        const { handler, codeLensProvider } = makeConversionHandler(converterOverrides());
+        const document = makeDocument(WEAPONS_UTILS);
+
+        await run(handler, document);
+
+        expect(codeLensProvider.keepHoverStateActive).toHaveBeenCalledWith(document.uri.toString());
+        expect(codeLensProvider.forceRefreshAfterConversion).toHaveBeenCalledWith(document.uri.toString());
+    });
+
+    it.each(CONVERSION_COMMANDS)("%s forwards a distinct uri for each of two same-named documents", async (_name, converterOverrides, run) => {
+        const { handler, codeLensProvider } = makeConversionHandler(converterOverrides());
+        const weapons = makeDocument(WEAPONS_UTILS);
+        const ui = makeDocument(UI_UTILS);
+
+        await run(handler, weapons);
+        await run(handler, ui);
+
+        const forwarded = codeLensProvider.forceRefreshAfterConversion.mock.calls.map(([documentUri]) => documentUri);
+        expect(forwarded).toEqual([weapons.uri.toString(), ui.uri.toString()]);
+        // Both sides of that comparison run through the same toString(), so it
+        // would still hold if the key itself collapsed onto one value. This is
+        // the half that fails when it does.
+        expect(new Set(forwarded).size).toBe(2);
     });
 });

--- a/src/imports/__tests__/ImportCodeLensProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeLensProvider.test.ts
@@ -4,12 +4,15 @@ import { ImportCodeLensProvider } from "../ImportCodeLensProvider";
 /**
  * A document that only carries what provideCodeLenses reads: its text, a uri to
  * key hover state on, and a name for the log line.
+ *
+ * @param fsPath distinguishes documents within one test; the hover-state keying
+ * tests rely on two documents differing only in their folder.
  */
-function documentWith(text: string): vscode.TextDocument {
+function documentWith(text: string, fsPath = "C:\\project\\Content\\Main.verse"): vscode.TextDocument {
     return {
         getText: () => text,
-        uri: vscode.Uri.file("C:\\project\\Content\\Main.verse"),
-        fileName: "C:\\project\\Content\\Main.verse",
+        uri: vscode.Uri.file(fsPath),
+        fileName: fsPath,
         languageId: "verse",
     } as unknown as vscode.TextDocument;
 }
@@ -171,5 +174,67 @@ describe("ImportCodeLensProvider hide timers and teardown", () => {
         provider.dispose();
 
         expect(jest.getTimerCount()).toBe(0);
+    });
+});
+
+// Both hover maps are keyed by document.uri.toString(), and two Verse files
+// that share a basename differ only in their folder. Any key that collapsed
+// them - a basename, or a Uri carrying no toString of its own - would let one
+// file's hover decide whether the other file's lenses appear.
+describe("ImportCodeLensProvider per-document hover state", () => {
+    /** The registered default for pathConversion.codeLensHideDelay. */
+    const DEFAULT_HIDE_DELAY_MS = 1000;
+    /** One relative import, so a visible document offers exactly one lens. */
+    const IMPORT_TEXT = "using { Gadgets.Tools }\n\ncode()";
+    const WEAPONS_UTILS = "C:\\project\\Content\\Weapons\\utils.verse";
+    const UI_UTILS = "C:\\project\\Content\\UI\\utils.verse";
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+        // "hover" visibility, so the lenses are a readout of the hover state.
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: (key: string, defaultValue?: unknown) => (key === "pathConversion.codeLensVisibility" ? "hover" : defaultValue),
+            update: jest.fn(),
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it("offers nothing on a document that was never hovered", async () => {
+        const provider = new ImportCodeLensProvider(vscode.window.createOutputChannel("test"));
+
+        const lenses = await provider.provideCodeLenses(documentWith(IMPORT_TEXT), {} as vscode.CancellationToken);
+
+        expect(lenses).toEqual([]);
+    });
+
+    it("confines a hover to the document hovered, not its same-named neighbour", async () => {
+        const provider = new ImportCodeLensProvider(vscode.window.createOutputChannel("test"));
+        const weapons = documentWith(IMPORT_TEXT, WEAPONS_UTILS);
+        const ui = documentWith(IMPORT_TEXT, UI_UTILS);
+
+        provider.setHoverState(weapons.uri.toString(), true, 0);
+
+        await expect(provider.provideCodeLenses(weapons, {} as vscode.CancellationToken)).resolves.toHaveLength(1);
+        await expect(provider.provideCodeLenses(ui, {} as vscode.CancellationToken)).resolves.toEqual([]);
+    });
+
+    it("confines a hide timer to the document it was armed for", async () => {
+        const provider = new ImportCodeLensProvider(vscode.window.createOutputChannel("test"));
+        const weapons = documentWith(IMPORT_TEXT, WEAPONS_UTILS);
+        const ui = documentWith(IMPORT_TEXT, UI_UTILS);
+
+        provider.setHoverState(weapons.uri.toString(), true, 0);
+        provider.setHoverState(ui.uri.toString(), true, 0);
+        provider.setHoverState(weapons.uri.toString(), false);
+        jest.advanceTimersByTime(DEFAULT_HIDE_DELAY_MS);
+
+        await expect(provider.provideCodeLenses(weapons, {} as vscode.CancellationToken)).resolves.toEqual([]);
+        await expect(provider.provideCodeLenses(ui, {} as vscode.CancellationToken)).resolves.toHaveLength(1);
     });
 });

--- a/src/imports/__tests__/ImportCodeLensProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeLensProvider.test.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
 import { ImportCodeLensProvider } from "../ImportCodeLensProvider";
 
+/** The registered default for pathConversion.codeLensHideDelay. */
+const DEFAULT_HIDE_DELAY_MS = 1000;
+
 /**
  * A document that only carries what provideCodeLenses reads: its text, a uri to
  * key hover state on, and a name for the log line.
- *
- * @param fsPath distinguishes documents within one test; the hover-state keying
- * tests rely on two documents differing only in their folder.
  */
 function documentWith(text: string, fsPath = "C:\\project\\Content\\Main.verse"): vscode.TextDocument {
     return {
@@ -92,9 +92,6 @@ describe("ImportCodeLensProvider.provideCodeLenses", () => {
 // every document in the window - kept calling in, and a hide timer (delay
 // configurable up to 10000 ms) could still fire seconds later.
 describe("ImportCodeLensProvider hide timers and teardown", () => {
-    /** The registered default for pathConversion.codeLensHideDelay. */
-    const DEFAULT_HIDE_DELAY_MS = 1000;
-
     beforeEach(() => {
         jest.useFakeTimers();
         jest.clearAllMocks();
@@ -182,8 +179,6 @@ describe("ImportCodeLensProvider hide timers and teardown", () => {
 // them - a basename, or a Uri carrying no toString of its own - would let one
 // file's hover decide whether the other file's lenses appear.
 describe("ImportCodeLensProvider per-document hover state", () => {
-    /** The registered default for pathConversion.codeLensHideDelay. */
-    const DEFAULT_HIDE_DELAY_MS = 1000;
     /** One relative import, so a visible document offers exactly one lens. */
     const IMPORT_TEXT = "using { Gadgets.Tools }\n\ncode()";
     const WEAPONS_UTILS = "C:\\project\\Content\\Weapons\\utils.verse";


### PR DESCRIPTION
Closes #173

Adds the per-document `uri.toString()` collision coverage the ticket asks for. No production change and no mock change: the keying is already correct.

## The ticket had gone half-stale

Every reason #173 gives for why these tests could not exist has since been fixed by other merged work. Recorded here because the ticket still reads as though the blocker stands:

- `EventEmitter` (`src/__mocks__/vscode.ts:53`, exported at `:379`), `workspace.onDidChangeTextDocument` (`:240`) and `window.showQuickPick` (`:293`) are all in the mock. The ticket's "real blocker" is gone, so Scope bullet 1 needed no work.
- Both "missing" test files exist — `src/imports/__tests__/ImportCodeLensProvider.test.ts` and `src/commands/__tests__/CommandsHandler.test.ts`.
- The cited line numbers have drifted: the two maps are at `ImportCodeLensProvider.ts:23-24`, and the forwarding is at `CommandsHandler.ts:392,399`.

What was still missing is the coverage itself, which is what this PR adds. Every existing provider test used a single document, and the conversion tests asserted call *counts* rather than which URI string was passed.

## What is covered

`ImportCodeLensProvider` — three tests over two documents differing only in their folder (`Weapons/utils.verse`, `UI/utils.verse`):

- a document never hovered offers no lenses in `hover` visibility mode
- hovering one document does not reveal the other's lenses
- a hide timer armed for one document does not clear the other's hover state

`CommandsHandler` — all four conversion commands, over the same pair:

- each forwards the acting document's own URI into `keepHoverStateActive` and `forceRefreshAfterConversion`
- the two documents forward distinct strings through both methods

The distinctness assertion is deliberate rather than redundant. Comparing the forwarded value against `document.uri.toString()` runs the same function on both sides, so it would still hold if that call itself collapsed onto one value — the trap the mock's own doc comment at `vscode.ts:123-130` warns about. `new Set(forwarded).size` is the half that fails when it does.

## Acceptance criterion, verified

The ticket asks that the tests fail if the per-document key is ever made non-unique. Collapsing the mock's `Uri.toString()` to return only the basename produced exactly this, and the edit was reverted:

```
● CommandsHandler per-document conversion keying › convertAllToFullPath forwards a distinct uri for each of two same-named documents
● CommandsHandler per-document conversion keying › convertAllToRelativePath forwards a distinct uri for each of two same-named documents
● CommandsHandler per-document conversion keying › convertToFullPath forwards a distinct uri for each of two same-named documents
● CommandsHandler per-document conversion keying › convertToRelativePath forwards a distinct uri for each of two same-named documents
● ImportCodeLensProvider per-document hover state › confines a hide timer to the document it was armed for
● ImportCodeLensProvider per-document hover state › confines a hover to the document hovered, not its same-named neighbour
Tests:       6 failed, 30 passed, 36 total
```

The six new collision tests fail and the 30 pre-existing tests in those files still pass. An independent reviewer reproduced the same split using its own isolated Jest config rather than editing the mock in place.

No changelog fragment: tests only, nothing user-facing.

## Verification

`npm run compile`

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       547 passed, 547 total
Snapshots:   0 total
Time:        7.581 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
