### PR TITLE
docs(ui,commands,diagnostics): apply the comment standard to the user-facing surfaces

### DIFF
--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -12,20 +12,22 @@ export interface CommandsDependencies {
     importCodeLensProvider: ImportCodeLensProvider;
     /**
      * Absent when the cache setting is off, so the dependency is missing in
-     * fact and not only in type. The three cache commands refuse rather than
-     * build one: a cache constructed here would have no file watchers behind
-     * it and would be stale from the moment it was written.
+     * fact and not only in type. The commands that would build one refuse
+     * instead; only the status command carries on and reports the cache as
+     * disabled. See activation for why one constructed here would be stale
+     * from the moment it was written.
      */
     projectPathCache?: ProjectPathCache;
 }
 
 /**
- * A structural copy of ImportPathConverter's conversion result, which that
+ * A hand-maintained copy of ImportPathConverter's conversion result, which that
  * module does not export.
  *
- * The converter's return values are cast to this type rather than checked
- * against it, so the compiler will not report a drift between the two. Keep
- * them in step by hand.
+ * The converter's return values reach this type by a cast, so nothing checks
+ * the copy against the original at the point it is made. What does check it is
+ * passing one back to applyConversion, which is typed on the original: a field
+ * this copy lacks fails there, a field only this copy has fails nowhere.
  */
 interface PathConversionResult {
     originalImport: string;
@@ -53,8 +55,9 @@ export class CommandsHandler {
      * Each id here must also be declared in package.json under
      * `contributes.commands`, and the five that take caller-supplied arguments
      * must stay hidden from the Command Palette there - invoking one from the
-     * palette dereferences an undefined document. commandManifest.test.ts pins
-     * the package.json half of that; nothing pins this half.
+     * palette dereferences an undefined document. Both halves are pinned:
+     * commandManifest.test.ts checks the manifest, and the integration suite
+     * checks every id is registered once the extension has activated.
      */
     registerAll(context: vscode.ExtensionContext): void {
         const commands: Array<[string, (...args: any[]) => any]> = [

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -4,20 +4,28 @@ import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../i
 import { StatusBarHandler } from "../ui";
 import { ProjectPathCache } from "../services";
 
-/**
- * Dependencies required by CommandsHandler.
- */
+/** The collaborators the commands act on, wired once during activation. */
 export interface CommandsDependencies {
     importHandler: ImportHandler;
     statusBarHandler: StatusBarHandler;
     importPathConverter: ImportPathConverter;
     importCodeLensProvider: ImportCodeLensProvider;
+    /**
+     * Absent when the cache setting is off, so the dependency is missing in
+     * fact and not only in type. The three cache commands refuse rather than
+     * build one: a cache constructed here would have no file watchers behind
+     * it and would be stale from the moment it was written.
+     */
     projectPathCache?: ProjectPathCache;
 }
 
 /**
- * Result from path conversion operations.
- * Matches the shape returned by ImportPathConverter.
+ * A structural copy of ImportPathConverter's conversion result, which that
+ * module does not export.
+ *
+ * The converter's return values are cast to this type rather than checked
+ * against it, so the compiler will not report a drift between the two. Keep
+ * them in step by hand.
  */
 interface PathConversionResult {
     originalImport: string;
@@ -29,53 +37,48 @@ interface PathConversionResult {
 }
 
 /**
- * Centralized handler for all extension commands.
- * Consolidates command logic that was previously scattered across extension.ts.
+ * The body of every command the extension contributes, and the one place they
+ * are registered.
  */
 export class CommandsHandler {
-    // Named constants for timing delays
     private static readonly STATUS_MESSAGE_DURATION_MS = 3000;
     private static readonly SNOOZE_DURATION_MINUTES = 5;
 
     constructor(private readonly deps: CommandsDependencies) {}
 
-    //==========================================================================
-    // Public Registration
-    //==========================================================================
-
     /**
-     * Registers all extension commands with VS Code.
+     * Registers every command against the extension context, which disposes
+     * them on deactivation.
+     *
+     * Each id here must also be declared in package.json under
+     * `contributes.commands`, and the five that take caller-supplied arguments
+     * must stay hidden from the Command Palette there - invoking one from the
+     * palette dereferences an undefined document. commandManifest.test.ts pins
+     * the package.json half of that; nothing pins this half.
      */
     registerAll(context: vscode.ExtensionContext): void {
         const commands: Array<[string, (...args: any[]) => any]> = [
-            // Import operations
             ["verseAutoImports.addSingleImport", this.addSingleImport.bind(this)],
             ["verseAutoImports.optimizeImports", this.optimizeImports.bind(this)],
 
-            // UI/Menu
             ["verseAutoImports.showStatusMenu", this.showStatusMenu.bind(this)],
 
-            // Toggle commands
             ["verseAutoImports.toggleAutoImport", this.toggleAutoImport.bind(this)],
             ["verseAutoImports.togglePreserveLocations", this.togglePreserveLocations.bind(this)],
             ["verseAutoImports.toggleImportSyntax", this.toggleImportSyntax.bind(this)],
             ["verseAutoImports.toggleDigestFiles", this.toggleDigestFiles.bind(this)],
             ["verseAutoImports.toggleFullPathCodeLens", this.toggleFullPathCodeLens.bind(this)],
 
-            // Snooze
             ["verseAutoImports.snoozeAutoImport", this.snoozeAutoImport.bind(this)],
             ["verseAutoImports.cancelSnooze", this.cancelSnooze.bind(this)],
 
-            // Debug/Logs
             ["verseAutoImports.exportDebugLogs", this.exportDebugLogs.bind(this)],
             ["verseAutoImports.captureDiagnosticsCorpus", this.captureDiagnosticsCorpus.bind(this)],
 
-            // Cache
             ["verseAutoImports.rebuildPathCache", this.rebuildPathCache.bind(this)],
             ["verseAutoImports.clearPathCache", this.clearPathCache.bind(this)],
             ["verseAutoImports.showCacheStatus", this.showCacheStatus.bind(this)],
 
-            // Path conversion
             ["verseAutoImports.convertToFullPath", this.convertToFullPath.bind(this)],
             ["verseAutoImports.convertAllToFullPath", this.convertAllToFullPath.bind(this)],
             ["verseAutoImports.convertToRelativePath", this.convertToRelativePath.bind(this)],
@@ -87,13 +90,6 @@ export class CommandsHandler {
         }
     }
 
-    //==========================================================================
-    // Import Operations
-    //==========================================================================
-
-    /**
-     * Adds a single import statement to a document.
-     */
     async addSingleImport(document: vscode.TextDocument, importStatement: string): Promise<void> {
         // A false here means applyEdit was rejected - a stale document version
         // or a read-only file - and the document is unchanged. Reporting the
@@ -110,7 +106,8 @@ export class CommandsHandler {
     }
 
     /**
-     * Optimizes imports in the active document by removing, re-adding, and organizing them.
+     * Rebuilds the active document's import block and saves it. Anything the
+     * compiler currently reports as a missing import is added along the way.
      */
     async optimizeImports(): Promise<void> {
         logger.info("CommandsHandler", "Optimizing imports command triggered");
@@ -131,16 +128,15 @@ export class CommandsHandler {
         try {
             const document = editor.document;
 
-            // Anything the compiler currently reports as a missing import gets
-            // added during the rebuild. No waiting: the command does not race
-            // the auto-import debounce, it computes the result itself.
+            // Read straight from the current diagnostics rather than waiting on
+            // the auto-import debounce, so the command does not race it.
             const diagnostics = vscode.languages.getDiagnostics(document.uri);
             const missingImportPaths = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
             logger.debug("CommandsHandler", `Found ${missingImportPaths.length} missing import(s) in current diagnostics`);
 
-            // Rebuild the import block in one atomic edit: existing imports plus
-            // missing ones, deduplicated, grouped, sorted, and written in the
-            // preferred syntax. The document is never left import-less.
+            // The missing paths are handed to the organizer rather than added
+            // first, so the block is rewritten once and the document is never
+            // left between the two states.
             const applied = await this.deps.importHandler.organizeImports(document, missingImportPaths);
 
             // Saving a document whose edit was rejected writes the unorganized
@@ -161,23 +157,16 @@ export class CommandsHandler {
         }
     }
 
-    //==========================================================================
-    // UI Commands
-    //==========================================================================
-
-    /**
-     * Shows the status bar menu.
-     */
     async showStatusMenu(): Promise<void> {
         await this.deps.statusBarHandler.showMenu();
     }
 
-    //==========================================================================
-    // Toggle Commands
-    //==========================================================================
-
     /**
-     * Generic helper for toggling configuration values.
+     * Writes the opposite of a setting's current value to global scope, then
+     * refreshes the status bar.
+     *
+     * @param toggleFn How to invert a value that is not a boolean. Omit it and
+     *   the current value is negated.
      */
     private async toggleConfig<T>(configKey: string, toggleFn?: (current: T) => T): Promise<void> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -207,10 +196,6 @@ export class CommandsHandler {
         await this.toggleConfig<boolean>("pathConversion.enableCodeLens");
     }
 
-    //==========================================================================
-    // Snooze Commands
-    //==========================================================================
-
     async snoozeAutoImport(): Promise<void> {
         this.deps.statusBarHandler.startSnooze(CommandsHandler.SNOOZE_DURATION_MINUTES);
     }
@@ -219,13 +204,6 @@ export class CommandsHandler {
         this.deps.statusBarHandler.cancelSnooze();
     }
 
-    //==========================================================================
-    // Debug/Logs
-    //==========================================================================
-
-    /**
-     * Exports debug logs to a file.
-     */
     async exportDebugLogs(): Promise<void> {
         try {
             const uri = await logger.exportDebugLogs();
@@ -243,9 +221,9 @@ export class CommandsHandler {
     }
 
     /**
-     * Captures the current Verse compiler diagnostics of all open documents to
-     * a JSON file. Used to maintain the message-format regression corpus in
-     * test-fixtures/corpus (see its README for the curation workflow).
+     * Writes the current Verse compiler diagnostics of every open document to a
+     * JSON file, which is how the message-format regression corpus in
+     * test-fixtures/corpus is maintained. Its README has the curation workflow.
      */
     async captureDiagnosticsCorpus(): Promise<void> {
         try {
@@ -294,13 +272,6 @@ export class CommandsHandler {
         }
     }
 
-    //==========================================================================
-    // Cache Commands
-    //==========================================================================
-
-    /**
-     * Rebuilds the project path cache.
-     */
     async rebuildPathCache(): Promise<void> {
         if (!this.deps.projectPathCache) {
             vscode.window.showWarningMessage("Project path cache is not enabled");
@@ -325,9 +296,8 @@ export class CommandsHandler {
     }
 
     /**
-     * Clears the project path cache without rebuilding it.
-     * Wipes both the in-memory state and the persisted workspace-storage copy;
-     * useful for testing cold-start behavior or recovering from a corrupt cache.
+     * Clears the project path cache without rebuilding it, wiping both the
+     * in-memory state and the persisted workspace-storage copy.
      */
     async clearPathCache(): Promise<void> {
         if (!this.deps.projectPathCache) {
@@ -347,9 +317,6 @@ export class CommandsHandler {
         }
     }
 
-    /**
-     * Shows the current cache status.
-     */
     async showCacheStatus(): Promise<void> {
         try {
             const cacheStats = this.deps.projectPathCache?.getStats();
@@ -381,20 +348,16 @@ export class CommandsHandler {
         }
     }
 
-    //==========================================================================
-    // Path Conversion Commands
-    //==========================================================================
-
     /**
-     * Prepares for a path conversion by keeping hover state active.
+     * Holds the CodeLens open across a conversion, by cancelling the pending
+     * hide timer and pinning the hover flag. Without it a conversion that takes
+     * longer than the hide delay - an ambiguous one waits on a quick pick -
+     * finishes against a lens that has already gone.
      */
     private prepareForConversion(documentUri: string): void {
         this.deps.importCodeLensProvider.keepHoverStateActive(documentUri);
     }
 
-    /**
-     * Finalizes a path conversion by forcing a CodeLens refresh.
-     */
     private finalizeConversion(documentUri: string): void {
         this.deps.importCodeLensProvider.forceRefreshAfterConversion(documentUri);
     }
@@ -428,7 +391,9 @@ export class CommandsHandler {
     }
 
     /**
-     * Shows a quick pick for selecting an ambiguous path.
+     * Asks which of several candidate paths to use, and returns undefined when
+     * the user dismisses the pick. A dismissal is a decline rather than a
+     * failure, and callers count it as neither converted nor failed.
      */
     private async selectAmbiguousPath(result: PathConversionResult): Promise<string | undefined> {
         if (!result.possiblePaths) return undefined;
@@ -447,9 +412,6 @@ export class CommandsHandler {
         return selected?.path;
     }
 
-    /**
-     * Converts a single import to absolute path format.
-     */
     async convertToFullPath(document: vscode.TextDocument, importStatement: string, lineNumber: number): Promise<void> {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);
@@ -487,9 +449,6 @@ export class CommandsHandler {
         }
     }
 
-    /**
-     * Converts all imports in a document to absolute path format.
-     */
     async convertAllToFullPath(document: vscode.TextDocument): Promise<void> {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);
@@ -505,7 +464,8 @@ export class CommandsHandler {
         let failedCount = 0;
         const ambiguousImports: PathConversionResult[] = [];
 
-        // First pass: handle non-ambiguous imports
+        // Every unambiguous conversion is applied before the first question is
+        // asked, so a user who dismisses the picks still gets the rest.
         for (const result of results) {
             if (!result.isAmbiguous) {
                 const success = await this.deps.importPathConverter.applyConversion(document, result);
@@ -516,8 +476,6 @@ export class CommandsHandler {
             }
         }
 
-        // Second pass: handle ambiguous imports interactively. A cancelled quick
-        // pick is a decline rather than a failure, so it counts as neither.
         for (const result of ambiguousImports) {
             const selectedPath = await this.selectAmbiguousPath(result);
             if (selectedPath) {
@@ -531,9 +489,6 @@ export class CommandsHandler {
         this.finalizeConversion(documentUri);
     }
 
-    /**
-     * Converts a single import to relative path format.
-     */
     async convertToRelativePath(document: vscode.TextDocument, importStatement: string, lineNumber: number): Promise<void> {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);
@@ -555,9 +510,6 @@ export class CommandsHandler {
         this.finalizeConversion(documentUri);
     }
 
-    /**
-     * Converts all imports in a document to relative path format.
-     */
     async convertAllToRelativePath(document: vscode.TextDocument): Promise<void> {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -4,6 +4,14 @@ import { logger } from "../utils";
 import { ImportSuggestion } from "../types";
 import { ImportHandler } from "../imports";
 
+/**
+ * Turns the Verse compiler's diagnostics into imports: one debounce timer per
+ * document, and on expiry, the high-confidence suggestions written into it.
+ *
+ * Disposable, and registered as one during activation: the delay is
+ * user-configurable, so an armed timer outlives teardown by that long unless it
+ * is cancelled.
+ */
 export class DiagnosticsHandler {
     private importHandler: ImportHandler;
     private processingDocuments: Set<string> = new Set();
@@ -21,18 +29,21 @@ export class DiagnosticsHandler {
         // lose suppression silently at runtime instead of failing the build.
         private isAutoImportSuppressed: () => boolean,
     ) {
-        // Use the shared, fully-wired ImportHandler so the auto-import path has
-        // the same asset-class detection and precompiled digests as quick fixes.
+        // Injected rather than constructed so the auto-import path resolves
+        // through the same handler as quick fixes; one built here would carry
+        // neither the extension context nor the assets digest parser.
         this.importHandler = importHandler;
         logger.debug("DiagnosticsHandler", `Initialized with ${this.delayMs}ms delay`);
     }
 
     /**
-     * Decides whether a diagnostics URI should be processed at all, before any
-     * document is opened. Diagnostics events also carry VS Code internal
-     * documents (e.g. private: replace-preview buffers, git: views) that throw
-     * on openTextDocument, and Epic's generated *.digest.verse files, which
-     * hold permanent LSP errors and must never be edited by the extension.
+     * Whether a diagnostics URI is a Verse file the extension may edit, asked
+     * before any document is opened.
+     *
+     * A diagnostics event also carries VS Code's internal documents - private:
+     * replace-preview buffers, git: views - which throw on openTextDocument,
+     * and Epic's generated *.digest.verse files, which hold permanent LSP
+     * errors and must never be edited.
      */
     static shouldProcessUri(uri: { scheme: string; fsPath: string }): boolean {
         if (uri.scheme !== "file") {
@@ -43,28 +54,27 @@ export class DiagnosticsHandler {
     }
 
     /**
-     * Decides whether a diagnostics URI is inside the configured auto-import
-     * scope. The Verse LSP publishes diagnostics for the whole project, not
-     * only for what is on screen, so without this the extension edits any
-     * .verse file the compiler complains about.
+     * Whether a diagnostics URI is inside the configured auto-import scope. The
+     * Verse LSP publishes diagnostics for the whole project, not only for what
+     * is on screen, so without this the extension edits any .verse file the
+     * compiler complains about.
      *
-     * Callers must consult this before opening the document: opening one is
-     * itself the behaviour "openFiles" exists to prevent, since it pulls a file
-     * the user never opened into the workspace.
-     *
-     * URIs are compared by their string form, as the rest of the extension
-     * keys per-document state, never by fsPath - two URIs can share a path and
-     * differ in scheme or query.
-     *
-     * visibility.openUris must be built from the open tabs, not from
-     * vscode.workspace.textDocuments. That list holds every document opened
-     * programmatically by anything, and this extension's own ProjectPathScanner
-     * opens every .verse file in the project to build the path cache - so keyed
-     * on it, "openFiles" would admit the whole project and mean nothing.
+     * Call this before opening the document. Opening one is itself the
+     * behaviour "openFiles" exists to prevent, since it pulls a file the user
+     * never opened into the workspace.
      *
      * An unrecognized scope falls back to "allFiles", so a mistyped setting
-     * degrades to the previous behaviour instead of silently disabling
-     * auto-import altogether.
+     * degrades to the unrestricted scope rather than disabling auto-import
+     * altogether.
+     *
+     * @param visibility `openUris` must come from the open tabs, never from
+     *   vscode.workspace.textDocuments: that list holds every document opened
+     *   programmatically by anything, and this extension's own
+     *   ProjectPathScanner opens every .verse file in the project to build the
+     *   path cache, so keyed on it "openFiles" admits the whole project. Both
+     *   fields hold URI strings, as the rest of the extension keys
+     *   per-document state - never fsPath, since two URIs can share a path and
+     *   differ in scheme or query.
      */
     static isUriInScope(uri: { toString(): string }, scope: string, visibility: { openUris: readonly string[]; activeUri?: string }): boolean {
         if (!DiagnosticsHandler.scopeRestrictsDocuments(scope)) {
@@ -84,17 +94,22 @@ export class DiagnosticsHandler {
     }
 
     /**
-     * Whether a scope narrows anything at all. Callers use it to skip building
-     * a visibility snapshot they will not read.
+     * Whether a scope narrows anything at all, which is what lets a caller skip
+     * building a visibility snapshot it will not read.
      *
-     * It is the single definition of that question on purpose: expressing it
-     * again at the call site, in the opposite polarity, would make the cheap
-     * path correct only for as long as the two stayed exact complements.
+     * The single definition of that question on purpose: expressing it again at
+     * the call site, in the opposite polarity, leaves the cheap path correct
+     * only for as long as the two stay exact complements.
      */
     static scopeRestrictsDocuments(scope: string): boolean {
         return scope === "openFiles" || scope === "activeFile";
     }
 
+    /**
+     * Arms the debounce timer for a document, cancelling the one it already
+     * has, and does nothing while that document is already being processed. The
+     * import happens when the timer expires, long after this returns.
+     */
     async handle(document: vscode.TextDocument) {
         // The diagnostics listener awaits openTextDocument before calling in,
         // so a continuation can resume after teardown. Arming a timer here
@@ -113,7 +128,6 @@ export class DiagnosticsHandler {
 
         logger.trace("DiagnosticsHandler", `Received diagnostics for ${displayName}`);
 
-        // Cancel any pending timer for this document
         const existingTimer = this.pendingTimers.get(documentKey);
         if (existingTimer) {
             clearTimeout(existingTimer);
@@ -121,7 +135,6 @@ export class DiagnosticsHandler {
             logger.trace("DiagnosticsHandler", `Cancelled pending timer for ${displayName} (debouncing)`);
         }
 
-        // If already processing this document, don't start a new timer
         if (this.processingDocuments.has(documentKey)) {
             logger.debug("DiagnosticsHandler", `Already processing ${displayName}, skipping new timer`);
             return;
@@ -129,12 +142,8 @@ export class DiagnosticsHandler {
 
         logger.debug("DiagnosticsHandler", `Starting debounce timer (${this.delayMs}ms) for ${displayName}`);
 
-        // Create new timer with proper debouncing
         const timer = setTimeout(async () => {
-            // Remove from pending timers
             this.pendingTimers.delete(documentKey);
-
-            // Mark as processing
             this.processingDocuments.add(documentKey);
             try {
                 const currentDiagnostics = vscode.languages.getDiagnostics(document.uri);
@@ -152,28 +161,25 @@ export class DiagnosticsHandler {
                     const suggestions = await this.importHandler.extractImportSuggestions(diagnostic.message);
 
                     if (suggestions.length === 0) {
-                        // No suggestions found, skip this diagnostic
                         continue;
                     }
 
                     if (suggestions.length > 1) {
-                        // Multi-option scenario detected
                         hasMultiOptionSuggestions = true;
                         logger.debug("DiagnosticsHandler", `Multi-option diagnostic found with ${suggestions.length} suggestions - will use quick fixes`);
 
                         if (multiOptionStrategy.startsWith("auto_")) {
-                            // Auto-select one option for import
                             const selectedSuggestion = this.selectBestSuggestion(suggestions, multiOptionStrategy);
                             if (selectedSuggestion && autoImportEnabled) {
                                 autoImportSuggestions.add(selectedSuggestion.importStatement);
                                 logger.debug("DiagnosticsHandler", `Auto-selected: ${selectedSuggestion.importStatement}`);
                             }
                         }
-                        // For quickfix strategy, let ImportCodeActionProvider handle it
+                        // Under the quickfix strategy nothing is imported here:
+                        // ImportCodeActionProvider offers the options instead.
                         continue;
                     }
 
-                    // Single suggestion - can auto-import if enabled
                     const suggestion = suggestions[0];
                     if (autoImportEnabled && suggestion.confidence === "high") {
                         logger.debug("DiagnosticsHandler", `Adding high-confidence import: ${suggestion.importStatement}`);
@@ -192,7 +198,6 @@ export class DiagnosticsHandler {
                     return;
                 }
 
-                // Apply auto-imports if any were collected
                 if (autoImportSuggestions.size > 0) {
                     logger.info("DiagnosticsHandler", `Auto-importing ${autoImportSuggestions.size} statements`);
                     autoImportSuggestions.forEach((imp) => {
@@ -212,7 +217,6 @@ export class DiagnosticsHandler {
                     }
                 }
 
-                // Show status for multi-option diagnostics
                 if (hasMultiOptionSuggestions && multiOptionStrategy === "quickfix") {
                     vscode.window.setStatusBarMessage(`Multiple import options available - use quick fixes (Ctrl+.)`, 5000);
                 }
@@ -224,10 +228,14 @@ export class DiagnosticsHandler {
             }
         }, this.delayMs);
 
-        // Store the timer so it can be cancelled if needed
         this.pendingTimers.set(documentKey, timer);
     }
 
+    /**
+     * Picks the one suggestion to import from several. An unrecognized strategy
+     * takes the first, so a mistyped setting still imports something rather
+     * than nothing.
+     */
     private selectBestSuggestion(suggestions: ImportSuggestion[], strategy: string): ImportSuggestion | null {
         if (suggestions.length === 0) {
             return null;
@@ -235,25 +243,31 @@ export class DiagnosticsHandler {
 
         switch (strategy) {
             case "auto_shortest":
-                // Return the suggestion with the shortest import statement
                 return suggestions.reduce((shortest, current) => (current.importStatement.length < shortest.importStatement.length ? current : shortest));
             case "auto_first":
                 return suggestions[0];
             default:
-                return suggestions[0]; // fallback
+                return suggestions[0];
         }
     }
 
+    /**
+     * Sets the debounce delay for timers armed from now on. A timer already
+     * pending keeps the delay it was armed with.
+     */
     setDelay(delayMs: number) {
         this.delayMs = delayMs;
         logger.info("DiagnosticsHandler", `Diagnostic processing delay set to ${delayMs}ms`);
     }
 
     /**
-     * Cancels every armed debounce timer so none can fire after deactivation.
+     * Cancels every armed debounce timer so none can fire after deactivation,
+     * and refuses any further work.
+     *
      * The delay is user-configurable, so a timer armed by the last keystroke
      * before a reload would otherwise apply an edit to a document belonging to
-     * a torn-down extension.
+     * a torn-down extension. A callback that has already started cannot be
+     * cancelled, which is why `disposed` is re-checked before the edit.
      */
     dispose(): void {
         this.disposed = true;

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -6,7 +6,9 @@ import { ImportHandler } from "../imports";
 
 /**
  * Turns the Verse compiler's diagnostics into imports: one debounce timer per
- * document, and on expiry, the high-confidence suggestions written into it.
+ * document, and on expiry, the suggestions it may act on without asking
+ * written into it. A lone suggestion has to be high confidence; one picked out
+ * of several by an auto_ strategy does not.
  *
  * Disposable, and registered as one during activation: the delay is
  * user-configurable, so an armed timer outlives teardown by that long unless it

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -30,8 +30,8 @@ export class StatusBarHandler {
     constructor(private outputChannel: vscode.OutputChannel) {
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, STATUS_BAR_PRIORITY);
         // Clicking the item invokes this id, which CommandsHandler registers.
-        // Nothing checks the two agree; a rename on either side leaves an item
-        // whose click does nothing.
+        // The registration is pinned by the integration suite, this literal by
+        // nothing: change it alone and the item stops responding to clicks.
         this.statusBarItem.command = "verseAutoImports.showStatusMenu";
         this.statusBarItem.name = "Verse Auto Imports";
 
@@ -59,9 +59,9 @@ export class StatusBarHandler {
     }
 
     /**
-     * Whether auto imports are currently suppressed by a snooze. This is the
-     * whole of the suppression signal: activation reads it directly and hands
-     * it to DiagnosticsHandler, so nothing else has to be consulted.
+     * Whether auto imports are currently suppressed by a snooze. Callers weigh
+     * this against the autoImport setting; a snooze suppresses imports without
+     * touching it, so neither answers the question alone.
      *
      * Snooze state is deliberately in-memory only: it is ephemeral and
      * time-boxed, so it must not outlive the extension host. Persisting it (or

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { logger } from "../utils";
 
 interface QuickPickItemWithAction extends vscode.QuickPickItem {
+    /** What selecting the item does. Separators and labels carry none. */
     action?: () => void | Promise<void>;
 }
 
@@ -13,6 +14,13 @@ function toggleIcon(enabled: boolean, label: string): string {
     return enabled ? `$(check) ${label}` : `$(blank) ${label}`;
 }
 
+/**
+ * The extension's status bar item, the quick-pick menu behind it, and the
+ * snooze that suppresses auto-import for a few minutes at a time.
+ *
+ * Disposable, and registered as one during activation: an armed snooze holds a
+ * repeating interval that would otherwise keep running after teardown.
+ */
 export class StatusBarHandler {
     private statusBarItem: vscode.StatusBarItem;
     private snoozeEndTime: number | null = null;
@@ -21,13 +29,15 @@ export class StatusBarHandler {
 
     constructor(private outputChannel: vscode.OutputChannel) {
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, STATUS_BAR_PRIORITY);
+        // Clicking the item invokes this id, which CommandsHandler registers.
+        // Nothing checks the two agree; a rename on either side leaves an item
+        // whose click does nothing.
         this.statusBarItem.command = "verseAutoImports.showStatusMenu";
         this.statusBarItem.name = "Verse Auto Imports";
 
         this.updateDisplay();
         this.statusBarItem.show();
 
-        // Listen for configuration changes to update status bar
         this.configListener = vscode.workspace.onDidChangeConfiguration((event) => {
             if (event.affectsConfiguration("verseAutoImports")) {
                 // A snooze does not touch the setting, so this only fires when
@@ -40,7 +50,6 @@ export class StatusBarHandler {
                     const autoImportEnabled = config.get<boolean>("general.autoImport", true);
 
                     if (autoImportEnabled) {
-                        // User manually enabled auto imports - cancel the snooze silently
                         this.cancelSnoozeSilently();
                     }
                 }
@@ -50,11 +59,14 @@ export class StatusBarHandler {
     }
 
     /**
-     * Whether auto imports are currently suppressed by a snooze. Snooze state
-     * is deliberately in-memory only: it is ephemeral and time-boxed, so it
-     * must not outlive the extension host. Persisting it (or mirroring it into
-     * user settings) is what could leave auto imports off forever after a
-     * reload mid-snooze.
+     * Whether auto imports are currently suppressed by a snooze. This is the
+     * whole of the suppression signal: activation reads it directly and hands
+     * it to DiagnosticsHandler, so nothing else has to be consulted.
+     *
+     * Snooze state is deliberately in-memory only: it is ephemeral and
+     * time-boxed, so it must not outlive the extension host. Persisting it (or
+     * mirroring it into user settings) is what could leave auto imports off
+     * forever after a reload mid-snooze.
      */
     isSnoozeActive(): boolean {
         return this.snoozeEndTime !== null && Date.now() < this.snoozeEndTime;
@@ -62,15 +74,14 @@ export class StatusBarHandler {
 
     updateDisplay(): void {
         if (this.isSnoozeActive()) {
-            // Snooze is active - show text with countdown
             const remaining = this.getRemainingTime();
             this.statusBarItem.text = `Verse Auto Imports (${remaining})`;
         } else {
-            // Normal state - just show text
             this.statusBarItem.text = "Verse Auto Imports";
         }
     }
 
+    /** The time left on the snooze as `m:ss`, or "0:00" once it has run out. */
     private getRemainingTime(): string {
         if (this.snoozeEndTime === null) return "0:00";
 
@@ -82,6 +93,11 @@ export class StatusBarHandler {
         return `${minutes}:${seconds.toString().padStart(2, "0")}`;
     }
 
+    /**
+     * Shows the quick-pick menu and runs whatever the user picked. Every row
+     * reads its state from configuration at the moment the menu opens, so a
+     * setting changed elsewhere is reflected the next time it is shown.
+     */
     async showMenu(): Promise<void> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const autoImportEnabled = config.get<boolean>("general.autoImport", true);
@@ -95,7 +111,6 @@ export class StatusBarHandler {
 
         const items: QuickPickItemWithAction[] = [];
 
-        // ── Quick Actions ──
         items.push({
             label: "Quick Actions",
             kind: vscode.QuickPickItemKind.Separator,
@@ -109,14 +124,14 @@ export class StatusBarHandler {
             },
         });
 
-        // ── General ──
         items.push({
             label: "General",
             kind: vscode.QuickPickItemKind.Separator,
         });
 
-        // A snooze no longer flips the setting, so the row would otherwise
-        // report "Enabled" while imports are suppressed.
+        // Three states, not two: a snooze suppresses imports without touching
+        // the setting, so a row derived from the setting alone reads "Enabled"
+        // while nothing is being imported.
         let autoImportDescription: string;
         if (!autoImportEnabled) {
             autoImportDescription = "Disabled";
@@ -135,7 +150,6 @@ export class StatusBarHandler {
             },
         });
 
-        // Snooze section
         if (this.isSnoozeActive()) {
             const remaining = this.getRemainingTime();
 
@@ -164,7 +178,6 @@ export class StatusBarHandler {
             });
         }
 
-        // ── Import Behavior ──
         items.push({
             label: "Import Behavior",
             kind: vscode.QuickPickItemKind.Separator,
@@ -188,7 +201,6 @@ export class StatusBarHandler {
             },
         });
 
-        // Import Grouping option
         let groupingLabel = "";
         let groupingDescription = "";
 
@@ -215,7 +227,6 @@ export class StatusBarHandler {
             },
         });
 
-        // Import Syntax checkbox
         const isDotSyntax = importSyntax === "dot";
         items.push({
             label: toggleIcon(isDotSyntax, "Dot Syntax (using.)"),
@@ -227,7 +238,6 @@ export class StatusBarHandler {
             },
         });
 
-        // ── Path Conversion ──
         items.push({
             label: "Path Conversion",
             kind: vscode.QuickPickItemKind.Separator,
@@ -242,7 +252,6 @@ export class StatusBarHandler {
             },
         });
 
-        // CodeLens Visibility submenu
         const visibilityLabel = codeLensVisibility === "hover" ? "Hover Only" : "Always Visible";
         items.push({
             label: `$(list-unordered) CodeLens Visibility: ${visibilityLabel} $(chevron-right)`,
@@ -252,7 +261,6 @@ export class StatusBarHandler {
             },
         });
 
-        // ── Experimental ──
         items.push({
             label: "Experimental",
             kind: vscode.QuickPickItemKind.Separator,
@@ -267,7 +275,6 @@ export class StatusBarHandler {
             },
         });
 
-        // ── Utilities ──
         items.push({
             label: "Utilities",
             kind: vscode.QuickPickItemKind.Separator,
@@ -297,13 +304,11 @@ export class StatusBarHandler {
             },
         });
 
-        // Show the menu
         const selected = await vscode.window.showQuickPick(items, {
             placeHolder: "Verse Auto Imports - Quick Actions",
             matchOnDescription: true,
         });
 
-        // Execute the action if an item was selected
         if (selected?.action) {
             try {
                 await selected.action();
@@ -314,13 +319,13 @@ export class StatusBarHandler {
         }
     }
 
+    /** Shows the import-grouping submenu, and returns to the main menu on Back. */
     async showImportGroupingMenu(): Promise<void> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const currentGrouping = config.get<string>("behavior.importGrouping", "none");
 
         const items: QuickPickItemWithAction[] = [];
 
-        // Add back option
         items.push({
             label: "$(arrow-left) Back to main menu",
             description: "",
@@ -329,13 +334,11 @@ export class StatusBarHandler {
             },
         });
 
-        // Separator
         items.push({
             label: "",
             kind: vscode.QuickPickItemKind.Separator,
         });
 
-        // None option
         items.push({
             label: toggleIcon(currentGrouping === "none", "No Grouping"),
             description: "All imports mixed together (default)",
@@ -346,7 +349,6 @@ export class StatusBarHandler {
             },
         });
 
-        // Digest First option
         items.push({
             label: toggleIcon(currentGrouping === "digestFirst", "Digest First"),
             description: "Digest imports (/Verse.org, /Fortnite.com, /UnrealEngine.com), then local imports",
@@ -357,7 +359,6 @@ export class StatusBarHandler {
             },
         });
 
-        // Local First option
         items.push({
             label: toggleIcon(currentGrouping === "localFirst", "Local First"),
             description: "Local imports, then digest imports",
@@ -368,13 +369,11 @@ export class StatusBarHandler {
             },
         });
 
-        // Show the submenu
         const selected = await vscode.window.showQuickPick(items, {
             placeHolder: "Select Import Grouping Option",
             matchOnDescription: true,
         });
 
-        // Execute the action if an item was selected
         if (selected?.action) {
             try {
                 await selected.action();
@@ -385,13 +384,13 @@ export class StatusBarHandler {
         }
     }
 
+    /** Shows the CodeLens visibility submenu, and returns to the main menu on Back. */
     async showCodeLensVisibilityMenu(): Promise<void> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const currentVisibility = config.get<string>("pathConversion.codeLensVisibility", "hover");
 
         const items: QuickPickItemWithAction[] = [];
 
-        // Add back option
         items.push({
             label: "$(arrow-left) Back to main menu",
             description: "",
@@ -400,13 +399,11 @@ export class StatusBarHandler {
             },
         });
 
-        // Separator
         items.push({
             label: "",
             kind: vscode.QuickPickItemKind.Separator,
         });
 
-        // Hover Only option
         items.push({
             label: toggleIcon(currentVisibility === "hover", "Hover Only"),
             description: "Show only when hovering over imports (default)",
@@ -417,7 +414,6 @@ export class StatusBarHandler {
             },
         });
 
-        // Always Visible option
         items.push({
             label: toggleIcon(currentVisibility === "always", "Always Visible"),
             description: "Always show above import statements",
@@ -428,13 +424,11 @@ export class StatusBarHandler {
             },
         });
 
-        // Show the submenu
         const selected = await vscode.window.showQuickPick(items, {
             placeHolder: "Select CodeLens Visibility Option",
             matchOnDescription: true,
         });
 
-        // Execute the action if an item was selected
         if (selected?.action) {
             try {
                 await selected.action();
@@ -445,20 +439,22 @@ export class StatusBarHandler {
         }
     }
 
+    /**
+     * Suppresses auto imports for a number of minutes, restarting the snooze if
+     * one is already running.
+     */
     startSnooze(minutes: number): void {
         logger.debug("StatusBarHandler", `Starting snooze for ${minutes} minutes`);
 
-        // Clear any existing snooze first so re-invoking (e.g. the command
-        // palette while already snoozed) cannot orphan a running interval.
+        // Clear first so re-invoking (the command palette while already
+        // snoozed, say) cannot orphan a running interval.
         this.clearSnoozeState();
 
-        // Set snooze end time. This is the whole of the snooze state: the
-        // auto-import path consults isSnoozeActive(), and no user setting is
+        // The end time is the whole of the snooze state. No user setting is
         // touched, so nothing can survive the extension host and leave auto
         // imports disabled.
         this.snoozeEndTime = Date.now() + minutes * MS_PER_MINUTE;
 
-        // Start countdown interval
         this.snoozeInterval = setInterval(() => {
             if (this.snoozeEndTime && Date.now() >= this.snoozeEndTime) {
                 this.endSnooze();
@@ -467,7 +463,6 @@ export class StatusBarHandler {
             }
         }, SNOOZE_INTERVAL_MS);
 
-        // Update immediately
         this.updateDisplay();
 
         vscode.window.showInformationMessage(`Auto imports snoozed for ${minutes} minutes`);
@@ -491,6 +486,7 @@ export class StatusBarHandler {
         }
     }
 
+    /** Ends the snooze at the user's request, and says so. */
     cancelSnooze(): void {
         logger.debug("StatusBarHandler", "Cancelling snooze");
         this.clearSnoozeState();
@@ -499,6 +495,11 @@ export class StatusBarHandler {
         vscode.window.showInformationMessage("Auto imports resumed");
     }
 
+    /**
+     * Ends the snooze without a notification, for the case where the user has
+     * just turned auto import on themselves: they already know imports are
+     * back, and saying so again is noise on an action they took.
+     */
     private cancelSnoozeSilently(): void {
         if (this.snoozeEndTime === null) {
             return;
@@ -516,6 +517,12 @@ export class StatusBarHandler {
         vscode.window.showInformationMessage("Auto imports resumed automatically");
     }
 
+    /**
+     * Stops the countdown interval and releases the status bar item and the
+     * configuration listener. The interval repeats every second until it is
+     * cleared, so a snooze armed at deactivation would otherwise keep firing
+     * against a torn-down status bar item.
+     */
     dispose(): void {
         if (this.snoozeInterval) {
             clearInterval(this.snoozeInterval);


### PR DESCRIPTION
Closes #228

The comment standard applied to the three user-facing surfaces, calibrated against the merged pilot in #249 and against its two correction commits, which are the sharper lesson: both fixed a comment that asserted a mechanism the code did not have.

## What changed

**`StatusBarHandler`** had one doc block across 526 lines and was where restated branches were thickest, including the standard's own example of one. The class, the menu entry points and the snooze lifecycle are documented; the `// ── X ──` separators that restated the separator row directly below them are gone. Its note on why snooze state is in-memory only is kept and tightened - it is the calibration example the ticket names.

**`CommandsHandler`** loses the refactor history from its class doc, and both kinds of section header: the six class banners and the seven dividing the `registerAll` table. `PathConversionResult` now records what it actually is - a hand-maintained copy of a type `ImportPathConverter` does not export, reached by a cast - and where that copy is and is not checked. `registerAll` carries the id/manifest coupling.

**`DiagnosticsHandler`** gains a class doc and docs on `handle`, `setDelay` and `selectBestSuggestion`. Its four static-method blocks were already the strongest comments in the file and are kept, tightened, with every constraint intact.

Fourteen restated lines came out of `handle` alone.

## What did not change

The three barrels. Each is a single export line, and a comment on one could only restate it - which is the thing this pass removes. The pilot's barrel comment earned its place because that module has six exports and a facade to point at; these have neither.

No changelog fragment: nothing here is user-facing.

## Follow-up filed

#250, for splitting the command table out of `registerAll`. The section headers this PR deleted were standing in for that structure, and the ticket instructed filing it rather than doing it here.

## Review

A fresh reviewer returned **PASS_WITH_SUGGESTIONS**, no Critical. Its three Important findings were all the same class of defect - a comment of mine claiming more than the code does - and all three are fixed in `3d00a1b`, along with two of the suggestions:

- `registerAll` claimed nothing pins its ids. `src/test-integration/suite/commands.itest.ts` asserts all nineteen are registered after activation.
- `PathConversionResult` claimed the compiler cannot see a drift. Passing one back to `applyConversion` is typed on the original, so a missing field does fail there.
- The status bar command id is pinned on the registration side; only the literal is unguarded.
- Two of the three cache commands refuse when the cache is off, not three - `showCacheStatus` reports it as disabled and carries on.
- A suggestion picked by an `auto_` strategy is imported without the confidence check the class doc claimed applied to everything.

The reviewer independently confirmed the remaining claims against the code they describe, and checked for over-deletion - no load-bearing constraint was lost, the two at-risk ones having moved rather than gone.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test

Test Suites: 28 passed, 28 total
Tests:       595 passed, 595 total
Snapshots:   0 total
Time:        7.257 s, estimated 9 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

### Strip-diff gate

The gate the ticket specifies: compile both revisions with comments stripped and compare.

```
$ npx tsc -p ./ --removeComments --sourceMap false --outDir <base-out>   # main
$ npx tsc -p ./ --removeComments --sourceMap false --outDir <head-out>   # this branch
$ diff -r base-out head-out
strip-diff exit code: 0
base: 63 js files, head: 63 js files
```

Empty, with 63 files on each side rather than two empty directories. Nothing but comments changed.
