### PR TITLE
fix(config): treat emptyLinesAfterImports as a whole number of lines

### DIFF
--- a/changelog.d/242.fixed.md
+++ b/changelog.d/242.fixed.md
@@ -1,1 +1,1 @@
-**Import spacing**: a fractional `behavior.emptyLinesAfterImports` such as 1.5 no longer makes every save apply an edit that changes nothing; the setting now takes whole numbers only and rounds anything else.
+**Import spacing**: `behavior.emptyLinesAfterImports` now takes whole numbers only, so a fractional value no longer stops the spacing after your imports settling on the count you configured. A value already saved rounds to the nearest whole number.

--- a/changelog.d/242.fixed.md
+++ b/changelog.d/242.fixed.md
@@ -1,0 +1,1 @@
+**Import spacing**: a fractional `behavior.emptyLinesAfterImports` such as 1.5 no longer makes every save apply an edit that changes nothing; the setting now takes whole numbers only and rounds anything else.

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
           "order": 13
         },
         "verseAutoImports.behavior.emptyLinesAfterImports": {
-          "type": "number",
+          "type": "integer",
           "default": 1,
           "minimum": -1,
           "maximum": 5,

--- a/src/__tests__/extension.saveSpacing.test.ts
+++ b/src/__tests__/extension.saveSpacing.test.ts
@@ -52,6 +52,19 @@ function stubConfiguration(): void {
     });
 }
 
+/**
+ * Re-answers emptyLinesAfterImports with `value` for the rest of the test. The
+ * listener reads the setting when the save fires, not when it is registered, so
+ * this works on the listener activate() already installed.
+ */
+function stubEmptyLines(value: number): void {
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+        get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key === "behavior.emptyLinesAfterImports" ? value : defaultValue)),
+        inspect: jest.fn().mockReturnValue(undefined),
+        update: jest.fn().mockResolvedValue(undefined),
+    });
+}
+
 function fakeDocument(text: string, languageId: string = "verse"): vscode.TextDocument {
     const lines = text.split(/\r?\n/);
     return {
@@ -115,6 +128,18 @@ describe("import spacing on save", () => {
 
     it("stays out of the save when the spacing already matches", () => {
         const event = fireWillSave(fakeDocument(ALREADY_SPACED));
+
+        expect(event.waitUntil).not.toHaveBeenCalled();
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+    });
+
+    // #242: a fractional setting the UI used to accept gave a difference that
+    // no count of real blank lines could close, so every save was handed an
+    // edit whose text was empty.
+    it("stays out of the save when a fractional setting rounds to the spacing the file has", () => {
+        stubEmptyLines(1.5);
+
+        const event = fireWillSave(fakeDocument(["using { /Fortnite.com/Devices }", "", "", "code()"].join("\n")));
 
         expect(event.waitUntil).not.toHaveBeenCalled();
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1055,7 +1055,16 @@ export class ImportDocumentEditor {
             return [];
         }
 
-        logger.debug("ImportDocumentEditor", `Ensuring ${emptyLinesAfterImports} empty lines after imports`);
+        // A line count has to be a whole number: the difference below is taken
+        // against a count of real lines, and `repeat` truncates a fractional
+        // count to nothing, so a stored 1.5 would ask for an edit that changes
+        // nothing on every save and never converge. package.json declares this
+        // an integer, but a hand-edited settings.json still reaches here.
+        // Must round after the negative return above, not before: -0.4 rounds
+        // to 0, which would take the opt-out's meaning away from it.
+        const targetEmptyLines = Math.round(emptyLinesAfterImports);
+
+        logger.debug("ImportDocumentEditor", `Ensuring ${targetEmptyLines} empty lines after imports`);
 
         const text = document.getText();
         const eol = resolveEol(document, text);
@@ -1102,10 +1111,10 @@ export class ImportDocumentEditor {
         }
 
         // Calculate adjustment needed
-        const lineDifference = emptyLinesAfterImports - existingEmptyLines;
+        const lineDifference = targetEmptyLines - existingEmptyLines;
 
         if (lineDifference === 0) {
-            logger.debug("ImportDocumentEditor", `Already has ${emptyLinesAfterImports} empty lines after imports`);
+            logger.debug("ImportDocumentEditor", `Already has ${targetEmptyLines} empty lines after imports`);
             return [];
         }
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1434,6 +1434,12 @@ describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {
 describe("ImportDocumentEditor.computeEmptyLinesAfterImportsEdits", () => {
     let editor: ImportDocumentEditor;
 
+    /** The setting as the manifest declares it, which is what the settings UI enforces. */
+    function emptyLinesSetting(): { type: string; minimum: number; description: string } {
+        const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json"), "utf8"));
+        return manifest.contributes.configuration.properties["verseAutoImports.behavior.emptyLinesAfterImports"];
+    }
+
     /** Answers emptyLinesAfterImports with `value`, defaults for everything else. */
     function mockEmptyLines(value: number): void {
         (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
@@ -1506,13 +1512,51 @@ describe("ImportDocumentEditor.computeEmptyLinesAfterImportsEdits", () => {
     });
 
     it("honours -1 only because package.json admits it, so the settings UI can offer it", () => {
-        const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json"), "utf8"));
-        const setting = manifest.contributes.configuration.properties["verseAutoImports.behavior.emptyLinesAfterImports"];
+        const setting = emptyLinesSetting();
 
         // Declared below the minimum, the opt-out is unreachable however well
         // the code above honours it: the settings UI refuses to store it.
         expect(setting.minimum).toBeLessThanOrEqual(-1);
         expect(setting.description).toContain("-1");
+    });
+
+    // A blank-line count is whole. Declared "number" the settings UI offered
+    // 1.5, and the pass then asked for an edit that changed nothing on every
+    // save (#242).
+    it("declares the setting an integer, so the settings UI cannot offer a fraction", () => {
+        expect(emptyLinesSetting().type).toBe("integer");
+    });
+
+    it("asks for nothing when a fractional setting rounds to the spacing the file already has", () => {
+        mockEmptyLines(1.5);
+
+        const input = ["using { /Top }", "", "", "code()"].join("\n");
+
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(input))).toEqual([]);
+    });
+
+    // The convergence itself: the first pass has to reach a state the second
+    // pass leaves alone. 1.5 used to give a difference of 0.5 forever, since
+    // the count of real blank lines can never equal it.
+    it("converges on a fractional setting instead of editing on every pass", () => {
+        mockEmptyLines(1.5);
+        const edits = editor.computeEmptyLinesAfterImportsEdits(fakeDocument(["using { /Top }", "", "code()"].join("\n")));
+
+        expect(edits).toHaveLength(1);
+        expect(edits[0].newText).toBe("\n");
+
+        mockEmptyLines(1.5);
+        const settled = ["using { /Top }", "", "", "code()"].join("\n");
+
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(settled))).toEqual([]);
+    });
+
+    it("keeps the spacing a fraction just below the opt-out asks it to keep", () => {
+        mockEmptyLines(-0.4);
+
+        const input = ["using { /Top }", "", "", "", "code()"].join("\n");
+
+        expect(editor.computeEmptyLinesAfterImportsEdits(fakeDocument(input))).toEqual([]);
     });
 
     it("never edits the document itself", () => {


### PR DESCRIPTION
Closes #242

## What was wrong

`verseAutoImports.behavior.emptyLinesAfterImports` was declared `"type": "number"`, so the settings UI accepted and stored `1.5`. `computeEmptyLinesAfterImportsEdits` then took `lineDifference = 1.5 - 1 = 0.5`, sailed past the `=== 0` "already correct" return, and called `eol.repeat(0.5)` — which truncates to `""`. The save participant's `edits.length > 0` gate saw a one-element array and handed VS Code an edit with empty text on every single save. A count of real blank lines can never equal `1.5`, so it never converged.

## The fix, both halves

The issue offered the schema change and the read-site change as alternatives. This takes both, because they defend different things:

- **`"type": "integer"` in `package.json`** stops the settings UI offering a fraction. It does nothing for a value already stored, and nothing for a hand-edited `settings.json` — VS Code squiggles an out-of-type value but `config.get()` still returns it verbatim.
- **`Math.round` at the read site** is what makes an already-stored `1.5` converge.

That is the same split the existing manifest test for the `-1` opt-out already articulates: the schema governs what the UI will store, and the code has to be correct on its own regardless. Doing both also makes the issue's open question about VS Code's handling of an out-of-type stored value moot.

The rounding is deliberately placed **after** the existing `< 0` opt-out return, not before. Rounding first would turn `-0.4` into `0` and hand it to the normal path, where today it means "leave the spacing alone". A test pins that ordering.

## Not in scope

A non-numeric hand-edited value still yields `NaN` and reaches the delete branch with a `NaN` range. It is pre-existing, unchanged by this diff, and caught by the save participant's `try/catch`. Happy to file it separately rather than widen this one.

## Tests

Four new assertions, all proven to fail against the unfixed code (`git stash push` on `package.json` and `ImportDocumentEditor.ts`, run, restore) — the convergence test failing with `Received: ""`, which is the reported no-op edit itself:

- `1.5` against a file already at the rounded count returns no edits
- `1.5` inserts one line and the result is then left alone — the convergence property that was broken
- the manifest declares the setting an `integer`
- `-0.4` still preserves the file's own spacing, pinning the rounding order
- and at the save participant, where the user meets the symptom: a fractional setting at the rounded count never calls `waitUntil`

## Review

Fresh-context review gate: **PASS_WITH_SUGGESTIONS**, no Critical and no Important findings. It independently confirmed there is only one production read site of the setting, that the rounding is placed correctly relative to the opt-out, and that neither test stub leaks into later tests. The three suggestions were the out-of-scope `NaN`/clamp hardening, a test-stub duplication the reviewer itself judged not worth merging, and a changelog wording nit that has been applied.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

```
$ npm test

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       579 passed, 579 total
Snapshots:   0 total
Time:        13.719 s
Ran all test suites.
```

```
$ npm run format:check

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
