### PR TITLE
fix(imports): pin a line that writes a definition after its import

### DIFF
--- a/changelog.d/235.fixed.md
+++ b/changelog.d/235.fixed.md
@@ -1,0 +1,1 @@
+**Organize imports**: A line that writes a definition after an import, such as `using { /X }; MyVal := 5`, is now left as written instead of losing the definition.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -170,8 +170,8 @@ export class ImportFormatter {
      * because the comment is only stripped afterwards, from that capture.
      *
      * One home for the two patterns, so a caller asking where the statement
-     * ends cannot answer it from a looser second copy that disagrees with the
-     * path about which statement was read.
+     * ends cannot answer it from a looser second copy that, on the same input,
+     * disagrees about which statement was read.
      *
      * @returns The path and the offset just past the statement **in the
      *   trimmed input**, or null when there is no statement (including one
@@ -214,11 +214,13 @@ export class ImportFormatter {
      * the statement is the whole of it.
      *
      * A writer rebuilds an import line from its path, so whatever this reports
-     * is text that rebuild would delete. That makes it the question to ask
-     * about a line carrying a `;`: the separator itself is never searched for,
-     * so a `;` inside the braces or in a path is part of the statement and
-     * reported as nothing, and no string-literal tracking is needed to tell a
-     * separator from a character in a literal.
+     * is text that rebuild would lose. Asking it this way rather than searching
+     * the line for the `;` that separates two statements is what keeps a
+     * separator apart from a `;` that is only a character - one inside the
+     * braces, or in a path, is part of the statement and leaves nothing over,
+     * and one inside a string literal cannot arise without leftover text around
+     * it. So no depth or string tracking is needed, which nothing in this file
+     * does.
      *
      * Only the braced style can answer usefully. The dotted style has no
      * closing delimiter and its capture is greedy to end of line, so a
@@ -226,12 +228,11 @@ export class ImportFormatter {
      * nothing is left over to report - the weakness usingPathsOnLine documents,
      * not one this repairs.
      *
-     * @param importStatement A line of Verse **with its comments already
-     *   removed**. A trailing comment left on it reads as code written after
-     *   the statement, which is exactly the wrong answer.
+     * @param lineCode A line of Verse with its comments already removed. A
+     *   trailing comment left on it reads as code written after the statement.
      */
-    textAfterImport(importStatement: string): string {
-        const trimmed = importStatement.trim();
+    textAfterImport(lineCode: string): string {
+        const trimmed = lineCode.trim();
         const match = ImportFormatter.matchImport(trimmed);
         return match ? trimmed.slice(match.end).trim() : "";
     }

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -160,10 +160,8 @@ export class ImportFormatter {
     }
 
     /**
-     * Extracts the module path from an import statement.
-     * Handles both curly syntax (using { /path }) and dot syntax (using. /path).
-     * A trailing comment is stripped, so the returned path never carries trivia
-     * that would corrupt the statement when it is re-emitted.
+     * The `using` statement written at the head of a string: its path, and how
+     * much of the string it occupies.
      *
      * Anchored on the trimmed statement, and dotted before braced, following
      * isModuleImport. Unanchored, the braced pattern is free to match
@@ -171,24 +169,71 @@ export class ImportFormatter {
      * `using. Economy.Shop # was using { Inventory }` read as `Inventory`,
      * because the comment is only stripped afterwards, from that capture.
      *
+     * One home for the two patterns, so a caller asking where the statement
+     * ends cannot answer it from a looser second copy that disagrees with the
+     * path about which statement was read.
+     *
+     * @returns The path and the offset just past the statement **in the
+     *   trimmed input**, or null when there is no statement (including one
+     *   whose content is nothing but a comment)
+     */
+    private static matchImport(importStatement: string): { path: string; end: number } | null {
+        const trimmed = importStatement.trim();
+
+        const dotMatch = trimmed.match(/^using\.\s*(.+)/);
+        if (dotMatch) {
+            const path = ImportFormatter.stripTrailingComment(dotMatch[1]);
+            return path ? { path, end: dotMatch[0].length } : null;
+        }
+
+        const curlyMatch = trimmed.match(/^using\s*\{\s*([^}]+)\s*\}/);
+        if (curlyMatch) {
+            const path = ImportFormatter.stripTrailingComment(curlyMatch[1]);
+            return path ? { path, end: curlyMatch[0].length } : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts the module path from an import statement.
+     * Handles both curly syntax (using { /path }) and dot syntax (using. /path).
+     * A trailing comment is stripped, so the returned path never carries trivia
+     * that would corrupt the statement when it is re-emitted.
+     *
      * @param importStatement The full import statement
      * @returns The extracted path, or null if there is none (including a
      *   statement whose content is nothing but a comment)
      */
     extractPathFromImport(importStatement: string): string | null {
+        return ImportFormatter.matchImport(importStatement)?.path ?? null;
+    }
+
+    /**
+     * The code written after the statement at the head of a line, or "" when
+     * the statement is the whole of it.
+     *
+     * A writer rebuilds an import line from its path, so whatever this reports
+     * is text that rebuild would delete. That makes it the question to ask
+     * about a line carrying a `;`: the separator itself is never searched for,
+     * so a `;` inside the braces or in a path is part of the statement and
+     * reported as nothing, and no string-literal tracking is needed to tell a
+     * separator from a character in a literal.
+     *
+     * Only the braced style can answer usefully. The dotted style has no
+     * closing delimiter and its capture is greedy to end of line, so a
+     * statement sharing a line swallows what follows it into its path and
+     * nothing is left over to report - the weakness usingPathsOnLine documents,
+     * not one this repairs.
+     *
+     * @param importStatement A line of Verse **with its comments already
+     *   removed**. A trailing comment left on it reads as code written after
+     *   the statement, which is exactly the wrong answer.
+     */
+    textAfterImport(importStatement: string): string {
         const trimmed = importStatement.trim();
-
-        const dotMatch = trimmed.match(/^using\.\s*(.+)/);
-        if (dotMatch) {
-            return ImportFormatter.stripTrailingComment(dotMatch[1]) || null;
-        }
-
-        const curlyMatch = trimmed.match(/^using\s*\{\s*([^}]+)\s*\}/);
-        if (curlyMatch) {
-            return ImportFormatter.stripTrailingComment(curlyMatch[1]) || null;
-        }
-
-        return null;
+        const match = ImportFormatter.matchImport(trimmed);
+        return match ? trimmed.slice(match.end).trim() : "";
     }
 
     /**

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -51,17 +51,19 @@ export interface ScannedImport {
      * still counts as present - only rewriting is off limits, exactly as for
      * anchorsCommentBelow, and rewritableImports filters on both.
      *
-     * `false` is "no loss known", not "provably none". Detection looks for a
-     * second `using` on the line, so two shapes carry the same hazard
-     * undetected:
+     * Detection asks two questions of the line: how many `using` statements it
+     * writes, and - where it writes one - whether any code is left over after
+     * it. What the leftover says does not matter, so a `;` followed by
+     * something that is not a `using` at all is caught by the second question
+     * rather than the first.
      *
-     * - a `;` followed by anything that is not a `using` at all,
-     *   `using { /X }; MyVal := 5`, where the rebuild deletes the definition
-     *   (#235)
-     * - `using. /X; using:`, where the dotted statement has no closing
-     *   delimiter and swallows the rest of the line into its path, so the pair
-     *   is pinned under a path that is not `/X` and `/X` itself goes
-     *   unreported - the same weakness usingPathsOnLine documents
+     * `false` is still "no loss known", not "provably none". One shape carries
+     * the hazard undetected: `using. /X; using:`, where the dotted statement
+     * has no closing delimiter and swallows the rest of the line into its path,
+     * so the pair is pinned under a path that is not `/X` and `/X` itself goes
+     * unreported - the same weakness usingPathsOnLine documents. Nothing is
+     * left over after a dotted statement, so the second question cannot see it
+     * either.
      *
      * `true` is likewise not a promise that every path on the span was
      * recorded. A line ending in a `using:` pair reports the statement at its
@@ -509,6 +511,26 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             continue;
         }
 
+        // One statement, and the line is rewritable only if that statement is
+        // the whole of what it says. A `;` can be followed by something that is
+        // not a `using` at all, which neither branch above sees - the count of
+        // `using` statements is one - and rebuilding the line from its path
+        // then deletes the definition after it.
+        //
+        // Asked as "what is left over", never as "where is the `;`". The
+        // separator is not searched for, so a `;` inside the braces or in a
+        // path is part of the statement rather than a second one, and telling a
+        // separator from a `;` in a string literal never arises. What is left
+        // over is what a rebuild deletes, whatever put it there.
+        //
+        // Asked of the line's code, as the two branches above are. A trailing
+        // comment is left over on the raw text, and pinning on that would
+        // refuse to organize every annotated import in the file.
+        //
+        // A line ending in a bare `;` is pinned too, on text that means
+        // nothing. That is the safe direction: the cost is a line left as
+        // written, and the alternative trims the separator away before the test
+        // and has to be right about which separators mean nothing.
         const path = formatter.extractPathFromImport(trimmed);
         if (path) {
             imports.push({
@@ -516,7 +538,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 startLine: i,
                 endLine: i,
                 anchorsCommentBelow: anchorsCommentBelow(i, i),
-                rebuildLosesText: false,
+                rebuildLosesText: formatter.textAfterImport(code) !== "",
                 trailingComment: ImportFormatter.extractTrailingComment(trimmed),
             });
         }

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -53,17 +53,19 @@ export interface ScannedImport {
      *
      * Detection asks two questions of the line: how many `using` statements it
      * writes, and - where it writes one - whether any code is left over after
-     * it. What the leftover says does not matter, so a `;` followed by
-     * something that is not a `using` at all is caught by the second question
-     * rather than the first.
+     * it. What the leftover says does not matter, so a statement written after
+     * a `;` is caught by the second question when it is not a `using` and the
+     * first cannot count it.
      *
-     * `false` is still "no loss known", not "provably none". One shape carries
-     * the hazard undetected: `using. /X; using:`, where the dotted statement
-     * has no closing delimiter and swallows the rest of the line into its path,
-     * so the pair is pinned under a path that is not `/X` and `/X` itself goes
-     * unreported - the same weakness usingPathsOnLine documents. Nothing is
-     * left over after a dotted statement, so the second question cannot see it
-     * either.
+     * `false` is still "no loss known", not "provably none". Both questions are
+     * blind to the same shape, a dotted statement sharing its line: it has no
+     * closing delimiter, so it swallows the rest of the line into its path -
+     * leaving nothing over for the second question, and no second `using` for
+     * the first to find in `using. /X; MyVal := 5`. The path is then the whole
+     * of the line and rebuilding from it corrupts rather than deletes, which is
+     * the weakness usingPathsOnLine documents. Where the tail is a `using`, the
+     * line is pinned but under that swallowed path, so the path it really
+     * imports goes unreported and a writer may add a second copy of it.
      *
      * `true` is likewise not a promise that every path on the span was
      * recorded. A line ending in a `using:` pair reports the statement at its
@@ -512,25 +514,18 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         }
 
         // One statement, and the line is rewritable only if that statement is
-        // the whole of what it says. A `;` can be followed by something that is
-        // not a `using` at all, which neither branch above sees - the count of
-        // `using` statements is one - and rebuilding the line from its path
-        // then deletes the definition after it.
+        // the whole of what it says. What follows a `;` need not be a `using`,
+        // and neither branch above counts it - so the leftover is what says the
+        // definition after it would be deleted. See textAfterImport for why the
+        // question is "what is left over" rather than "where is the `;`".
         //
-        // Asked as "what is left over", never as "where is the `;`". The
-        // separator is not searched for, so a `;` inside the braces or in a
-        // path is part of the statement rather than a second one, and telling a
-        // separator from a `;` in a string literal never arises. What is left
-        // over is what a rebuild deletes, whatever put it there.
-        //
-        // Asked of the line's code, as the two branches above are. A trailing
-        // comment is left over on the raw text, and pinning on that would
-        // refuse to organize every annotated import in the file.
+        // Asked of the line's code, as the two branches above are: a trailing
+        // comment is leftover text on the raw line, and pinning on that refuses
+        // to organize every annotated import in the file.
         //
         // A line ending in a bare `;` is pinned too, on text that means
-        // nothing. That is the safe direction: the cost is a line left as
-        // written, and the alternative trims the separator away before the test
-        // and has to be right about which separators mean nothing.
+        // nothing. The cost is one line left as written; trimming separators
+        // away first means being right about which ones mean nothing.
         const path = formatter.extractPathFromImport(trimmed);
         if (path) {
             imports.push({

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -184,6 +184,25 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Economy.Shop"], curlySorted)).toBeNull();
     });
 
+    // A `;` separates definitions exactly as a newline does, so what follows the
+    // import need not be an import. Counting `using` statements says one, and
+    // organizing rebuilt the line from `/X` alone - MyVal simply gone, with a
+    // well-formed import block left in its place.
+    it("leaves a line that writes a definition after its import alone", () => {
+        const input = ["using { /X }; MyVal := 5", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    it("organizes the other imports around a line that writes a definition after its import", () => {
+        const input = ["using { /X }; MyVal := 5", "using { /B }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using { /X }; MyVal := 5", "", "code()"].join("\n"));
+    });
+
+    it("does not write a second copy of a path such a line already provides, next to a definition", () => {
+        const input = ["using { /X }; MyVal := 5", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/X"], curlySorted)).toBeNull();
+    });
+
     // A module whose name merely ends in those five letters writes one
     // statement, and organizing has to keep treating it as one. Counted by
     // every occurrence of `using`, this line reads as two, and the file stops

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -138,6 +138,24 @@ describe("ImportFormatter trailing comments on import statements", () => {
         expect(formatter.extractPathFromImport("/mygame@fortnite.com/mygame/Housing.Shop")).toBeNull();
     });
 
+    it("reports the code written after a braced statement", () => {
+        expect(formatter.textAfterImport("using { /mygame@fortnite.com/mygame/Economy/Shop }; MyVal := 5")).toBe("; MyVal := 5");
+    });
+
+    it("reports nothing after a braced statement that is the whole line", () => {
+        expect(formatter.textAfterImport("using { /Verse.org/Simulation }")).toBe("");
+    });
+
+    // The dotted capture is greedy to end of line, so a statement sharing a line
+    // swallows what follows it into its path and nothing is left over to report.
+    it("reports nothing after a dotted statement, which has no closing delimiter", () => {
+        expect(formatter.textAfterImport("using. /Verse.org/Simulation; MyVal := 5")).toBe("");
+    });
+
+    it("reports nothing for a line that writes no statement", () => {
+        expect(formatter.textAfterImport("MyVal := 5")).toBe("");
+    });
+
     it("a trailing comment does not change module-import classification", () => {
         // Without stripping, the `.` in a comment such as `# see Foo.Bar` made a
         // bare local-scope using look like a dotted module import.

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -293,6 +293,44 @@ describe("scanModuleImports", () => {
         ]);
     });
 
+    // The line writes one `using`, so counting them says one and the line was
+    // recorded as rewritable. Organizing rebuilt it from `/X` and the definition
+    // was gone, under an import block well-formed enough to say nothing.
+    it("pins a line that writes a definition after its import", () => {
+        expect(scanModuleImports(["using { /X }; MyVal := 5", "", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("offers no rewritable import for a line that writes a definition after its import", () => {
+        expect(rewritableImports(scanModuleImports(["using { /X }; MyVal := 5", "", "code()"]))).toEqual([]);
+    });
+
+    // What is left over is read from the line's code. A trailing comment is left
+    // over on the raw text, and pinning on that refuses to organize every
+    // annotated import in the file.
+    it("leaves a single statement rewritable when a semicolon sits in its trailing comment", () => {
+        expect(rewritableImports(scanModuleImports(["using { /A } # note; and more", "code()"]))).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# note; and more" },
+        ]);
+    });
+
+    // The separator is never searched for, only the text after the statement,
+    // so a `;` the braces enclose is part of the path rather than a second
+    // statement - and no string-literal tracking is needed to tell the two apart.
+    it("leaves a single statement rewritable when a semicolon sits inside its braces", () => {
+        expect(rewritableImports(scanModuleImports(["using { /X;Y }", "code()"]))).toEqual([
+            { path: "/X;Y", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+    });
+
+    // Nothing follows the separator, so the rebuild would lose only the `;`
+    // itself. Pinned anyway: the cost is a line left as written, where trimming
+    // the separator away first means being right about which ones mean nothing.
+    it("pins a line whose import is followed by a bare separator", () => {
+        expect(rewritableImports(scanModuleImports(["using { /X };", "code()"]))).toEqual([]);
+    });
+
     it("keeps a trailing comment out of the path but on the entry, in all three styles", () => {
         // Out of `path`, which is re-emitted inside the braces and would be
         // corrupted by it, and onto `trailingComment`, which is what a writer

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -317,7 +317,9 @@ describe("scanModuleImports", () => {
 
     // The separator is never searched for, only the text after the statement,
     // so a `;` the braces enclose is part of the path rather than a second
-    // statement - and no string-literal tracking is needed to tell the two apart.
+    // statement. A `;` in a string literal is covered by the same property
+    // without a case of its own: it can only ever sit inside leftover text,
+    // never be what decides there is any.
     it("leaves a single statement rewritable when a semicolon sits inside its braces", () => {
         expect(rewritableImports(scanModuleImports(["using { /X;Y }", "code()"]))).toEqual([
             { path: "/X;Y", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },


### PR DESCRIPTION
Closes #235

A `;` separates definitions exactly as a newline does, so an import can share its line with a definition that is not an import. Organizing deleted it:

```
in : using { /X }; MyVal := 5      out: using { /X }
```

The output was a well-formed import block, so nothing signalled the loss.

## The approach: no `;` scanner

The ticket flags the hard part — detecting a `;` that really is a separator means finding one at depth 0 outside comments and string literals, and nothing in `src/` tracks string state or brace depth.

Asking a different question removes the problem: **did the statement account for the whole line?** The braced pattern has a closing delimiter, so live text after it is text a rebuild would lose, whatever the separator is. The `;` itself is never searched for, which is what makes the three acceptance shapes fall out rather than needing cases:

- a `;` in a comment — `classifyLines` already hands back a comment-free `code` string, and the check is asked of that, never the raw line;
- a `;` inside the braces — captured as the path, nothing left over, still rewritable;
- a `;` in a string literal — it can only ever sit inside leftover text, never be what decides there is any.

## Changes

- `ImportFormatter`: one private `matchImport` now owns the dotted-then-braced patterns and additionally reports where the statement ends; `extractPathFromImport` reads its path (behaviour unchanged), and the new `textAfterImport` reads the rest.
- `ImportScanner`: the single-statement branch sets `rebuildLosesText` from that leftover. Every writer already reads `rewritableImports`, so pinning is the whole fix.
- The `ScannedImport.rebuildLosesText` doc named this shape as a known miss; rewritten for what detection now covers and what it still does not.

## Deliberately out of scope

The dotted style, `using. /X; MyVal := 5`, is unchanged and still rewritable: its capture is greedy to end of line, so the statement swallows the tail into its path and nothing is left over to detect. It corrupts rather than deletes, it is the separately documented `usingPathsOnLine` weakness rather than the shape this ticket names, and the field doc now records it accurately. Worth its own issue.

A line ending in a bare `;` is now pinned, on text that means nothing. That is the safe direction — the cost is one line left as written — and trimming separators away before the test means being right about which ones mean nothing.

## Tests

Regression tests in `src/imports/__tests__/`, all without the VS Code runtime: the ticket's shape pinned and not rewritable at the scanner, left as written at the organize level with the other imports organizing around it, `textAfterImport` covered directly, plus negative controls for a `;` in a trailing comment and a `;` inside the braces.

Proven to have power — with `ImportScanner.ts` and `ImportFormatter.ts` stashed, 6 of the new cases fail and the `textAfterImport` suite does not compile. The two negative controls pass either way, which is what makes them controls.

Reviewed by a fresh reviewer: PASS_WITH_SUGGESTIONS, 0 Critical, 0 Important, 5 Suggestions. Four were applied (the doc inaccuracy above, comment trimming, a parameter renamed to carry its precondition, one over-broad claim tightened); the fifth records the bare-`;` narrowing as accepted.

## Verification

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./

=== TEST ===

Test Suites: 28 passed, 28 total
Tests:       571 passed, 571 total
Snapshots:   0 total
Time:        9.146 s
Ran all test suites.
=== FORMAT ===

Checking formatting...
All matched files use Prettier code style!
```
