### PR TITLE
feat(config): let emptyLinesAfterImports preserve existing spacing

### DIFF
--- a/changelog.d/144.fixed.md
+++ b/changelog.d/144.fixed.md
@@ -1,1 +1,1 @@
-**Saving no longer re-dirties the file**: the import spacing pass now runs as part of the save rather than editing the file once the save has finished, so the tab no longer shows unsaved changes the moment you press Ctrl+S. A hand-edited negative `behavior.emptyLinesAfterImports` is ignored instead of removing a line of code.
+**Saving no longer re-dirties the file**: the import spacing pass now runs as part of the save rather than editing the file once the save has finished, so the tab no longer shows unsaved changes the moment you press Ctrl+S.

--- a/changelog.d/151.added.md
+++ b/changelog.d/151.added.md
@@ -1,0 +1,1 @@
+**Empty lines after imports**: setting `behavior.emptyLinesAfterImports` to -1 now leaves the spacing after your import block exactly as you wrote it, instead of normalizing it on every save, add and organize.

--- a/package.json
+++ b/package.json
@@ -212,9 +212,9 @@
         "verseAutoImports.behavior.emptyLinesAfterImports": {
           "type": "number",
           "default": 1,
-          "minimum": 0,
+          "minimum": -1,
           "maximum": 5,
-          "description": "Number of empty lines to add after the imports section at the top of the file",
+          "description": "Number of empty lines to keep after the imports section at the top of the file. Set to -1 to leave the existing spacing untouched.",
           "order": 14
         },
         "verseAutoImports.behavior.ambiguousImports": {

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1047,11 +1047,11 @@ export class ImportDocumentEditor {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const emptyLinesAfterImports = config.get<number>("behavior.emptyLinesAfterImports", 1);
 
-        // package.json declares a minimum of 0, but a hand-edited settings.json
-        // does not have to honour it, and a negative value reaches the delete
-        // branch below, where it would take real code rather than blank lines.
+        // A negative value means "leave the file's own spacing alone";
+        // package.json declares -1 for it. Without this return the negative
+        // difference below deletes real code.
         if (emptyLinesAfterImports < 0) {
-            logger.debug("ImportDocumentEditor", `Ignoring a negative emptyLinesAfterImports (${emptyLinesAfterImports})`);
+            logger.debug("ImportDocumentEditor", `Preserving the existing spacing (emptyLinesAfterImports is ${emptyLinesAfterImports})`);
             return [];
         }
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import { detectEol, ImportDocumentEditor } from "../ImportDocumentEditor";
 import { ImportFormatter } from "../ImportFormatter";
 import * as vscode from "vscode";
@@ -1467,13 +1469,31 @@ describe("ImportDocumentEditor.computeEmptyLinesAfterImportsEdits", () => {
         expect(edits[0].newText).toBe("\r\n");
     });
 
-    // package.json declares minimum 0, but settings.json can be hand-edited
-    // past it. Unguarded, the negative difference reaches the delete branch and
-    // takes the first line of real code with it.
+    // -1 is the opt-out: the file keeps whatever spacing it has. Both
+    // directions matter - it must not take the blank lines the author wrote,
+    // and it must not take the line of code below an import block with none.
     it("deletes nothing when the setting is negative", () => {
         mockEmptyLines(-1);
 
         expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(["using { /Top }", "code()"].join("\n")))).toEqual([]);
+    });
+
+    it("keeps the blank lines the file already has when the setting is negative", () => {
+        mockEmptyLines(-1);
+
+        const input = ["using { /Top }", "", "", "", "code()"].join("\n");
+
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(input))).toEqual([]);
+    });
+
+    it("honours -1 only because package.json admits it, so the settings UI can offer it", () => {
+        const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json"), "utf8"));
+        const setting = manifest.contributes.configuration.properties["verseAutoImports.behavior.emptyLinesAfterImports"];
+
+        // Declared below the minimum, the opt-out is unreachable however well
+        // the code above honours it: the settings UI refuses to store it.
+        expect(setting.minimum).toBeLessThanOrEqual(-1);
+        expect(setting.description).toContain("-1");
     });
 
     it("never edits the document itself", () => {


### PR DESCRIPTION
Closes #151

`behavior.emptyLinesAfterImports` declared `"minimum": 0`, so no value expressed "leave the spacing after my import block alone" — and `0`, the value the reporter reached for, deletes the blank lines the author wrote. This declares `-1` as the minimum and documents the sentinel.

## The ticket was half-landed already

#151 was filed before #144 merged, and #144 already added the negative-value early return that the ticket's second and third bullets ask for. So the runtime half exists on `main` today: a hand-edited `-1` in `settings.json` already preserves spacing on the save, add and organize paths, since all three reach `computeEmptyLinesAfterImportsEdits`. What was missing is that the settings UI refuses to store a value below the declared minimum, so the opt-out was unreachable and undocumented.

This PR is therefore only the schema, the comment that described the guard and is now wrong, and tests. It deliberately does not touch `src/extension.ts`, and does not change the guard's logic.

Two line references in the ticket body are stale and were not acted on: the save handler is now an `onWillSaveTextDocument` participant at `src/extension.ts:223-234`, and the dead `>= 0` guard the ticket asks to revive no longer exists in `extension.ts` at all.

## Changes

- `package.json` — `"minimum": -1`, description documents the sentinel. `default: 1` and `maximum: 5` are unchanged, so existing installs see no behaviour change.
- `src/imports/ImportDocumentEditor.ts` — comment and debug message only. The old comment explained the guard as defence against a settings file edited past the declared minimum; that reading is wrong once `-1` is supported.
- `src/imports/__tests__/ImportDocumentEditor.test.ts` — a test that existing blank lines survive at `-1` (the case the ticket is actually about; the existing negative test only covered the zero-blank-lines input), and one asserting the manifest admits `-1`, following the repo's existing idiom of reading `contributes.configuration.properties`.
- `changelog.d/151.added.md` — new fragment.
- `changelog.d/144.fixed.md` — dropped one sentence. It framed a negative value as unsupported input that gets ignored, which contradicts this PR's "set it to -1 to keep your spacing" in the same unreleased section. Both fragments assemble into one release body. Revert that hunk if you would rather keep it.

## On the regression tests

Being straight about what these demonstrate: only the manifest test fails without this diff. Taking the fix away proves it:

```
git stash push -- package.json
npx jest src/imports/__tests__/ImportDocumentEditor.test.ts -t "package.json admits"

    Expected: <= -1
    Received:    0

    > 1495 |         expect(setting.minimum).toBeLessThanOrEqual(-1);

Test Suites: 1 failed, 1 total
Tests:       1 failed, 138 skipped, 139 total
```

The two behavioural tests pass against unfixed code, because #144 already shipped that behaviour. They pin it rather than prove a fix.

## Verification

`npm run compile`

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       561 passed, 561 total
Snapshots:   0 total
Time:        7.801 s, estimated 9 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Review gate: PASS_WITH_SUGGESTIONS, 0 critical, 1 important, 4 suggestions. The comment trim, the test name, and the `144.fixed.md` sentence are the suggestions applied.

## Follow-up, not in this PR

The wiki still documents this setting's range as `0-5` (`Configuration.md:39`, which `README.md:70` points at as the settings reference), so the opt-out stays undiscoverable for exactly the reported use case until that page is updated. It lives in the separate `.wiki` repo, so it cannot land here.

Left alone deliberately: `CHANGELOG.md:136` also says `0-5 lines`, but that is a released historical entry.
