### PR TITLE
docs: apply the comment standard to activation, project, types and utils

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,8 +66,10 @@ export function activate(context: vscode.ExtensionContext) {
     logger.info("Extension", `Verse Auto Imports ${environment.extensionVersion} is now active (${formatHostSummary(environment, sessionState)})`);
     logger.debug("Extension", "Settings at activation", sessionState.settings);
 
-    // Handlers predate the logger and still take an OutputChannel rather than
-    // reaching for the singleton themselves.
+    // Handlers take this channel but log through the `logger` singleton. The
+    // parameter survives from before the logger existed, and the only real
+    // uses left are StatusBarHandler showing the channel and ProjectPathCache
+    // passing it on to the scanner.
     const outputChannel = logger.getUserChannel();
 
     const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -177,8 +179,9 @@ export function activate(context: vscode.ExtensionContext) {
         ),
     );
 
-    // Clears the snooze timer on deactivation, so a snooze cannot expire and
-    // re-enable auto-import after the extension is torn down.
+    // Disposal is what removes the handler's own configuration listener, which
+    // would otherwise outlive the extension; it also stops the snooze countdown
+    // and disposes the status bar item.
     context.subscriptions.push(statusBarHandler);
 
     context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,9 +67,9 @@ export function activate(context: vscode.ExtensionContext) {
     logger.debug("Extension", "Settings at activation", sessionState.settings);
 
     // Handlers take this channel but log through the `logger` singleton. The
-    // parameter survives from before the logger existed, and the only real
-    // uses left are StatusBarHandler showing the channel and ProjectPathCache
-    // passing it on to the scanner.
+    // parameter survives from before the logger existed and is threaded down
+    // the whole handler tree; the only thing anyone does with it at the end is
+    // StatusBarHandler showing the channel.
     const outputChannel = logger.getUserChannel();
 
     const config = vscode.workspace.getConfiguration("verseAutoImports");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,9 +28,9 @@ function getExplicitSetting(config: vscode.WorkspaceConfiguration, key: string):
 }
 
 /**
- * Gets the configured debounce delay, handling backward compatibility with
- * the deprecated diagnosticDelay setting. Only explicit overrides are
- * considered so diagnosticDelay's registered default (1000) cannot shadow
+ * The debounce delay in milliseconds, honouring the deprecated
+ * diagnosticDelay setting. Only explicit overrides are considered, so
+ * diagnosticDelay's registered default (1000) cannot shadow
  * autoImportDebounceDelay; an explicit autoImportDebounceDelay wins over an
  * explicit legacy value.
  */
@@ -46,8 +46,14 @@ function getConfiguredDebounceDelay(config: vscode.WorkspaceConfiguration): numb
     return config.get<number>("general.autoImportDebounceDelay", 3000);
 }
 
+/**
+ * Builds the handlers, registers every provider, watcher, command and listener
+ * on the extension context, and starts the two caches.
+ *
+ * Whether the project path cache exists at all is decided once, here, from the
+ * setting as it reads at activation. Nothing downstream can turn it on later.
+ */
 export function activate(context: vscode.ExtensionContext) {
-    // Initialize the logger
     logger.initialize(context);
 
     // Record which build and host this is before anything else logs, so an
@@ -60,13 +66,13 @@ export function activate(context: vscode.ExtensionContext) {
     logger.info("Extension", `Verse Auto Imports ${environment.extensionVersion} is now active (${formatHostSummary(environment, sessionState)})`);
     logger.debug("Extension", "Settings at activation", sessionState.settings);
 
-    // Get output channel for backward compatibility with handlers
+    // Handlers predate the logger and still take an OutputChannel rather than
+    // reaching for the singleton themselves.
     const outputChannel = logger.getUserChannel();
 
     const config = vscode.workspace.getConfiguration("verseAutoImports");
     const cacheEnabled = config.get<boolean>(CACHE_SETTING, CACHE_SETTING_DEFAULT);
 
-    // Create core services
     logger.debug("Extension", "Creating handlers");
     const projectPathHandler = new ProjectPathHandler(outputChannel);
     const assetsDigestParser = new AssetsDigestParser(outputChannel, projectPathHandler);
@@ -77,14 +83,12 @@ export function activate(context: vscode.ExtensionContext) {
     // so it is stale from the moment it is stored.
     const projectPathCache = cacheEnabled ? new ProjectPathCache(context, outputChannel, projectPathHandler) : undefined;
 
-    // Create handlers and providers
     const importHandler = new ImportHandler(outputChannel, assetsDigestParser, context);
     const statusBarHandler = new StatusBarHandler(outputChannel);
     const diagnosticsHandler = new DiagnosticsHandler(outputChannel, importHandler, () => statusBarHandler.isSnoozeActive());
     const importPathConverter = new ImportPathConverter(outputChannel, projectPathCache);
     const importCodeLensProvider = new ImportCodeLensProvider(outputChannel);
 
-    // Create CommandsHandler with all dependencies
     const commandsDeps: CommandsDependencies = {
         importHandler,
         statusBarHandler,
@@ -94,12 +98,12 @@ export function activate(context: vscode.ExtensionContext) {
     };
     const commandsHandler = new CommandsHandler(commandsDeps);
 
-    // Initialize assets digest cache asynchronously
+    // Both caches populate off the activation path: a synchronous scan here
+    // would delay every other registration below.
     assetsDigestParser.ensureCachePopulated().catch((err) => {
         logger.warn("Extension", `Failed to initialize assets digest cache: ${err}`);
     });
 
-    // Initialize project path cache asynchronously (if enabled)
     if (projectPathCache) {
         projectPathCache.initialize().catch((err) => {
             logger.warn("Extension", `Failed to initialize project path cache: ${err}`);
@@ -121,15 +125,13 @@ export function activate(context: vscode.ExtensionContext) {
             });
     }
 
-    // Set initial debounce delay (handles backward compat with deprecated setting)
     const delayMs = getConfiguredDebounceDelay(config);
     diagnosticsHandler.setDelay(delayMs);
     logger.info("Extension", `Initial debounce delay set to ${delayMs}ms`);
 
-    // Register providers. The CodeLens provider is pushed alongside its
-    // registration, not instead of it: registerCodeLensProvider disposes the
-    // registration only, leaving the provider's own listeners and hide timers
-    // live after deactivation.
+    // The CodeLens provider is pushed alongside its registration, not instead
+    // of it: registerCodeLensProvider disposes the registration only, leaving
+    // the provider's own listeners and hide timers live after deactivation.
     context.subscriptions.push(
         vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ImportCodeActionProvider(outputChannel, importHandler)),
         vscode.languages.registerCodeLensProvider({ language: "verse" }, importCodeLensProvider),
@@ -140,17 +142,16 @@ export function activate(context: vscode.ExtensionContext) {
     // auto-import cannot edit a document after the extension is torn down.
     context.subscriptions.push(diagnosticsHandler);
 
-    // Set up file watchers
     context.subscriptions.push(projectPathHandler.setupFileWatcher());
     context.subscriptions.push(assetsDigestParser.setupFileWatcher());
     if (projectPathCache) {
         context.subscriptions.push(projectPathCache.setupFileWatchers());
     }
 
-    // Register all commands via CommandsHandler
     commandsHandler.registerAll(context);
 
-    // Register hover provider for CodeLens visibility
+    // The hover provider exists only to drive CodeLens visibility: it always
+    // returns null, and its work is the setHoverState call.
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(
             { language: "verse" },
@@ -176,11 +177,10 @@ export function activate(context: vscode.ExtensionContext) {
         ),
     );
 
-    // Register the status bar handler for disposal (clears the snooze timer
-    // and disposes the status bar item on deactivation).
+    // Clears the snooze timer on deactivation, so a snooze cannot expire and
+    // re-enable auto-import after the extension is torn down.
     context.subscriptions.push(statusBarHandler);
 
-    // Configuration change listener for debounce delay
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((event) => {
             if (event.affectsConfiguration("verseAutoImports.general.diagnosticDelay") || event.affectsConfiguration("verseAutoImports.general.autoImportDebounceDelay")) {
@@ -192,8 +192,7 @@ export function activate(context: vscode.ExtensionContext) {
         }),
     );
 
-    // Configuration change listener for the project path cache toggle. Whether
-    // the cache exists at all is decided once, here in activate(), so a toggle
+    // The cache is constructed once at activation, so toggling the setting
     // cannot take effect until the window reloads - say so rather than leaving
     // the user with a setting that silently does nothing.
     context.subscriptions.push(
@@ -214,11 +213,11 @@ export function activate(context: vscode.ExtensionContext) {
         }),
     );
 
-    // Save participant for import spacing. This has to run *during* the save,
-    // not after it: an edit applied once the save has completed makes the tab
-    // dirty again the instant the user saves, and only a second save converges.
-    // waitUntil hands the edits to VS Code, which applies them before writing
-    // the file, so the saved content is already correct.
+    // Import spacing has to be applied *during* the save, not after it: an
+    // edit applied once the save has completed makes the tab dirty again the
+    // instant the user saves, and only a second save converges. waitUntil hands
+    // the edits to VS Code, which applies them before writing the file, so the
+    // saved content is already correct.
     context.subscriptions.push(
         vscode.workspace.onWillSaveTextDocument((event) => {
             if (event.document.languageId !== "verse") {
@@ -238,7 +237,6 @@ export function activate(context: vscode.ExtensionContext) {
         }),
     );
 
-    // Diagnostics change listener for auto-import
     context.subscriptions.push(
         vscode.languages.onDidChangeDiagnostics(async (e) => {
             // Read once per event, and snapshot what the user has on screen only
@@ -296,6 +294,10 @@ export function activate(context: vscode.ExtensionContext) {
     logger.info("Extension", "Verse Auto Imports extension activated successfully");
 }
 
+/**
+ * Logs the shutdown. Teardown itself belongs to the disposables registered on
+ * the extension context during activation, not here.
+ */
 export function deactivate() {
     logger.info("Extension", "Verse Auto Imports extension deactivated");
 }

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -3,6 +3,11 @@ import * as path from "path";
 import * as fs from "fs";
 import { logger } from "../utils";
 
+/**
+ * The subset of the on-disk `.uefnproject` JSON this extension reads. Every
+ * field is optional because the file is written by UEFN, not by us, and an
+ * older or newer editor may omit any of them.
+ */
 interface UEFNProjectFile {
     bindings?: {
         projectVersePath?: string;
@@ -17,6 +22,14 @@ interface UEFNProjectFile {
     }>;
 }
 
+/**
+ * Resolves the project's Verse path, name and module list from its
+ * `.uefnproject` file.
+ *
+ * All three cached fields come from a single parse and are cleared together by
+ * `clearCache`; leaving one behind would answer from a project file that is no
+ * longer on disk.
+ */
 export class ProjectPathHandler {
     private projectVersePath: string | null = null;
     private projectName: string | null = null;
@@ -25,8 +38,12 @@ export class ProjectPathHandler {
     constructor(private outputChannel: vscode.OutputChannel) {}
 
     /**
-     * Finds and parses the .uefnproject file in the workspace
-     * @returns The parsed project file or null if not found
+     * The parsed `.uefnproject`, from cache after the first call.
+     *
+     * Searched in each workspace folder first, then up to five directories
+     * above the first one: UEFN's older project layout nests the Verse code
+     * under `<project>/Plugins/<ProjectName>/Content`, so the folder the user
+     * opens is often below the project file rather than at it.
      */
     async findAndParseProjectFile(): Promise<UEFNProjectFile | null> {
         if (this.cachedProjectFile) {
@@ -61,6 +78,9 @@ export class ProjectPathHandler {
 
                     return this.cachedProjectFile;
                 } catch (error) {
+                    // A project file that exists but will not parse ends the
+                    // search. Walking on would answer from some parent
+                    // project's paths, which is worse than answering nothing.
                     logger.debug("ProjectPathHandler", `Error parsing .uefnproject file: ${error}`);
                     return null;
                 }
@@ -112,7 +132,8 @@ export class ProjectPathHandler {
     }
 
     /**
-     * Gets the project's Verse path (e.g., /vukefn@fortnite.com/MyGame)
+     * The project's Verse path, the prefix every module in it is addressed
+     * under: `/vukefn@fortnite.com/MyGame`, no trailing slash.
      */
     async getProjectVersePath(): Promise<string | null> {
         if (this.projectVersePath) {
@@ -124,7 +145,8 @@ export class ProjectPathHandler {
     }
 
     /**
-     * Gets the project name from the .uefnproject file
+     * The project's display title, which is not necessarily the name of the
+     * directory holding it.
      */
     async getProjectName(): Promise<string | null> {
         if (this.projectName) {
@@ -136,7 +158,7 @@ export class ProjectPathHandler {
     }
 
     /**
-     * Gets the modules defined in the project
+     * The project's module bindings, keyed by module name.
      */
     async getProjectModules(): Promise<Record<string, string> | null> {
         const projectFile = await this.findAndParseProjectFile();
@@ -144,7 +166,8 @@ export class ProjectPathHandler {
     }
 
     /**
-     * Clears the cached project file
+     * Drops the parsed project file and everything derived from it, so the
+     * next read re-runs the search.
      */
     clearCache(): void {
         this.cachedProjectFile = null;
@@ -154,7 +177,9 @@ export class ProjectPathHandler {
     }
 
     /**
-     * Watches for changes to .uefnproject files
+     * Starts clearing the cache whenever a `.uefnproject` file is created,
+     * changed or deleted. The caller owns the returned watcher and must
+     * dispose it.
      */
     setupFileWatcher(): vscode.Disposable {
         const watcher = vscode.workspace.createFileSystemWatcher("**/*.uefnproject");

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -4,9 +4,12 @@ import * as fs from "fs";
 import { logger } from "../utils";
 
 /**
- * The subset of the on-disk `.uefnproject` JSON this extension reads. Every
- * field is optional because the file is written by UEFN, not by us, and an
- * older or newer editor may omit any of them.
+ * The part of the on-disk `.uefnproject` JSON this file models. UEFN writes
+ * the file, so the optional markers are a guard against an editor version that
+ * omits a field, not a statement that the field is rare.
+ *
+ * Wider than what is actually consumed: only `bindings.projectVersePath`,
+ * `bindings.modules` and `title` have readers.
  */
 interface UEFNProjectFile {
     bindings?: {
@@ -38,12 +41,14 @@ export class ProjectPathHandler {
     constructor(private outputChannel: vscode.OutputChannel) {}
 
     /**
-     * The parsed `.uefnproject`, from cache after the first call.
+     * The parsed `.uefnproject`, searched for in each workspace folder and then
+     * up to five directories above the first one: UEFN's older project layout
+     * nests the Verse code under `<project>/Plugins/<ProjectName>/Content`, so
+     * the folder the user opens is often below the project file rather than at
+     * it.
      *
-     * Searched in each workspace folder first, then up to five directories
-     * above the first one: UEFN's older project layout nests the Verse code
-     * under `<project>/Plugins/<ProjectName>/Content`, so the folder the user
-     * opens is often below the project file rather than at it.
+     * Only a success is cached. Every call that ends in null repeats the whole
+     * search, which matters on the paths that call this per document.
      */
     async findAndParseProjectFile(): Promise<UEFNProjectFile | null> {
         if (this.cachedProjectFile) {
@@ -133,7 +138,8 @@ export class ProjectPathHandler {
 
     /**
      * The project's Verse path, the prefix every module in it is addressed
-     * under: `/vukefn@fortnite.com/MyGame`, no trailing slash.
+     * under: `/vukefn@fortnite.com/MyGame`. Passed through exactly as UEFN
+     * wrote it - callers that join onto it add their own separator.
      */
     async getProjectVersePath(): Promise<string | null> {
         if (this.projectVersePath) {
@@ -158,7 +164,8 @@ export class ProjectPathHandler {
     }
 
     /**
-     * The project's module bindings, keyed by module name.
+     * The project's `bindings.modules` map, verbatim. Nothing in `src/` calls
+     * this, so what the keys and values mean is UEFN's to define.
      */
     async getProjectModules(): Promise<Record<string, string> | null> {
         const projectFile = await this.findAndParseProjectFile();

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -47,8 +47,8 @@ export class ProjectPathHandler {
      * the folder the user opens is often below the project file rather than at
      * it.
      *
-     * Only a success is cached. Every call that ends in null repeats the whole
-     * search, which matters on the paths that call this per document.
+     * Only a success is cached, so in a workspace with no `.uefnproject` every
+     * call redoes the folder scan and the parent walk from scratch.
      */
     async findAndParseProjectFile(): Promise<UEFNProjectFile | null> {
         if (this.cachedProjectFile) {

--- a/src/scripts/parseDigestFiles.ts
+++ b/src/scripts/parseDigestFiles.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Precompiles the bundled `.verse` digests into JSON, so the runtime loads a
- * parsed index instead of parsing megabytes of Verse at activation.
+ * Precompiles the bundled `.verse` digests into JSON, so the first lookup
+ * loads a parsed index instead of parsing megabytes of Verse.
  *
  * Run with `npm run parse-digest`. Its output under `src/data` is generated and
  * checked in: refresh it by replacing the `.verse` inputs and re-running, never

--- a/src/scripts/parseDigestFiles.ts
+++ b/src/scripts/parseDigestFiles.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 /**
- * Build-time script to parse .verse digest files into JSON.
- * This pre-compiles the digest files so they can be loaded quickly at runtime
- * without parsing the raw .verse files each time.
+ * Precompiles the bundled `.verse` digests into JSON, so the runtime loads a
+ * parsed index instead of parsing megabytes of Verse at activation.
  *
- * Run with: npx ts-node src/scripts/parseDigestFiles.ts
- * Or via npm: npm run parse-digest
+ * Run with `npm run parse-digest`. Its output under `src/data` is generated and
+ * checked in: refresh it by replacing the `.verse` inputs and re-running, never
+ * by editing the JSON.
  */
 
 import * as fs from "fs";
@@ -28,8 +28,8 @@ const DIGEST_FILES = ["Fortnite.digest.verse", "UnrealEngine.digest.verse", "Ver
 const VERSION = "1.0.0";
 
 /**
- * Extract the build reference from the digest file content.
- * Looks for patterns like: ++Fortnite+Release-37.20-CL-45679054
+ * The UEFN build a digest came from, as stamped in its header
+ * (`++Fortnite+Release-37.20-CL-45679054`), or "unknown" if absent.
  */
 function extractBuildReference(content: string): string {
     const buildMatch = content.match(/\+\+Fortnite\+Release-[\d.]+-CL-\d+/);
@@ -37,8 +37,9 @@ function extractBuildReference(content: string): string {
 }
 
 /**
- * Parse a single digest file into structured data.
- * The parsing logic is shared with the runtime path via `parseDigestContent`.
+ * One digest file, parsed and stamped for storage. Parsing itself is shared
+ * with the runtime path through `parseDigestContent`, so the precompiled data
+ * cannot drift from what a live parse would produce.
  */
 function parseDigestFile(filePath: string): PrecompiledDigest {
     const content = fs.readFileSync(filePath, "utf8");
@@ -56,9 +57,6 @@ function parseDigestFile(filePath: string): PrecompiledDigest {
     };
 }
 
-/**
- * Main function to parse all digest files
- */
 function main() {
     const scriptDir = __dirname;
     const srcDir = path.resolve(scriptDir, "..");
@@ -70,7 +68,6 @@ function main() {
     console.log(`  Output: ${dataDir}`);
     console.log("");
 
-    // Ensure data directory exists
     if (!fs.existsSync(dataDir)) {
         fs.mkdirSync(dataDir, { recursive: true });
         console.log(`Created directory: ${dataDir}`);

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,5 +1,12 @@
 /**
- * Configuration types for the Verse Auto Imports extension
+ * The shape of the `verseAutoImports` settings section, mirroring the
+ * configuration contribution in package.json.
+ *
+ * Nothing in `src/` reads these types: every call site goes through
+ * `getConfiguration("verseAutoImports").get<T>(key, default)` with an inline
+ * type argument. They therefore drift silently - the `cache` section has no
+ * interface here at all - so treat package.json as the authority and these as
+ * a summary of it.
  */
 
 /**
@@ -9,13 +16,18 @@
  */
 export type AutoImportScope = "allFiles" | "openFiles" | "activeFile";
 
+/** The `verseAutoImports.general` settings. */
 export interface GeneralConfig {
     autoImport: boolean;
-    diagnosticDelay: number; // Deprecated
+
+    /** Superseded by autoImportDebounceDelay, and read only when explicitly set. */
+    diagnosticDelay: number;
+
     autoImportDebounceDelay: number;
     autoImportScope: AutoImportScope;
 }
 
+/** The `verseAutoImports.behavior` settings: how an import is written. */
 export interface BehaviorConfig {
     importSyntax: "curly" | "dot";
     preserveImportLocations: boolean;
@@ -27,21 +39,25 @@ export interface BehaviorConfig {
     digestImportPrefixes: string[];
 }
 
+/** The `verseAutoImports.quickFix` settings: how the offered fixes are listed. */
 export interface QuickFixConfig {
     sortAlphabetically: boolean;
     showDescriptions: boolean;
 }
 
+/** The `verseAutoImports.pathConversion` settings: the CodeLens on an import. */
 export interface PathConversionConfig {
     enableCodeLens: boolean;
     codeLensVisibility: "hover" | "always";
     codeLensHideDelay: number;
 }
 
+/** The `verseAutoImports.experimental` settings. */
 export interface ExperimentalConfig {
     useDigestFiles: boolean;
 }
 
+/** Every section above, as one object. */
 export interface VerseAutoImportsConfig {
     general: GeneralConfig;
     behavior: BehaviorConfig;

--- a/src/types/moduleInfo.ts
+++ b/src/types/moduleInfo.ts
@@ -1,3 +1,10 @@
+/**
+ * The parts of a project-local module path.
+ *
+ * Nothing in `src/` constructs or reads one, and the field names do not carry
+ * enough to reconstruct what each segment spans. Establish that from a real
+ * call site before relying on it; do not infer a contract from the names.
+ */
 export interface ModuleInfo {
     projectName: string;
     intermediatePath: string;
@@ -5,16 +12,37 @@ export interface ModuleInfo {
     internalModule: string;
 }
 
+/** Which of the extractor's routes produced a suggestion. */
 export type ImportSuggestionSource = "error_message" | "digest_lookup" | "inference";
+
+/**
+ * How far a suggestion can be trusted. Anything below "high" is labelled in
+ * the quick-fix title when descriptions are on; it does not affect ordering.
+ */
 export type ImportConfidence = "high" | "medium" | "low";
+
+/**
+ * What to do when a diagnostic offers several import paths. Unused here: the
+ * live setting is typed inline on `BehaviorConfig.multiOptionStrategy`.
+ */
 export type MultiOptionStrategy = "quickfix" | "auto_shortest" | "auto_first" | "disabled";
+
+/** Unused; no setting or call site in `src/` corresponds to it. */
 export type UnknownIdentifierResolution = "digest_only" | "digest_and_inference" | "disabled";
+
+/** Unused; no setting or call site in `src/` corresponds to it. */
 export type QuickFixOrdering = "confidence" | "alphabetical" | "module_priority";
 
+/** One offered import, ready to be written into a document. */
 export interface ImportSuggestion {
     importStatement: string;
     source: ImportSuggestionSource;
     confidence: ImportConfidence;
     description?: string;
-    modulePath?: string; // The actual module path extracted from the import statement
+
+    /**
+     * The path alone, taken back out of `importStatement`. Undefined where it
+     * could not be extracted, so callers must not treat it as always present.
+     */
+    modulePath?: string;
 }

--- a/src/types/moduleInfo.ts
+++ b/src/types/moduleInfo.ts
@@ -22,8 +22,9 @@ export type ImportSuggestionSource = "error_message" | "digest_lookup" | "infere
 export type ImportConfidence = "high" | "medium" | "low";
 
 /**
- * What to do when a diagnostic offers several import paths. Unused here: the
- * live setting is typed inline on `BehaviorConfig.multiOptionStrategy`.
+ * What to do when a diagnostic offers several import paths. Unused: the live
+ * setting is read as a plain string in `DiagnosticsHandler`, so adding a case
+ * here changes nothing on its own.
  */
 export type MultiOptionStrategy = "quickfix" | "auto_shortest" | "auto_first" | "disabled";
 

--- a/src/types/projectCache.ts
+++ b/src/types/projectCache.ts
@@ -1,9 +1,4 @@
 /**
- * Type definitions for the Project Path Cache system.
- * Used to cache and quickly look up project module structure.
- */
-
-/**
  * Version of the persisted cache format. Bumping this invalidates previously
  * stored caches (they are rebuilt on next activation). Shared by the scanner
  * that stamps payloads and the cache that validates them.
@@ -14,7 +9,6 @@ export const PROJECT_CACHE_VERSION = "2";
  * A single declaration found in a .verse file.
  */
 export interface ProjectPathNode {
-    /** The identifier name */
     name: string;
 
     /**
@@ -26,16 +20,14 @@ export interface ProjectPathNode {
      */
     fullPath: string;
 
-    /** The type of declaration */
     type: "module" | "class" | "struct" | "function" | "variable" | "interface" | "enum";
 
-    /** Whether this declaration is public */
     isPublic: boolean;
 
-    /** Relative path to the source .verse file (from workspace root, "/" separators) */
+    /** Relative to the workspace folder, and without the folder's own name. */
     sourceFile?: string;
 
-    /** Line number in the source file where this declaration starts */
+    /** One-based line the declaration starts on, as an editor would show it. */
     sourceLine?: number;
 }
 
@@ -44,16 +36,14 @@ export interface ProjectPathNode {
  * All lookup indexes are derived from `nodes` and are not persisted.
  */
 export interface ProjectPathData {
-    /** The project Verse path */
     projectVersePath: string;
 
-    /** The project name from .uefnproject */
     projectName: string;
 
-    /** Timestamp when this data was generated */
+    /** Milliseconds since the epoch, restamped every time the data changes. */
     generatedAt: number;
 
-    /** Every declaration found in the project, flat */
+    /** Every declaration in the project, flat: nesting lives in `fullPath`. */
     nodes: ProjectPathNode[];
 }
 
@@ -69,15 +59,18 @@ export interface SerializedProjectPathCache extends ProjectPathData {
  * Options for scanning the project for declarations.
  */
 export interface ProjectScanOptions {
-    /** File patterns to include */
+    /**
+     * Globs relative to the workspace folder. Only the first is read; the
+     * scanner passes one include pattern to `findFiles` and drops the rest.
+     */
     includePatterns?: string[];
 
-    /** File patterns to exclude */
+    /** Globs; a match here is skipped even when the include pattern took it. */
     excludePatterns?: string[];
 
-    /** Whether to include private declarations */
+    /** Off by default, which also excludes anything neither public nor internal. */
     includePrivate?: boolean;
 
-    /** Progress callback for UI feedback */
+    /** Called per file scanned, with `file` relative to the workspace folder. */
     onProgress?: (current: number, total: number, file: string) => void;
 }

--- a/src/types/projectCache.ts
+++ b/src/types/projectCache.ts
@@ -41,9 +41,9 @@ export interface ProjectPathData {
     projectName: string;
 
     /**
-     * Milliseconds since the epoch, stamped by a full scan and by invalidation.
-     * Deleting a file prunes `nodes` without restamping, so this is the age of
-     * the last scan and not a last-modified time.
+     * Milliseconds since the epoch, stamped by a full scan and by invalidation,
+     * whichever ran last. Deleting a file prunes `nodes` without restamping, so
+     * this is not a last-modified time for the data.
      */
     generatedAt: number;
 

--- a/src/types/projectCache.ts
+++ b/src/types/projectCache.ts
@@ -40,7 +40,11 @@ export interface ProjectPathData {
 
     projectName: string;
 
-    /** Milliseconds since the epoch, restamped every time the data changes. */
+    /**
+     * Milliseconds since the epoch, stamped by a full scan and by invalidation.
+     * Deleting a file prunes `nodes` without restamping, so this is the age of
+     * the last scan and not a last-modified time.
+     */
     generatedAt: number;
 
     /** Every declaration in the project, flat: nesting lives in `fullPath`. */
@@ -68,7 +72,10 @@ export interface ProjectScanOptions {
     /** Globs; a match here is skipped even when the include pattern took it. */
     excludePatterns?: string[];
 
-    /** Off by default, which also excludes anything neither public nor internal. */
+    /**
+     * Off by default, dropping private declarations. Modules are held to more
+     * than that: one is kept only when it is public or internal.
+     */
     includePrivate?: boolean;
 
     /** Called per file scanned, with `file` relative to the workspace folder. */

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -154,8 +154,8 @@ export class Logger {
     }
 
     /**
-     * The user channel, for handlers that still take an OutputChannel rather
-     * than the logger.
+     * The user channel itself, for the callers that need to show it or hand it
+     * on. Logging goes through this class, not through the returned channel.
      */
     public getUserChannel(): vscode.OutputChannel {
         return this.userChannel;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,7 +2,8 @@ import * as vscode from "vscode";
 import { EnvironmentSnapshot, formatEnvironmentLines, readSessionState } from "./environment";
 
 /**
- * Log levels for the logger
+ * Severity, ordered: the numeric value is compared against INFO to decide
+ * whether an entry reaches the user channel, so the order is load-bearing.
  */
 export enum LogLevel {
     TRACE = 0,
@@ -13,17 +14,15 @@ export enum LogLevel {
     FATAL = 5,
 }
 
-/**
- * Interface for structured log data
- */
 interface LogData {
     [key: string]: unknown;
 }
 
 /**
- * Enhanced logger for VS Code extension with dual-channel output
- * - User channel: Shows INFO+ levels for end users
- * - Debug channel: Shows all levels for debugging
+ * Writes to two output channels at once: INFO and above reach the channel the
+ * user sees, while every level reaches the debug channel and the export
+ * buffer. Anything logged below INFO is therefore invisible in the UI but
+ * still present in an exported log.
  */
 export class Logger {
     private static instance: Logger;
@@ -40,7 +39,8 @@ export class Logger {
     }
 
     /**
-     * Get the singleton logger instance
+     * The one Logger, created on first call. Both output channels are created
+     * with it, so nothing may call this before the extension host is up.
      */
     public static getInstance(): Logger {
         if (!Logger.instance) {
@@ -50,7 +50,8 @@ export class Logger {
     }
 
     /**
-     * Initialize the logger and register channels with the extension context
+     * Hands both channels to the extension context so they are disposed on
+     * deactivation. Logging works without this; only cleanup depends on it.
      */
     public initialize(context: vscode.ExtensionContext): void {
         context.subscriptions.push(this.userChannel);
@@ -65,37 +66,22 @@ export class Logger {
         this.environment = snapshot;
     }
 
-    /**
-     * Log a TRACE level message (most detailed)
-     */
     public trace(module: string, message: string, data?: LogData): void {
         this.log(LogLevel.TRACE, module, message, data);
     }
 
-    /**
-     * Log a DEBUG level message
-     */
     public debug(module: string, message: string, data?: LogData): void {
         this.log(LogLevel.DEBUG, module, message, data);
     }
 
-    /**
-     * Log an INFO level message
-     */
     public info(module: string, message: string, data?: LogData): void {
         this.log(LogLevel.INFO, module, message, data);
     }
 
-    /**
-     * Log a WARN level message
-     */
     public warn(module: string, message: string, data?: LogData): void {
         this.log(LogLevel.WARN, module, message, data);
     }
 
-    /**
-     * Extract structured data from an error object
-     */
     private extractErrorData(error: Error | unknown): LogData {
         if (error instanceof Error) {
             return {
@@ -107,7 +93,8 @@ export class Logger {
     }
 
     /**
-     * Log an ERROR level message with optional error object
+     * @param error unwrapped into errorMessage and errorStack, which override
+     * keys of the same name in `data`
      */
     public error(module: string, message: string, error?: Error | unknown, data?: LogData): void {
         const logData = error ? { ...data, ...this.extractErrorData(error) } : { ...data };
@@ -115,22 +102,23 @@ export class Logger {
     }
 
     /**
-     * Log a FATAL level message with optional error object
+     * @param error unwrapped as in `error()`
      */
     public fatal(module: string, message: string, error?: Error | unknown, data?: LogData): void {
         const logData = error ? { ...data, ...this.extractErrorData(error) } : { ...data };
         this.log(LogLevel.FATAL, module, message, logData);
     }
 
-    /**
-     * Start a performance timer
-     */
     public startTimer(operationId: string): void {
         this.performanceTimers.set(operationId, Date.now());
     }
 
     /**
-     * End a performance timer and log the duration
+     * Stops the timer, logs the elapsed time and returns it in milliseconds.
+     * Anything over a second is logged at WARN rather than DEBUG, so a slow
+     * operation surfaces in the user's channel without a caller deciding.
+     *
+     * Returns 0 for an operation that was never started, having warned.
      */
     public endTimer(operationId: string, module: string, message: string): number {
         const startTime = this.performanceTimers.get(operationId);
@@ -148,22 +136,17 @@ export class Logger {
         return duration;
     }
 
-    /**
-     * Show the user output channel
-     */
     public showUserChannel(): void {
         this.userChannel.show();
     }
 
-    /**
-     * Show the debug output channel
-     */
     public showDebugChannel(): void {
         this.debugChannel.show();
     }
 
     /**
-     * Clear both output channels
+     * Clears what both channels display. The export buffer is untouched, so a
+     * log exported afterwards still holds everything.
      */
     public clearChannels(): void {
         this.userChannel.clear();
@@ -171,21 +154,20 @@ export class Logger {
     }
 
     /**
-     * Get the user output channel (for backward compatibility)
+     * The user channel, for handlers that still take an OutputChannel rather
+     * than the logger.
      */
     public getUserChannel(): vscode.OutputChannel {
         return this.userChannel;
     }
 
-    /**
-     * Get the current number of log entries in the buffer
-     */
     public getBufferSize(): number {
         return this.logBuffer.length;
     }
 
     /**
-     * Get debug logs as a single string for file export
+     * The whole export: a header identifying the build, then every buffered
+     * entry.
      */
     public getDebugLogsAsString(): string {
         const header = [
@@ -204,8 +186,8 @@ export class Logger {
     }
 
     /**
-     * Export debug logs to a file chosen by the user
-     * @returns The URI of the saved file, or undefined if cancelled/failed
+     * Prompts for a location and writes the export there.
+     * @returns undefined when the user cancels; write failures throw
      */
     public async exportDebugLogs(): Promise<vscode.Uri | undefined> {
         const timestamp = this.formatTimestampForFilename(new Date());
@@ -223,7 +205,7 @@ export class Logger {
         });
 
         if (!uri) {
-            return undefined; // User cancelled
+            return undefined;
         }
 
         try {
@@ -239,9 +221,7 @@ export class Logger {
         }
     }
 
-    /**
-     * Format a timestamp for use in the export filename
-     */
+    /** Local time as `YYYYMMDD_HHMMSS`, safe for a filename on any platform. */
     private formatTimestampForFilename(date: Date): string {
         const year = date.getFullYear();
         const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -253,54 +233,47 @@ export class Logger {
         return `${year}${month}${day}_${hours}${minutes}${seconds}`;
     }
 
-    /**
-     * Core logging method
-     */
     private log(level: LogLevel, module: string, message: string, data?: LogData): void {
         const timestamp = new Date();
         const levelName = LogLevel[level];
 
-        // Format for user channel (INFO+ levels only)
         if (level >= LogLevel.INFO) {
             const userFormat = this.formatUserMessage(timestamp, levelName, message);
             this.userChannel.appendLine(userFormat);
         }
 
-        // Format for debug channel (all levels)
+        // The debug format is what gets buffered, so the export carries the
+        // module name and structured data that the user channel drops.
         const debugFormat = this.formatDebugMessage(timestamp, levelName, module, message, data);
         this.debugChannel.appendLine(debugFormat);
 
-        // Store in buffer for export
         this.addToBuffer(debugFormat);
     }
 
     /**
-     * Add a log entry to the circular buffer
+     * Appends to the export buffer, dropping the oldest entry once it holds
+     * MAX_LOG_ENTRIES. A long session therefore loses its activation entries,
+     * which is why the export header repeats the environment.
      */
     private addToBuffer(logEntry: string): void {
         if (this.logBuffer.length >= this.MAX_LOG_ENTRIES) {
-            this.logBuffer.shift(); // Remove oldest entry
+            this.logBuffer.shift();
         }
         this.logBuffer.push(logEntry);
     }
 
-    /**
-     * Format message for user channel (simpler format)
-     */
+    /** Wall-clock time, level and message. No module name and no data. */
     private formatUserMessage(timestamp: Date, level: string, message: string): string {
         const time = timestamp.toTimeString().substring(0, 8);
         return `[${time}] [${level}] ${message}`;
     }
 
-    /**
-     * Format message for debug channel (detailed format)
-     */
+    /** UTC time to the millisecond, level, module, message, then any data. */
     private formatDebugMessage(timestamp: Date, level: string, module: string, message: string, data?: LogData): string {
         const time = timestamp.toISOString().substring(11, 23);
         let formatted = `[${time}] [${level}] [${module}] ${message}`;
 
         if (data && Object.keys(data).length > 0) {
-            // Format data object, handling special cases
             const dataStr = this.formatLogData(data);
             if (dataStr) {
                 formatted += ` ${dataStr}`;
@@ -311,17 +284,17 @@ export class Logger {
     }
 
     /**
-     * Format log data for output
+     * Renders the data object into one line, dropping undefined and null
+     * entries. A stack trace breaks the line instead, indented under its own
+     * heading, so it stays readable in the channel.
      */
     private formatLogData(data: LogData): string {
         const parts: string[] = [];
 
         for (const [key, value] of Object.entries(data)) {
             if (key === "errorStack" && typeof value === "string") {
-                // Handle stack traces specially
                 parts.push(`\n  Stack trace:\n    ${value.replace(/\n/g, "\n    ")}`);
             } else if (value !== undefined && value !== null) {
-                // Handle other values
                 let valueStr: string;
                 if (typeof value === "string") {
                     valueStr = value;
@@ -342,5 +315,5 @@ export class Logger {
     }
 }
 
-// Export singleton instance for convenience
+/** The shared logger. Take this rather than calling `getInstance` again. */
 export const logger = Logger.getInstance();


### PR DESCRIPTION
Closes #229

Fifth and last slice of the comment-quality sweep tracked by #224, following the pilot in #249 and matching its calibration: a method whose name and signature answer the question gets no doc, and a paragraph has to be paying for a reader who would otherwise get it wrong.

Eleven files: `src/extension.ts`, `src/project/ProjectPathHandler.ts`, `src/project/index.ts`, `src/types/{configuration,index,moduleInfo,projectCache}.ts`, `src/utils/{environment,index,logger}.ts`, `src/scripts/parseDigestFiles.ts`. Seven changed. The four untouched are a deliberate no-op: the three barrels are re-export lines with nothing to say, and `utils/environment.ts` was already written to this standard.

## What changed

Deleted the restatement layer: the section headers in `activate` (`// Initialize the logger`, `// Create core services`, `// Set up file watchers`), the signature restatements on every `ProjectPathHandler` method and every `Logger` level method, and the field restatements in `projectCache.ts` (`/** The type of declaration */` on `type`).

Kept and tightened what carries a constraint: the undefined project path cache, the dropped stored payload, the save participant that must run during the save, the diagnostics scope snapshot, `fullPath`, and `PROJECT_CACHE_VERSION`.

Added contracts the types cannot carry - and the useful half of this diff is that writing them meant checking each against a call site:

- `sourceLine` is **one-based** (`i + 1` in `ProjectPathScanner`).
- `generatedAt` is milliseconds since the epoch, stamped by a full scan and by invalidation. A file deletion prunes `nodes` without restamping it, so it is the age of the last scan rather than a last-modified time.
- `ProjectScanOptions.includePatterns` - **only the first is read**; the scanner passes one include pattern to `findFiles` and drops the rest.
- `includePrivate` drops private declarations; modules alone are additionally held to public-or-internal.
- `ImportSuggestion.modulePath` is extracted back out of `importStatement` and is undefined when extraction fails, so callers must not assume it is present.
- `findAndParseProjectFile` caches only successes; a call that returns null repeats the whole search including the five-level parent walk.
- `Logger` writes INFO and above to the user channel and every level to the debug channel and the export buffer, and the two channels timestamp in different clocks (local wall-clock vs UTC to the millisecond).

## Two findings worth a maintainer's eye

**`src/types/configuration.ts` has no reader.** Every settings read in `src/` goes through `getConfiguration("verseAutoImports").get<T>(key, default)` with an inline type argument, so `AutoImportScope`, `GeneralConfig`, `BehaviorConfig`, `QuickFixConfig`, `PathConversionConfig`, `ExperimentalConfig` and `VerseAutoImportsConfig` describe the settings contract without participating in it. They have already drifted: the `cache` section has no interface at all. Documented as such rather than left looking live.

**Four types in `src/types/moduleInfo.ts` have no consumer anywhere in `src/`**: `ModuleInfo`, `MultiOptionStrategy`, `UnknownIdentifierResolution` and `QuickFixOrdering`. `ModuleInfo`'s field names (`intermediatePath`, `outerModule`, `internalModule`) do not carry enough to reconstruct what each segment spans, so rather than invent a contract the doc says that and warns against inferring one from the names.

Deleting either set is a type change and out of scope here. Happy to file a follow-up cleanup ticket if you want it.

No comment in the file set exists only to compensate for a poor name, so no refactor follow-up is required by that criterion.

## Deviation from one acceptance criterion, stated rather than skipped

"Every exported symbol in the file set has a doc comment" - the exported symbols all have one. Public *members* of exported classes do not: `Logger.trace`, `.debug`, `.info`, `.warn`, `.startTimer`, `.showUserChannel`, `.showDebugChannel` and `.getBufferSize` lost theirs, because each was the exact restated-signature shape the standard's delete table names (`/** Log a TRACE level message */`), and the rewritten class doc now carries the level semantics they were gesturing at. This matches the pilot, where `ImportHandler`'s four self-evident methods carry no doc.

## Review

Three rounds against a reviewer with a fresh context, briefed to treat "a comment that states something false about the code" as the defect that matters here, since no test catches one. Rounds 1 and 2 both returned FAIL, and every finding was the same species - a comment asserting more than the code supports. Each was verified against the source before being fixed:

| Claim | What the code says | Fixed in |
| --- | --- | --- |
| Handlers "still take an OutputChannel rather than reaching for the singleton" | Inverted: they take the channel and log through `logger` | `28e8e6f` |
| Disposing `StatusBarHandler` stops a snooze "expiring and re-enabling auto-import" | `isSnoozeActive()` is time-based and a snooze never touches the setting; the disposal that matters is its config listener | `28e8e6f` |
| `generatedAt` "restamped every time the data changes" | `handleFileDelete` prunes `nodes` and saves without restamping | `28e8e6f` |
| `UEFNProjectFile` is "the subset this extension reads", every field optional | `plugins[].name` is required, and `projectId` and `plugins` have no reader | `28e8e6f` |
| `findAndParseProjectFile` caches "after the first call" | Only a success is cached | `28e8e6f` |
| The two named `outputChannel` uses are "the only real uses left" | It is handed on at seven sites; the one terminal use is `StatusBarHandler.ts:280` | `eff5743` |
| `generatedAt` is "the age of the last scan" | Invalidation restamps it too | `eff5743` |

Round 3 confirmed all three replacements against the code and returned **PASS** with no findings.

## Verification

No test file was added, removed or edited. No changelog fragment: not a user-facing change.

### Strip-diff gate

Comment-stripped compiled output, base against head:

```
npx tsc -p ./ --removeComments --sourceMap false --outDir out/strip-base   # at origin/main
npx tsc -p ./ --removeComments --sourceMap false --outDir out/strip-head   # at HEAD
diff -r out/strip-base out/strip-head
STRIP-DIFF EXIT: 0
```

Empty. Nothing but comments changed.

### `npm run compile`

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

### `npm test`

```
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       595 passed, 595 total
Snapshots:   0 total
Time:        7.727 s
Ran all test suites.
```

### `npm run format:check`

```
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
