### PR TITLE
docs(imports): apply the comment standard to scanning, formatting and extraction

### DIFF
--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -23,9 +23,10 @@ export class ImportFormatter {
      *
      * A comment left on the content is re-emitted inside the braces -
      * `using { /X # note }`, where it swallows the closing brace and the
-     * statement no longer parses. Nothing upstream removes it: `#` and `<#` are
-     * both illegal in a module path, so a capture that runs to end of line
-     * takes the comment with it.
+     * statement no longer parses. A path may hold no `#`, but the captures that
+     * produce one may: the braced capture stops only at its `}`, and the dotted
+     * and indented forms read to end of line. So the comment arrives here still
+     * attached, and this is where it comes off.
      */
     static stripTrailingComment(content: string): string {
         const commentStart = ImportFormatter.commentStartIndex(content);

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -13,21 +13,18 @@ export interface IsModuleImportOptions {
 }
 
 /**
- * Handles import formatting, syntax preferences, grouping, and path utilities.
+ * Reads and writes `using` statements: their syntax, their paths, their
+ * ordering rank, and the grouping the settings ask for.
  */
 export class ImportFormatter {
     /**
-     * Strips a trailing Verse comment from the content of a `using` statement.
+     * The content of a `using` statement with any trailing comment removed,
+     * trimmed.
      *
-     * `#` opens a line comment and `<#` opens a block comment. Neither
-     * character is legal in a module path, so everything from the first
-     * comment opener onward is trivia. The path captures are greedy to end of
-     * line, so without this a trailing comment is captured as part of the path
-     * and re-emitted inside the braces — `using { /X # note }`, where the
-     * comment swallows the closing brace and the statement no longer parses.
-     *
-     * @param content The captured content of a `using` statement
-     * @returns The content with any trailing comment removed, trimmed
+     * The path captures are greedy to end of line, so a comment left on the
+     * content is captured as part of the path and re-emitted inside the braces
+     * - `using { /X # note }`, where the comment swallows the closing brace and
+     * the statement no longer parses.
      */
     static stripTrailingComment(content: string): string {
         const commentStart = ImportFormatter.commentStartIndex(content);
@@ -43,7 +40,6 @@ export class ImportFormatter {
      * this is what it needs to put back so the annotation survives.
      *
      * @param content A `using` statement, or the indented path line of one
-     * @returns The comment, trimmed, or "" when the content carries none
      */
     static extractTrailingComment(content: string): string {
         const commentStart = ImportFormatter.commentStartIndex(content);
@@ -69,40 +65,32 @@ export class ImportFormatter {
     }
 
     /**
-     * Determines if a line is a module import (as opposed to a local-scope `using`).
+     * Whether a line is a module import rather than a local-scope `using`.
      *
      * `using` has two meanings in Verse:
      * - Module import: `using { /Verse.org/Simulation }`, `using { game_systems.inventory }`
      * - Local-scope using: `using{Variable}` — brings an instance's members into scope
      *
-     * Verse supports three equivalent syntactic styles for `using`:
-     * - Braced:   `using { /Verse.org/Simulation }`
-     * - Dotted:   `using. /Verse.org/Simulation`
-     * - Indented: `using:` followed by an indented path on the next line
+     * Either meaning can be written in any of the three equivalent styles:
+     * braced `using { /Path }`, dotted `using. /Path`, or indented `using:`
+     * with the path on the next line. So the two are separated by content, and
+     * at file scope by position as well:
      *
-     * All three styles can express either a module import or a local-scope using.
-     * Detection has two modes:
+     * - Default (`options.atFileScope` absent or `false`): content only. A
+     *   path (leading `/`) or a dot-notation reference (containing `.`) is a
+     *   module import; a bare identifier is a local-scope using. This is the
+     *   mode for callers that see a matched line in isolation and cannot
+     *   attest to where it sits in the file.
+     * - `options.atFileScope: true`: a bare identifier is a module import too
+     *   (a same-directory folder-module import, `using { Features }`). Module
+     *   `using` is legal at file level or module-definition body level, while
+     *   local-scope `using{instance}` is legal only inside a function body, so
+     *   at file scope a bare `using { X }` can only be the former. Pass this
+     *   only when you know the line is not inside a function body.
      *
-     * - Default (`options.atFileScope` absent or `false`): content-based only.
-     *   Paths (starting with `/`) and dot-notation module references
-     *   (containing `.`) indicate module imports. Bare identifiers indicate
-     *   local-scope using. This mode is used by call sites that lack
-     *   positional context (they see a matched line in isolation and cannot
-     *   attest to where it sits in the file).
-     * - `options.atFileScope: true`: additionally treats a bare identifier as
-     *   a module import (a same-directory folder-module import, e.g.
-     *   `using { Features }`). This is legal per the Book of Verse only
-     *   because module `using` is valid at file level or module-definition
-     *   body level, while local-scope `using{instance}` is legal only inside
-     *   function bodies — so a bare `using { X }` at file scope can only be a
-     *   module import, never a legal local-scope using. Callers must only
-     *   pass this when they know the line is not inside a function body.
-     *
-     * @param line The line to check
-     * @param nextLine The following line in the document (needed for indented style
-     *   where the content is on the next line). When not provided and the line is
-     *   `using:`, conservatively returns `true`.
-     * @param options Classification options; see above.
+     * @param nextLine The following line, which carries the content for the
+     *   indented style. When it is not given and the line is `using:`, this
+     *   conservatively returns `true`.
      */
     static isModuleImport(line: string, nextLine?: string, options?: IsModuleImportOptions): boolean {
         const trimmed = line.trim();
@@ -124,24 +112,21 @@ export class ImportFormatter {
             return false;
         };
 
-        // Indented style: using:
-        //     /Verse.org/Simulation
-        // Content is on the next line — use nextLine for content-based detection.
+        // Indented style: the content is on the next line.
         if (/^using\s*:\s*$/.test(trimmed)) {
             if (nextLine !== undefined) {
                 return isModuleImportContent(ImportFormatter.stripTrailingComment(nextLine));
             }
-            // Without next line context, conservatively assume module import
             return true;
         }
 
-        // Dotted style: using. <content>
+        // Dotted style.
         const dotMatch = trimmed.match(/^using\.\s+(.+)/);
         if (dotMatch) {
             return isModuleImportContent(ImportFormatter.stripTrailingComment(dotMatch[1]));
         }
 
-        // Braced style: using { /path } or using{Variable}
+        // Braced style.
         const curlyMatch = trimmed.match(/^using\s*\{\s*([^}]+)\s*\}/);
         if (curlyMatch) {
             return isModuleImportContent(ImportFormatter.stripTrailingComment(curlyMatch[1]));
@@ -151,9 +136,9 @@ export class ImportFormatter {
     }
 
     /**
-     * Formats an import statement using the specified syntax.
-     * @param path The module path to import
-     * @param useDotSyntax Whether to use dot syntax (using. /path) or curly syntax (using { /path })
+     * A `using` statement for a path, written in the caller's preferred style.
+     *
+     * @param useDotSyntax `using. /path` when true, `using { /path }` when false
      */
     formatImportStatement(path: string, useDotSyntax: boolean): string {
         return useDotSyntax ? `using. ${path.trim()}` : `using { ${path.trim()} }`;
@@ -176,13 +161,10 @@ export class ImportFormatter {
      * already imports it. An unbalanced `'` matches neither branch, so the
      * capture ends before it and the remainder pins the line.
      *
-     * A comment opener is outside the class, though a quoted group admits one.
-     * matchImport strips it regardless, so none reaches a path - but the strip
-     * cuts inside the group while `end` measures the unstripped capture, so on
-     * `using. Foo'a#b'` the path and the leftover disagree about where the
-     * statement ends. No caller reaches that: isModuleImport refuses `Foo'a`,
-     * and the leftover is read from the line's code, which has no comment left
-     * in it. Widening the class is what would make the two meet.
+     * Do not widen the class to admit a comment opener. matchImport strips a
+     * comment from the capture but measures `end` on the unstripped text, so a
+     * `#` reaching the capture makes the path and the leftover disagree about
+     * where the statement ends.
      */
     private static readonly DOTTED_STATEMENT = /^using\.\s*((?:[A-Za-z0-9_./@:()-]|'[^']*')*)/;
 
@@ -191,8 +173,8 @@ export class ImportFormatter {
      * much of the string it occupies.
      *
      * Anchored on the trimmed statement, and dotted before braced, following
-     * isModuleImport. Unanchored, the braced pattern is free to match
-     * inside the trailing comment of a dotted statement and win the path -
+     * isModuleImport. Unanchored, the braced pattern is free to match inside
+     * the trailing comment of a dotted statement and win the path -
      * `using. Economy.Shop # was using { Inventory }` read as `Inventory`,
      * because the comment is only stripped afterwards, from that capture.
      *
@@ -203,10 +185,10 @@ export class ImportFormatter {
      * The dotted style closes with nothing, so its own content is what ends it:
      * the capture stops at the first character a dotted content cannot hold,
      * which is how Verse itself lexes a path - `/a/b-c` is the path `/a/b`, then
-     * `-`, then `c`. Reading to end of line instead is what let a statement
-     * written after a `;` be captured into the path and re-emitted inside the
-     * braces. See DOTTED_STATEMENT for what a dotted content may hold, and why
-     * ending the capture early is not the safe direction it looks.
+     * `-`, then `c`. Reading to end of line instead captures a statement written
+     * after a `;` into the path, which is then re-emitted inside the braces. See
+     * DOTTED_STATEMENT for what a dotted content may hold, and why ending the
+     * capture early is not the safe direction it looks.
      *
      * @returns The path and the offset just past the statement **in the
      *   trimmed input**, or null when there is no statement (including one
@@ -231,14 +213,12 @@ export class ImportFormatter {
     }
 
     /**
-     * Extracts the module path from an import statement.
-     * Handles both curly syntax (using { /path }) and dot syntax (using. /path).
-     * A trailing comment is stripped, so the returned path never carries trivia
-     * that would corrupt the statement when it is re-emitted.
+     * The module path of the `using` statement at the head of a string, or null
+     * when there is none - including a statement whose content is nothing but a
+     * comment.
      *
-     * @param importStatement The full import statement
-     * @returns The extracted path, or null if there is none (including a
-     *   statement whose content is nothing but a comment)
+     * The trailing comment is stripped, so the path never carries trivia that
+     * would corrupt the statement when it is re-emitted.
      */
     extractPathFromImport(importStatement: string): string | null {
         return ImportFormatter.matchImport(importStatement)?.path ?? null;
@@ -273,22 +253,21 @@ export class ImportFormatter {
     }
 
     /**
-     * Determines if an import is a digest import (from Verse.org, Fortnite.com, or UnrealEngine.com).
-     * @param importPath The import path or statement to check
-     * @returns true if the import is from a digest source, false otherwise
+     * Whether an import comes from a digest source, which the
+     * `behavior.digestImportPrefixes` setting defines and defaults to
+     * Verse.org, Fortnite.com and UnrealEngine.com.
+     *
+     * @param importPath A bare path or a whole `using` statement
      */
     isDigestImport(importPath: string): boolean {
-        // Extract the path if this is a full import statement
         let path = importPath;
         if (importPath.includes("using")) {
             path = this.extractPathFromImport(importPath) || importPath;
         }
 
-        // Get configurable digest prefixes
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const digestPrefixes = config.get<string[]>("behavior.digestImportPrefixes", ["/Verse.org/", "/Fortnite.com/", "/UnrealEngine.com/"]);
 
-        // Check if it's a digest import
         return digestPrefixes.some((prefix) => path.startsWith(prefix));
     }
 
@@ -302,9 +281,6 @@ export class ImportFormatter {
      * Placement reads the same ranks the sort compares, so a new import can be
      * ranked against the whole file rather than only against the block it is
      * merged into.
-     *
-     * @param path The import path to rank
-     * @returns 0, 1 or 2
      */
     importRank(path: string): number {
         if (path.startsWith("/")) {
@@ -317,37 +293,27 @@ export class ImportFormatter {
     }
 
     /**
-     * Sorts import paths for a `using` block using rank-based ordering rather
-     * than plain alphabetical order.
+     * A new array of the paths ordered by rank, and alphabetically within ranks
+     * 0 and 2. The input is not modified.
      *
-     * Verse resolves `using` statements top-down: a statement can only see
-     * identifiers brought into scope by statements above it. This matters
-     * because `using` has two meanings — a module import (`using { /Path }`,
-     * `using { Foo.Bar }`) and a local-scope using (`using { Variable }`) —
-     * and a dotted module import's first segment is itself only in scope if
-     * some other import (a bare module reference) already provided it. For
-     * example `using { Economy.Shop }` needs `Economy` in scope, which
-     * `using { Features }` provides if `Features` declares the `Economy`
-     * submodule. Plain alphabetical sorting can reorder `Economy.Shop` before
-     * `Features` (E < F) and break compilation even though both imports are
-     * individually valid.
+     * Rank ordering rather than plain alphabetical order, because Verse
+     * resolves `using` statements top-down: a statement sees only identifiers
+     * brought into scope above it. A dotted import's first segment is in scope
+     * only if a bare module reference already provided it, so
+     * `using { Economy.Shop }` needs the `Economy` that `using { Features }`
+     * brings - and alphabetical order puts `Economy.Shop` first (E < F) and
+     * breaks compilation, though both imports are individually valid.
      *
-     * Paths are grouped into three ranks, and only alphabetized within a rank:
-     * - Rank 0 — absolute paths (start with `/`): self-contained, sorted alphabetically.
-     * - Rank 1 — bare identifiers (no `/`, no `.`): kept in their original
-     *   input order, never alphabetized, since the relative order between
-     *   bare module imports is semantic — a nested child must follow the
-     *   parent that provides it.
-     * - Rank 2 — everything else (dotted references such as `Economy.Shop`,
-     *   and any other non-absolute form): sorted alphabetically.
+     * - Rank 0, absolute paths (leading `/`): self-contained, alphabetized.
+     * - Rank 1, bare identifiers (no `/`, no `.`): kept in input order, never
+     *   alphabetized, since the order between bare module imports is semantic
+     *   - a nested child must follow the parent that provides it.
+     * - Rank 2, everything else (dotted references such as `Economy.Shop`):
+     *   alphabetized.
      *
-     * A lower rank always precedes a higher rank, so bare imports precede
-     * dotted ones, guaranteeing a provider precedes anything that might
-     * depend on it. The sort is stable, so rank 1 entries keep their input
-     * order (the comparator returns 0 for two rank-1 paths).
-     *
-     * @param paths Import paths to sort
-     * @returns A new array with paths ordered by rank, then alphabetically within rank 0 and rank 2
+     * A lower rank always precedes a higher one, so a provider precedes
+     * anything that might depend on it. The sort is stable, which is what keeps
+     * rank 1 in input order once its comparator returns 0.
      */
     sortImportsByRank(paths: string[]): string[] {
         const rankOf = (path: string): number => this.importRank(path);
@@ -366,24 +332,19 @@ export class ImportFormatter {
     }
 
     /**
-     * Groups and formats imports based on the configuration settings.
-     * @param importPaths Array of import paths to group and format
-     * @param preferDotSyntax Whether to use dot syntax for imports
-     * @param sortAlphabetically Whether to sort imports alphabetically
-     * @param importGrouping The grouping strategy ('none', 'digestFirst', or 'localFirst').
-     *   Any other value falls back to 'none', so a setting typo or a renamed
-     *   enum member degrades to ungrouped output rather than dropping imports.
-     * @returns Array of formatted import statements with potential empty lines for grouping
+     * The formatted `using` statements for a set of paths, with an empty string
+     * between the two groups when a grouping strategy puts imports in both.
+     *
+     * @param importGrouping 'none', 'digestFirst' or 'localFirst'. Any other
+     *   value falls back to 'none', so a setting typo or a renamed enum member
+     *   degrades to ungrouped output rather than dropping imports.
      */
     groupAndFormatImports(importPaths: string[], preferDotSyntax: boolean, sortAlphabetically: boolean, importGrouping: string): string[] {
         if (importGrouping !== "digestFirst" && importGrouping !== "localFirst") {
-            // Rank-based sort if enabled (see sortImportsByRank for why plain
-            // alphabetical order is unsafe for local imports)
             const sortedPaths = sortAlphabetically ? this.sortImportsByRank(importPaths) : importPaths;
             return sortedPaths.map((path) => this.formatImportStatement(path, preferDotSyntax));
         }
 
-        // New grouping behavior: separate digest and local imports
         let digestImports: string[] = [];
         let localImports: string[] = [];
 
@@ -395,26 +356,22 @@ export class ImportFormatter {
             }
         }
 
-        // Sort within groups if enabled. digestImports are always absolute
-        // paths, so rank sort and plain alphabetical sort are equivalent
-        // there; the same helper is used for both groups for consistency.
+        // digestImports are always absolute paths, so rank sort and plain
+        // alphabetical sort agree there; one helper serves both groups.
         if (sortAlphabetically) {
             digestImports = this.sortImportsByRank(digestImports);
             localImports = this.sortImportsByRank(localImports);
         }
 
-        // Format the imports
         const formattedDigestImports = digestImports.map((path) => this.formatImportStatement(path, preferDotSyntax));
         const formattedLocalImports = localImports.map((path) => this.formatImportStatement(path, preferDotSyntax));
 
-        // Combine based on configuration. Only the two grouped strategies reach
-        // this point, so both branches of the pair are covered.
+        // Only the two grouped strategies reach here, so the pair covers both.
         const [firstGroup, secondGroup] = importGrouping === "digestFirst" ? [formattedDigestImports, formattedLocalImports] : [formattedLocalImports, formattedDigestImports];
 
         const formattedImports: string[] = [...firstGroup];
-        // Add spacing between groups if both have imports
         if (firstGroup.length > 0 && secondGroup.length > 0) {
-            formattedImports.push(""); // Empty line between groups
+            formattedImports.push("");
         }
         formattedImports.push(...secondGroup);
 

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -21,10 +21,11 @@ export class ImportFormatter {
      * The content of a `using` statement with any trailing comment removed,
      * trimmed.
      *
-     * The path captures are greedy to end of line, so a comment left on the
-     * content is captured as part of the path and re-emitted inside the braces
-     * - `using { /X # note }`, where the comment swallows the closing brace and
-     * the statement no longer parses.
+     * A comment left on the content is re-emitted inside the braces -
+     * `using { /X # note }`, where it swallows the closing brace and the
+     * statement no longer parses. Nothing upstream removes it: `#` and `<#` are
+     * both illegal in a module path, so a capture that runs to end of line
+     * takes the comment with it.
      */
     static stripTrailingComment(content: string): string {
         const commentStart = ImportFormatter.commentStartIndex(content);
@@ -161,10 +162,13 @@ export class ImportFormatter {
      * already imports it. An unbalanced `'` matches neither branch, so the
      * capture ends before it and the remainder pins the line.
      *
-     * Do not widen the class to admit a comment opener. matchImport strips a
-     * comment from the capture but measures `end` on the unstripped text, so a
-     * `#` reaching the capture makes the path and the leftover disagree about
-     * where the statement ends.
+     * A `#` reaching the capture makes the path and the leftover disagree about
+     * where the statement ends, because matchImport strips the comment from the
+     * capture but measures `end` on the unstripped text. The class keeps one
+     * out; the quoted alternative does not, so `using. Foo'a#b'` is only kept
+     * away by isModuleImport, which refuses `Foo'a` before the line is scanned.
+     * Relaxing that gate, or widening this class, brings the disagreement into
+     * reach.
      */
     private static readonly DOTTED_STATEMENT = /^using\.\s*((?:[A-Za-z0-9_./@:()-]|'[^']*')*)/;
 
@@ -335,6 +339,9 @@ export class ImportFormatter {
      * The formatted `using` statements for a set of paths, with an empty string
      * between the two groups when a grouping strategy puts imports in both.
      *
+     * @param sortAlphabetically Enables the rank sort, which is not alphabetical
+     *   order - see sortImportsByRank for why plain alphabetical order breaks
+     *   local imports.
      * @param importGrouping 'none', 'digestFirst' or 'localFirst'. Any other
      *   value falls back to 'none', so a setting typo or a renamed enum member
      *   degrades to ungrouped output rather than dropping imports.

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -7,12 +7,11 @@ import { ImportDocumentEditor } from "./ImportDocumentEditor";
 
 /**
  * The way in to import handling: suggestion extraction, document editing and
- * formatting behind one object that owns their shared instances.
+ * formatting behind one object.
  *
- * Go through this rather than around it. The three collaborators are
- * constructed here and share one ImportFormatter, so reaching for
- * ImportSuggestionExtractor or ImportDocumentEditor directly builds a second
- * set that no longer agrees with this one.
+ * Go through this rather than around it. It is where the collaborators are
+ * wired to the extension context and the assets digest parser, so one built
+ * directly gets whichever of those the caller remembered to pass.
  */
 export class ImportHandler {
     private formatter: ImportFormatter;

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -6,8 +6,13 @@ import { ImportSuggestionExtractor } from "./ImportSuggestionExtractor";
 import { ImportDocumentEditor } from "./ImportDocumentEditor";
 
 /**
- * Facade class that coordinates import handling operations.
- * Maintains backward compatibility while delegating to specialized classes.
+ * The way in to import handling: suggestion extraction, document editing and
+ * formatting behind one object that owns their shared instances.
+ *
+ * Go through this rather than around it. The three collaborators are
+ * constructed here and share one ImportFormatter, so reaching for
+ * ImportSuggestionExtractor or ImportDocumentEditor directly builds a second
+ * set that no longer agrees with this one.
  */
 export class ImportHandler {
     private formatter: ImportFormatter;
@@ -24,23 +29,14 @@ export class ImportHandler {
         this.documentEditor = new ImportDocumentEditor(outputChannel, this.formatter);
     }
 
-    /**
-     * Extracts existing import statements from a document.
-     */
     extractExistingImports(document: vscode.TextDocument): string[] {
         return this.documentEditor.extractExistingImports(document);
     }
 
-    /**
-     * Extracts import suggestions from an error message.
-     */
     async extractImportSuggestions(errorMessage: string): Promise<ImportSuggestion[]> {
         return this.suggestionExtractor.extractImportSuggestions(errorMessage);
     }
 
-    /**
-     * Adds import statements to a document.
-     */
     async addImportsToDocument(document: vscode.TextDocument, importStatements: string[]): Promise<boolean> {
         return this.documentEditor.addImportsToDocument(document, importStatements);
     }
@@ -54,9 +50,6 @@ export class ImportHandler {
         return this.documentEditor.organizeImports(document, additionalPaths);
     }
 
-    /**
-     * Extracts import suggestions from VS Code diagnostics.
-     */
     extractImportsFromDiagnostics(diagnostics: vscode.Diagnostic[]): string[] {
         return this.suggestionExtractor.extractImportsFromDiagnostics(diagnostics);
     }

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -9,9 +9,10 @@ import { ImportDocumentEditor } from "./ImportDocumentEditor";
  * The way in to import handling: suggestion extraction, document editing and
  * formatting behind one object.
  *
- * Go through this rather than around it. It is where the collaborators are
- * wired to the extension context and the assets digest parser, so one built
- * directly gets whichever of those the caller remembered to pass.
+ * Go through this rather than around it. It is the only place the extension
+ * context and the assets digest parser are threaded into
+ * ImportSuggestionExtractor, so an extractor built directly gets whichever of
+ * the two the caller remembered to pass.
  */
 export class ImportHandler {
     private formatter: ImportFormatter;

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -40,8 +40,9 @@ export interface ScannedImport {
      *
      * Neither value is a promise. `false` means no loss is known, not that none
      * is possible: content the statement patterns cannot lex, such as an
-     * unbalanced `'`, ends the capture early, so the reported path is a prefix
-     * of the real one - present, but never re-emitted. `true` does not promise
+     * unbalanced `'`, ends the capture early, which leaves a remainder over and
+     * so pins the line - the reported path is then a prefix of the real one,
+     * present but never re-emitted. `true` does not promise
      * every path on the span was recorded either: a line ending in a `using:`
      * pair reports the statement at its head and the path below, and none in
      * between. The line is pinned either way, so nothing is deleted; the cost is
@@ -74,9 +75,12 @@ interface LineScan {
      * reads a `using` written in trivia as the line's own statement.
      *
      * Nothing is put in a removed comment's place, so text on either side of
-     * one joins. Do not insert a space instead: `usingPathsOnLine` requires a
-     * `using` to begin a token, and every legal separator already survives the
-     * join because none of them is an identifier character.
+     * one joins. That is what the field is for: a comment splicing a token
+     * apart, `us<##>ing { /A }`, rejoins into a `using` the search can find,
+     * and a missed `using` is the one error its callers cannot survive. Putting
+     * a space there instead loses that, and buys only
+     * `X := 1<# note #>using { /A }` - a shape two statements with nothing
+     * between them do not compile as anyway.
      */
     code: string;
     /**

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -13,66 +13,40 @@ export const LINE_SPLIT = /\r?\n/;
 export interface ScannedImport {
     /** The module path, e.g. "/Verse.org/Simulation" or "Gadgets.Tools". */
     path: string;
-    /** First line of the statement. */
     startLine: number;
     /** Last line of the statement: equal to startLine, or startLine + 1 for the indented pair. */
     endLine: number;
     /**
      * Whether the statement's own text opens a comment whose body is the lines
-     * below it, which pins the statement to the position it was written at.
+     * below it. Set by either marker, since their consequence is the same: `<#`
+     * leaves a block comment open until a matching `#>`, and `<#>` opens an
+     * indented comment over the lines indented past it.
      *
-     * Two markers do this, and their consequences are identical, so they are
-     * one flag rather than two:
-     *
-     * - `<#` leaves a block comment open, making every line below it comment
-     *   body until a matching `#>`.
-     * - `<#>` opens an indented comment, making every line below it indented
-     *   past it comment body.
-     *
-     * Writers rebuild an import line from `path` alone, so trailing text is
-     * restored from `trailingComment` rather than preserved in place. That is
-     * enough for an annotation, but not for either marker: what a marker
-     * comments out is decided by where it sits, so re-emitting it at a
+     * What a marker comments out is decided by where it sits, so such a
+     * statement may be neither rebuilt nor moved - re-emitting it at a
      * different line makes it swallow lines the author never wrote it around.
-     * Such a statement cannot be rewritten or moved: it stays on its own line,
-     * with everything else organized around it.
+     * It stays where it is, with everything else organized around it.
      */
     anchorsCommentBelow: boolean;
     /**
      * Whether rebuilding this statement's lines from `path` would delete text
-     * the author wrote, because the span carries a statement `path` cannot
-     * reproduce.
+     * the author wrote, because the span says more than any one path can. A `;`
+     * is what makes that possible: it separates statements exactly as a newline
+     * does, so one span can hold two.
      *
-     * Every writer reconstructs a span from `path` and `trailingComment`, which
-     * is faithful only while the statement is the whole of what its lines say.
-     * A `;` breaks that, because it separates statements exactly as a newline
-     * does: the span holds another statement as well, and a rebuild from either
-     * path alone deletes the other. Such a statement is still a real import and
-     * still counts as present - only rewriting is off limits, exactly as for
-     * anchorsCommentBelow, and rewritableImports filters on both.
+     * Such a statement is still a real import and still counts as present. Only
+     * rewriting is off limits, as for `anchorsCommentBelow`; `rewritableImports`
+     * filters on both.
      *
-     * Detection asks two questions of the line: how many `using` statements it
-     * writes, and - where it writes one - whether any code is left over after
-     * it. What the leftover says does not matter, so a statement written after
-     * a `;` is caught by the second question when it is not a `using` and the
-     * first cannot count it.
-     *
-     * `false` is still "no loss known", not "provably none". The dotted style is
-     * what made that gap real: having no closing delimiter, it once ran to end
-     * of line, leaving nothing over for the second question and no second
-     * `using` for the first to count in `using. /X; MyVal := 5` - so the path
-     * was the whole of the line and a rebuild corrupted it rather than deleting
-     * from it. matchImport now ends that capture where a dotted content stops,
-     * and both questions see what follows the separator. What remains is content
-     * it cannot lex at all, such as an unbalanced `'`: the capture ends early,
-     * which leaves a remainder over and pins the line - so the path it reports
-     * is a prefix of the real one, present but never re-emitted.
-     *
-     * `true` is likewise not a promise that every path on the span was
-     * recorded. A line ending in a `using:` pair reports the statement at its
-     * head and the path below, and no statement in between (#233). The line is
-     * pinned either way, so nothing is deleted; the cost is a path that does not
-     * count as present, which lets a writer add a second copy of it.
+     * Neither value is a promise. `false` means no loss is known, not that none
+     * is possible: content the statement patterns cannot lex, such as an
+     * unbalanced `'`, ends the capture early, so the reported path is a prefix
+     * of the real one - present, but never re-emitted. `true` does not promise
+     * every path on the span was recorded either: a line ending in a `using:`
+     * pair reports the statement at its head and the path below, and none in
+     * between. The line is pinned either way, so nothing is deleted; the cost is
+     * a path that does not count as present, which lets a writer add a second
+     * copy of it.
      */
     rebuildLosesText: boolean;
     /**
@@ -94,28 +68,15 @@ interface LineScan {
     /** Whether the line carries any text outside a comment. */
     hasCode: boolean;
     /**
-     * The line with its comments removed. A reader searching a line for a
-     * statement it cannot prefix-test needs this: a statement is not required
-     * to open its line - one can follow a `;`, or the `#>` that closes a block
-     * comment - so the search has to cover the whole line, and searching the
-     * raw line finds a `using` written in the trivia.
+     * The line with its comments removed. A statement is not required to open
+     * its line - one can follow a `;`, or the `#>` that closes a block comment
+     * - so a reader has to search the whole line, and searching the raw line
+     * reads a `using` written in trivia as the line's own statement.
      *
      * Nothing is put in a removed comment's place, so text on either side of
-     * one joins. Whether Verse splits a token there is not something its test
-     * corpus settles: comments appear only between tokens throughout
-     * Tests/Roundtrip/Comments.versetest, and the one splicing case,
-     * `"abc<#def#>ghi" = "abcghi"` in Tests/Literals/String.versetest, is
-     * string contents rather than an identifier. Joining is the side to be
-     * wrong on: missing a `using` is the error its caller cannot survive.
-     *
-     * That is no longer unconditional. usingPathsOnLine requires a `using` to
-     * begin a token, so joining a statement onto the token before it hides it.
-     * Every legal separator survives - a `;`, a space, a `)`, a `}`, a line
-     * start - because none of them is an identifier character. Only
-     * `X := 1<# note #>using { /A }` does not, and two statements with nothing
-     * between them do not compile anyway. Putting a space where a comment was
-     * would repair that shape and break the reason this field exists, so it is
-     * the wrong repair; see the cost usingPathsOnLine documents.
+     * one joins. Do not insert a space instead: `usingPathsOnLine` requires a
+     * `using` to begin a token, and every legal separator already survives the
+     * join because none of them is an identifier character.
      */
     code: string;
     /**
@@ -129,8 +90,7 @@ interface LineScan {
  * Advances `<# ... #>` block-comment nesting across one line, and reports
  * whether anything on the line was code rather than comment text.
  *
- * Three Verse rules decide what counts as an opener, all taken from the
- * language's own lexer and comment round-trip tests:
+ * Three Verse rules decide what counts as an opener:
  *
  * - Block comments nest, so an inner `#>` closes only the innermost `<#`.
  * - `<#>` is the *indented* comment marker, not a block opener. Its body is
@@ -164,14 +124,10 @@ function scanLine(line: string, depth: number): LineScan {
         }
 
         if (line.startsWith("<#>", i)) {
-            // Indented comment: the rest of this line is comment text, and so
-            // is everything below indented past this line.
             return { depth: nesting, hasCode, code, opensIndentedComment: true };
         }
 
         if (line[i] === "#") {
-            // Line comment: the rest of the line is comment text and cannot
-            // open a block.
             return { depth: nesting, hasCode, code, opensIndentedComment: false };
         }
 
@@ -191,7 +147,6 @@ function scanLine(line: string, depth: number): LineScan {
     return { depth: nesting, hasCode, code, opensIndentedComment: false };
 }
 
-/** The width of a line's leading whitespace, which is its indentation. */
 function indentWidth(line: string): number {
     return line.length - line.trimStart().length;
 }
@@ -217,9 +172,8 @@ export interface LineClassification {
      */
     continuesCommentAbove: boolean;
     /**
-     * The line with its comments removed. A reader that searches a line rather
-     * than prefix-testing it needs this: search the raw line and a `using`
-     * written in its trivia reads as the line's own statement.
+     * The line with its comments removed. Search the raw line instead and a
+     * `using` written in its trivia reads as the line's own statement.
      */
     code: string;
 }
@@ -231,13 +185,12 @@ export interface LineClassification {
  * decide this line by line: a bare `#>` reads as a line comment on its own but
  * is the tail of a block comment when something above it opened one, a line of
  * ordinary prose is comment text under an open `<#`, and an indented line is
- * comment text under a `<#>` marker. Both writers here and in
- * ImportDocumentEditor need the same answer, so it is computed once, here,
- * next to the lexing rules it depends on.
+ * comment text under a `<#>` marker. Callers here and in ImportDocumentEditor
+ * need the same answer, so it is computed once, next to the lexing rules it
+ * depends on.
  *
  * Block-comment depth advances across an indented comment's body exactly as it
- * does anywhere else, so what the scanner sees is unchanged by this: the
- * indented body affects `kind` only.
+ * does anywhere else, so the indented body affects `kind` only.
  */
 export function classifyLines(lines: string[]): LineClassification[] {
     const classifications: LineClassification[] = new Array(lines.length);
@@ -251,8 +204,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
         const blank = line.trim() === "";
 
         // An indented comment runs until a line that is neither blank nor
-        // indented past its marker: "everything indented by four spaces on
-        // subsequent lines becomes part of the comment", blank lines included.
+        // indented past its marker. Blank lines do not end it.
         if (indentedCommentIndent !== null && !blank && indentWidth(line) <= indentedCommentIndent) {
             indentedCommentIndent = null;
         }
@@ -296,14 +248,14 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   `;` is consumed as well, but pinned rather than rewritable: its span says
  *   more than any one path can, so a writer rebuilding it deletes what it did
  *   not read. A `using:` following anything that is not itself a `using` is
- *   not an import line at all and is skipped whole, as it always was.
+ *   not an import line at all and is skipped whole.
  * - Content classification (module import vs local-scope using) is delegated
  *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
- *   every candidate here already sits at column 0. This means a bare
- *   identifier at file level, e.g. `using { Features }`, is now collected as
- *   a module import (a same-directory folder-module import): module `using`
- *   is only legal at file level or module-definition body level, so a bare
- *   `using` at column 0 can never be a legal local-scope using.
+ *   every candidate here already sits at column 0. So a bare identifier at
+ *   file level, `using { Features }`, counts as a module import (a
+ *   same-directory folder-module import): module `using` is legal only at
+ *   file level or module-definition body level, so a bare `using` at column 0
+ *   can never be a legal local-scope using.
  * - A collected import that itself opens a comment over the lines below it is
  *   flagged with `anchorsCommentBelow`. It is a real import and still counts
  *   as present, but no writer may rebuild or move its line, because where the
@@ -314,22 +266,17 @@ export function classifyLines(lines: string[]): LineClassification[] {
 export function scanModuleImports(lines: string[]): ScannedImport[] {
     const formatter = new ImportFormatter();
     const imports: ScannedImport[] = [];
-    // Computed in one pass up front because comment structure is a property of
-    // everything above a line, which the main loop cannot see once it starts
-    // skipping. `insideBlockComment` decides whether a line may be read as an
-    // import at all, and `code` is what a test searching a line rather than
-    // prefix-testing it has to search - see the tail test below.
+    // Computed up front because the main loop cannot see comment structure
+    // once it starts skipping lines.
     const classifications = classifyLines(lines);
 
-    // Whether the statement's own text opens a comment over the lines below it,
-    // read from that text alone rather than from what currently sits under it.
+    // Whether the statement's own text opens a comment over the lines below it:
+    // a `<#>` anywhere on the span, or a `<#` the span never closes.
     //
-    // Both markers are decided the same way: a `<#>` anywhere on the span, or a
-    // `<#` the span never closes. Neither depends on there being a body today,
-    // because a rebuild is free to move the line and hand it one - sorting an
-    // unclosed opener above another import makes it swallow that import, and
-    // moving a `<#>` above an indented line makes it swallow that line. The
-    // statement is what carries the marker, so the statement is what is asked.
+    // Asked of that text alone rather than of what currently sits under it,
+    // because a rebuild is free to move the line and hand it a body - sorting
+    // an unclosed opener above another import makes it swallow that import, and
+    // moving a `<#>` above an indented line makes it swallow that line.
     //
     // A span always starts at depth 0: lines inside a block comment are skipped
     // below, and the `using:` opening an indented pair holds no `#` to open one
@@ -397,44 +344,36 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
 
         // The same pair, opened after a `;` rather than at the head of its line.
         // `;` separates definitions in a scope exactly as a newline does, so a
-        // statement can precede the `using:` - which is why allUsingPaths tests
-        // the tail of the line rather than the whole of it (#218). Read whole,
-        // the line is not a pair at all: it falls through to the single-statement
-        // branch below, which reports the path before the `;` and a span of one
-        // line, and a writer then rebuilds that line from that path alone -
-        // deleting the `; using:` and leaving its path stranded in the body.
+        // statement can precede the `using:`. Without this branch such a line
+        // falls through to the single-statement branch below, which reports the
+        // path before the `;` and a span of one line - and a writer rebuilding
+        // that line from that path deletes the `; using:`, stranding its path in
+        // the body.
         //
-        // Tested against the line's code rather than its raw text, for the same
-        // reason allUsingPaths is: a `$` anchored on the raw line is defeated by
-        // any comment after the `using:`, which puts the line straight back on
-        // the mangling path this branch exists to keep it off. Searching the raw
-        // text has the mirror failure - `using { /A } <# note about using:` ends
-        // in `using:` inside a comment, and reading it as an opener records the
-        // comment text below as an import path.
+        // Tested against the line's code rather than its raw text. A `$`
+        // anchored on the raw line is defeated by any comment after the
+        // `using:`, and searching the raw text has the mirror failure:
+        // `using { /A } <# note about using:` ends in `using:` inside a comment,
+        // and reading that as an opener records the comment text below as a
+        // path.
         //
         // Order is load-bearing. A whole-line `using:` matches this tail test
         // too, so the branch above has to keep first refusal or the plain pair
-        // changes shape.
-        //
-        // That branch still tests the raw line, and the two inputs cannot
-        // disagree where it runs: isModuleImport gates this loop on the raw text
-        // as well, and a line whose raw text is not exactly `using:` matches
-        // none of its three patterns - so `using: # note` is refused above and
-        // never reaches either branch. The gate is what protects it, not the
-        // input choice. Relaxing the gate is what would make the choice matter.
+        // changes shape. That branch tests the raw line, which is safe only
+        // while isModuleImport gates this loop on the raw text as well:
+        // relaxing that gate is what would let the two inputs disagree.
         //
         // Every path the line writes is recorded, because each is imported and
         // none may be written again, and all are pinned, because no writer can
-        // reproduce this span from any one of them. Their spans overlap. No
-        // writer sees that, because all of them read rewritableImports, which
-        // excludes a pinned entry; a reader of the unfiltered scan does, and
-        // gets the region reported once per path it carries.
+        // reproduce this span from any one of them. Their spans overlap. Writers
+        // never see that, because they all read rewritableImports, which
+        // excludes a pinned entry; a reader of the unfiltered scan gets the
+        // region reported once per path it carries.
         if (/\busing\s*:\s*$/.test(code)) {
-            // The statement before the `;`, when the line writes one. A line
-            // whose `using:` follows something that is not a `using` at all
-            // never reaches here: isModuleImport rejects it above, so the line
-            // is skipped whole and left alone, which is the same outcome by a
-            // different route.
+            // The statement before the `;`, when the line writes one. A
+            // `using:` following something that is not a `using` never reaches
+            // here - isModuleImport rejects the line above and it is skipped
+            // whole.
             const precedingPath = formatter.extractPathFromImport(code);
             if (precedingPath) {
                 imports.push({
@@ -443,23 +382,20 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     endLine: i,
                     anchorsCommentBelow: anchorsCommentBelow(i, i),
                     rebuildLosesText: true,
-                    // Read from the raw line, so on a line whose comment sits
-                    // mid-statement this holds the `; using:` after it as well
-                    // as the comment. Nothing re-emits it - that is what being
-                    // pinned means - and the alternative is worse: the code has
-                    // its comments already removed, so it can only ever answer
-                    // "none".
+                    // Read from the raw line, so where the comment sits
+                    // mid-statement this holds the `; using:` after it as well.
+                    // Nothing re-emits a pinned entry, and the code has its
+                    // comments already removed so it could only answer "none".
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
                 });
             }
 
             const indentedPath = nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "";
             if (!indentedPath) {
-                // The `using:` opens nothing usable, exactly as in the branch
-                // above - but the line still carries a statement this scanner
-                // cannot reproduce, so it is pinned rather than handed to the
-                // single-statement branch, which would rebuild it and delete the
-                // `; using:`.
+                // The `using:` opens nothing usable, but the line still carries
+                // a statement this scanner cannot reproduce. Falling through to
+                // the single-statement branch would rebuild the line and delete
+                // the `; using:`.
                 i += 1;
                 continue;
             }
@@ -477,25 +413,21 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         }
 
         // Two complete statements sharing a line, `using { /X }; using { /Y }`.
-        // extractPathFromImport below reads the statement at the head of what it
-        // is given and says nothing about the remainder, so the line used to be
-        // recorded as its first path alone, spanning one line and rewritable -
-        // and organizing then rebuilt it from that path, deleting the second
-        // statement with no trace left that anything had gone.
-        //
-        // All of them recorded, all of them pinned, spans coinciding, for the
-        // reasons the branch above gives.
+        // extractPathFromImport reads the statement at the head of what it is
+        // given and says nothing about the remainder, so a line read that way
+        // is recorded as its first path alone and a rebuild deletes the second
+        // statement. All of them recorded, all of them pinned, spans coinciding,
+        // for the reasons the branch above gives.
         //
         // Asked of the line's code rather than its raw text, as that branch is.
         // `using { /A } # see using { /B }` writes one statement and mentions
         // another in a comment; searching the raw text finds two, and refuses to
         // organize a plain single-statement line over the words after its `#`.
         //
-        // usingPathsOnLine is what allUsingPaths asks, so reader and writer now
-        // agree on how many statements a line writes. Asking it a second way
-        // here would be the looser second copy its doc warns against - and this
-        // caller needs the count exact in both directions, which is why that
-        // function only offers a `using` that begins a token.
+        // usingPathsOnLine is what allUsingPaths asks, so reader and writer
+        // agree on how many statements a line writes. Counting a second way
+        // here would be the looser copy its doc warns against, and this caller
+        // needs the count exact in both directions.
         const pathsOnLine = usingPathsOnLine(formatter, code);
         if (pathsOnLine.length > 1) {
             for (const linePath of pathsOnLine) {
@@ -516,7 +448,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
 
         // One statement, and the line is rewritable only if that statement is
         // the whole of what it says. What follows a `;` need not be a `using`,
-        // and neither branch above counts it - so the leftover is what says the
+        // and neither branch above counts it, so the leftover is what says a
         // definition after it would be deleted. See textAfterImport for why the
         // question is "what is left over" rather than "where is the `;`".
         //
@@ -524,9 +456,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // comment is leftover text on the raw line, and pinning on that refuses
         // to organize every annotated import in the file.
         //
-        // A line ending in a bare `;` is pinned too, on text that means
-        // nothing. The cost is one line left as written; trimming separators
-        // away first means being right about which ones mean nothing.
+        // A line ending in a bare `;` is pinned too, on text that means nothing.
+        // The cost is one line left as written; trimming separators away first
+        // means being right about which ones mean nothing.
         const path = formatter.extractPathFromImport(trimmed);
         if (path) {
             imports.push({
@@ -547,20 +479,16 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
 /**
  * The subset of scanned imports a writer is allowed to rebuild or move.
  *
- * Every writer reconstructs an import line from its path alone, so an import
- * whose line also opens a comment over the lines below it has to be excluded
- * from both halves of that: its lines never enter a range a writer replaces,
- * and its path is never re-emitted somewhere else. Anything else relocates the
- * marker so the comment swallows different lines than the author wrote it
- * around, or - for a `<#` - drops it and resurrects the region below. See
- * ScannedImport.anchorsCommentBelow.
- *
- * A statement sharing its span with another one is excluded for the same
- * reason, arrived at from the other direction: there the rebuild is faithful to
- * the path and deletes the rest of the span. See ScannedImport.rebuildLosesText.
+ * Every writer reconstructs an import line from its path alone, which is unsafe
+ * in two ways: an import whose line opens a comment over the lines below it
+ * cannot survive being moved (ScannedImport.anchorsCommentBelow), and one
+ * sharing its span with another statement is rebuilt faithfully to its own path
+ * while the rest of the span is deleted (ScannedImport.rebuildLosesText). An
+ * excluded import's lines never enter a range a writer replaces, and its path
+ * is never re-emitted elsewhere.
  *
  * Such an import is still present for existence and deduplication purposes;
- * only rewriting is off limits. Callers wanting "is this path imported" must
+ * only rewriting is off limits. Callers asking "is this path imported" must
  * read the unfiltered scan.
  */
 export function rewritableImports(scannedImports: ScannedImport[]): ScannedImport[] {
@@ -572,33 +500,24 @@ export function rewritableImports(scannedImports: ScannedImport[]): ScannedImpor
  * order, or [] when it writes none.
  *
  * extractPathFromImport reads a statement from the head of what it is given, so
- * a statement that does not open the line has to be handed its own head rather
- * than the line. Every `using` on the line is offered in turn, which keeps one
- * copy of the two patterns instead of a looser second copy that searches - the
- * looser copy is what read a comment as the statement in the first place.
+ * a statement that does not open the line is handed its own head rather than
+ * the line. That keeps one copy of the two statement patterns instead of a
+ * looser second copy that searches, which is what reads a comment as the line's
+ * statement.
  *
- * All of them are collected rather than the first, because a line can carry more
- * than one live statement - `;` separates definitions in a scope exactly as a
- * newline does. Stopping at the first is how a rank-0 path written before a
- * rank-1 or rank-2 one on the same line hid it from the caller, which reads an
- * all-absolute answer as permission to remove an import.
- *
- * A dotted statement has no closing delimiter, so where it ends is decided by
- * its own content rather than by a delimiter - see matchImport. Each `using` on
- * the line therefore contributes the path it actually writes, whatever style
- * its neighbours are written in.
+ * Every `using` is collected rather than the first, because `;` separates
+ * definitions in a scope exactly as a newline does. Stopping at the first hides
+ * a rank-1 or rank-2 path written after a rank-0 one, and a caller reading an
+ * all-absolute answer takes it as permission to remove an import.
  *
  * Only a `using` that begins a token is offered. `using` is a substring of
  * ordinary identifiers - `Housing` holds one - and the dotted pattern needs no
- * space after its `.`, so `using { Housing.Data }` offered every occurrence
- * reports `Housing.Data` and then `Data`, a path the line does not write. A
- * caller counting statements reads that as two.
+ * space after its `.`, so offering every occurrence of `using { Housing.Data }`
+ * reports `Housing.Data` and then `Data`, a path the line does not write, which
+ * a caller counting statements reads as two.
  *
  * The cost is a `using` glued to an identifier by a comment removed from
- * between them, `X := 1<# note #>using { /A }`. Whether Verse splits a token
- * where a comment was is not something its test corpus settles, so this is a
- * shape whose meaning is already unclear; a path invented out of every
- * identifier ending in `using` is not.
+ * between them, `X := 1<# note #>using { /A }`, which this does not report.
  */
 function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
     const paths: string[] = [];
@@ -632,29 +551,25 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
  * off the leading whitespace silently drops a bare module import written inside
  * a module. A caller weighing whether removing an import is safe does not need
  * the distinction anyway: an absolute path is always a module import, and any
- * other `using`, of either meaning, is reason enough not to remove anything. So
- * every `using` is reported and the caller judges by rank.
+ * other `using`, of either meaning, is reason enough not to remove anything.
  *
- * Only whole comment lines are skipped - a `<# ... #>` body and the indented
- * body of a `<#>` marker - so a commented-out `using` does not count while one
- * sharing a line with comment trivia still does. A missed `using` is the one
- * error this must not make: the caller reads an empty answer as permission to
- * remove an import, so anything unrecognised has to fail towards reporting a
- * path rather than away from it. That is also why the statement is not required
- * to open its line: it can follow a `;`, the `#>` that closes a block comment,
- * or closed inline trivia. So the whole line is searched - but the line with its
- * comments already removed, which is the classifier's answer rather than
- * anything read off the raw text. Searching the raw text is what let a
- * `using { X }` written in a comment stand in for the line's own statement,
- * the same defect extractPathFromImport itself had.
+ * A missed `using` is the one error this must not make, because the caller
+ * reads an empty answer as permission to remove an import. Everything here
+ * fails towards reporting a path rather than away from it:
  *
- * A `;` also means a line can carry more than one statement, so a line
- * contributes every `using` statement usingPathsOnLine finds on it, in written
- * order, rather than the first. Reporting the first was the same error under
- * another name - see that function. For the same reason a `using:` opening an
- * indented pair is recognised at the end of its line rather than as the whole
- * of it: a statement can precede it there too. The pair is the one shape still
- * counted once, because its path is read here from the line below.
+ * - Only whole comment lines are skipped, so a commented-out `using` does not
+ *   count while one sharing a line with comment trivia still does.
+ * - The statement need not open its line - it can follow a `;`, the `#>` that
+ *   closes a block comment, or closed inline trivia - so the whole line is
+ *   searched. The line searched is the classifier's `code` rather than the raw
+ *   text, or a `using { X }` written in a comment stands in for the line's own
+ *   statement.
+ * - A line contributes every `using` usingPathsOnLine finds on it, in written
+ *   order, rather than the first.
+ * - A `using:` opening an indented pair is recognised at the end of its line
+ *   rather than as the whole of it, since a statement can precede it there too.
+ *   The pair is the one shape counted once, because its path is read here from
+ *   the line below.
  *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */
@@ -676,16 +591,15 @@ export function allUsingPaths(lines: string[]): string[] {
         // extractPathFromImport reads neither pattern out of it - so the path
         // below it is read here instead.
         //
-        // Only the tail of the line has to match. Requiring the whole of it
-        // dropped the path below a pair opened after a `;`, and a line left
-        // reporting nothing but its absolute statements is read by the caller
-        // as permission to remove an import. Matching the tail alone errs the
-        // other way: a line merely ending in `using:` contributes the text
-        // below it as a path, which can only make the caller decline to tidy.
+        // Only the tail of the line has to match, because a statement can
+        // precede the `using:`. Requiring the whole line drops the path below
+        // such a pair, which the caller reads as permission to remove an
+        // import; matching the tail alone errs the safe way, since a line
+        // merely ending in `using:` contributes the text below it as a path and
+        // can only make the caller decline to tidy.
         //
-        // The indented half holds no `using` statement of its own, so the loop
-        // reaching it adds no second copy of the path - as scanModuleImports
-        // consumes both lines at once.
+        // The indented half holds no `using` of its own, so the loop reaching
+        // it adds no second copy of the path.
         if (!/\busing\s*:\s*$/.test(trimmed)) {
             continue;
         }
@@ -704,7 +618,6 @@ export function allUsingPaths(lines: string[]): string[] {
 export interface ConvertibleImport {
     /** The statement text, trimmed, exactly as it appears on its line. */
     statement: string;
-    /** The line the statement occupies. */
     line: number;
 }
 
@@ -715,10 +628,10 @@ export interface ConvertibleImport {
  * Conversion reads a statement's path, rewrites the whole line around it, and
  * offers a lens on it, so the set is narrower than the full scan in three ways:
  *
- * - It comes from scanModuleImports, which already rejects a `using` inside a
- *   `<# ... #>` block comment and one indented inside a module body. Deriving
- *   membership line by line instead is what let a lens appear on inert text and
- *   on a module-scoped import, and acting on that lens edited a line inside a
+ * - Membership comes from scanModuleImports, which already rejects a `using`
+ *   inside a `<# ... #>` block comment and one indented inside a module body.
+ *   Deriving it line by line instead offers a lens on inert text and on a
+ *   module-scoped import, and acting on that lens edits a line inside a
  *   comment.
  * - An import that opens a comment over the lines below it is excluded:
  *   rebuilding its line moves the marker away from the lines it was written

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -4,7 +4,9 @@ import { ImportSuggestion, ImportSuggestionSource, ImportConfidence } from "../t
 import { DigestParser, AssetsDigestParser } from "../services";
 import { ImportFormatter } from "./ImportFormatter";
 
-// Regex patterns for error message parsing
+// Each entry is documented by the compiler text it matches, since the message
+// wording is the contract these depend on. Precedence between them lives in
+// classifyMessage, not here.
 const PATTERNS = {
     /** "Did you mean any of:\n<options>" */
     DID_YOU_MEAN_ANY: /Did you mean any of:\s*\n(.+)/s,
@@ -35,9 +37,9 @@ const QUALIFIED_NAME = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 
 /**
  * Fallback for behavior.ambiguousImports. package.json is the source of truth
- * and registers exactly these three mappings; config.get returns the registered
- * default for a registered setting, so an empty fallback never reached
- * production and only ever changed what the tests saw. Keep the two in step.
+ * and registers exactly these three mappings; keep the two in step. Only a
+ * caller with no registered setting behind it, such as a test, ever sees this
+ * value - config.get returns the registered default otherwise.
  */
 export const DEFAULT_AMBIGUOUS_IMPORTS: Record<string, string> = {
     vector3: "/UnrealEngine.com/Temporary/SpatialMath",
@@ -65,7 +67,8 @@ type DiagnosticClassification =
     | { kind: "identifier"; identifier: string; inferred?: ImportCandidate };
 
 /**
- * Handles parsing error messages and diagnostics to extract import suggestions.
+ * Turns Verse compiler messages into import suggestions, for both the quick-fix
+ * menu and Optimize Imports.
  */
 export class ImportSuggestionExtractor {
     private readonly digestParser: DigestParser;
@@ -78,9 +81,7 @@ export class ImportSuggestionExtractor {
         this.assetsDigestParser = assetsDigestParser || null;
     }
 
-    /**
-     * Extracts paths from "using { /Path }" format.
-     */
+    /** Every path written as `using { /Path }` in the text. */
     private extractUsingPaths(text: string): string[] {
         const paths: string[] = [];
         const pattern = new RegExp(PATTERNS.USING_PATH.source, "g");
@@ -91,9 +92,7 @@ export class ImportSuggestionExtractor {
         return paths;
     }
 
-    /**
-     * Extracts paths from "(/Path:)" format (used in "Identifier could be one of many types").
-     */
+    /** Every path written as `(/Path:)`, the form used by "could be one of many types". */
     private extractParenPaths(text: string): string[] {
         const paths: string[] = [];
         const pattern = new RegExp(PATTERNS.PATH_IN_PARENS.source, "g");
@@ -105,17 +104,21 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Finds the correct module path from a fully qualified name by checking
-     * if any intermediate segments are known asset class names.
+     * Splits a fully qualified name into the module path to import and the
+     * class name within it, or null when the name is not a dotted identifier
+     * chain or carries no module part at all.
      *
-     * @param fullName The fully qualified name (e.g., "Ake.UI.UI_UMG.ClassName")
-     * @returns The correct module path and class name, or null if invalid
+     * The split normally falls before the last segment. An intermediate segment
+     * that names a known asset class moves it earlier, since everything from
+     * that class onward addresses members rather than modules.
+     *
+     * @param fullName e.g. "MyGame.UI.UI_Widget.ClassName"
      */
     private findCorrectModulePath(fullName: string): { modulePath: string; className: string } | null {
         // "Did you mean" captures raw sentence text, so trailing punctuation
         // ("Economy.Shop.") or prose ("to use Bar.Baz instead?") reaches this
-        // point; splitting those would produce a plausible-looking but wrong
-        // import. Anything that is not a dotted identifier chain is dropped.
+        // point, and splitting those produces a plausible-looking but wrong
+        // import.
         if (!QUALIFIED_NAME.test(fullName)) {
             logger.debug("ImportSuggestionExtractor", `Rejecting suggestion text that is not a dotted identifier chain: ${fullName}`);
             return null;
@@ -126,14 +129,12 @@ export class ImportSuggestionExtractor {
             return null;
         }
 
-        // Check from second-to-last segment backwards to find asset class names
-        // The last segment is always assumed to be the actual identifier being referenced
+        // Backwards from the second-to-last segment: the last is always taken to
+        // be the identifier being referenced, never a module.
         for (let i = parts.length - 2; i > 0; i--) {
             const segment = parts[i];
 
-            // Check if this segment is a known asset class name
             if (this.assetsDigestParser?.isAssetClassName(segment)) {
-                // This segment is a class, so the module path is everything before it
                 const modulePath = parts.slice(0, i).join(".");
                 const className = parts[parts.length - 1];
 
@@ -143,8 +144,8 @@ export class ImportSuggestionExtractor {
             }
         }
 
-        // No asset class found in intermediate segments - use default behavior
-        // (last segment is the class, everything else is the module)
+        // No asset class in between: the last segment is the class and
+        // everything before it the module.
         const lastDotIndex = fullName.lastIndexOf(".");
         return {
             modulePath: fullName.substring(0, lastDotIndex),
@@ -153,17 +154,14 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Parses error messages for multi-option import candidates.
-     * Handles three patterns:
-     * 1. "Did you mean any of:\n<options>"
-     * 2. "Did you forget to specify one of:\nusing { /Path }\nusing { /Path }"
-     * 3. "Identifier X could be one of many types: (/Path1:)X or (/Path2:)X"
+     * The importable candidates offered by a message that lists several.
      *
-     * Returns null when no multi-option pattern matches; an empty array when a
-     * pattern matched but no option was importable (e.g. only bare identifiers).
+     * Null and [] mean different things: null when no multi-option pattern
+     * matched at all, [] when one matched but no option was importable, such as
+     * a list of bare identifiers. Callers use the difference to decide whether
+     * the single-option patterns still deserve a try.
      */
     private parseMultiOptionCandidates(errorMessage: string): ImportCandidate[] | null {
-        // Pattern 1: "Did you mean any of:\n<options>"
         const match1 = errorMessage.match(PATTERNS.DID_YOU_MEAN_ANY);
         if (match1) {
             const options = match1[1]
@@ -175,24 +173,23 @@ export class ImportSuggestionExtractor {
             const candidates: ImportCandidate[] = [];
             for (const option of options) {
                 if (option.startsWith("/")) {
-                    // Direct module path
                     candidates.push({ path: option, description: `Import from ${option}` });
                     continue;
                 }
-                // Fully qualified name (e.g., "Module.ClassName" or "Module.AssetClass.Member")
+                // A fully qualified name, "Module.ClassName" or
+                // "Module.AssetClass.Member".
                 const result = this.findCorrectModulePath(option);
                 if (result && result.modulePath) {
                     candidates.push({ path: result.modulePath, description: `${result.className} from ${result.modulePath}` });
                 } else {
-                    // Bare identifiers (e.g. a local definition echoed in the option
-                    // list) carry no module path and are not importable.
+                    // A bare identifier, such as a local definition echoed in
+                    // the option list, carries no module path to import.
                     logger.debug("ImportSuggestionExtractor", `Dropping non-importable multi-option entry: ${option}`);
                 }
             }
             return candidates;
         }
 
-        // Pattern 2: "Did you forget to specify one of:\nusing { /Path }\nusing { /Path }"
         const match2 = errorMessage.match(PATTERNS.FORGET_ONE_OF);
         if (match2) {
             const options = this.extractUsingPaths(match2[1]);
@@ -200,7 +197,6 @@ export class ImportSuggestionExtractor {
             return options.map((path) => ({ path, description: `Import from ${path}` }));
         }
 
-        // Pattern 3: "Identifier X could be one of many types: (/Path1:)X or (/Path2:)X"
         const match3 = errorMessage.match(PATTERNS.IDENTIFIER_MANY_TYPES);
         if (match3) {
             const options = this.extractParenPaths(match3[1]);
@@ -212,9 +208,9 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Derives an import candidate from a "Did you mean Namespace.Component"
-     * suggestion. Returns null for suggestions without a module path (single
-     * segment names never produce an import).
+     * The import candidate behind a "Did you mean Namespace.Component"
+     * suggestion, or null when the suggestion carries no module path - a
+     * single-segment name never produces an import.
      */
     private inferFromDidYouMean(errorMessage: string): ImportCandidate | null {
         const didYouMeanMatch = errorMessage.match(PATTERNS.DID_YOU_MEAN_SINGLE);
@@ -265,7 +261,6 @@ export class ImportSuggestionExtractor {
             }
         }
 
-        // "Unknown identifier `x`. Did you forget to specify using { /Path }"
         const specificMatch = errorMessage.match(PATTERNS.UNKNOWN_WITH_SUGGESTION);
         if (specificMatch) {
             const identifierMatch = errorMessage.match(PATTERNS.UNKNOWN_IDENTIFIER);
@@ -273,22 +268,21 @@ export class ImportSuggestionExtractor {
             return { kind: "singleImport", candidate: { path: specificMatch[1], description: `Import ${name} from ${specificMatch[1]}` } };
         }
 
-        // "Did you forget to specify using { /Path }"
         const forgetMatch = errorMessage.match(PATTERNS.FORGET_SINGLE);
         if (forgetMatch) {
             return { kind: "singleImport", candidate: { path: forgetMatch[1], description: `Standard import for ${forgetMatch[1]}` } };
         }
 
-        // "Unknown identifier `x`" without an inline path: the consumer decides
-        // how to resolve it (configured mapping, digest lookup, or the inferred
-        // "Did you mean" path).
+        // An unknown identifier with no inline path. The consumer decides how to
+        // resolve it: configured mapping, digest lookup, or the inferred
+        // "Did you mean" path.
         const unknownMatch = errorMessage.match(PATTERNS.UNKNOWN_IDENTIFIER);
         if (unknownMatch) {
             const inferred = this.inferFromDidYouMean(errorMessage);
             return { kind: "identifier", identifier: unknownMatch[1], inferred: inferred ?? undefined };
         }
 
-        // "Did you mean Namespace.Component" without an unknown-identifier prefix
+        // A "Did you mean" with no unknown-identifier prefix in front of it.
         const inferred = this.inferFromDidYouMean(errorMessage);
         if (inferred) {
             return { kind: "singleImport", candidate: inferred };
@@ -297,9 +291,6 @@ export class ImportSuggestionExtractor {
         return { kind: "none" };
     }
 
-    /**
-     * Creates an ImportSuggestion object.
-     */
     private createImportSuggestion(importStatement: string, source: ImportSuggestionSource, confidence: ImportConfidence, description?: string): ImportSuggestion {
         const modulePath = this.formatter.extractPathFromImport(importStatement);
         return {
@@ -312,7 +303,12 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Looks up an identifier in digest files for import suggestions.
+     * The import suggestions the digest files offer for an identifier. Empty
+     * unless `experimental.useDigestFiles` is on, and empty rather than
+     * throwing when the lookup fails.
+     *
+     * Confidence is high only for an exact identifier match; a near match is
+     * medium.
      */
     private async lookupIdentifierInDigest(identifier: string): Promise<ImportSuggestion[]> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -351,8 +347,12 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Extracts import suggestions from an error message.
-     * This is the main method for parsing compiler errors.
+     * Every import suggestion a single compiler message supports, ambiguous
+     * ones included - the quick-fix menu is where the user picks between them.
+     *
+     * An unknown identifier is resolved in a fixed order: a configured
+     * ambiguous mapping first, then the digest lookup, then the path inferred
+     * from a "Did you mean". The order is the precedence, most specific first.
      */
     async extractImportSuggestions(errorMessage: string): Promise<ImportSuggestion[]> {
         logger.debug("ImportSuggestionExtractor", `Extracting import suggestions from error: ${errorMessage}`);
@@ -382,7 +382,6 @@ export class ImportSuggestionExtractor {
             }
 
             case "identifier": {
-                // Configured ambiguous mappings take precedence
                 if (ambiguousImportMappings[classification.identifier]) {
                     const preferredPath = ambiguousImportMappings[classification.identifier];
                     const importStatement = this.formatter.formatImportStatement(preferredPath, preferDotSyntax);
@@ -390,14 +389,12 @@ export class ImportSuggestionExtractor {
                     return [this.createImportSuggestion(importStatement, "error_message", "high", `Configured import for ${classification.identifier}`)];
                 }
 
-                // Then digest-based lookup
                 const digestSuggestions = await this.lookupIdentifierInDigest(classification.identifier);
                 if (digestSuggestions.length > 0) {
                     logger.debug("ImportSuggestionExtractor", `Found digest-based suggestions for unknown identifier: ${classification.identifier}`);
                     return digestSuggestions;
                 }
 
-                // Finally the path inferred from a "Did you mean" suggestion
                 if (classification.inferred) {
                     const importStatement = this.formatter.formatImportStatement(classification.inferred.path, preferDotSyntax);
                     logger.debug("ImportSuggestionExtractor", `Inferred import statement: ${importStatement}`);
@@ -416,10 +413,12 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Extracts unambiguous import paths from VS Code diagnostics for the
-     * Optimize Imports command. Only single, unambiguous suggestions are
-     * collected: multi-option (ambiguous) messages need a user choice and are
-     * left to the quick-fix menu, and non-import messages contribute nothing.
+     * The unambiguous import paths across a set of diagnostics, deduplicated,
+     * for the Optimize Imports command.
+     *
+     * Ambiguous messages are left out rather than resolved: they need a user
+     * choice, which belongs to the quick-fix menu. A command that adds imports
+     * in bulk has nobody to ask.
      */
     extractImportsFromDiagnostics(diagnostics: vscode.Diagnostic[]): string[] {
         logger.debug("ImportSuggestionExtractor", `Extracting imports from ${diagnostics.length} diagnostics`);

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -158,8 +158,7 @@ export class ImportSuggestionExtractor {
      *
      * Null and [] mean different things: null when no multi-option pattern
      * matched at all, [] when one matched but no option was importable, such as
-     * a list of bare identifiers. Callers use the difference to decide whether
-     * the single-option patterns still deserve a try.
+     * a list of bare identifiers.
      */
     private parseMultiOptionCandidates(errorMessage: string): ImportCandidate[] | null {
         const match1 = errorMessage.match(PATTERNS.DID_YOU_MEAN_ANY);

--- a/src/imports/index.ts
+++ b/src/imports/index.ts
@@ -1,3 +1,6 @@
+// ImportHandler is the entry point for import handling. The collaborators below
+// it are exported for the providers and commands that construct one directly;
+// anything coordinating several of them goes through the facade.
 export { ImportHandler } from "./ImportHandler";
 export { ImportFormatter } from "./ImportFormatter";
 export { ImportSuggestionExtractor } from "./ImportSuggestionExtractor";

--- a/src/imports/index.ts
+++ b/src/imports/index.ts
@@ -1,6 +1,7 @@
-// ImportHandler is the entry point for import handling. The collaborators below
-// it are exported for the providers and commands that construct one directly;
-// anything coordinating several of them goes through the facade.
+// ImportHandler is the entry point for import handling: outside this module,
+// take it, the converter and the two providers. ImportSuggestionExtractor and
+// ImportDocumentEditor are the facade's own collaborators and have no caller
+// outside it.
 export { ImportHandler } from "./ImportHandler";
 export { ImportFormatter } from "./ImportFormatter";
 export { ImportSuggestionExtractor } from "./ImportSuggestionExtractor";

--- a/src/imports/index.ts
+++ b/src/imports/index.ts
@@ -1,7 +1,7 @@
 // ImportHandler is the entry point for import handling: outside this module,
-// take it, the converter and the two providers. ImportSuggestionExtractor and
-// ImportDocumentEditor are the facade's own collaborators and have no caller
-// outside it.
+// take it, the converter, the two providers, or ImportFormatter for its static
+// classification. ImportSuggestionExtractor and ImportDocumentEditor are the
+// facade's own collaborators and have no caller outside it.
 export { ImportHandler } from "./ImportHandler";
 export { ImportFormatter } from "./ImportFormatter";
 export { ImportSuggestionExtractor } from "./ImportSuggestionExtractor";


### PR DESCRIPTION
Closes #225

The pilot for the `src/` comment pass. Applies the standard to `ImportScanner`, `ImportFormatter`, `ImportSuggestionExtractor`, the `ImportHandler` facade and the module barrel. Net 426 deletions against 303 insertions, all of it comment text.

## What changed, by category

**Incident-shaped comments rewritten down to the constraint.** `ScannedImport.anchorsCommentBelow` carried twenty lines for one boolean; it now says which two markers set it and why marker position pins the line. `ScannedImport.rebuildLosesText` carried thirty-six that narrated how the dotted style produced the gap, plus an issue number; it now says what the flag means and that neither value is a promise. `LineScan.code` carried sixteen that defended a design by citing two named Book of Verse test corpora; the citations are gone and the rule is not. The same treatment for the large inline blocks in `scanModuleImports`, each keeping its load-bearing order and its reason for reading the line's code rather than its raw text.

**Comments that restate the code deleted.** Including the standard's own canonical example, `/** Extracts existing import statements from a document. */` above `extractExistingImports(document)`, and every `@param`/`@returns` that repeated a TypeScript type.

**Refactor history deleted.** The facade's "Maintains backward compatibility while delegating to specialized classes", and `groupAndFormatImports`'s "New grouping behavior".

**The genuine Verse rules kept and tightened.** `scanLine`'s three lexing rules and `classifyLines`'s reason comment structure cannot be decided line by line. #224 calls these the clearest earned long comments in the repository; only the citations came off.

**Doc comments added where exported symbols lacked them**, one present-tense sentence each, with `@param` only where it carries a fact the type cannot.

`ImportHandler.computeEmptyLinesAfterImportsEdits` is untouched. It documents why there is no applying counterpart, which is the calibration target rather than material to rewrite.

## Follow-up ticket

#248, per the acceptance criterion that a comment existing only because a name is poor stays put and the rename is ticketed separately. It covers `LineScan.code` / `LineClassification.code` and `findCorrectModulePath`. `anchorsCommentBelow` was considered and excluded: its comment carries a Verse language fact rather than a name repair.

## One conflict worth a decision

The acceptance criteria ask that every exported symbol carry a doc comment. The standard names `/** Extracts existing imports from a document. */` on `extractExistingImports(document)` as its canonical delete-this example. Four `ImportHandler` delegating methods sit exactly on that seam, and they now carry no doc: the substance lives on the delegates in `ImportDocumentEditor` and `ImportSuggestionExtractor`, and anything written here would restate the signature. The standard wins in this diff. If the criterion is meant to hold without exception, say so and they come back.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./

```

```
$ npm test

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       595 passed, 595 total
Snapshots:   0 total
Time:        5.762 s, estimated 8 s
Ran all test suites.
```

```
$ npm run format:check

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No test file was added, removed or edited.

### Strip-diff gate

`out/strip-base` was compiled in this worktree at a clean `origin/main` tree before the first edit, so the comparison is against the real base.

```
$ npx tsc -p ./ --removeComments --sourceMap false --outDir out/strip-head
$ diff -r out/strip-base out/strip-head
$ echo $?
0
```

Empty, as required. Nothing but comments changed.

## Review

Two rounds, fresh context each.

Round 1 returned FAIL on two comments that misstated the code, both confirmed against the source before fixing:

- The facade doc claimed the collaborators share one `ImportFormatter` and that a directly-built one would disagree with it. `ImportFormatter` holds no instance state, and `ImportScanner` constructs its own at two places, so the mechanism was invented. It now names what the facade actually owns, the wiring of the extension context and the assets digest parser into `ImportSuggestionExtractor`.
- `parseMultiOptionCandidates` claimed callers act on the difference between `null` and `[]`. Its one caller falls through on both.

Three constraints compressed past the point of standing on their own were also restored: why a space must not replace a removed comment, that a pinned line is what makes an early-ended capture safe, and that `isModuleImport` is what keeps a quoted `#` away from `DOTTED_STATEMENT`.

Round 2 returned PASS_WITH_SUGGESTIONS and verified the comments-only property independently, by comparing TypeScript token streams against `origin/main` with comment nodes excluded: 1615, 1113, 2308, 297 and 49 tokens, zero differences. Its one Important finding, an over-broad claim about which captures run to end of line, is fixed here, along with two accuracy suggestions about scope.
