### PR TITLE
fix(imports): pin a line carrying two using statements

### DIFF
--- a/changelog.d/223.fixed.md
+++ b/changelog.d/223.fixed.md
@@ -1,0 +1,1 @@
+**Organize imports**: a line writing two `using` statements keeps both, instead of being rebuilt from the first and silently dropping the second.

--- a/changelog.d/223.fixed.md
+++ b/changelog.d/223.fixed.md
@@ -1,1 +1,1 @@
-**Organize imports**: a line writing two `using` statements keeps both, instead of being rebuilt from the first and silently dropping the second.
+**Optimize Imports**: a line writing two `using` statements keeps both, instead of being rebuilt from the first and silently dropping the second.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -42,11 +42,17 @@ export interface ScannedImport {
      * still counts as present - only rewriting is off limits, exactly as for
      * anchorsCommentBelow, and rewritableImports filters on both.
      *
-     * `false` is "no loss known", not "provably none". One shape carries the
-     * same hazard undetected: `using. /X; using:`, where the dotted statement
-     * has no closing delimiter and swallows the rest of the line into its path,
-     * so the pair is pinned under a path that is not `/X` and `/X` itself goes
-     * unreported - the same weakness usingPathsOnLine documents.
+     * `false` is "no loss known", not "provably none". Detection looks for a
+     * second `using` on the line, so two shapes carry the same hazard
+     * undetected:
+     *
+     * - a `;` followed by anything that is not a `using` at all,
+     *   `using { /X }; MyVal := 5`, where the rebuild deletes the definition
+     *   (#235)
+     * - `using. /X; using:`, where the dotted statement has no closing
+     *   delimiter and swallows the rest of the line into its path, so the pair
+     *   is pinned under a path that is not `/X` and `/X` itself goes
+     *   unreported - the same weakness usingPathsOnLine documents
      *
      * `true` is likewise not a promise that every path on the span was
      * recorded. A line ending in a `using:` pair reports the statement at its
@@ -455,20 +461,19 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // and organizing then rebuilt it from that path, deleting the second
         // statement with no trace left that anything had gone.
         //
-        // Every path the line writes is recorded, because each is imported and
-        // none may be written again, and all are pinned, because a rebuild from
-        // any one of them deletes the others. Their spans coincide, which no
-        // writer sees: all of them read rewritableImports, which excludes a
-        // pinned entry.
+        // All of them recorded, all of them pinned, spans coinciding, for the
+        // reasons the branch above gives.
         //
-        // Asked of the line's code rather than its raw text, as the branch above
-        // is. `using { /A } <# note about using { /B }` writes one statement and
-        // mentions another in a comment; searching the raw text finds two, and
-        // pins - and misreports - a line that is a plain single statement.
+        // Asked of the line's code rather than its raw text, as that branch is.
+        // `using { /A } # see using { /B }` writes one statement and mentions
+        // another in a comment; searching the raw text finds two, and refuses to
+        // organize a plain single-statement line over the words after its `#`.
         //
         // usingPathsOnLine is what allUsingPaths asks, so reader and writer now
         // agree on how many statements a line writes. Asking it a second way
-        // here would be the looser second copy its doc warns against.
+        // here would be the looser second copy its doc warns against - and this
+        // caller needs the count exact in both directions, which is why that
+        // function only offers a `using` that begins a token.
         const pathsOnLine = usingPathsOnLine(formatter, code);
         if (pathsOnLine.length > 1) {
             for (const linePath of pathsOnLine) {
@@ -548,10 +553,25 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
  * the next iteration finds the statement after it and reports that path on its
  * own - which is the guarantee this owes its caller. Reading the swallowed copy
  * is not what makes the line safe; finding the statement inside it again is.
+ *
+ * Only a `using` that begins a token is offered. `using` is a substring of
+ * ordinary identifiers - `Housing` holds one - and the dotted pattern needs no
+ * space after its `.`, so `using { Housing.Data }` offered every occurrence
+ * reports `Housing.Data` and then `Data }`, a path the line does not write. A
+ * caller counting statements reads that as two.
+ *
+ * The cost is a `using` glued to an identifier by a comment removed from
+ * between them, `X := 1<# note #>using { /A }`. Whether Verse splits a token
+ * where a comment was is not something its test corpus settles, so this is a
+ * shape whose meaning is already unclear; a path invented out of every
+ * identifier ending in `using` is not.
  */
 function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
     const paths: string[] = [];
     for (let at = code.indexOf("using"); at !== -1; at = code.indexOf("using", at + 1)) {
+        if (at > 0 && /[A-Za-z0-9_]/.test(code[at - 1])) {
+            continue;
+        }
         const path = formatter.extractPathFromImport(code.slice(at));
         if (path) {
             paths.push(path);

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -36,22 +36,23 @@ export interface ScannedImport {
      *
      * Every writer reconstructs a span from `path` and `trailingComment`, which
      * is faithful only while the statement is the whole of what its lines say.
-     * A `using:` opening an indented pair after a `;` breaks that: the span
-     * holds the statement before the `;` as well, and a rebuild from either
+     * A `;` breaks that, because it separates statements exactly as a newline
+     * does: the span holds another statement as well, and a rebuild from either
      * path alone deletes the other. Such a statement is still a real import and
      * still counts as present - only rewriting is off limits, exactly as for
      * anchorsCommentBelow, and rewritableImports filters on both.
      *
-     * `false` is "no loss known", not "provably none". Two shapes carry the
-     * same hazard undetected:
+     * `false` is "no loss known", not "provably none". One shape carries the
+     * same hazard undetected: `using. /X; using:`, where the dotted statement
+     * has no closing delimiter and swallows the rest of the line into its path,
+     * so the pair is pinned under a path that is not `/X` and `/X` itself goes
+     * unreported - the same weakness usingPathsOnLine documents.
      *
-     * - a line writing two complete statements, `using { /X }; using { /Y }`,
-     *   which reads as its first path alone and drops the second silently
-     *   (#223)
-     * - `using. /X; using:`, where the dotted statement has no closing
-     *   delimiter and swallows the rest of the line into its path, so the pair
-     *   is pinned under a path that is not `/X` and `/X` itself goes
-     *   unreported - the same weakness usingPathsOnLine documents
+     * `true` is likewise not a promise that every path on the span was
+     * recorded. A line ending in a `using:` pair reports the statement at its
+     * head and the path below, and no statement in between (#233). The line is
+     * pinned either way, so nothing is deleted; the cost is a path that does not
+     * count as present, which lets a writer add a second copy of it.
      */
     rebuildLosesText: boolean;
     /**
@@ -444,6 +445,45 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 trailingComment: ImportFormatter.extractTrailingComment(nextLine),
             });
             i += 2;
+            continue;
+        }
+
+        // Two complete statements sharing a line, `using { /X }; using { /Y }`.
+        // extractPathFromImport below reads the statement at the head of what it
+        // is given and says nothing about the remainder, so the line used to be
+        // recorded as its first path alone, spanning one line and rewritable -
+        // and organizing then rebuilt it from that path, deleting the second
+        // statement with no trace left that anything had gone.
+        //
+        // Every path the line writes is recorded, because each is imported and
+        // none may be written again, and all are pinned, because a rebuild from
+        // any one of them deletes the others. Their spans coincide, which no
+        // writer sees: all of them read rewritableImports, which excludes a
+        // pinned entry.
+        //
+        // Asked of the line's code rather than its raw text, as the branch above
+        // is. `using { /A } <# note about using { /B }` writes one statement and
+        // mentions another in a comment; searching the raw text finds two, and
+        // pins - and misreports - a line that is a plain single statement.
+        //
+        // usingPathsOnLine is what allUsingPaths asks, so reader and writer now
+        // agree on how many statements a line writes. Asking it a second way
+        // here would be the looser second copy its doc warns against.
+        const pathsOnLine = usingPathsOnLine(formatter, code);
+        if (pathsOnLine.length > 1) {
+            for (const linePath of pathsOnLine) {
+                imports.push({
+                    path: linePath,
+                    startLine: i,
+                    endLine: i,
+                    anchorsCommentBelow: anchorsCommentBelow(i, i),
+                    rebuildLosesText: true,
+                    // The same comment for each entry, since they share a line.
+                    // Nothing re-emits it - that is what being pinned means.
+                    trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                });
+            }
+            i += 1;
             continue;
         }
 

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -92,8 +92,16 @@ interface LineScan {
      * Tests/Roundtrip/Comments.versetest, and the one splicing case,
      * `"abc<#def#>ghi" = "abcghi"` in Tests/Literals/String.versetest, is
      * string contents rather than an identifier. Joining is the side to be
-     * wrong on: it can only report a `using` this reader would otherwise miss,
-     * and missing one is the error its caller cannot survive.
+     * wrong on: missing a `using` is the error its caller cannot survive.
+     *
+     * That is no longer unconditional. usingPathsOnLine requires a `using` to
+     * begin a token, so joining a statement onto the token before it hides it.
+     * Every legal separator survives - a `;`, a space, a `)`, a `}`, a line
+     * start - because none of them is an identifier character. Only
+     * `X := 1<# note #>using { /A }` does not, and two statements with nothing
+     * between them do not compile anyway. Putting a space where a comment was
+     * would repair that shape and break the reason this field exists, so it is
+     * the wrong repair; see the cost usingPathsOnLine documents.
      */
     code: string;
     /**

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -164,6 +164,26 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
     });
 
+    // A line writing two complete statements read as its first path alone, so
+    // organizing rebuilt it as `using { /X }` and Economy.Shop was simply gone.
+    // The output was a well-formed import block, which is what made the loss
+    // silent - nothing was left stranded to signal it (#223).
+    it("leaves a line carrying two statements alone", () => {
+        const input = ["using { /X }; using { Economy.Shop }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    it("organizes the other imports around a line carrying two statements", () => {
+        const input = ["using { /X }; using { Economy.Shop }", "using { /B }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using { /X }; using { Economy.Shop }", "", "code()"].join("\n"));
+    });
+
+    it("does not write a second copy of a path such a line already provides", () => {
+        const input = ["using { /X }; using { Economy.Shop }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/X"], curlySorted)).toBeNull();
+        expect(editor.buildOrganizedContent(input, ["Economy.Shop"], curlySorted)).toBeNull();
+    });
+
     // The anchored line ends up below the rebuilt block, so dropping the copy
     // above it can leave a `using` without the import that brings its first
     // segment into scope - the ordering #91 and #129 fixed. Only an absolute

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -184,6 +184,16 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Economy.Shop"], curlySorted)).toBeNull();
     });
 
+    // A module whose name merely ends in those five letters writes one
+    // statement, and organizing has to keep treating it as one. Counted by
+    // every occurrence of `using`, this line reads as two, and the file stops
+    // being organized at all - the import is left where it sits, splitting the
+    // block in two.
+    it("organizes an import whose path holds the word using", () => {
+        const input = ["using { /Verse.org/Simulation }", "using { Housing.Data }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /Verse.org/Simulation }", "using { Housing.Data }", "", "code()"].join("\n"));
+    });
+
     // The anchored line ends up below the rebuilt block, so dropping the copy
     // above it can leave a `using` without the import that brings its first
     // segment into scope - the ordering #91 and #129 fixed. Only an absolute

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -113,6 +113,14 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using { /X } # see using { Economy.Shop }", "code()"])).toEqual(["/X"]);
     });
 
+    // Only a `using` beginning a token is a statement. `Housing` holds those
+    // five letters, and the dotted pattern needs no space after its `.`, so
+    // offering every occurrence invented `Data }` as a second path.
+    it("invents no second path from an identifier that merely contains using", () => {
+        expect(allUsingPaths(["using { Housing.Data }", "code()"])).toEqual(["Housing.Data"]);
+        expect(allUsingPaths(["using { A_using.B }", "code()"])).toEqual(["A_using.B"]);
+    });
+
     it("strips a trailing comment from the path", () => {
         expect(allUsingPaths(["using { /A } # why", "code()"])).toEqual(["/A"]);
     });
@@ -253,6 +261,23 @@ describe("scanModuleImports", () => {
     it("leaves a single statement rewritable when its comment mentions another using", () => {
         expect(rewritableImports(scanModuleImports(["using { /A } # see using { /B }", "code()"]))).toEqual([
             { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# see using { /B }" },
+        ]);
+    });
+
+    // `using` is a substring of ordinary identifiers, and the dotted pattern
+    // needs no space after its `.`, so offering every occurrence reads
+    // `Housing.Data` as `Housing.Data` and then `Data }` - two statements, on a
+    // line that writes one. Pinning on that count stops the file being organized
+    // at all, for a module whose name merely ends in those five letters.
+    it("leaves a single statement rewritable when its path holds the word using", () => {
+        expect(rewritableImports(scanModuleImports(["using { Housing.Data }", "code()"]))).toEqual([
+            { path: "Housing.Data", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+        expect(rewritableImports(scanModuleImports(["using { /Verse.org/Housing.Sim }", "code()"]))).toEqual([
+            { path: "/Verse.org/Housing.Sim", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+        expect(rewritableImports(scanModuleImports(["using { A_using.B }", "code()"]))).toEqual([
+            { path: "A_using.B", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -228,6 +228,46 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["X := 1; using:", "    Economy.Shop", "code()"])).toEqual([]);
     });
 
+    // extractPathFromImport reads the statement at the head of what it is given
+    // and reports nothing about the rest, so the line used to be recorded as
+    // `/X` alone, spanning one line and rewritable. Organizing rebuilt it from
+    // that path and Economy.Shop was gone - a well-formed import block importing
+    // one path fewer than the file had, with nothing left behind to say so.
+    it("records both statements a line carrying two writes, pinning both", () => {
+        expect(scanModuleImports(["using { /X }; using { Economy.Shop }", "", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // Both count as imported, so nothing writes either one again, and neither
+    // may be moved, because a rebuild from one path deletes the other. The two
+    // entries share a span; only a reader of the unfiltered scan ever sees that.
+    it("offers no rewritable import for a line carrying two statements", () => {
+        expect(rewritableImports(scanModuleImports(["using { /X }; using { Economy.Shop }", "", "code()"]))).toEqual([]);
+    });
+
+    // The count is taken from the line's code. Searching the raw text finds the
+    // `using` in this trailing comment as well, and pinning on that would refuse
+    // to organize an ordinary single-statement line for the words after its `#`.
+    it("leaves a single statement rewritable when its comment mentions another using", () => {
+        expect(rewritableImports(scanModuleImports(["using { /A } # see using { /B }", "code()"]))).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# see using { /B }" },
+        ]);
+    });
+
+    // A dotted statement has no closing delimiter, so one sharing a line
+    // swallows what follows it into its path. Both are recorded, the malformed
+    // one included - what makes the line safe is that a second statement was
+    // found on it at all, which is what pins the line. Rewritable, it was
+    // rebuilt from the swallowed path into `using { /X; using { Economy.Shop } }`.
+    it("pins a line whose dotted statement swallows the one written after it", () => {
+        expect(scanModuleImports(["using. /X; using { Economy.Shop }", "code()"])).toEqual([
+            { path: "/X; using { Economy.Shop }", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
     it("keeps a trailing comment out of the path but on the entry, in all three styles", () => {
         // Out of `path`, which is re-emitted inside the braces and would be
         // corrupted by it, and onto `trailingComment`, which is what a writer


### PR DESCRIPTION
Closes #223

A line writing two complete `using` statements was recorded as its first path alone. `extractPathFromImport` reads the statement at the head of what it is given and reports nothing about the remainder, so the entry spanned one line and was rewritable - and organizing rebuilt the line from that path, deleting the second statement. Unlike #219 nothing was left stranded to signal it: the output was a well-formed import block importing one path fewer.

```
in : using { /X }; using { /Y }        out: using { /X }

     code()                                 code()
```

## The fix

Ask `usingPathsOnLine` how many statements the line writes. More than one records them all, every one pinned with `rebuildLosesText: true`, so the line stays exactly as written and the file organizes around it. `allUsingPaths` has counted this way since #215; the writer now agrees with the reader.

Pinning rather than splitting was settled before implementing, matching #231's fix for the sibling shape. Splitting would reformat a line the author chose to keep on one line, and would force a decision about which statement inherits the line's leading and trailing comments.

No writer is touched. `rewritableImports` already filters on `rebuildLosesText`, so `buildOrganizedContent`, `scanConvertibleImports` and `computeEmptyLinesAfterImportsEdits` all inherit the fix.

## Found by the review gate

`usingPathsOnLine` searched for the bare substring `using`, and ordinary identifiers contain it - `Housing` holds it at index 2. Since the dotted pattern needs no space after its `.`, `using { Housing.Data }` reported `Housing.Data` and then `Data }`, a path the line does not write. `allUsingPaths` survived that because it reads an over-report as a reason to decline to tidy; counting statements does not, so an ordinary import would have been pinned and the file would have stopped being organized.

It now offers only a `using` not preceded by an identifier character - the same identifier class `ImportFormatter.isModuleImport` already tests bare content against. Every legal separator survives: `;`, whitespace, `)`, `}`, `,`, `:`, a line start, indentation. The one shape that no longer reports is `X := 1<# note #>using { /A }`, two statements with nothing between them, which does not compile.

## Not fixed here

Two shapes in the same family, both verified and filed rather than folded into this diff:

- #235 - `using { /X }; MyVal := 5` organizes to `using { /X }`, deleting the definition. Detection in this family keys on finding a second `using`, and a `;` followed by anything else matches neither this fix nor #231's. Real data loss, pre-existing.
- #233 - a line of three or more statements ending in a `using:` pair under-reports the statements in between. The line is pinned either way, so nothing is deleted; the cost is a path that does not count as present.

`ScannedImport.rebuildLosesText`'s doc now names both.

## Tests

Seven new jest tests, no VS Code runtime. Each was proven to detect its defect by removing the fix and watching it fail:

- with the scanner change stashed, the six #223 tests fail - `records both statements a line carrying two writes, pinning both`, `offers no rewritable import for a line carrying two statements`, `pins a line whose dotted statement swallows the one written after it`, `leaves a line carrying two statements alone`, `organizes the other imports around a line carrying two statements`, `does not write a second copy of a path such a line already provides`
- with only the boundary check deleted, the three guard tests fail - `invents no second path from an identifier that merely contains using`, `leaves a single statement rewritable when its path holds the word using`, `organizes an import whose path holds the word using`

## Verification

`npm run compile`

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       546 passed, 546 total
Snapshots:   0 total
Time:        8.106 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

Two rounds, fresh context each time. Round 1 FAIL on the `Housing` regression above (1 Critical, 2 Important, 3 Suggestions). Round 2 PASS_WITH_SUGGESTIONS (0 Critical, 1 Important, 2 Suggestions), all three addressed or recorded: the `LineScan.code` doc that argued joining can never lose a `using` now records what the token boundary costs it, the changelog component is spelled as the command is registered, and the third is #231's pre-existing placement blindness, left as a follow-up.
