### PR TITLE
refactor(imports): derive the lens range from the real line length

### DIFF
--- a/src/imports/ImportCodeLensProvider.ts
+++ b/src/imports/ImportCodeLensProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
 import { ImportPathConverter } from "./ImportPathConverter";
-import { scanConvertibleImports } from "./ImportScanner";
+import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
 /**
  * Tracks hover state for a document's imports. An entry can exist purely to
@@ -161,7 +161,7 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         const text = document.getText();
-        const lines = text.split("\n");
+        const lines = text.split(LINE_SPLIT);
 
         // Membership is the shared scanner's call, not this provider's: a lens
         // must appear on exactly the lines a conversion would act on, which

--- a/src/imports/__tests__/ImportCodeLensProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeLensProvider.test.ts
@@ -83,6 +83,21 @@ describe("ImportCodeLensProvider.provideCodeLenses", () => {
             "$(arrow-swap)  Use absolute paths for all",
         ]);
     });
+
+    it("ends the lens range at the true end of a CRLF line", async () => {
+        // The end column comes from the split line's length, so splitting on
+        // "\n" puts it one past the end of the line on every CRLF document.
+        // Real VS Code clamps that overshoot, which is exactly why nothing here
+        // can be left resting on it.
+        const importLine = "using { Gadgets.Tools }";
+        const provider = new ImportCodeLensProvider(vscode.window.createOutputChannel("test"));
+
+        const lenses = await provider.provideCodeLenses(documentWith([importLine, "", "code()"].join("\r\n")), {} as vscode.CancellationToken);
+
+        expect(lenses).toHaveLength(1);
+        expect(lenses[0].range.start).toEqual({ line: 0, character: 0 });
+        expect(lenses[0].range.end).toEqual({ line: 0, character: importLine.length });
+    });
 });
 
 // Regression for #142: the provider discarded both listener Disposables and had


### PR DESCRIPTION
Closes #238.

`ImportCodeLensProvider` was the last place in `src/imports/` that split a document on a bare `"\n"`. On a CRLF file every line kept its carriage return, so the lens range's end column at `:178` landed one past the true end of the line. VS Code clamps an out-of-range column when it resolves a lens, so the lens rendered where it should — the range was right only because the host salvaged it.

Split on the exported `LINE_SPLIT` from `ImportScanner.ts` instead, which #234 put there for exactly this and which `ImportPathConverter` and `ImportDocumentEditor` already use.

## Scope

- In: the split at `:164`, and the range end at `:178` that reads from it.
- Out: lens placement and membership, which remain the shared scanner's call. `scanConvertibleImports` trims, so the lines it classifies are unchanged either way.

No changelog fragment: this is not user-visible. #234, the identical change one file over, shipped none either.

## Verification

The new regression test was proven to detect the defect — with the production change stashed it reports `character: 24` against an expected 23, the exact one-past-the-end overshoot.

`npm run compile`:

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       560 passed, 560 total
Snapshots:   0 total
Time:        6.574 s, estimated 9 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

`PASS_WITH_SUGGESTIONS` — 0 Critical, 0 Important, 2 Suggestions, reviewed on opus in a fresh context.

- Applied: assert `lenses` has length 1 before indexing it, so a regression to "no lens offered" fails on the range rather than on a `TypeError`.
- Not applied: extracting a shared `lensesFor(text)` helper out of the existing `lensTitlesFor`. It would edit a helper this ticket does not touch, which is adjacent tidying rather than scope.
