### PR TITLE
fix(imports): end a dotted import where its path ends

### DIFF
--- a/changelog.d/244.fixed.md
+++ b/changelog.d/244.fixed.md
@@ -1,0 +1,1 @@
+**Import organizing**: a statement written after a dotted `using.` import on the same line is no longer folded into the import path, and the line is left exactly as written.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -160,6 +160,25 @@ export class ImportFormatter {
     }
 
     /**
+     * A dotted `using` statement, capturing its content.
+     *
+     * The content class is the union of the three things a dotted `using` can
+     * name: an absolute path, a dot-notation module reference such as
+     * `Economy.Shop`, and a bare folder-module identifier. Verse's path
+     * production allows two further forms this omits on purpose - a `'...'`
+     * segment suffix, which admits almost every printable character, and a
+     * `(path:)` qualifier - because admitting either means parsing where this
+     * only lexes, and truncating one costs the line nothing but its
+     * rewritability.
+     *
+     * A comment opener cannot appear in the class, so a trailing comment ends
+     * the capture rather than entering it. matchImport strips one from the
+     * capture regardless, so widening the class cannot quietly put a comment
+     * back into a path.
+     */
+    private static readonly DOTTED_STATEMENT = /^using\.\s*([A-Za-z0-9_./@-]*)/;
+
+    /**
      * The `using` statement written at the head of a string: its path, and how
      * much of the string it occupies.
      *
@@ -173,6 +192,13 @@ export class ImportFormatter {
      * ends cannot answer it from a looser second copy that, on the same input,
      * disagrees about which statement was read.
      *
+     * The dotted style closes with nothing, so its own content is what ends it:
+     * the capture stops at the first character a dotted content cannot hold,
+     * which is how Verse itself lexes a path - `/a/b-c` is the path `/a/b`, then
+     * `-`, then `c`. Reading to end of line instead is what let a statement
+     * written after a `;` be captured into the path and re-emitted inside the
+     * braces. See DOTTED_STATEMENT for what a dotted content may hold.
+     *
      * @returns The path and the offset just past the statement **in the
      *   trimmed input**, or null when there is no statement (including one
      *   whose content is nothing but a comment)
@@ -180,7 +206,7 @@ export class ImportFormatter {
     private static matchImport(importStatement: string): { path: string; end: number } | null {
         const trimmed = importStatement.trim();
 
-        const dotMatch = trimmed.match(/^using\.\s*(.+)/);
+        const dotMatch = trimmed.match(ImportFormatter.DOTTED_STATEMENT);
         if (dotMatch) {
             const path = ImportFormatter.stripTrailingComment(dotMatch[1]);
             return path ? { path, end: dotMatch[0].length } : null;
@@ -222,11 +248,11 @@ export class ImportFormatter {
      * it. So no depth or string tracking is needed, which nothing in this file
      * does.
      *
-     * Only the braced style can answer usefully. The dotted style has no
-     * closing delimiter and its capture is greedy to end of line, so a
-     * statement sharing a line swallows what follows it into its path and
-     * nothing is left over to report - the weakness usingPathsOnLine documents,
-     * not one this repairs.
+     * Both styles can answer. The braced one ends at its `}`; the dotted one
+     * has no closing delimiter, so it ends where its content stops being
+     * content - see matchImport. A dotted statement whose content is truncated
+     * there reports the remainder as leftover, which pins the line, so the
+     * shapes this cannot lex are refused rather than rewritten wrongly.
      *
      * @param lineCode A line of Verse with its comments already removed. A
      *   trailing comment left on it reads as code written after the statement.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -162,21 +162,26 @@ export class ImportFormatter {
     /**
      * A dotted `using` statement, capturing its content.
      *
-     * The content class is the union of the three things a dotted `using` can
-     * name: an absolute path, a dot-notation module reference such as
-     * `Economy.Shop`, and a bare folder-module identifier. Verse's path
-     * production allows two further forms this omits on purpose - a `'...'`
-     * segment suffix, which admits almost every printable character, and a
-     * `(path:)` qualifier - because admitting either means parsing where this
-     * only lexes, and truncating one costs the line nothing but its
-     * rewritability.
+     * The class covers every character Verse's path production admits outside a
+     * quoted suffix - a label may hold `.` and `-`, `@` introduces the account,
+     * `/` separates segments, and `(`, `)` and `:` are the qualifier form
+     * `(path:)ident` - together with the bare identifier and the dot-notation
+     * reference a `using` may name instead of a path.
      *
-     * A comment opener cannot appear in the class, so a trailing comment ends
+     * A quoted segment suffix, `Economy.Shop'Loc'`, is consumed whole by the
+     * alternative rather than by the class, because inside one nearly every
+     * printable character is legal - `;` and a space included. Stopping at the
+     * `'` instead would report `Economy.Shop`, a different module that exists,
+     * and a writer asked for that module would then believe the file already
+     * imports it. An unbalanced `'` matches neither branch, so the capture ends
+     * before it and the remainder pins the line.
+     *
+     * A comment opener appears in neither branch, so a trailing comment ends
      * the capture rather than entering it. matchImport strips one from the
-     * capture regardless, so widening the class cannot quietly put a comment
-     * back into a path.
+     * capture regardless, so widening this cannot quietly put a comment back
+     * into a path.
      */
-    private static readonly DOTTED_STATEMENT = /^using\.\s*([A-Za-z0-9_./@-]*)/;
+    private static readonly DOTTED_STATEMENT = /^using\.\s*((?:[A-Za-z0-9_./@:()-]|'[^']*')*)/;
 
     /**
      * The `using` statement written at the head of a string: its path, and how
@@ -197,7 +202,8 @@ export class ImportFormatter {
      * which is how Verse itself lexes a path - `/a/b-c` is the path `/a/b`, then
      * `-`, then `c`. Reading to end of line instead is what let a statement
      * written after a `;` be captured into the path and re-emitted inside the
-     * braces. See DOTTED_STATEMENT for what a dotted content may hold.
+     * braces. See DOTTED_STATEMENT for what a dotted content may hold, and why
+     * ending the capture early is not the safe direction it looks.
      *
      * @returns The path and the offset just past the statement **in the
      *   trimmed input**, or null when there is no statement (including one
@@ -248,11 +254,11 @@ export class ImportFormatter {
      * it. So no depth or string tracking is needed, which nothing in this file
      * does.
      *
-     * Both styles can answer. The braced one ends at its `}`; the dotted one
-     * has no closing delimiter, so it ends where its content stops being
-     * content - see matchImport. A dotted statement whose content is truncated
-     * there reports the remainder as leftover, which pins the line, so the
-     * shapes this cannot lex are refused rather than rewritten wrongly.
+     * Both styles can answer. The braced one ends at its `}`; the dotted one has
+     * no closing delimiter, so it ends where its content stops being content -
+     * see matchImport. Content this cannot lex, such as an unbalanced `'`, ends
+     * the statement early and reports the rest as leftover, which pins the line
+     * rather than rewriting it from a path that was never the whole of it.
      *
      * @param lineCode A line of Verse with its comments already removed. A
      *   trailing comment left on it reads as code written after the statement.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -169,17 +169,20 @@ export class ImportFormatter {
      * reference a `using` may name instead of a path.
      *
      * A quoted segment suffix, `Economy.Shop'Loc'`, is consumed whole by the
-     * alternative rather than by the class, because inside one nearly every
-     * printable character is legal - `;` and a space included. Stopping at the
-     * `'` instead would report `Economy.Shop`, a different module that exists,
-     * and a writer asked for that module would then believe the file already
-     * imports it. An unbalanced `'` matches neither branch, so the capture ends
-     * before it and the remainder pins the line.
+     * alternative rather than by the class, because a suffix admits characters
+     * no identifier may hold and the capture therefore cannot stop at the `'`.
+     * Stopping there would report `Economy.Shop`, a different module that
+     * exists, and a writer asked for that module would then believe the file
+     * already imports it. An unbalanced `'` matches neither branch, so the
+     * capture ends before it and the remainder pins the line.
      *
-     * A comment opener appears in neither branch, so a trailing comment ends
-     * the capture rather than entering it. matchImport strips one from the
-     * capture regardless, so widening this cannot quietly put a comment back
-     * into a path.
+     * A comment opener is outside the class, though a quoted group admits one.
+     * matchImport strips it regardless, so none reaches a path - but the strip
+     * cuts inside the group while `end` measures the unstripped capture, so on
+     * `using. Foo'a#b'` the path and the leftover disagree about where the
+     * statement ends. No caller reaches that: isModuleImport refuses `Foo'a`,
+     * and the leftover is read from the line's code, which has no comment left
+     * in it. Widening the class is what would make the two meet.
      */
     private static readonly DOTTED_STATEMENT = /^using\.\s*((?:[A-Za-z0-9_./@:()-]|'[^']*')*)/;
 

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -63,9 +63,10 @@ export interface ScannedImport {
      * `using` for the first to count in `using. /X; MyVal := 5` - so the path
      * was the whole of the line and a rebuild corrupted it rather than deleting
      * from it. matchImport now ends that capture where a dotted content stops,
-     * and both questions see what follows the separator. What remains is the
-     * two path forms that capture omits: they truncate, which leaves a
-     * remainder over and pins the line rather than mis-reporting it.
+     * and both questions see what follows the separator. What remains is content
+     * it cannot lex at all, such as an unbalanced `'`: the capture ends early,
+     * which leaves a remainder over and pins the line - so the path it reports
+     * is a prefix of the real one, present but never re-emitted.
      *
      * `true` is likewise not a promise that every path on the span was
      * recorded. A line ending in a `using:` pair reports the statement at its

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -57,15 +57,15 @@ export interface ScannedImport {
      * a `;` is caught by the second question when it is not a `using` and the
      * first cannot count it.
      *
-     * `false` is still "no loss known", not "provably none". Both questions are
-     * blind to the same shape, a dotted statement sharing its line: it has no
-     * closing delimiter, so it swallows the rest of the line into its path -
-     * leaving nothing over for the second question, and no second `using` for
-     * the first to find in `using. /X; MyVal := 5`. The path is then the whole
-     * of the line and rebuilding from it corrupts rather than deletes, which is
-     * the weakness usingPathsOnLine documents. Where the tail is a `using`, the
-     * line is pinned but under that swallowed path, so the path it really
-     * imports goes unreported and a writer may add a second copy of it.
+     * `false` is still "no loss known", not "provably none". The dotted style is
+     * what made that gap real: having no closing delimiter, it once ran to end
+     * of line, leaving nothing over for the second question and no second
+     * `using` for the first to count in `using. /X; MyVal := 5` - so the path
+     * was the whole of the line and a rebuild corrupted it rather than deleting
+     * from it. matchImport now ends that capture where a dotted content stops,
+     * and both questions see what follows the separator. What remains is the
+     * two path forms that capture omits: they truncate, which leaves a
+     * remainder over and pins the line rather than mis-reporting it.
      *
      * `true` is likewise not a promise that every path on the span was
      * recorded. A line ending in a `using:` pair reports the statement at its
@@ -582,16 +582,15 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
  * rank-1 or rank-2 one on the same line hid it from the caller, which reads an
  * all-absolute answer as permission to remove an import.
  *
- * A dotted statement has no closing delimiter, so one sharing a line swallows
- * what follows it into its path. That malformed path is reported as well, but
- * the next iteration finds the statement after it and reports that path on its
- * own - which is the guarantee this owes its caller. Reading the swallowed copy
- * is not what makes the line safe; finding the statement inside it again is.
+ * A dotted statement has no closing delimiter, so where it ends is decided by
+ * its own content rather than by a delimiter - see matchImport. Each `using` on
+ * the line therefore contributes the path it actually writes, whatever style
+ * its neighbours are written in.
  *
  * Only a `using` that begins a token is offered. `using` is a substring of
  * ordinary identifiers - `Housing` holds one - and the dotted pattern needs no
  * space after its `.`, so `using { Housing.Data }` offered every occurrence
- * reports `Housing.Data` and then `Data }`, a path the line does not write. A
+ * reports `Housing.Data` and then `Data`, a path the line does not write. A
  * caller counting statements reads that as two.
  *
  * The cost is a `using` glued to an identifier by a comment removed from

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -205,6 +205,29 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["/X"], curlySorted)).toBeNull();
     });
 
+    // The dotted style closes with nothing, so the definition after the `;` was
+    // captured into the path and the line still read as one plain statement.
+    // Organizing rebuilt it as `using { /X; MyVal := 5 }` - MyVal not deleted
+    // this time but folded inside the braces, and the file stopped compiling.
+    it("leaves a line that writes a definition after its dotted import alone", () => {
+        const input = ["using. /X; MyVal := 5", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    it("organizes the other imports around a line that writes a definition after its dotted import", () => {
+        const input = ["using. /X; MyVal := 5", "using { /B }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using. /X; MyVal := 5", "", "code()"].join("\n"));
+    });
+
+    // Under the swallowed path the line provided `/X; using { Economy.Shop }`
+    // and no `/X`, so a writer asked for `/X` wrote a second copy of an import
+    // the line was already making.
+    it("does not write a second copy of a path a dotted statement provides beside another", () => {
+        const input = ["using. /X; using { Economy.Shop }", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/X"], curlySorted)).toBeNull();
+        expect(editor.buildOrganizedContent(input, ["Economy.Shop"], curlySorted)).toBeNull();
+    });
+
     // A module whose name merely ends in those five letters writes one
     // statement, and organizing has to keep treating it as one. Counted by
     // every occurrence of `using`, this line reads as two, and the file stops

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -146,10 +146,31 @@ describe("ImportFormatter trailing comments on import statements", () => {
         expect(formatter.textAfterImport("using { /Verse.org/Simulation }")).toBe("");
     });
 
-    // The dotted capture is greedy to end of line, so a statement sharing a line
-    // swallows what follows it into its path and nothing is left over to report.
-    it("reports nothing after a dotted statement, which has no closing delimiter", () => {
-        expect(formatter.textAfterImport("using. /Verse.org/Simulation; MyVal := 5")).toBe("");
+    // The dotted capture used to run to end of line, so a statement sharing a
+    // line was swallowed into the path and nothing was left over to report -
+    // and the line read as rewritable.
+    it("reports the code written after a dotted statement, which has no closing delimiter", () => {
+        expect(formatter.textAfterImport("using. /Verse.org/Simulation; MyVal := 5")).toBe("; MyVal := 5");
+    });
+
+    it("reports nothing after a dotted statement that is the whole line", () => {
+        expect(formatter.textAfterImport("using. /Verse.org/Simulation")).toBe("");
+    });
+
+    // Every character a dotted content may hold, so the capture cannot end
+    // early on an ordinary path: `.` and `-` in a label, `@` before the account,
+    // `/` between segments, `_` and a digit in an identifier.
+    it("carries a whole path through the dotted capture", () => {
+        expect(formatter.extractPathFromImport("using. /my-game@fortnite.com/my_game2/Economy.Shop")).toBe("/my-game@fortnite.com/my_game2/Economy.Shop");
+        expect(formatter.textAfterImport("using. /my-game@fortnite.com/my_game2/Economy.Shop")).toBe("");
+    });
+
+    // A `'...'` segment suffix and a `(path:)` qualifier are legal Verse the
+    // dotted capture deliberately does not lex. Truncating leaves a remainder,
+    // which pins the line - the statement is refused, never rewritten wrongly.
+    it("truncates a path form it cannot lex, leaving the remainder over", () => {
+        expect(formatter.extractPathFromImport("using. /a/b'c'")).toBe("/a/b");
+        expect(formatter.textAfterImport("using. /a/b'c'")).toBe("'c'");
     });
 
     it("reports nothing for a line that writes no statement", () => {

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -161,16 +161,31 @@ describe("ImportFormatter trailing comments on import statements", () => {
     // early on an ordinary path: `.` and `-` in a label, `@` before the account,
     // `/` between segments, `_` and a digit in an identifier.
     it("carries a whole path through the dotted capture", () => {
-        expect(formatter.extractPathFromImport("using. /my-game@fortnite.com/my_game2/Economy.Shop")).toBe("/my-game@fortnite.com/my_game2/Economy.Shop");
-        expect(formatter.textAfterImport("using. /my-game@fortnite.com/my_game2/Economy.Shop")).toBe("");
+        expect(formatter.extractPathFromImport("using. /mygame@fortnite.com/my-game_2/Economy.Shop")).toBe("/mygame@fortnite.com/my-game_2/Economy.Shop");
+        expect(formatter.textAfterImport("using. /mygame@fortnite.com/my-game_2/Economy.Shop")).toBe("");
     });
 
-    // A `'...'` segment suffix and a `(path:)` qualifier are legal Verse the
-    // dotted capture deliberately does not lex. Truncating leaves a remainder,
-    // which pins the line - the statement is refused, never rewritten wrongly.
-    it("truncates a path form it cannot lex, leaving the remainder over", () => {
-        expect(formatter.extractPathFromImport("using. /a/b'c'")).toBe("/a/b");
-        expect(formatter.textAfterImport("using. /a/b'c'")).toBe("'c'");
+    // A quoted segment suffix admits nearly every printable character, `;` and
+    // a space included, so ending the capture at the `'` would report
+    // `Economy.Shop` - a different module that exists, which a writer asked for
+    // that module would then read as already imported.
+    it("carries a quoted segment suffix through the dotted capture", () => {
+        expect(formatter.extractPathFromImport("using. Economy.Shop'Loc'")).toBe("Economy.Shop'Loc'");
+        expect(formatter.textAfterImport("using. Economy.Shop'Loc'")).toBe("");
+        expect(formatter.extractPathFromImport("using. /a/b'; x := 5'")).toBe("/a/b'; x := 5'");
+    });
+
+    it("carries a qualified path through the dotted capture", () => {
+        expect(formatter.extractPathFromImport("using. (/A/M:)M")).toBe("(/A/M:)M");
+        expect(formatter.textAfterImport("using. (/A/M:)M")).toBe("");
+    });
+
+    // Neither branch matches an unbalanced `'`, so the capture ends before it.
+    // The path is then a prefix of the real one, which is why the remainder has
+    // to be left over: leftover text is what pins the line against a rebuild.
+    it("ends the capture before content it cannot lex, leaving the remainder over", () => {
+        expect(formatter.extractPathFromImport("using. /a/b'c")).toBe("/a/b");
+        expect(formatter.textAfterImport("using. /a/b'c")).toBe("'c");
     });
 
     it("reports nothing for a line that writes no statement", () => {

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -313,6 +313,24 @@ describe("scanModuleImports", () => {
         expect(rewritableImports(scanModuleImports(["using. /X;", "code()"]))).toEqual([]);
     });
 
+    // Ending the capture at the `'` would record `Economy.Shop`, a module that
+    // exists and is not the one this line imports - so a writer asked for
+    // `Economy.Shop` would read the file as already importing it and withhold
+    // the import the compiler asked for.
+    it("records the whole path of a dotted import carrying a quoted suffix", () => {
+        expect(rewritableImports(scanModuleImports(["using. Economy.Shop'Loc'", "code()"]))).toEqual([
+            { path: "Economy.Shop'Loc'", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+        expect(allUsingPaths(["using. Economy.Shop'Loc'", "code()"])).toEqual(["Economy.Shop'Loc'"]);
+    });
+
+    // allUsingPaths reads an empty answer as permission to remove an import, so
+    // a content it cannot lex must still report a path rather than none.
+    it("records the whole path of a dotted import carrying a qualifier", () => {
+        expect(scanModuleImports(["using. (/A:)B.C", "code()"]).map((imp) => imp.path)).toEqual(["(/A:)B.C"]);
+        expect(allUsingPaths(["using. (/A:)B.C", "code()"])).toEqual(["(/A:)B.C"]);
+    });
+
     // The dotted capture ends at the first character a content cannot hold, so
     // a comment cannot enter the path and the statement stays rewritable.
     it("leaves an ordinary dotted import rewritable, with and without a comment", () => {

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -78,11 +78,16 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using { /X }; using { Features }; using { Economy.Shop }", "code()"])).toEqual(["/X", "Features", "Economy.Shop"]);
     });
 
-    // A dotted statement has no closing delimiter, so it swallows what follows
-    // it into its path. The statement after it is still found and reported on
-    // its own, which is the guarantee that matters: nothing is missed.
-    it("still reports a statement written after a dotted one on the same line", () => {
-        expect(allUsingPaths(["using. /X; using { Economy.Shop }", "code()"])).toEqual(["/X; using { Economy.Shop }", "Economy.Shop"]);
+    // A dotted statement has no closing delimiter, so it used to swallow what
+    // followed it into its path and report `/X; using { Economy.Shop }`. The
+    // path it really imports has to be reported in its own right, or a writer
+    // adds a second copy of it.
+    it("reports both statements when the first of them is dotted", () => {
+        expect(allUsingPaths(["using. /X; using { Economy.Shop }", "code()"])).toEqual(["/X", "Economy.Shop"]);
+    });
+
+    it("reports both statements when a dotted one is written second", () => {
+        expect(allUsingPaths(["using { Economy.Shop }; using. /X", "code()"])).toEqual(["Economy.Shop", "/X"]);
     });
 
     it("collects a second statement written after a braced one in a module body", () => {
@@ -115,7 +120,7 @@ describe("allUsingPaths", () => {
 
     // Only a `using` beginning a token is a statement. `Housing` holds those
     // five letters, and the dotted pattern needs no space after its `.`, so
-    // offering every occurrence invented `Data }` as a second path.
+    // offering every occurrence invented `Data` as a second path.
     it("invents no second path from an identifier that merely contains using", () => {
         expect(allUsingPaths(["using { Housing.Data }", "code()"])).toEqual(["Housing.Data"]);
         expect(allUsingPaths(["using { A_using.B }", "code()"])).toEqual(["A_using.B"]);
@@ -266,7 +271,7 @@ describe("scanModuleImports", () => {
 
     // `using` is a substring of ordinary identifiers, and the dotted pattern
     // needs no space after its `.`, so offering every occurrence reads
-    // `Housing.Data` as `Housing.Data` and then `Data }` - two statements, on a
+    // `Housing.Data` as `Housing.Data` and then `Data` - two statements, on a
     // line that writes one. Pinning on that count stops the file being organized
     // at all, for a module whose name merely ends in those five letters.
     it("leaves a single statement rewritable when its path holds the word using", () => {
@@ -281,15 +286,41 @@ describe("scanModuleImports", () => {
         ]);
     });
 
-    // A dotted statement has no closing delimiter, so one sharing a line
-    // swallows what follows it into its path. Both are recorded, the malformed
-    // one included - what makes the line safe is that a second statement was
-    // found on it at all, which is what pins the line. Rewritable, it was
-    // rebuilt from the swallowed path into `using { /X; using { Economy.Shop } }`.
-    it("pins a line whose dotted statement swallows the one written after it", () => {
+    // Two statements, the first dotted. The line was pinned before, but under
+    // the swallowed path `/X; using { Economy.Shop }` - so `/X` did not count as
+    // imported and a writer was free to add a second copy of it.
+    it("pins a line whose dotted statement precedes another, under both real paths", () => {
         expect(scanModuleImports(["using. /X; using { Economy.Shop }", "code()"])).toEqual([
-            { path: "/X; using { Economy.Shop }", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
             { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The shape the two guards used to miss together: one `using` on the line,
+    // so counting them says one, and nothing left over, because the greedy
+    // capture had already taken it. The entry was rewritable, and organizing
+    // rebuilt the line from that path into `using { /X; MyVal := 5 }` - the
+    // definition folded inside the braces, and the file no longer compiled.
+    it("pins a line that writes a definition after its dotted import", () => {
+        expect(scanModuleImports(["using. /X; MyVal := 5", "", "code()"])).toEqual([{ path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" }]);
+    });
+
+    it("offers no rewritable import for a line that writes a definition after its dotted import", () => {
+        expect(rewritableImports(scanModuleImports(["using. /X; MyVal := 5", "", "code()"]))).toEqual([]);
+    });
+
+    it("pins a dotted import followed by a bare separator", () => {
+        expect(rewritableImports(scanModuleImports(["using. /X;", "code()"]))).toEqual([]);
+    });
+
+    // The dotted capture ends at the first character a content cannot hold, so
+    // a comment cannot enter the path and the statement stays rewritable.
+    it("leaves an ordinary dotted import rewritable, with and without a comment", () => {
+        expect(rewritableImports(scanModuleImports(["using. /Verse.org/Simulation", "code()"]))).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+        expect(rewritableImports(scanModuleImports(["using. /Verse.org/Simulation # keep me", "code()"]))).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# keep me" },
         ]);
     });
 
@@ -519,6 +550,12 @@ describe("scanConvertibleImports", () => {
 
     it("keeps the dotted style, which converts the same way as the braced one", () => {
         expect(scanConvertibleImports(["using. /Old/Path"])).toEqual([{ statement: "using. /Old/Path", line: 0 }]);
+    });
+
+    // Conversion rewrites the whole line around the path it reads, so a line
+    // carrying a definition after its dotted import must not be offered one.
+    it("excludes a dotted import that shares its line with a definition", () => {
+        expect(scanConvertibleImports(["using. /Old/Path; MyVal := 5", "", "code()"])).toEqual([]);
     });
 
     it("keeps a bare-identifier import, which is a folder module at file scope", () => {


### PR DESCRIPTION
Closes #244

The dotted style closes with nothing, so `matchImport` read its content to end of line and took a statement written after a `;` into the import path. Both of `scanModuleImports`' guards were blind to the result, because the greedy capture had already consumed the evidence each looks for: one `using` on the line, and nothing left over. The entry reached the single-statement branch as rewritable, and organizing rebuilt the line from that path into `using { /X; MyVal := 5 }` — the definition folded inside the braces, and the file stopped compiling.

The capture now ends where a dotted content ends, which is how Verse itself lexes a path.

## Where a dotted path stops

The ticket flagged this as the thing to settle first, so it was settled against the language's own corpus rather than by choosing a separator:

- `Tests/Literals/Path.versetest:3` carries the path production, and `:13-15` states outright that a character outside it ends the path and the remainder parses as a separate compound expression — `/a/b-c` is the path `/a/b`, then `-`, then `c`. Path lexing is maximal munch.
- `docs/01_expressions.md:1241` confirms `;` separates definitions in a scope, so a second statement on the line must be preceded by one.
- `Tests/QualifiedIdentifier.versetest:70` and `:300` show the `(path:)` qualifier used inside a real `using`, which is why `(`, `)` and `:` are in the class.
- A quoted segment suffix, `Economy.Shop'Loc'`, admits characters no identifier may hold, so it is consumed whole rather than stopped at.

What the Book does **not** settle is whether `using. /X; MyVal := 5` parses as two definitions or as one malformed `using` whose argument is a sequence — the dotted `using` is undocumented and appears nowhere in the corpus. That does not block the fix: leaving the line as written is correct under both readings, and under the second the line is already invalid Verse, since `using` takes exactly one argument (`Tests/Modules/Using.versetest:68`).

## Acceptance

| Input | Result |
| --- | --- |
| `using. /X; MyVal := 5` | path `/X`, leftover `; MyVal := 5`, line pinned; organize returns unchanged and no conversion lens is offered |
| `using. /X; using { Economy.Shop }` | `/X` reported in its own right alongside `Economy.Shop`, so nothing writes a second copy of it; still pinned |
| `using. /Verse.org/Simulation`, with or without a trailing comment | unchanged, still rewritable and organizable |

Regression tests are in `src/imports/__tests__/`, which run without the VS Code runtime. Each was proved to detect the defect: reverting `ImportFormatter.ts` to its pre-fix version fails 11 tests, restoring it returns the suite to green.

## Review gate

Two rounds, both against a fresh reviewer with its own context.

**Round 1 — FAIL, one Critical, accepted and reproduced before acting.** Ending the capture at the first character outside a bare path truncated two legal path forms, and truncation turned out not to be the conservative direction it looked. `using. Economy.Shop'Loc'` recorded the path as `Economy.Shop` — a different module that exists — so a writer asked for `Economy.Shop` read the file as already importing it and withheld the import the compiler asked for. Separately `using. (/A:)B.C` became invisible to `allUsingPaths`, whose contract names a missed `using` as the one error it must not make; that was a regression this branch introduced against `main`, so it was fixed in code rather than documented as a gap.

**Round 2 — PASS_WITH_SUGGESTIONS.** Both suggestions concerned doc comments that had stopped being true once the class widened, and both are fixed in `713c470`. The reviewer independently confirmed the class admits exactly `()-./0-9:@A-Za-z_` with no unintended ranges and no backtracking risk, and that seven adversarial shapes are byte-identical to `main`.

## Scope

Two sibling copies of the same greedy pattern are deliberately untouched, per the maintainer's call:

- `ImportFormatter.isModuleImport` — consequence is that `using. Features; MyVal := 5` is classified as not-an-import and skipped whole. Non-destructive, but the path goes uncounted, so a writer may add a second copy of it. Worth a follow-up issue; the reproduction is in hand.
- `ImportPathConverter.extractPathFromImport` — unreachable with a swallowing statement, since every statement it sees arrives through `scanConvertibleImports`, which filters out pinned entries.

The braced branch is unchanged, `using { /X;Y }` included. Braces delimit, so the scanner can decline to parse inside them; the dotted form has no delimiter, so it must.

## Verification

```
$ npm run compile
> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       590 passed, 590 total
Snapshots:   0 total
Time:        12.93 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
