### PR TITLE
docs(services): apply the comment standard to digest and project-path services

### DIFF
--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -29,8 +29,8 @@ const INSTANCE_DECL = /^(\w+)(?:<[^>]*>)*\s*:\s*\w+\s*=\s*external\b/;
  * Assets.digest.verse.
  *
  * These names are what tells a dotted suggestion where the module ends: in
- * "Did you mean X.Y.Z.ClassName", a segment naming an asset class means
- * everything after it addresses members rather than modules.
+ * "Did you mean X.Y.Z.ClassName", a segment naming an asset class ends the
+ * module path, and that segment onward addresses members rather than modules.
  */
 export class AssetsDigestParser {
     private classNames: Set<string> = new Set();

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -25,9 +25,12 @@ const CLASS_OR_STRUCT_DECL = /^(\w+)(?:<[^>]*>)*\s*:=\s*(?:class|struct)\b/;
 const INSTANCE_DECL = /^(\w+)(?:<[^>]*>)*\s*:\s*\w+\s*=\s*external\b/;
 
 /**
- * Parses the project's Assets.digest.verse file to extract class names.
- * This is used to determine the correct module boundary when inferring imports
- * from "Did you mean X.Y.Z.ClassName" error messages.
+ * The set of asset type names UEFN generated for this project, read from its
+ * Assets.digest.verse.
+ *
+ * These names are what tells a dotted suggestion where the module ends: in
+ * "Did you mean X.Y.Z.ClassName", a segment naming an asset class means
+ * everything after it addresses members rather than modules.
  */
 export class AssetsDigestParser {
     private classNames: Set<string> = new Set();
@@ -52,8 +55,13 @@ export class AssetsDigestParser {
     ) {}
 
     /**
-     * Gets the path to the project's Assets.digest.verse file.
-     * Location: {LOCALAPPDATA}\UnrealEditorFortnite\Saved\VerseProject\{ProjectName}\{ProjectName}-Assets\Assets.digest.verse
+     * The project's Assets.digest.verse, or null when there is no project name
+     * or no file at either known location.
+     *
+     * The file lives outside the workspace, under
+     * `{LOCALAPPDATA}\UnrealEditorFortnite\Saved\VerseProject\{ProjectName}\`,
+     * in a `{ProjectName}-Assets` subfolder on current UEFN and directly in the
+     * project folder on older versions.
      */
     async getAssetsDigestPath(): Promise<string | null> {
         if (this.cachedDigestPath && fs.existsSync(this.cachedDigestPath)) {
@@ -66,10 +74,8 @@ export class AssetsDigestParser {
             return null;
         }
 
-        // Get LocalAppData path
         const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
 
-        // Try primary path structure (newer UEFN versions)
         const primaryPath = path.join(localAppData, "UnrealEditorFortnite", "Saved", "VerseProject", projectName, `${projectName}-Assets`, "Assets.digest.verse");
 
         if (fs.existsSync(primaryPath)) {
@@ -78,7 +84,6 @@ export class AssetsDigestParser {
             return primaryPath;
         }
 
-        // Try fallback path structure (older UEFN versions)
         const fallbackPath = path.join(localAppData, "UnrealEditorFortnite", "Saved", "VerseProject", projectName, "Assets.digest.verse");
 
         if (fs.existsSync(fallbackPath)) {
@@ -93,7 +98,9 @@ export class AssetsDigestParser {
     }
 
     /**
-     * Parses the Assets.digest.verse file and extracts class names.
+     * Refreshes the cached names, doing nothing if they were parsed within
+     * CACHE_DURATION or if the digest cannot be located. A file that cannot be
+     * read leaves the previously cached names in place.
      */
     async parseAssetsDigest(): Promise<void> {
         const now = Date.now();
@@ -186,37 +193,33 @@ export class AssetsDigestParser {
     }
 
     /**
-     * Checks if a name is a known asset class name (synchronous, uses cache).
-     * Call parseAssetsDigest() first to ensure cache is populated.
+     * Whether the name is a known asset class, answered from the cache alone.
+     * Nothing fills that cache lazily, so a caller that has not awaited
+     * {@link ensureCachePopulated} gets false for every name.
      */
     isAssetClassName(name: string): boolean {
         return this.classNames.has(name);
     }
 
-    /**
-     * Checks if a name is a known asset class name (async, ensures cache is fresh).
-     */
+    /** As {@link isAssetClassName}, but refreshes the cache first. */
     async isAssetClassNameAsync(name: string): Promise<boolean> {
         await this.parseAssetsDigest();
         return this.classNames.has(name);
     }
 
-    /**
-     * Ensures the cache is populated. Call this during initialization.
-     */
+    /** Fills the cache so the synchronous {@link isAssetClassName} can answer. */
     async ensureCachePopulated(): Promise<void> {
         await this.parseAssetsDigest();
     }
 
-    /**
-     * Gets all known asset class names (for debugging).
-     */
+    /** A copy of the cached names, safe for a caller to keep. */
     getAssetClassNames(): Set<string> {
         return new Set(this.classNames);
     }
 
     /**
-     * Clears the cache and forces a re-parse on next access.
+     * Empties the cache and forgets the located digest path, so the next parse
+     * searches for the file again.
      */
     clearCache(): void {
         this.classNames.clear();
@@ -265,14 +268,13 @@ export class AssetsDigestParser {
     }
 
     /**
-     * Sets up a file watcher for the Assets.digest.verse file.
-     * The file changes when assets are modified in UEFN.
+     * Starts watching for asset changes and returns the handle that stops it.
+     * Disposing is not optional: it is what cancels a queued refresh that would
+     * otherwise run against a deactivated extension.
      */
     setupFileWatcher(): vscode.Disposable {
-        // Create a composite disposable to hold multiple watchers
         const disposables: vscode.Disposable[] = [];
 
-        // Watch for Assets.digest.verse in the VerseProject folder
         const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
         // The digest lives outside the workspace. A plain string glob is only
         // honored inside workspace folders, so watch the external VerseProject

--- a/src/services/DigestParser.ts
+++ b/src/services/DigestParser.ts
@@ -64,8 +64,9 @@ export class DigestParser {
 
     /**
      * Entries whose identifier matches, the exact one first and then every
-     * case-insensitive substring match. This order survives into the quick-fix
-     * menu, so the exact match is what the user is offered first.
+     * case-insensitive substring match. Ranking beyond that order is the
+     * caller's: the quick-fix menu re-sorts alphabetically when
+     * `quickFix.sortAlphabetically` is on.
      */
     async lookupIdentifier(identifier: string): Promise<DigestEntry[]> {
         const index = await this.getDigestIndex();

--- a/src/services/DigestParser.ts
+++ b/src/services/DigestParser.ts
@@ -7,6 +7,17 @@ import { DigestEntry, parseDigestContent, rootDomainForDigestFile } from "./dige
 
 export { DigestEntry } from "./digestParsing";
 
+/**
+ * The index of importable Verse API identifiers, served from precompiled JSON
+ * where possible and parsed from the bundled `.digest.verse` files where not.
+ *
+ * The fallback is one-way: the first failure to load the precompiled data
+ * latches precompiled use off for the lifetime of the instance, so a transient
+ * failure costs runtime parsing for the rest of the session rather than
+ * retrying on every lookup. {@link forceReparse} is the only way back to
+ * runtime parsing by choice, and nothing returns to precompiled data short of a
+ * new instance.
+ */
 export class DigestParser {
     private digestCache: Map<string, DigestEntry> = new Map();
     private lastParsed: number = 0;
@@ -24,7 +35,6 @@ export class DigestParser {
     }
 
     async getDigestIndex(): Promise<Map<string, DigestEntry>> {
-        // Try precompiled loader first
         if (this.usePrecompiled && this.precompiledLoader) {
             try {
                 if (!this.precompiledLoader.isLoaded()) {
@@ -40,7 +50,6 @@ export class DigestParser {
             }
         }
 
-        // Fallback to runtime parsing
         const now = Date.now();
         if (this.digestCache.size > 0 && now - this.lastParsed < this.CACHE_DURATION) {
             logger.debug("DigestParser", "Using cached digest index (runtime parsed)");
@@ -53,17 +62,20 @@ export class DigestParser {
         return this.digestCache;
     }
 
+    /**
+     * Entries whose identifier matches, the exact one first and then every
+     * case-insensitive substring match. This order survives into the quick-fix
+     * menu, so the exact match is what the user is offered first.
+     */
     async lookupIdentifier(identifier: string): Promise<DigestEntry[]> {
         const index = await this.getDigestIndex();
         const results: DigestEntry[] = [];
 
-        // Exact match
         const exactMatch = index.get(identifier);
         if (exactMatch) {
             results.push(exactMatch);
         }
 
-        // Partial matches (case-insensitive)
         const lowerIdentifier = identifier.toLowerCase();
         for (const [key, entry] of index) {
             if (key.toLowerCase().includes(lowerIdentifier) && key !== identifier) {
@@ -105,10 +117,11 @@ export class DigestParser {
     }
 
     /**
-     * Parses one digest file via the shared {@link parseDigestContent} module and
-     * merges its entries into the runtime cache. Entries already present are kept
-     * (first occurrence wins across the Fortnite, UnrealEngine, and Verse files, in
-     * that iteration order), matching the precompiled loader's merge semantics.
+     * Merges one digest file's entries into the runtime cache, keeping the entry
+     * already there on a collision. First occurrence therefore wins across the
+     * Fortnite, UnrealEngine and Verse files in that iteration order, which is
+     * what the precompiled loader does too - the two must agree, or the same
+     * identifier resolves differently depending on which path served it.
      */
     private parseDigestFile(filePath: string): void {
         try {
@@ -136,9 +149,9 @@ export class DigestParser {
     }
 
     /**
-     * Force reparse of digest files at runtime.
-     * This bypasses the precompiled loader and parses the raw .verse files.
-     * Useful if user suspects the precompiled data is outdated.
+     * Reparses the bundled `.verse` files and switches this instance to runtime
+     * parsing for good, for when the precompiled data is suspected stale.
+     * Nothing switches it back.
      */
     async forceReparse(): Promise<void> {
         logger.info("DigestParser", "Forcing runtime reparse of digest files...");
@@ -149,9 +162,7 @@ export class DigestParser {
         logger.info("DigestParser", `Runtime reparse complete: ${this.digestCache.size} entries`);
     }
 
-    /**
-     * Get statistics about the current digest data
-     */
+    /** Which of the two sources is currently serving lookups, and how much it holds. */
     getStats(): { entries: number; source: "precompiled" | "runtime"; loaded: boolean } {
         if (this.usePrecompiled && this.precompiledLoader?.isLoaded()) {
             const stats = this.precompiledLoader.getStats();

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -5,7 +5,9 @@ import { logger } from "../utils";
 import { DigestEntry } from "./DigestParser";
 
 /**
- * Structure of the pre-compiled JSON digest files
+ * One `src/data/*.digest.json` payload, as written by `npm run parse-digest`.
+ * Hand-editing these files is not supported; change the generator or its
+ * `src/utils/*.digest.verse` input instead.
  */
 export interface PrecompiledDigest {
     version: string;
@@ -17,8 +19,13 @@ export interface PrecompiledDigest {
 }
 
 /**
- * Loads pre-compiled JSON digest files for fast runtime access.
- * These files are generated at build time by src/scripts/parseDigestFiles.ts
+ * The bundled Verse API index, read from the JSON that
+ * `src/scripts/parseDigestFiles.ts` generates at build time rather than parsed
+ * from Verse source at startup.
+ *
+ * This is DigestParser's fast path. It reports failure by throwing from
+ * {@link loadPrecompiledDigests} and by leaving {@link isLoaded} false, which is
+ * the signal DigestParser falls back on.
  */
 export class PrecompiledDigestLoader {
     private digestCache: Map<string, DigestEntry> = new Map();
@@ -31,8 +38,13 @@ export class PrecompiledDigestLoader {
     constructor(private extensionContext: vscode.ExtensionContext) {}
 
     /**
-     * Load all pre-compiled digest files into memory.
-     * Call this once during extension activation.
+     * Loads every digest file into memory, throwing if none of them could be
+     * read.
+     *
+     * Loaded state is all-or-nothing on purpose: a partial index would answer
+     * lookups with confident misses, so anything short of one successful file
+     * leaves {@link isLoaded} false and sends the caller to runtime parsing.
+     * Calling again after success is a no-op.
      */
     async loadPrecompiledDigests(): Promise<void> {
         if (this.loaded) {
@@ -47,9 +59,9 @@ export class PrecompiledDigestLoader {
             const dataDir = path.join(extensionPath, "src", "data");
             let successCount = 0;
 
-            // Check if data directory exists
+            // A packaged extension ships the data under out/, a source checkout
+            // under src/; neither layout is guaranteed, so both are tried.
             if (!fs.existsSync(dataDir)) {
-                // Try out directory for compiled extension
                 const outDataDir = path.join(extensionPath, "out", "data");
                 if (fs.existsSync(outDataDir)) {
                     successCount = await this.loadFromDirectory(outDataDir);
@@ -60,7 +72,6 @@ export class PrecompiledDigestLoader {
                 successCount = await this.loadFromDirectory(dataDir);
             }
 
-            // Only mark as loaded if at least one file was successfully parsed
             if (successCount > 0) {
                 this.loaded = true;
                 const elapsed = Date.now() - startTime;
@@ -76,8 +87,9 @@ export class PrecompiledDigestLoader {
     }
 
     /**
-     * Load digest files from a directory
-     * @returns number of successfully loaded files
+     * How many of the expected digest files were read and merged. A file that
+     * is missing or unparseable is logged and skipped rather than failing the
+     * others.
      */
     private async loadFromDirectory(dataDir: string): Promise<number> {
         let successCount = 0;
@@ -94,14 +106,17 @@ export class PrecompiledDigestLoader {
                 const content = fs.readFileSync(filePath, "utf8");
                 const digest: PrecompiledDigest = JSON.parse(content);
 
-                // Merge entries into cache
+                // First file to declare an identifier wins, matching
+                // DigestParser's runtime merge. DIGEST_FILES order is therefore
+                // the precedence between the three domains.
                 for (const [identifier, entry] of Object.entries(digest.entries)) {
                     if (!this.digestCache.has(identifier)) {
                         this.digestCache.set(identifier, entry);
                     }
                 }
 
-                // Merge module index using Set for efficiency
+                // The module index unions instead, so a module re-declared
+                // across files keeps every member.
                 for (const [modulePath, identifiers] of Object.entries(digest.moduleIndex)) {
                     const existingSet = new Set(this.moduleIndex.get(modulePath) || []);
                     for (const id of identifiers) {
@@ -120,44 +135,27 @@ export class PrecompiledDigestLoader {
         return successCount;
     }
 
-    /**
-     * Get a digest entry by identifier
-     */
     getEntry(identifier: string): DigestEntry | undefined {
         return this.digestCache.get(identifier);
     }
 
-    /**
-     * Get all identifiers in a module
-     */
     getModuleIdentifiers(modulePath: string): string[] {
         return this.moduleIndex.get(modulePath) || [];
     }
 
-    /**
-     * Get all loaded entries as a Map (compatible with DigestParser interface)
-     */
+    /** The live cache, not a copy: mutating it corrupts the index. */
     getAllEntries(): Map<string, DigestEntry> {
         return this.digestCache;
     }
 
-    /**
-     * Check if the loader has successfully loaded data
-     */
     isLoaded(): boolean {
         return this.loaded;
     }
 
-    /**
-     * Get the load error if loading failed
-     */
     getLoadError(): Error | null {
         return this.loadError;
     }
 
-    /**
-     * Get statistics about loaded data
-     */
     getStats(): { entries: number; modules: number; loaded: boolean } {
         return {
             entries: this.digestCache.size,
@@ -166,9 +164,7 @@ export class PrecompiledDigestLoader {
         };
     }
 
-    /**
-     * Clear all cached data and reset loaded state
-     */
+    /** Empties the index and allows {@link loadPrecompiledDigests} to run again. */
     clear(): void {
         this.digestCache.clear();
         this.moduleIndex.clear();

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -41,9 +41,9 @@ export class PrecompiledDigestLoader {
      * Loads every digest file into memory, throwing if none of them could be
      * read.
      *
-     * Loaded state is all-or-nothing on purpose: a partial index would answer
-     * lookups with confident misses, so anything short of one successful file
-     * leaves {@link isLoaded} false and sends the caller to runtime parsing.
+     * One file is enough to count as loaded, so a caller that sees
+     * {@link isLoaded} true may still be holding a partial index. Only a total
+     * failure leaves it false and sends DigestParser to runtime parsing.
      * Calling again after success is a no-op.
      */
     async loadPrecompiledDigests(): Promise<void> {
@@ -59,8 +59,10 @@ export class PrecompiledDigestLoader {
             const dataDir = path.join(extensionPath, "src", "data");
             let successCount = 0;
 
-            // A packaged extension ships the data under out/, a source checkout
-            // under src/; neither layout is guaranteed, so both are tried.
+            // src/data is the live location in both a checkout and a .vsix -
+            // .vscodeignore excludes src/** but re-includes src/data/**, and
+            // nothing copies the JSON into out/. The out/data branch below is
+            // dormant, and stays only against a build that starts copying.
             if (!fs.existsSync(dataDir)) {
                 const outDataDir = path.join(extensionPath, "out", "data");
                 if (fs.existsSync(outDataDir)) {

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -156,8 +156,12 @@ export class ProjectPathCache {
     }
 
     /**
-     * Reparses the named files and swaps their declarations into the cache,
-     * keeping the previous nodes for any file that failed to parse.
+     * Reparses the named files and swaps their declarations into the cache.
+     *
+     * A file the scanner could not read yields no nodes rather than an error,
+     * so it is committed as empty and its previous declarations are dropped;
+     * only a failure raised outside the scanner keeps the old nodes. Both cases
+     * self-correct on the file's next change event.
      *
      * Parsing awaits, and `this.data` can be replaced while it does - the
      * .uefnproject watcher, watcher teardown and the Clear Project Path Cache
@@ -194,7 +198,8 @@ export class ProjectPathCache {
                 failedFiles.push(filePath);
                 // Staying out of parsedResults is what keeps this file's
                 // existing nodes: the commit below only replaces files it
-                // reparsed.
+                // reparsed. Reachable only for a throw from outside
+                // parseVerseFile, which swallows its own read and parse errors.
             }
         }
 

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -47,7 +47,9 @@ export class ProjectPathCache {
     }
 
     /**
-     * Initialize the cache - load from storage or build fresh.
+     * Brings the cache up, from workspace storage where possible and from a
+     * fresh scan otherwise. Safe to call more than once; only a call that ends
+     * with data latches.
      *
      * cache.autoRebuildOnStartup skips the stored payload entirely and scans
      * the project instead. The stored cache is only as fresh as the watchers
@@ -100,9 +102,10 @@ export class ProjectPathCache {
     }
 
     /**
-     * Look up the possible locations of a module import path.
+     * The possible locations of a module import path, empty when nothing is
+     * cached.
      *
-     * Returns candidates in the same location contract the converter's
+     * Candidates use the same location contract the converter's
      * filesystem scan produces ("" or "/Dir/Sub", Content-relative), each
      * with the source file that declares the module so callers can validate
      * against the filesystem before trusting the (possibly stale) cache.
@@ -120,7 +123,10 @@ export class ProjectPathCache {
     }
 
     /**
-     * Force a full cache rebuild.
+     * Rescans the whole project and replaces the cache with the result.
+     *
+     * A scan that finds no project leaves the existing cache untouched rather
+     * than emptying it, so a rebuild can never be worse than not rebuilding.
      */
     async rebuildCache(): Promise<void> {
         const startTime = Date.now();
@@ -150,8 +156,8 @@ export class ProjectPathCache {
     }
 
     /**
-     * Invalidate cache for specific files.
-     * Uses transaction-like pattern: parse first, then swap old for new only on success.
+     * Reparses the named files and swaps their declarations into the cache,
+     * keeping the previous nodes for any file that failed to parse.
      *
      * Parsing awaits, and `this.data` can be replaced while it does - the
      * .uefnproject watcher, watcher teardown and the Clear Project Path Cache
@@ -175,7 +181,6 @@ export class ProjectPathCache {
 
         const scanner = new ProjectPathScanner(this.outputChannel, this.projectPathHandler);
 
-        // Phase 1: Parse all files first and collect new nodes (transaction preparation)
         const parsedResults: Map<string, ProjectPathNode[]> = new Map();
         const failedFiles: string[] = [];
 
@@ -187,7 +192,9 @@ export class ProjectPathCache {
             } catch (error) {
                 logger.error("ProjectPathCache", `Failed to reparse ${filePath}`, error);
                 failedFiles.push(filePath);
-                // Keep old data for failed files - don't add to parsedResults
+                // Staying out of parsedResults is what keeps this file's
+                // existing nodes: the commit below only replaces files it
+                // reparsed.
             }
         }
 
@@ -198,7 +205,6 @@ export class ProjectPathCache {
             return;
         }
 
-        // Phase 2: Apply changes only for successfully parsed files (transaction commit)
         const reparsedFiles = new Set(parsedResults.keys());
         const keptNodes = data.nodes.filter((node) => !node.sourceFile || !reparsedFiles.has(node.sourceFile));
         for (const newNodes of parsedResults.values()) {
@@ -216,12 +222,13 @@ export class ProjectPathCache {
     }
 
     /**
-     * Set up file watchers for .verse files and project files.
+     * Starts watching the project and returns the handle that stops it.
+     * Disposing also clears the in-memory cache, which is what cancels a
+     * debounced update that would otherwise run after deactivation.
      */
     setupFileWatchers(): vscode.Disposable {
         const disposables: vscode.Disposable[] = [];
 
-        // Watch for .verse file changes
         this.fileWatcher = vscode.workspace.createFileSystemWatcher("**/*.verse");
 
         this.fileWatcher.onDidChange((uri) => this.handleFileChange(uri));
@@ -255,9 +262,6 @@ export class ProjectPathCache {
         return vscode.Disposable.from(...disposables);
     }
 
-    /**
-     * Get cache statistics.
-     */
     getStats(): {
         loaded: boolean;
         identifiers: number;
@@ -273,7 +277,9 @@ export class ProjectPathCache {
     }
 
     /**
-     * Clear all cached data.
+     * Drops the in-memory cache and any queued update, leaving the persisted
+     * copy alone. Doubles as the watcher-teardown hook, so it must stay safe to
+     * call when nothing was ever loaded.
      */
     clear(): void {
         this.data = null;
@@ -327,7 +333,8 @@ export class ProjectPathCache {
     }
 
     /**
-     * Save cache to VS Code workspace storage.
+     * Writes the cache to workspace storage, stamped with the current
+     * PROJECT_CACHE_VERSION, and drops the legacy payload on the way past.
      */
     private async saveToStorage(): Promise<void> {
         if (!this.data) {
@@ -353,7 +360,10 @@ export class ProjectPathCache {
     }
 
     /**
-     * Load cache from VS Code workspace storage.
+     * Whether a usable cache was restored from workspace storage. A stored
+     * payload is rejected when its version does not match the current one or
+     * when it belongs to a different project, since either makes its
+     * declarations wrong rather than merely stale.
      */
     private async loadFromStorage(): Promise<boolean> {
         try {
@@ -363,13 +373,13 @@ export class ProjectPathCache {
                 return false;
             }
 
-            // Check version compatibility (also rejects pre-2 tree-shaped payloads)
+            // The nodes check also rejects the pre-2 tree-shaped payload, whose
+            // version field a future bump could otherwise let through.
             if (serialized.version !== PROJECT_CACHE_VERSION || !Array.isArray(serialized.nodes)) {
                 logger.info("ProjectPathCache", "Cache version mismatch, will rebuild");
                 return false;
             }
 
-            // Check if project name matches
             const currentProjectName = await this.projectPathHandler.getProjectName();
             if (currentProjectName && serialized.projectName !== currentProjectName) {
                 logger.info("ProjectPathCache", "Project name mismatch, will rebuild");
@@ -394,9 +404,7 @@ export class ProjectPathCache {
         }
     }
 
-    /**
-     * Rebuild all lookup indexes from the flat node list.
-     */
+    /** Must follow every mutation of `data.nodes`, or lookups serve the old set. */
     private rebuildIndexes(): void {
         this.indexes = buildProjectIndexes(this.data ? this.data.nodes : []);
     }
@@ -426,9 +434,7 @@ export class ProjectPathCache {
         return uri.fsPath.toLowerCase().endsWith(".digest.verse");
     }
 
-    /**
-     * Handle file change events with debouncing.
-     */
+    /** Queues a changed file for reparsing once the debounce window closes. */
     private handleFileChange(uri: vscode.Uri): void {
         if (ProjectPathCache.isDigestFile(uri)) {
             return;
@@ -455,7 +461,8 @@ export class ProjectPathCache {
     }
 
     /**
-     * Handle file delete events.
+     * Drops a deleted file's declarations immediately, without the debounce a
+     * change gets - there is nothing left to reparse and nothing to coalesce.
      */
     private handleFileDelete(uri: vscode.Uri): void {
         if (ProjectPathCache.isDigestFile(uri)) {
@@ -471,7 +478,6 @@ export class ProjectPathCache {
         this.data.nodes = this.data.nodes.filter((node) => node.sourceFile !== relativePath);
         this.rebuildIndexes();
 
-        // Save asynchronously
         this.saveToStorage().catch((error) => {
             logger.error("ProjectPathCache", "Failed to save after file delete", error);
         });

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -7,8 +7,11 @@ import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 const SCAN_CONCURRENCY = 8;
 
 /**
- * Scans .verse files in the project and extracts module, class, struct,
- * function, and variable declarations as a flat node list.
+ * Reads the project's .verse files into a flat list of the module, class,
+ * struct, interface, enum, function and variable declarations they make.
+ *
+ * The nesting a declaration sits in survives only as the dotted `fullPath` on
+ * each node; nothing here returns a tree.
  */
 export class ProjectPathScanner {
     constructor(
@@ -17,8 +20,9 @@ export class ProjectPathScanner {
     ) {}
 
     /**
-     * Scans all .verse files in the workspace and returns the project's
-     * declaration data, or null when no UEFN project is found.
+     * Every declaration across the workspace's .verse files, or null when no
+     * UEFN project was found and null again when the scan itself failed - a
+     * caller cannot tell the two apart, and neither raises.
      */
     async scanProject(workspaceFolder: vscode.WorkspaceFolder, options: ProjectScanOptions = {}): Promise<ProjectPathData | null> {
         const startTime = Date.now();
@@ -83,7 +87,9 @@ export class ProjectPathScanner {
     }
 
     /**
-     * Parses a single .verse file and extracts declarations.
+     * The declarations in one .verse file, or [] when it could not be read or
+     * parsed. A failure here is logged and swallowed so one unreadable file
+     * cannot abandon a whole scan.
      */
     async parseVerseFile(fileUri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, options: ProjectScanOptions = {}): Promise<ProjectPathNode[]> {
         try {
@@ -99,32 +105,38 @@ export class ProjectPathScanner {
     }
 
     /**
-     * Extracts module, class, struct, and function declarations from Verse content.
+     * The declarations in a file's text, in source order.
+     *
+     * `sourceLine` is 1-based, for direct use as an editor position. `fullPath`
+     * carries the dotted chain of enclosing modules, so it equals `name` only at
+     * file scope. Declarations nested in a class or struct body are not filtered
+     * out here; only indentation-scoped module nesting is tracked.
      */
     extractDeclarations(content: string, filePath: string, options: ProjectScanOptions = {}): ProjectPathNode[] {
         const nodes: ProjectPathNode[] = [];
         const lines = content.split("\n");
 
-        // Track current module context with indentation levels
         let currentModulePath = "";
         const moduleStack: { name: string; indent: number }[] = [];
 
-        // Visibility specifiers in Verse: public, protected, private, internal, scoped
         const visibilitySpecifiers = "public|protected|private|internal|scoped";
 
-        // Helper to extract visibility from specifier string like "<native><public>"
+        // A declaration carries any number of stacked specifiers, of which at
+        // most one is a visibility; the rest (<native>, <final>, ...) are noise
+        // to this scan.
         const extractVisibility = (specifiers: string | undefined): string | undefined => {
             if (!specifiers) return undefined;
             const match = specifiers.match(new RegExp(`<(${visibilitySpecifiers})>`));
             return match ? match[1] : undefined;
         };
 
-        // Helper to check if a declaration should be skipped based on visibility
         const shouldSkipDeclaration = (visibility: string | undefined, isModuleType: boolean = false): boolean => {
             if (!options.includePrivate && visibility === "private") {
                 return true;
             }
-            // Modules have special logic: include public and internal (no visibility = internal)
+            // A module is kept when it is public or internal, and no specifier
+            // at all means internal in Verse. Anything narrower - protected or
+            // scoped - cannot be imported from outside and is dropped.
             if (isModuleType) {
                 const isPublic = visibility === "public";
                 const isInternal = !visibility || visibility === "internal";
@@ -135,17 +147,19 @@ export class ProjectPathScanner {
             return false;
         };
 
-        // Patterns for declarations
-        // Format: Name<specifier1><specifier2>... := type<typespec>...(parent):
-        // Captures: [1] = name, [2] = all specifiers after name (may contain visibility)
+        // Every pattern below captures [1] the declared name and [2] the
+        // specifiers attached to that name, matching the shape
+        // `Name<spec><spec> := type<typespec>(parent):`. Specifiers on the
+        // right of `:=` belong to the type, not the name, and are skipped
+        // rather than captured.
         const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*:/;
         const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\s*(?:<[^>]+>)*\s*[\(:]?/;
         const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\s*(?:<[^>]+>)*\s*[\(:]?/;
         const interfacePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*interface\s*(?:<[^>]+>)*\s*[\(:]?/;
         const enumPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*enum\s*(?:<[^>]+>)?\s*:/;
-        // Standard function: Name<specifiers>(params)<effects>:
+        /** `Name<specifiers>(params)<effects>:` */
         const functionPattern = /^(\w+)((?:<[^>]+>)*)\s*\([^)]*\)\s*(?:<[^>]+>)*\s*:/;
-        // Extension method: (Type:type).Name<specifiers>(params)<effects>:
+        /** `(Type:type).Name<specifiers>(params)<effects>:` */
         const extensionMethodPattern = /^\([^)]+\)\.(\w+)((?:<[^>]+>)*)\s*\([^)]*\)/;
         const variablePattern = /^(\w+)((?:<[^>]+>)*)\s*:/;
 
@@ -153,27 +167,26 @@ export class ProjectPathScanner {
             const rawLine = lines[i];
             const line = rawLine.trim();
 
-            // Skip comments and empty lines
             if (line === "" || line.startsWith("#") || line.startsWith("//")) {
                 continue;
             }
 
-            // Skip using statements
             if (line.startsWith("using")) {
                 continue;
             }
 
-            // Calculate indentation (spaces or tabs converted to spaces)
+            // Each tab counts as four spaces so mixed indentation compares
+            // consistently.
             const indentMatch = rawLine.match(/^(\s*)/);
             const indent = indentMatch ? indentMatch[1].replace(/\t/g, "    ").length : 0;
 
-            // Pop modules from stack when indentation decreases
+            // Indentation alone closes a module: a line at or left of the open
+            // module's own indent is outside it.
             while (moduleStack.length > 0 && indent <= moduleStack[moduleStack.length - 1].indent) {
                 moduleStack.pop();
             }
             currentModulePath = moduleStack.length > 0 ? moduleStack[moduleStack.length - 1].name : "";
 
-            // Check for module declaration
             const moduleMatch = line.match(modulePattern);
             if (moduleMatch) {
                 const [, name, specifiers] = moduleMatch;
@@ -199,7 +212,6 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Check for class declaration
             const classMatch = line.match(classPattern);
             if (classMatch) {
                 const [, name, specifiers] = classMatch;
@@ -223,7 +235,6 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Check for struct declaration
             const structMatch = line.match(structPattern);
             if (structMatch) {
                 const [, name, specifiers] = structMatch;
@@ -247,7 +258,6 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Check for interface declaration
             const interfaceMatch = line.match(interfacePattern);
             if (interfaceMatch) {
                 const [, name, specifiers] = interfaceMatch;
@@ -271,7 +281,6 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Check for enum declaration
             const enumMatch = line.match(enumPattern);
             if (enumMatch) {
                 const [, name, specifiers] = enumMatch;
@@ -295,7 +304,6 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Check for extension method first (before regular function)
             const extensionMatch = line.match(extensionMethodPattern);
             if (extensionMatch) {
                 const [, name, specifiers] = extensionMatch;
@@ -319,7 +327,6 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Check for function declaration
             const functionMatch = line.match(functionPattern);
             if (functionMatch) {
                 const [, name, specifiers] = functionMatch;
@@ -343,7 +350,10 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Check for variable declaration (should be last to avoid false positives)
+            // Last, and it must stay last. The `:` this pattern needs is also
+            // the first character of the `:=` that opens a type declaration, so
+            // it matches those too; the branches above only win by being asked
+            // first, and the guards below cover the shapes they did not match.
             const variableMatch = line.match(variablePattern);
             if (variableMatch) {
                 const [, name, specifiers] = variableMatch;
@@ -354,12 +364,15 @@ export class ProjectPathScanner {
                     continue;
                 }
 
-                // Skip if it looks like a function or type definition
+                // Both guards are backstops for a declaration whose specific
+                // pattern above did not match the exact shape written: a type,
+                // recognised by `:=` with a declaration keyword, and a function,
+                // recognised by a parameter list before the colon. Either would
+                // otherwise be recorded as a variable.
                 if (line.includes(":=") && (line.includes("class") || line.includes("struct") || line.includes("module") || line.includes("interface") || line.includes("enum"))) {
                     continue;
                 }
 
-                // Skip if it's a function (has parentheses before the colon)
                 if (/\([^)]*\)\s*(?:<[^>]+>)?\s*:/.test(line)) {
                     continue;
                 }

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -107,11 +107,11 @@ export class ProjectPathScanner {
     /**
      * The declarations in a file's text, in source order.
      *
-     * `sourceLine` is 1-based, so it is one more than the `vscode.Position`
-     * line for the same declaration. `fullPath`
-     * carries the dotted chain of enclosing modules, so it equals `name` only at
-     * file scope. Declarations nested in a class or struct body are not filtered
-     * out here; only indentation-scoped module nesting is tracked.
+     * `sourceLine` is 1-based, so it is one more than the `vscode.Position` line
+     * for the same declaration. `fullPath` carries the dotted chain of enclosing
+     * modules, so it equals `name` only at file scope. Declarations nested in a
+     * class or struct body are not filtered out here; only indentation-scoped
+     * module nesting is tracked.
      */
     extractDeclarations(content: string, filePath: string, options: ProjectScanOptions = {}): ProjectPathNode[] {
         const nodes: ProjectPathNode[] = [];

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -107,7 +107,8 @@ export class ProjectPathScanner {
     /**
      * The declarations in a file's text, in source order.
      *
-     * `sourceLine` is 1-based, for direct use as an editor position. `fullPath`
+     * `sourceLine` is 1-based, so it is one more than the `vscode.Position`
+     * line for the same declaration. `fullPath`
      * carries the dotted chain of enclosing modules, so it equals `name` only at
      * file scope. Declarations nested in a class or struct body are not filtered
      * out here; only indentation-scoped module nesting is tracked.
@@ -134,9 +135,10 @@ export class ProjectPathScanner {
             if (!options.includePrivate && visibility === "private") {
                 return true;
             }
-            // A module is kept when it is public or internal, and no specifier
-            // at all means internal in Verse. Anything narrower - protected or
-            // scoped - cannot be imported from outside and is dropped.
+            // By default a module is kept only when it is public or internal,
+            // and no specifier at all means internal in Verse. Anything
+            // narrower cannot be imported from outside. includePrivate lifts
+            // this along with the private check above, keeping everything.
             if (isModuleType) {
                 const isPublic = visibility === "public";
                 const isInternal = !visibility || visibility === "internal";
@@ -149,9 +151,10 @@ export class ProjectPathScanner {
 
         // Every pattern below captures [1] the declared name and [2] the
         // specifiers attached to that name, matching the shape
-        // `Name<spec><spec> := type<typespec>(parent):`. Specifiers on the
+        // `Name<spec><spec> := type<typespec>(parent):`. Specifiers to the
         // right of `:=` belong to the type, not the name, and are skipped
-        // rather than captured.
+        // rather than captured - except by modulePattern, which allows none
+        // there and so does not match a module carrying them.
         const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*:/;
         const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\s*(?:<[^>]+>)*\s*[\(:]?/;
         const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\s*(?:<[^>]+>)*\s*[\(:]?/;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,9 @@
+// From outside this module, take DigestParser for Verse API lookups and
+// ProjectPathCache for project-declaration lookups; both own the caching their
+// collaborators do not. PrecompiledDigestLoader is DigestParser's fast path and
+// ProjectPathScanner is what ProjectPathCache rebuilds from - reach for either
+// directly only to bypass a cache on purpose. AssetsDigestParser is separate
+// from the other two: it reads the project's generated assets, not the API.
 export { DigestParser, DigestEntry } from "./DigestParser";
 export { AssetsDigestParser } from "./AssetsDigestParser";
 export { PrecompiledDigestLoader, PrecompiledDigest } from "./PrecompiledDigestLoader";

--- a/src/services/moduleLocationLookup.ts
+++ b/src/services/moduleLocationLookup.ts
@@ -26,9 +26,7 @@ export interface ModuleLocationCandidate {
     sourceFile: string;
 }
 
-/**
- * Lookup indexes derived from the flat node list.
- */
+/** The lookup indexes derived from the flat node list. */
 export interface ProjectIndexes {
     /** Lowercased identifier name -> all declarations with that name */
     identifierIndex: Map<string, ProjectPathNode[]>;
@@ -41,7 +39,8 @@ export interface ProjectIndexes {
 }
 
 /**
- * Build all lookup indexes from the flat node list in one pass.
+ * Every lookup index, built from the node list in a single pass. Each index
+ * holds references into that list rather than copies.
  */
 export function buildProjectIndexes(nodes: readonly ProjectPathNode[]): ProjectIndexes {
     const identifierIndex = new Map<string, ProjectPathNode[]>();
@@ -80,7 +79,8 @@ export function buildProjectIndexes(nodes: readonly ProjectPathNode[]): ProjectI
 }
 
 /**
- * Resolve the possible locations of a module import path.
+ * The distinct locations a module import path could refer to, one entry per
+ * location with the first source file found for it.
  *
  * The requested path uses "/" separators as produced by
  * ImportPathConverter.extractModuleFromImport (e.g. "HUD/Textures" for the
@@ -168,10 +168,10 @@ export function resolveModuleLocations(modulePath: string, moduleNameIndex: Read
 }
 
 /**
- * Convert a workspace-relative source file path to its Content-relative
- * directory, or null when the file is not under the Content folder (such
- * files cannot provide importable module locations). Mirrors the path
- * normalization of the converter's filesystem scan.
+ * The Content-relative directory of a workspace-relative source file, or null
+ * when the file sits outside the Content folder and so cannot provide an
+ * importable module location. Mirrors the path normalization of the converter's
+ * filesystem scan.
  */
 function toContentRelativeDir(sourceFile: string, workspaceIsContent: boolean): string | null {
     const lastSlash = sourceFile.lastIndexOf("/");


### PR DESCRIPTION
Closes #227

Applies the comment standard to `src/services`: the digest parsing and lookup path, and the project-path cache and scanner. Calibrated against the merged diff from #225 (`f2da720`), which is this branch's base.

Seven of the eight files changed. `digestParsing.ts` is untouched: its regex and parser docs already conform, and churning them would have cost the diff its reviewability for nothing.

## What changed, by shape

**Restated signatures, lines and branches deleted.** `PrecompiledDigestLoader` carried nine docs of the `Get a digest entry by identifier` shape; `ProjectPathScanner` carried a `// Check for <X> declaration` label above each of seven pattern branches. Both sets are gone.

**Contracts added where the signature could not carry them.** `scanProject` returns null both when no project is found and when the scan fails, and a caller cannot tell those apart. `parseVerseFile` returns `[]` on failure rather than throwing. `extractDeclarations` emits a 1-based `sourceLine` and a `fullPath` prefixed by the enclosing module chain. `DigestParser` gained a class doc for the two-tier contract its three methods spread out, including that the fallback to runtime parsing is one-way for the life of the instance.

**Load-bearing order kept and sharpened.** The variable branch must stay last: the `:` its pattern needs is also the first character of the `:=` that opens a type declaration, so it matches those too, and only the guards below it keep them out. Verified rather than asserted.

**One ordering comment deleted as false.** `// Check for extension method first (before regular function)` claimed an ordering constraint that does not exist: both patterns are `^`-anchored, and the function pattern cannot match a receiver-prefixed line at all. Checked directly against both regexes before removing it.

**Verse semantics verified, not trusted.** The surviving module-visibility comment asserts that a declaration with no specifier is `internal`. Confirmed against the Book of Verse, `docs/12_access.md` — the `<internal>` specifier is the default access level when none is given.

## Second commit: six claims the review caught

The review gate found that six comments I had written did not hold against the code. Each is corrected in `453674e`, and each was re-verified against the source before the fix:

- The data-directory fallback described the packaged layout **backwards**. `.vscodeignore` excludes `src/**` but re-includes `!src/data/**`, and nothing copies the JSON into `out/` — there is no copy step in `package.json` and `tsc` does not emit JSON, so `out/data` is absent after a clean compile. `src/data` is the live location in both a checkout and the `.vsix`; the `out/data` branch is dormant.
- Loaded state is **at least one file**, not all-or-nothing: `successCount > 0` latches it, so `isLoaded()` can be true over a partial index.
- Lookup order does **not** survive into the quick-fix menu: `ImportCodeActionProvider.sortSuggestions` re-sorts alphabetically when `quickFix.sortAlphabetically` is on.
- A file the scanner cannot read commits as **empty** rather than keeping its previous declarations, because `parseVerseFile` swallows its own errors and returns `[]`. The `failedFiles` path is reachable only for a throw raised outside it.
- `sourceLine` is 1-based and therefore is **not** a `vscode.Position` line.
- The asset-class segment **ends** the module path rather than starting the member run, and `includePrivate` lifts the module visibility filter as well as the private check.

## Acceptance criteria

- [x] Comments conform: contracts, invariants, non-obvious rationale and load-bearing ordering kept; restated signatures, field names, lines, branches, refactor history and commented-out code gone.
- [x] Incident-shaped comments reduced to their constraint.
- [x] No issue or PR numbers in comments.
- [x] Exported symbols carry a doc opening with one present-tense sentence. See the note below on public methods.
- [x] Nothing but comments changed.
- [x] No follow-up refactor ticket needed: no surviving comment exists solely to compensate for a poor name.
- [x] `npm run compile`, `npm test`, `npm run format:check` pass.
- [x] Strip-diff gate empty.

**On "every exported symbol":** read as the exported class, function or const, not every public member. Six delegating or self-describing methods lost their docs outright (`getEntry`, `getModuleIdentifiers`, `isLoaded`, `getLoadError`, and the two `getStats`). This matches the calibration: `f2da720` deleted the same shape from `ImportHandler`'s five pass-through methods while keeping a rich doc on the class. Say the word if you read the criterion the other way and I will restore them as real docs.

## Verification

```
$ npm run compile
> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       595 passed, 595 total
Snapshots:   0 total
Time:        8.604 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No test file was added, removed or edited.

### Strip-diff gate

```
$ npx tsc -p ./ --removeComments --sourceMap false --outDir <head-out>     # on 453674e
$ git checkout f2da720 -- src/services
$ npx tsc -p ./ --removeComments --sourceMap false --outDir <base-out>     # on the merge base
$ git checkout HEAD -- src/services
$ diff -r <base-out> <head-out>
strip-diff exit=0
```

Empty, across all 63 emitted `.js` files. This is the assertion that covers "nothing but comments changed"; the green suite alone would not prove it.

No changelog fragment: not a user-facing change.
