### PR TITLE
docs(imports): apply the comment standard to document editing, path conversion and the providers

### DIFF
--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -26,9 +26,9 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
         const codeActions: vscode.CodeAction[] = [];
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const sortAlphabetically = config.get<boolean>("quickFix.sortAlphabetically", false);
-        // false is what package.json registers, and config.get returns the
-        // registered default for a registered setting - so a fallback of true
-        // never reached production and only ever changed what the tests saw.
+        // Only a caller with no registered setting behind it, such as a test,
+        // ever sees this fallback - config.get returns the registered default
+        // otherwise, and package.json registers false.
         const showDescriptions = config.get<boolean>("quickFix.showDescriptions", false);
 
         for (const diagnostic of context.diagnostics) {
@@ -47,7 +47,7 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
                     suggestion,
                     diagnostic,
                     document,
-                    index === 0, // Mark first as preferred
+                    index === 0, // isPreferred
                     showDescriptions,
                 );
                 codeActions.push(action);

--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -3,12 +3,25 @@ import { logger } from "../utils";
 import { ImportSuggestion } from "../types";
 import { ImportHandler } from "./ImportHandler";
 
+/**
+ * Turns the imports a Verse diagnostic suggests into quick fixes.
+ *
+ * The suggestions come from the diagnostic's own message, so a compiler error
+ * naming no import produces no action.
+ */
 export class ImportCodeActionProvider implements vscode.CodeActionProvider {
     constructor(
         private outputChannel: vscode.OutputChannel,
         private importHandler: ImportHandler,
     ) {}
 
+    /**
+     * A quick fix for every import the diagnostics at this range suggest, or
+     * undefined when they suggest none.
+     *
+     * The first action of each diagnostic is marked preferred, so which
+     * suggestion the editor offers first depends on the sort.
+     */
     async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[] | undefined> {
         const codeActions: vscode.CodeAction[] = [];
         const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -25,12 +38,10 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
                 continue;
             }
 
-            // Sort suggestions based on user preference
             const sortedSuggestions = this.sortSuggestions(suggestions, sortAlphabetically);
 
             logger.debug("ImportCodeActionProvider", `Creating ${sortedSuggestions.length} quick fix action(s) for diagnostic`);
 
-            // Create quick fix actions for each suggestion
             sortedSuggestions.forEach((suggestion, index) => {
                 const action = this.createQuickFixAction(
                     suggestion,
@@ -46,26 +57,26 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
         return codeActions.length > 0 ? codeActions : undefined;
     }
 
+    /**
+     * A new array of the suggestions, alphabetized by statement or left in the
+     * order the extractor produced them. The input is not modified.
+     */
     private sortSuggestions(suggestions: ImportSuggestion[], sortAlphabetically: boolean): ImportSuggestion[] {
-        const sorted = [...suggestions]; // Create a copy
+        const sorted = [...suggestions];
 
         if (sortAlphabetically) {
-            // Sort alphabetically by import statement
             sorted.sort((a, b) => a.importStatement.localeCompare(b.importStatement));
         }
-        // If not sorting alphabetically, preserve the original order
 
         return sorted;
     }
 
     private createQuickFixAction(suggestion: ImportSuggestion, diagnostic: vscode.Diagnostic, document: vscode.TextDocument, isPreferred: boolean, showDescriptions: boolean): vscode.CodeAction {
-        // Create descriptive title
         let title = `Add import: ${suggestion.importStatement}`;
         if (showDescriptions && suggestion.description) {
             title += ` (${suggestion.description})`;
         }
 
-        // Add confidence indicator for multiple options
         if (showDescriptions && suggestion.confidence !== "high") {
             const indicator = suggestion.confidence === "medium" ? "[medium confidence]" : "[low confidence]";
             title = `${indicator} ${title}`;

--- a/src/imports/ImportCodeLensProvider.ts
+++ b/src/imports/ImportCodeLensProvider.ts
@@ -142,12 +142,14 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     /**
-     * The conversion lenses for a document: one per convertible import, plus a
-     * "for all" lens beside each where the file holds more than one import of
-     * that direction.
+     * The conversion lenses for a document, and a "for all" lens beside each
+     * where the file holds more than one import of that direction.
      *
-     * Empty when the feature is off, and in "hover" mode when nothing in this
-     * document is hovered.
+     * An import gets a lens only where the conversion has somewhere to go: a
+     * built-in module has no relative form, and a statement no module name can
+     * be read out of has nothing to convert. So a file of nothing but Epic
+     * imports carries no lens at all, and neither does one where the feature is
+     * off or, in "hover" mode, nothing is hovered.
      */
     async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.CodeLens[]> {
         const codeLenses: vscode.CodeLens[] = [];

--- a/src/imports/ImportCodeLensProvider.ts
+++ b/src/imports/ImportCodeLensProvider.ts
@@ -4,17 +4,26 @@ import { ImportPathConverter } from "./ImportPathConverter";
 import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
 /**
- * Tracks hover state for a document's imports. An entry can exist purely to
- * hold a pending hide timer, with no line hovered, so lineNumber is optional:
- * a hide can be scheduled for a document that was never entered through the
- * hovering branch - after a conversion, for instance, which sets
- * isHoveringImport directly.
+ * What one document's lenses are doing: the import line under the pointer, and
+ * the timer that will hide them.
+ *
+ * An entry can exist purely to hold that timer, with no line hovered, so
+ * lineNumber is optional: a hide can be scheduled for a document that was never
+ * entered through the hovering branch - after a conversion, for instance, which
+ * sets isHoveringImport directly.
  */
 interface HoverState {
     lineNumber?: number;
     timeout: NodeJS.Timeout | null;
 }
 
+/**
+ * The path-conversion lenses on a document's import lines, and the hover state
+ * that decides whether they are shown at all.
+ *
+ * Hover state is per document uri, because the same provider serves every open
+ * Verse file and a lens shown in one must not follow the user into another.
+ */
 export class ImportCodeLensProvider implements vscode.CodeLensProvider {
     private readonly _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
     public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
@@ -32,47 +41,45 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
         // fires on every keystroke in every document in the window, so one left
         // registered past deactivation keeps calling into a dead provider.
         this.disposables.push(
-            // Watch for configuration changes
             vscode.workspace.onDidChangeConfiguration((e) => {
                 if (e.affectsConfiguration("verseAutoImports.pathConversion")) {
                     this._onDidChangeCodeLenses.fire();
                 }
             }),
 
-            // Watch for document changes to refresh CodeLens immediately
             vscode.workspace.onDidChangeTextDocument((e) => {
-                // Only refresh for Verse files that are currently showing CodeLens
                 if (e.document.languageId === "verse" && this.isHoveringImport.get(e.document.uri.toString())) {
-                    // Clear any pending refresh
                     if (this.refreshTimeout) {
                         clearTimeout(this.refreshTimeout);
                         this.refreshTimeout = null;
                     }
 
-                    // Single immediate refresh
                     this._onDidChangeCodeLenses.fire();
                 }
             }),
         );
     }
 
-    /** Gets the configured hide delay in milliseconds */
+    /** The configured delay before the lenses are hidden, in milliseconds. */
     private getHideDelay(): number {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         return config.get<number>("pathConversion.codeLensHideDelay", 1000);
     }
 
-    /** Gets the visibility mode setting */
     private getVisibilityMode(): "hover" | "always" {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         return config.get<"hover" | "always">("pathConversion.codeLensVisibility", "hover");
     }
 
     /**
-     * Sets the hover state for a document
+     * Shows the lenses for a document at once, or schedules them to be hidden
+     * once the hide delay elapses. A no-op in "always" mode, where visibility
+     * does not follow the pointer.
+     *
+     * @param lineNumber The hovered line; required for `hovering`, since a
+     *   hover reported without one leaves the state as it was.
      */
     setHoverState(documentUri: string, hovering: boolean, lineNumber?: number): void {
-        // In "always" mode, hover state management is not needed
         if (this.getVisibilityMode() === "always") {
             return;
         }
@@ -80,7 +87,6 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
         const currentState = this.hoverState.get(documentUri);
 
         if (hovering && lineNumber !== undefined) {
-            // Clear existing timeout if any
             if (currentState?.timeout) {
                 clearTimeout(currentState.timeout);
             }
@@ -92,7 +98,6 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
             this.isHoveringImport.set(documentUri, true);
             this._onDidChangeCodeLenses.fire();
         } else if (!hovering) {
-            // Set timeout to hide CodeLens after configured delay
             if (currentState?.timeout) {
                 clearTimeout(currentState.timeout);
             }
@@ -106,9 +111,9 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
 
             // Recorded whether or not a state already existed. The commonest
             // caller is the hover provider reporting a non-import line, which
-            // reaches here with nothing stored; the timer used to be dropped
-            // on the floor there, leaving nothing able to clear it - not
-            // keepHoverStateActive, and not dispose.
+            // reaches here with nothing stored, and a timer left out of the map
+            // is one nothing can clear afterwards - not keepHoverStateActive,
+            // and not dispose.
             this.hoverState.set(documentUri, {
                 ...currentState,
                 timeout,
@@ -117,7 +122,8 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     /**
-     * Keeps the hover state active (used during conversions)
+     * Holds the lenses open across a conversion, which the user drives from a
+     * lens and which takes long enough for a pending hide to fire mid-way.
      */
     keepHoverStateActive(documentUri: string): void {
         const currentState = this.hoverState.get(documentUri);
@@ -130,17 +136,22 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
             this.hoverState.set(documentUri, { ...currentState, timeout: null });
         }
 
-        // Keep the hover state active
         this.isHoveringImport.set(documentUri, true);
 
-        // Single immediate refresh
         this._onDidChangeCodeLenses.fire();
     }
 
+    /**
+     * The conversion lenses for a document: one per convertible import, plus a
+     * "for all" lens beside each where the file holds more than one import of
+     * that direction.
+     *
+     * Empty when the feature is off, and in "hover" mode when nothing in this
+     * document is hovered.
+     */
     async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.CodeLens[]> {
         const codeLenses: vscode.CodeLens[] = [];
 
-        // Check if CodeLens is enabled in configuration
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const showCodeLens = config.get<boolean>("pathConversion.enableCodeLens", true);
 
@@ -148,11 +159,9 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
             return codeLenses;
         }
 
-        // Check visibility mode
         const visibilityMode = this.getVisibilityMode();
         const documentUri = document.uri.toString();
 
-        // In "hover" mode, only show CodeLens if hovering over imports
         if (visibilityMode === "hover") {
             const isHovering = this.isHoveringImport.get(documentUri);
             if (!isHovering) {
@@ -177,14 +186,11 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
         for (const { statement: trimmedLine, line: i } of convertibleImports) {
             const range = new vscode.Range(new vscode.Position(i, 0), new vscode.Position(i, lines[i].length));
 
-            // Check if it's a full path import that can be converted to relative
             if (this.importPathConverter.isFullPathImport(trimmedLine)) {
-                // Only show relative conversion for non-built-in modules
                 if (!this.importPathConverter.isBuiltinModule(trimmedLine)) {
                     const moduleName = this.importPathConverter.extractModuleName(trimmedLine);
 
                     if (moduleName) {
-                        // Create CodeLens for converting to relative path
                         const convertToRelativeLens = new vscode.CodeLens(range, {
                             title: `$(arrow-both)  Use relative path`,
                             tooltip: `Use relative path for '${moduleName}'`,
@@ -193,7 +199,6 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
                         });
                         codeLenses.push(convertToRelativeLens);
 
-                        // Add "Use relative paths for all" option if there are multiple full path imports
                         if (hasMultipleFullPathImports) {
                             const convertAllRelativeLens = new vscode.CodeLens(range, {
                                 title: `$(arrow-swap)  Use relative paths for all`,
@@ -206,11 +211,9 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
                     }
                 }
             } else {
-                // It's a relative import - show option to convert to absolute path
                 const moduleName = this.importPathConverter.extractModuleName(trimmedLine);
 
                 if (moduleName) {
-                    // Create CodeLens for converting to absolute path
                     const convertSingleLens = new vscode.CodeLens(range, {
                         title: `$(arrow-both)  Use absolute path`,
                         tooltip: `Use absolute path for '${moduleName}'`,
@@ -219,7 +222,6 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
                     });
                     codeLenses.push(convertSingleLens);
 
-                    // Add "Use absolute paths for all" option if there are multiple relative imports
                     if (hasMultipleRelativeImports) {
                         const convertAllLens = new vscode.CodeLens(range, {
                             title: `$(arrow-swap)  Use absolute paths for all`,
@@ -237,26 +239,24 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
         return codeLenses;
     }
 
+    /** The lens unchanged: provideCodeLenses gives every lens its command, so none is resolved lazily. */
     resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens> {
-        // We already set the command in provideCodeLenses, so just return the same CodeLens
         return codeLens;
     }
 
-    /**
-     * Refresh CodeLens display
-     */
+    /** Asks VS Code to re-query the lenses. */
     refresh(): void {
         this._onDidChangeCodeLenses.fire();
     }
 
     /**
-     * Force immediate refresh after conversion (called after document edit)
+     * Re-queries the lenses of a document a conversion has just edited, and
+     * asserts the hover state first so the lenses survive the edit that the
+     * pointer, still over the import, would otherwise have to re-establish.
      */
     forceRefreshAfterConversion(documentUri: string): void {
-        // Ensure hover state remains active
         this.isHoveringImport.set(documentUri, true);
 
-        // Single immediate refresh - VS Code handles the timing
         this._onDidChangeCodeLenses.fire();
     }
 

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -166,12 +166,14 @@ interface AnchoredBounds {
 
 /**
  * Managing a document's import block: adding the imports a diagnostic asked
- * for, reorganizing what is there, and the blank lines after it. Converting an
- * existing import between path forms belongs to ImportPathConverter.
+ * for, reorganizing what is there, and the blank lines after it.
  *
  * The three share one set of placement rules, which is why they share a class:
  * where an import may go depends on the ranks of the imports already there and
  * on which of them are pinned to their line.
+ *
+ * Converting an existing import between path forms is ImportPathConverter's,
+ * and is the one write into an import line that does not come from here.
  */
 export class ImportDocumentEditor {
     private readonly formatter: ImportFormatter;

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -165,8 +165,9 @@ interface AnchoredBounds {
 }
 
 /**
- * Every write the extension makes to a document's imports: adding the ones a
- * diagnostic asked for, reorganizing the block, and the blank lines after it.
+ * Managing a document's import block: adding the imports a diagnostic asked
+ * for, reorganizing what is there, and the blank lines after it. Converting an
+ * existing import between path forms belongs to ImportPathConverter.
  *
  * The three share one set of placement rules, which is why they share a class:
  * where an import may go depends on the ranks of the imports already there and
@@ -203,10 +204,9 @@ export class ImportDocumentEditor {
             // is the marker that anchors it. Restoring that onto a rebuilt line
             // is what puts the marker somewhere it was not written, so it is
             // refused here rather than only by every caller passing a filtered
-            // list. Every caller does today; one that forgot would move the
-            // marker on its own. A statement sharing its span is refused for
-            // the same reason: what trails it is the rest of the span, not an
-            // annotation to re-emit.
+            // list. A statement sharing its span is refused for the same
+            // reason: what trails it is the rest of the span, not an annotation
+            // to re-emit.
             if (!imp.trailingComment || imp.anchorsCommentBelow || imp.rebuildLosesText) {
                 continue;
             }
@@ -885,10 +885,9 @@ export class ImportDocumentEditor {
         // resolves its own path top-down: a path that is not absolute needs its
         // first segment already in scope above it, which is why sorting ranks
         // them (see ImportFormatter.sortImportsByRank). The anchored line ends
-        // up below the rebuilt block, so withholding
-        // the copy above it can strand such a path - in the block, or further
-        // down the body where scanModuleImports does not even look, as in a
-        // module-definition body.
+        // up below the rebuilt block, so withholding the copy above it can
+        // strand such a path - in the block, or further down the body where
+        // scanModuleImports does not even look, as in a module-definition body.
         //
         // So this asks the whole file, every `using` at every indentation, and
         // withholds only where all of them are absolute. An absolute path needs

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -3,7 +3,11 @@ import { logger } from "../utils";
 import { ImportFormatter } from "./ImportFormatter";
 import { allUsingPaths, classifyLines, LINE_SPLIT, LineClassification, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
 
-/** Represents a contiguous block of import statements in the document. */
+/**
+ * A run of import statements on consecutive lines. Any gap starts a new block,
+ * because a rebuild rewrites a block's whole line range and would swallow
+ * whatever sat in the gap.
+ */
 interface ImportBlock {
     start: number;
     end: number;
@@ -53,7 +57,7 @@ function resolveEol(document: vscode.TextDocument, text: string): LineEnding {
  *
  * That run is the file header - a licence, an attribution, a description of
  * what the file is - and it belongs above the import block rather than below
- * it. Rebuilding the block at line 0 pushed the header into the middle of the
+ * it. Rebuilding the block at line 0 puts the header into the middle of the
  * file, which is the one place a header must never be.
  *
  * Position identifies it, never content: the first line carrying code ends the
@@ -69,8 +73,7 @@ function resolveEol(document: vscode.TextDocument, text: string): LineEnding {
  * following that import down through a sort. Line 0 is ambiguous - a file
  * header and a first-import annotation are written identically - and of the
  * two readings only this one leaves the comment where the author put it. The
- * other relocates a licence into the middle of the import block, which is the
- * defect this whole change exists to remove.
+ * other relocates a licence into the middle of the import block.
  */
 function headerLineCount(classifications: LineClassification[]): number {
     let end = 0;
@@ -162,7 +165,12 @@ interface AnchoredBounds {
 }
 
 /**
- * Handles all document modifications for imports.
+ * Every write the extension makes to a document's imports: adding the ones a
+ * diagnostic asked for, reorganizing the block, and the blank lines after it.
+ *
+ * The three share one set of placement rules, which is why they share a class:
+ * where an import may go depends on the ranks of the imports already there and
+ * on which of them are pinned to their line.
  */
 export class ImportDocumentEditor {
     private readonly formatter: ImportFormatter;
@@ -195,10 +203,10 @@ export class ImportDocumentEditor {
             // is the marker that anchors it. Restoring that onto a rebuilt line
             // is what puts the marker somewhere it was not written, so it is
             // refused here rather than only by every caller passing a filtered
-            // list. Every caller does today; one that forgot would resurrect a
-            // defect this branch has already shipped once. A statement sharing
-            // its span is refused for the same reason: what trails it is the
-            // rest of the span, not an annotation to re-emit.
+            // list. Every caller does today; one that forgot would move the
+            // marker on its own. A statement sharing its span is refused for
+            // the same reason: what trails it is the rest of the span, not an
+            // annotation to re-emit.
             if (!imp.trailingComment || imp.anchorsCommentBelow || imp.rebuildLosesText) {
                 continue;
             }
@@ -224,9 +232,6 @@ export class ImportDocumentEditor {
         return statements.map((statement) => this.withTrailingComment(statement, trailingByStatement));
     }
 
-    /**
-     * Creates an edit to replace an import block with combined and formatted imports.
-     */
     private createBlockReplacementEdit(
         edit: vscode.WorkspaceEdit,
         document: vscode.TextDocument,
@@ -236,7 +241,6 @@ export class ImportDocumentEditor {
         sortAlphabetically: boolean,
         eol: LineEnding,
     ): void {
-        // Get existing paths in this block for combined sorting
         const existingBlockPaths = block.imports.map((imp) => imp.path);
 
         let combinedPaths = [...existingBlockPaths, ...newPaths];
@@ -244,14 +248,11 @@ export class ImportDocumentEditor {
             combinedPaths = this.formatter.sortImportsByRank(combinedPaths);
         }
 
-        // Format all imports for this block, restoring the comment each
-        // existing one trailed its line with.
         const formattedImports = this.withTrailingComments(
             combinedPaths.map((path) => this.formatter.formatImportStatement(path, preferDotSyntax)),
             this.trailingCommentsByStatement(block.imports, preferDotSyntax),
         );
 
-        // Replace the entire block
         edit.replace(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)), formattedImports.join(eol) + eol);
     }
 
@@ -439,8 +440,9 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * Extracts existing import statements from a document. Indented pairs
-     * (`using:` plus the path line) are returned joined as a single statement.
+     * The module import statements a document holds, deduplicated, with an
+     * indented pair (`using:` plus its path line) joined into one statement.
+     * Local-scope `using` is not among them.
      */
     extractExistingImports(document: vscode.TextDocument): string[] {
         logger.debug("ImportDocumentEditor", "Extracting existing imports from document");
@@ -461,7 +463,14 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * Adds import statements to a document.
+     * Writes the statements whose paths the document does not already import,
+     * then normalizes the blank lines after the block. True when nothing needed
+     * adding, as well as when the edit succeeded.
+     *
+     * Where they go is `behavior.preserveImportLocations`: with it on, each
+     * path is merged into an existing block or written on its own line beside
+     * the imports it must sit relative to; with it off, every movable import in
+     * the file is consolidated at the top.
      */
     async addImportsToDocument(document: vscode.TextDocument, importStatements: string[]): Promise<boolean> {
         logger.info("ImportDocumentEditor", `Adding ${importStatements.length} import statements to document`);
@@ -495,11 +504,9 @@ export class ImportDocumentEditor {
 
             const lastBlock = importBlocks[importBlocks.length - 1];
             if (lastBlock && imp.startLine === lastBlock.end + 1) {
-                // Only extend block if import immediately follows (no gap)
                 lastBlock.end = imp.endLine;
                 lastBlock.imports.push(imp);
             } else {
-                // Any gap creates a new block
                 importBlocks.push({ start: imp.startLine, end: imp.endLine, imports: [imp] });
             }
         }
@@ -531,18 +538,18 @@ export class ImportDocumentEditor {
         const edit = new vscode.WorkspaceEdit();
 
         if (preserveImportLocations) {
-            // Check if existing imports are grouped (2+ blocks with gap between them)
+            // A gap between two blocks is the author's own grouping, so the
+            // configured strategy is applied by adding to whichever group each
+            // new path belongs in rather than by regrouping the file.
             const hasGrouping =
                 importGrouping !== "none" &&
                 importBlocks.length >= 2 &&
                 importBlocks.some((block, i) => {
                     if (i === 0) return false;
-                    // Check if there's a gap between this block and the previous one
                     return block.start > importBlocks[i - 1].end + 1;
                 });
 
             if (hasGrouping && importBlocks.length >= 2) {
-                // Analyze existing blocks to determine which is digest and which is local
                 let digestBlockIndex = -1;
                 let localBlockIndex = -1;
 
@@ -551,7 +558,9 @@ export class ImportDocumentEditor {
                     const hasDigest = blockPaths.some((path) => this.formatter.isDigestImport(path));
                     const hasLocal = blockPaths.some((path) => !this.formatter.isDigestImport(path));
 
-                    // Determine block type based on majority
+                    // A block counts as a group only if it is pure. A mixed one
+                    // is evidence of nothing, so it is left as neither and
+                    // takes no new import.
                     if (hasDigest && !hasLocal) {
                         digestBlockIndex = index;
                     } else if (hasLocal && !hasDigest) {
@@ -559,7 +568,6 @@ export class ImportDocumentEditor {
                     }
                 });
 
-                // Separate new imports into digest and local
                 const newDigestPaths: string[] = [];
                 const newLocalPaths: string[] = [];
 
@@ -594,12 +602,10 @@ export class ImportDocumentEditor {
                 const digest = splitForBlock(digestBlockIndex, newDigestPaths);
                 const local = splitForBlock(localBlockIndex, newLocalPaths);
 
-                // Add digest imports to digest block
                 if (digest.taken.length > 0) {
                     this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], digest.taken, preferDotSyntax, sortAlphabetically, eol);
                 }
 
-                // Add local imports to local block
                 if (local.taken.length > 0) {
                     this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], local.taken, preferDotSyntax, sortAlphabetically, eol);
                 }
@@ -609,17 +615,15 @@ export class ImportDocumentEditor {
                 const unhandledPaths = [...digest.unhandled, ...local.unhandled];
 
                 if (unhandledPaths.length > 0) {
-                    // Add unhandled imports at the appropriate position
                     const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;
                     for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, anchoredImports, classifications)) {
                         this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, importBlocks.length === 0);
                     }
                 }
             } else {
-                // Either no existing grouping or need to create initial groups
                 if (importGrouping !== "none" && existingPaths.size > 0) {
-                    // We have existing imports but no grouping - reorganize
-                    // everything into groups. A new path an anchored import
+                    // Grouping is wanted and the file has none, so the imports
+                    // are regrouped in place. A new path an anchored import
                     // keeps out of the rebuilt block is written on its own line
                     // below that import instead, rather than into a group that
                     // sits above it. Only the new paths are asked: this branch
@@ -638,11 +642,10 @@ export class ImportDocumentEditor {
                     );
 
                     if (importBlocks.length > 0) {
-                        // Replace the first existing block in place so it stays at its
-                        // original location rather than relocating to the top of the file.
-                        // Delete any additional blocks defensively (by construction this
-                        // branch only sees one block when grouping != "none", since 2+
-                        // gapped blocks are handled by the hasGrouping branch above).
+                        // In place, so the block stays where the author put it
+                        // rather than moving to the top of the file. The loop
+                        // over any further block is defensive: this branch sees
+                        // only one, as above.
                         const firstBlock = importBlocks[0];
                         edit.replace(document.uri, new vscode.Range(new vscode.Position(firstBlock.start, 0), new vscode.Position(firstBlock.end + 1, 0)), groupedImports.join(eol) + eol);
 
@@ -673,7 +676,6 @@ export class ImportDocumentEditor {
                         }
                     }
                 } else {
-                    // No grouping or no existing imports - use original behavior
                     const newImportPathsArray = Array.from(newImportPaths);
 
                     if (sortAlphabetically && importBlocks.length > 0) {
@@ -689,14 +691,14 @@ export class ImportDocumentEditor {
                         // Which block each import joins is a whole-file
                         // decision, not always the first one: rank-sorting one
                         // block orders the new import against that block alone,
-                        // which is how a consumer ended up above its provider in
-                        // another block (see selectTargetBlockIndex).
+                        // which leaves a consumer in another block free to sit
+                        // above its provider (see selectTargetBlockIndex).
                         //
                         // Only a block inside the space the anchored imports
                         // leave is eligible, and the selector chooses among
                         // those. An anchored import is in no block, so offering
-                        // it every block is what let a new import be merged into
-                        // one above the anchored provider it needs.
+                        // the selector every block lets it merge an import into
+                        // one above the anchored provider that import needs.
                         const pathsByBlock = new Map<number, string[]>();
                         const unblockedPaths: string[] = [];
                         for (const path of newImportPathsArray) {
@@ -750,9 +752,9 @@ export class ImportDocumentEditor {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), eol, true);
                         }
                     } else {
-                        // Sorting off or no existing block: keep the original
-                        // append-in-place behavior and leave existing lines
-                        // untouched.
+                        // Sorting off, or no block to merge into: the new
+                        // imports are appended and no existing line is touched.
+                        //
                         // After the last import block, not the first: with
                         // sorting off nothing reorders a block afterwards, so
                         // any earlier position could leave a new import above
@@ -760,9 +762,9 @@ export class ImportDocumentEditor {
                         //
                         // Wherever that block sits, not only when it starts at
                         // line 0. A file whose imports open below a licence
-                        // header has its first block at a later line, and
-                        // inserting at line 0 there put the new import above the
-                        // header and left two disconnected import regions
+                        // header has its first block at a later line, so
+                        // inserting at line 0 there writes the new import above
+                        // the header and leaves two disconnected import regions
                         // behind.
                         //
                         // With no block at all the top of the file is where a
@@ -780,21 +782,20 @@ export class ImportDocumentEditor {
                 }
             }
         } else {
-            // Consolidate all imports at the top
             const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths]);
             const allImportsArray = Array.from(allPaths);
 
-            // Use the new grouping method for all imports
             const formattedImports = this.withTrailingComments(
                 this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping),
                 this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
             );
 
-            // Insert imports at top with minimal spacing (will be fixed by ensureEmptyLinesAfterImports)
+            // No blank line after the block: ensureEmptyLinesAfterImports runs
+            // once the edit has been applied and puts the configured number
+            // there.
             const importsText = formattedImports.join(eol) + eol;
             edit.insert(document.uri, new vscode.Position(0, 0), importsText);
 
-            // Remove existing import blocks (in reverse order to maintain line numbers)
             for (let i = importBlocks.length - 1; i >= 0; i--) {
                 const block = importBlocks[i];
                 edit.delete(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)));
@@ -805,7 +806,6 @@ export class ImportDocumentEditor {
             const success = await vscode.workspace.applyEdit(edit);
             logger.info("ImportDocumentEditor", success ? "Successfully updated imports in document" : "Failed to update imports in document");
 
-            // After adding imports, ensure proper spacing
             if (success) {
                 await this.ensureEmptyLinesAfterImports(document);
             }
@@ -884,8 +884,8 @@ export class ImportDocumentEditor {
         // against it. File scope governs what code can see, but a `using`
         // resolves its own path top-down: a path that is not absolute needs its
         // first segment already in scope above it, which is why sorting ranks
-        // them (see ImportFormatter.sortImportsByRank, and the defects behind
-        // it). The anchored line ends up below the rebuilt block, so withholding
+        // them (see ImportFormatter.sortImportsByRank). The anchored line ends
+        // up below the rebuilt block, so withholding
         // the copy above it can strand such a path - in the block, or further
         // down the body where scanModuleImports does not even look, as in a
         // module-definition body.
@@ -1040,8 +1040,8 @@ export class ImportDocumentEditor {
      *
      * Kept separate from applying them because the save path participates in
      * the save with these edits (see the onWillSaveTextDocument listener in
-     * extension.ts) rather than editing the document afterwards, which is what
-     * used to leave the tab dirty the moment it was saved.
+     * extension.ts) rather than editing the document afterwards, which would
+     * leave the tab dirty the moment it was saved.
      */
     computeEmptyLinesAfterImportsEdits(document: vscode.TextDocument): vscode.TextEdit[] {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -1079,13 +1079,11 @@ export class ImportDocumentEditor {
         const scannedImports = rewritableImports(scanModuleImports(lines));
         const lastImportLine = scannedImports.length > 0 ? scannedImports[scannedImports.length - 1].endLine : -1;
 
-        // If no imports found or file only has imports, nothing to do
         if (lastImportLine === -1 || lastImportLine === lines.length - 1) {
             logger.debug("ImportDocumentEditor", "No imports found or file ends with imports, skipping spacing adjustment");
             return [];
         }
 
-        // Count existing empty lines after the last import
         let existingEmptyLines = 0;
         for (let i = lastImportLine + 1; i < lines.length; i++) {
             if (lines[i].trim() === "") {
@@ -1095,7 +1093,6 @@ export class ImportDocumentEditor {
             }
         }
 
-        // Check if there's non-import content after the imports
         let hasContentAfterImports = false;
         for (let i = lastImportLine + 1; i < lines.length; i++) {
             if (lines[i].trim() !== "") {
@@ -1104,13 +1101,14 @@ export class ImportDocumentEditor {
             }
         }
 
-        // Only adjust if there's content after imports
+        // The setting is spacing between the block and the code below it, so a
+        // file trailing nothing but blank lines has no gap to size and keeps
+        // whatever it has.
         if (!hasContentAfterImports) {
             logger.debug("ImportDocumentEditor", "No content after imports, skipping spacing adjustment");
             return [];
         }
 
-        // Calculate adjustment needed
         const lineDifference = targetEmptyLines - existingEmptyLines;
 
         if (lineDifference === 0) {
@@ -1119,14 +1117,12 @@ export class ImportDocumentEditor {
         }
 
         if (lineDifference > 0) {
-            // Need to add empty lines
             const newLines = eol.repeat(lineDifference);
             const insertPosition = new vscode.Position(lastImportLine + 1, 0);
             logger.info("ImportDocumentEditor", `Adding ${lineDifference} empty lines after imports`);
             return [vscode.TextEdit.insert(insertPosition, newLines)];
         }
 
-        // Need to remove empty lines
         const linesToRemove = Math.abs(lineDifference);
         const startLine = lastImportLine + 1;
         const endLine = Math.min(startLine + linesToRemove, lines.length);

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -6,10 +6,21 @@ import { ProjectPathCache } from "../services";
 import { ImportFormatter } from "./ImportFormatter";
 import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
+/** A conversion resolved but not yet written, ready for applyConversion. */
 interface ImportConversionResult {
     originalImport: string;
+    /**
+     * The statement to write in place of `originalImport`, whichever direction
+     * the conversion runs: convertToFullPath puts the absolute form here and
+     * convertFromFullPath the relative one, so the name reads true on only one
+     * of the two paths.
+     *
+     * Empty while `isAmbiguous`, where the statement cannot be built until the
+     * user has picked from `possiblePaths`.
+     */
     fullPathImport: string;
     moduleName: string;
+    /** Whether the module resolved to more than one location, listed in `possiblePaths`. */
     isAmbiguous: boolean;
     possiblePaths?: string[];
     /**
@@ -20,9 +31,16 @@ interface ImportConversionResult {
     line?: number;
 }
 
-/** Content folder name constant */
 const CONTENT_FOLDER = "Content";
 
+/**
+ * Converts a `using` between the absolute Verse path of a module and the
+ * relative reference to it, in either direction, and writes the result.
+ *
+ * Converting to an absolute path means finding where the module lives, which
+ * is a workspace search rather than a text transform, so only this direction
+ * can be ambiguous or fail outright.
+ */
 export class ImportPathConverter {
     private readonly projectPathHandler: ProjectPathHandler;
     private projectPathCache: ProjectPathCache | null = null;
@@ -36,15 +54,14 @@ export class ImportPathConverter {
     }
 
     /**
-     * Set the project path cache for faster lookups.
+     * Gives the converter a declaration cache to look module locations up in,
+     * sparing the workspace scan. Optional: with none, findModuleLocations
+     * scans every time.
      */
     setProjectPathCache(cache: ProjectPathCache): void {
         this.projectPathCache = cache;
     }
 
-    /**
-     * Helper function to check if a folder exists in the workspace
-     */
     private async folderExists(workspaceFolder: vscode.WorkspaceFolder, relativePath: string): Promise<boolean> {
         const folderUri = vscode.Uri.joinPath(workspaceFolder.uri, relativePath);
         try {
@@ -58,7 +75,7 @@ export class ImportPathConverter {
         }
     }
 
-    /** Checks whether a workspace-relative file still exists (guards against stale cache entries) */
+    /** Whether a workspace-relative path is still a file, which a cached declaration's source may no longer be. */
     private async sourceFileExists(workspaceFolder: vscode.WorkspaceFolder, relativePath: string): Promise<boolean> {
         try {
             const stat = await vscode.workspace.fs.stat(vscode.Uri.joinPath(workspaceFolder.uri, relativePath));
@@ -69,19 +86,21 @@ export class ImportPathConverter {
     }
 
     /**
-     * Builds the absolute Verse path for a module resolved at a location.
-     * `location` follows the location contract ("" or "/Dir/Sub" relative to
-     * the Content root); `modulePath` uses "/" separators.
+     * The absolute Verse path of a module resolved at a location.
+     *
+     * @param location Follows the findModuleLocations contract: "" or "/Dir/Sub", relative to the Content root
+     * @param modulePath Separated by "/", not by the dots the relative form is written with
      */
     static buildFullVersePath(projectVersePath: string, location: string, modulePath: string): string {
         return location === "/" || location === "" ? `${projectVersePath}/${modulePath}` : `${projectVersePath}${location}/${modulePath}`;
     }
 
     /**
-     * Builds a regex matching an explicit `Name := module:` declaration for the
-     * given module name. Non-global on purpose: this pattern is reused with
-     * `.test()` across many files, and a global flag would carry `lastIndex`
-     * between calls and skip valid definitions depending on file order.
+     * A regex matching an explicit `Name := module:` declaration of one module.
+     *
+     * Non-global on purpose: the pattern is reused with `.test()` across many
+     * files, and a global flag would carry `lastIndex` between calls and skip
+     * valid definitions depending on the order the files are read in.
      */
     static buildModuleDefinitionRegex(moduleName: string): RegExp {
         const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -89,7 +108,8 @@ export class ImportPathConverter {
     }
 
     /**
-     * Extracts the path string from an import statement, minus any trailing comment.
+     * The path a `using` statement names, with any trailing comment removed,
+     * or "" when the statement is in neither style.
      *
      * Anchored on the trimmed statement, and dotted before braced, to match
      * ImportFormatter. Unanchored, the braced pattern is free to match inside
@@ -118,24 +138,37 @@ export class ImportPathConverter {
         return ImportFormatter.stripTrailingComment(importStatement).includes("{");
     }
 
-    /** Checks if an import is already in full path format */
+    /** Whether an import already names an absolute path: a leading "/", or an Epic account somewhere in it. */
     isFullPathImport(importStatement: string): boolean {
         const path = this.extractPathFromImport(importStatement);
         return path.startsWith("/") || path.includes("@fortnite.com");
     }
 
-    /** Checks if an import is a built-in module from Fortnite.com, UnrealEngine.com, or Verse.org */
+    /**
+     * Whether an import comes from Fortnite.com, UnrealEngine.com or Verse.org,
+     * which have no relative form to convert to.
+     *
+     * The three are fixed here, unlike the digest prefixes ImportFormatter
+     * reads from `behavior.digestImportPrefixes`: a prefix the user adds is a
+     * grouping preference, not a claim that a module lives outside the project.
+     */
     isBuiltinModule(importStatement: string): boolean {
         const path = this.extractPathFromImport(importStatement);
         return path.startsWith("/Fortnite.com/") || path.startsWith("/UnrealEngine.com/") || path.startsWith("/Verse.org/");
     }
 
-    /** Extracts the module path and name from an import statement */
+    /**
+     * The module an import names, as a "/"-separated path and the last segment
+     * of it, or null when the statement names nothing.
+     *
+     * Both forms leave here separated the same way: an absolute path unchanged,
+     * and a relative `HUD.Textures` with its dots turned into "/". Which of the
+     * two it was is still readable from the leading "/".
+     */
     extractModuleFromImport(importStatement: string): { fullPath: string; moduleName: string } | null {
         const pathStr = this.extractPathFromImport(importStatement);
         if (!pathStr) return null;
 
-        // Full path format - extract last segment
         if (pathStr.startsWith("/")) {
             const segments = pathStr.split("/").filter((s) => s);
             const lastSegment = segments[segments.length - 1];
@@ -143,7 +176,7 @@ export class ImportPathConverter {
             return { fullPath: pathStr, moduleName };
         }
 
-        // Dot notation (e.g., HUD.Textures -> HUD/Textures)
+        // Dot notation: HUD.Textures becomes HUD/Textures.
         const identPattern = /[A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?/g;
         const dotSegments: string[] = [];
         let match;
@@ -170,18 +203,22 @@ export class ImportPathConverter {
         };
     }
 
-    /** Returns module name for display (shows full dot notation for relative imports) */
+    /**
+     * The module name to put in front of a user, which for a relative import is
+     * the whole dotted reference rather than its last segment: `HUD.Textures`
+     * names the module more precisely than `Textures` does, and the lens has
+     * room for it.
+     */
     extractModuleName(importStatement: string): string | null {
         const result = this.extractModuleFromImport(importStatement);
         if (!result) return null;
 
         const pathStr = this.extractPathFromImport(importStatement);
-        // For relative imports, show full path as-is for display
         if (pathStr && !pathStr.startsWith("/")) return pathStr;
         return result.moduleName;
     }
 
-    /** Parses explicit module definitions from Verse file content */
+    /** The names a Verse file declares as modules with `Name := module:`. */
     parseExplicitModuleDefinition(content: string): string[] {
         const modules: string[] = [];
         const moduleDefPattern = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)\s*(?:<\s*(?:public|private|internal|protected)\s*>)?\s*:=\s*module\s*[:>]/gm;
@@ -193,8 +230,13 @@ export class ImportPathConverter {
     }
 
     /**
-     * Phase 1: Search for folders (implicit modules) relative to the current file.
-     * Searches sibling folders, ascending directories, and Content root.
+     * Appends the locations where a folder of this name sits, searched outwards
+     * from the current file: siblings first, then each ancestor directory, then
+     * the Content root. A folder is an implicit module, so its presence is the
+     * whole of the evidence.
+     *
+     * Nearest first, because a module is far likelier to be the one beside the
+     * file importing it than a namesake elsewhere in the project.
      */
     private async searchImplicitModules(modulePath: string, currentFileUri: vscode.Uri, locations: string[]): Promise<void> {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(currentFileUri);
@@ -203,11 +245,11 @@ export class ImportPathConverter {
         const currentFilePath = path.relative(workspaceFolder.uri.fsPath, currentFileUri.fsPath).replace(/\\/g, "/");
         let currentFileDir = path.dirname(currentFilePath).replace(/\\/g, "/");
 
-        // Check if workspace IS the Content folder
         const workspaceFolderName = path.basename(workspaceFolder.uri.fsPath);
         const workspaceFolderIsContent = workspaceFolderName === CONTENT_FOLDER;
 
-        // Normalize paths when workspace IS Content
+        // Every path below is reasoned about with a leading Content/, so a
+        // workspace opened at Content itself has that segment put back on.
         if (workspaceFolderIsContent) {
             currentFileDir = currentFileDir === "" || currentFileDir === "." ? CONTENT_FOLDER : `${CONTENT_FOLDER}/${currentFileDir}`;
         }
@@ -218,7 +260,8 @@ export class ImportPathConverter {
 
         const dirSegments = currentFileDir.split("/");
 
-        // Helper to adjust path for filesystem checks
+        // The inverse of that: a filesystem check is made against the
+        // workspace, which in this layout is already inside Content.
         const getFsCheckPath = (logicalPath: string): string => {
             if (workspaceFolderIsContent && logicalPath.startsWith(`${CONTENT_FOLDER}/`)) {
                 return logicalPath.substring(CONTENT_FOLDER.length + 1);
@@ -226,7 +269,7 @@ export class ImportPathConverter {
             return logicalPath;
         };
 
-        // Check sibling modules
+        // Siblings.
         if (dirSegments.length > 1) {
             const parentPath = dirSegments.slice(0, dirSegments.length - 1).join("/");
             const siblingTestPath = `${parentPath}/${modulePath}`;
@@ -239,7 +282,7 @@ export class ImportPathConverter {
             }
         }
 
-        // Ascending directory traversal
+        // Ancestor directories, nearest outwards.
         for (let i = dirSegments.length - 2; i >= 0; i--) {
             const checkPath = dirSegments.slice(0, i + 1).join("/");
             const testPath = `${checkPath}/${modulePath}`;
@@ -252,7 +295,7 @@ export class ImportPathConverter {
             }
         }
 
-        // Check direct Content children
+        // The Content root.
         const contentDirectChild = `${CONTENT_FOLDER}/${modulePath}`;
         if (await this.folderExists(workspaceFolder, getFsCheckPath(contentDirectChild))) {
             if (!locations.includes("")) locations.push("");
@@ -260,8 +303,12 @@ export class ImportPathConverter {
     }
 
     /**
-     * Phase 2: Search for explicit module definitions in .verse files.
-     * Scans the project folder for files containing Name := module declarations.
+     * Appends the locations of the `.verse` files declaring this name with
+     * `Name := module:`, which is the other way a module comes to exist and
+     * the one no folder attests to.
+     *
+     * Capped at 100 files scanned, so a project larger than that resolves from
+     * whichever of them the search returned.
      */
     private async searchExplicitModuleDefinitions(modulePath: string, moduleName: string, pathSegments: string[], locations: string[]): Promise<void> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -293,17 +340,18 @@ export class ImportPathConverter {
             let relativePath = path.relative(workspaceFolder.uri.fsPath, file.fsPath).replace(/\\/g, "/");
             relativePath = path.dirname(relativePath).replace(/\\/g, "/");
 
-            // Normalize path when workspace IS Content
             if (workspaceIsContent) {
                 relativePath = relativePath === "" || relativePath === "." ? CONTENT_FOLDER : `${CONTENT_FOLDER}/${relativePath}`;
             }
 
             if (!relativePath.startsWith(CONTENT_FOLDER)) continue;
 
-            // Remove Content prefix
             relativePath = relativePath.startsWith(`${CONTENT_FOLDER}/`) ? relativePath.substring(CONTENT_FOLDER.length + 1) : relativePath === CONTENT_FOLDER ? "" : relativePath;
 
-            // For nested paths, verify parent path matches
+            // A dotted reference names the path to the module as well as the
+            // module, and only the last segment was searched for, so a
+            // declaration whose directory does not end in the rest of the
+            // reference declares a different module of the same name.
             if (pathSegments.length > 1) {
                 const parentPath = pathSegments.slice(0, -1).join("/");
                 if (!relativePath.endsWith(parentPath)) continue;
@@ -312,7 +360,6 @@ export class ImportPathConverter {
                 if (relativePath.endsWith("/")) relativePath = relativePath.substring(0, relativePath.length - 1);
             }
 
-            // Format path
             if (!relativePath.startsWith("/") && relativePath !== "") relativePath = "/" + relativePath;
 
             if (!locations.includes(relativePath)) {
@@ -321,7 +368,20 @@ export class ImportPathConverter {
         }
     }
 
-    /** Scans the workspace for possible locations of a module */
+    /**
+     * Every place in the workspace the module could be, as locations relative
+     * to the Content root: "" for the root itself, "/Dir/Sub" below it. Empty
+     * when the module is nowhere to be found, and longer than one entry when
+     * the name is ambiguous.
+     *
+     * Two searches, in preference order, and the second runs only if the first
+     * found nothing: a folder near the current file (searchImplicitModules),
+     * then an explicit declaration anywhere in the project
+     * (searchExplicitModuleDefinitions). Ordered that way because proximity is
+     * the better evidence of which module was meant, and because a folder
+     * module exists only on the filesystem, where no declaration cache can see
+     * it.
+     */
     async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<string[]> {
         const locations: string[] = [];
         const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -332,10 +392,6 @@ export class ImportPathConverter {
 
         logger.debug("ImportPathConverter", `Searching for module '${modulePath}'`);
 
-        // Phase 1: Search for folders (implicit modules) in Content folder.
-        // This runs first because it is locality-aware (prefers modules near
-        // the current file) and folder modules are filesystem-only knowledge
-        // that the declaration cache cannot provide.
         if (currentFileUri) {
             try {
                 await this.searchImplicitModules(modulePath, currentFileUri, locations);
@@ -344,10 +400,10 @@ export class ImportPathConverter {
             }
         }
 
-        // Phase 2: Explicit module definitions. The cache accelerates this
-        // phase; every candidate is validated against the filesystem before
-        // being trusted, and the full scan still runs when the cache has
-        // nothing valid (empty, stale, or disabled).
+        // The cache stands in for the declaration search, never above it: every
+        // candidate is checked against the filesystem before it is trusted, and
+        // the full scan below still runs whenever the cache yields nothing
+        // valid - empty, stale, or never set.
         if (locations.length === 0 && this.projectPathCache) {
             const candidates = this.projectPathCache.lookupModuleLocations(modulePath);
             for (const candidate of candidates) {
@@ -386,7 +442,13 @@ export class ImportPathConverter {
     }
 
     /**
-     * Converts a full path import to a relative import
+     * The relative form of an absolute import, in the style the author wrote,
+     * or null when there is none to give: a built-in module, an import that
+     * was never absolute, or a workspace with no `.uefnproject` to take the
+     * project path from.
+     *
+     * Never ambiguous. Shortening a path the file already carries needs
+     * nothing looked up, unlike the other direction.
      */
     async convertFromFullPath(importStatement: string, line?: number): Promise<ImportConversionResult | null> {
         if (this.isBuiltinModule(importStatement)) {
@@ -400,11 +462,11 @@ export class ImportPathConverter {
         }
 
         // Read through extractPathFromImport rather than a second copy of its
-        // regexes, because that copy skipped the trailing-comment strip: the
-        // dotted capture runs to end of line, so `using. /A/B # note` yielded the
-        // path `/A/B # note` and re-emitted the comment inside the converted
-        // statement - which applyConversion, restoring the comment itself, would
-        // then write a second time.
+        // regexes, so the trailing-comment strip cannot be left out of the
+        // copy. The dotted capture runs to end of line, so `using. /A/B # note`
+        // yields the path `/A/B # note` without it - and applyConversion
+        // restores the comment itself, so a comment left in the path is written
+        // twice.
         const fullPath = this.extractPathFromImport(importStatement);
 
         if (!fullPath || !fullPath.startsWith("/")) {
@@ -437,7 +499,7 @@ export class ImportPathConverter {
 
         return {
             originalImport: importStatement,
-            fullPathImport: relativeImport, // In this case, it's actually the relative import
+            fullPathImport: relativeImport,
             moduleName: modulePathSegments[modulePathSegments.length - 1] || relativeImportPath,
             isAmbiguous: false,
             line,
@@ -445,7 +507,9 @@ export class ImportPathConverter {
     }
 
     /**
-     * Converts all full path imports in a document to relative imports
+     * A conversion for each absolute import in a document that has a relative
+     * form, in the order the lines run. Built-in modules and imports already
+     * relative contribute nothing.
      */
     async convertAllImportsFromFullPath(document: vscode.TextDocument): Promise<ImportConversionResult[]> {
         const results: ImportConversionResult[] = [];
@@ -465,7 +529,15 @@ export class ImportPathConverter {
     }
 
     /**
-     * Converts a relative import to a full path import
+     * The absolute form of a relative import, in the style the author wrote,
+     * or null when the import is already absolute, names no module, or names
+     * one the workspace search cannot place. The last two also put a message
+     * in front of the user, since both are a request that failed rather than
+     * one that did not apply.
+     *
+     * A module resolving to several locations comes back `isAmbiguous`, with
+     * the candidates in `possiblePaths` and no statement built yet - the caller
+     * picks, then hands the choice to applyConversion.
      */
     async convertToFullPath(importStatement: string, documentUri: vscode.Uri, line?: number): Promise<ImportConversionResult | null> {
         if (this.isFullPathImport(importStatement)) {
@@ -524,7 +596,7 @@ export class ImportPathConverter {
 
             return {
                 originalImport: importStatement,
-                fullPathImport: "", // Will be determined by user selection
+                fullPathImport: "",
                 moduleName,
                 isAmbiguous: true,
                 possiblePaths,
@@ -534,7 +606,9 @@ export class ImportPathConverter {
     }
 
     /**
-     * Converts all relative imports in a document to full path imports
+     * A conversion for each relative import in a document, in the order the
+     * lines run. Any of them may be ambiguous, so a caller applying the whole
+     * set has a choice to put to the user for each one.
      */
     async convertAllImportsInDocument(document: vscode.TextDocument): Promise<ImportConversionResult[]> {
         const results: ImportConversionResult[] = [];
@@ -564,9 +638,8 @@ export class ImportPathConverter {
      * longer holds the statement because the document changed while the
      * conversion was being resolved - resolving one spans a workspace scan, and
      * an ambiguous one also spans a quick pick. That search goes through the
-     * shared scanner rather than every line, so a fallback cannot land somewhere
-     * a lens would never have appeared: searching the raw lines is what let the
-     * commented-out copy absorb the edit in the first place.
+     * shared scanner rather than every line, so the fallback can only land where
+     * a lens would have appeared.
      *
      * Comparison is by trimmed text, so the recorded line still matches after
      * the user indents or outdents the import while the conversion resolves.
@@ -583,7 +656,12 @@ export class ImportPathConverter {
     }
 
     /**
-     * Applies a conversion result to the document
+     * Writes a conversion over the line it came from, keeping that line's
+     * indentation and trailing comment. False when the line is no longer
+     * findable or the edit is refused.
+     *
+     * @param selectedPath The path chosen for an ambiguous conversion. Without
+     *   it such a conversion writes its empty statement, erasing the import.
      */
     async applyConversion(document: vscode.TextDocument, conversion: ImportConversionResult, selectedPath?: string): Promise<boolean> {
         const text = document.getText();

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -37,9 +37,9 @@ const CONTENT_FOLDER = "Content";
  * Converts a `using` between the absolute Verse path of a module and the
  * relative reference to it, in either direction, and writes the result.
  *
- * Converting to an absolute path means finding where the module lives, which
- * is a workspace search rather than a text transform, so only this direction
- * can be ambiguous or fail outright.
+ * The two directions are not mirror images. Going relative shortens a path the
+ * file already carries; going absolute has to find where the module lives,
+ * which is a workspace search, so only that direction can come back ambiguous.
  */
 export class ImportPathConverter {
     private readonly projectPathHandler: ProjectPathHandler;
@@ -176,7 +176,6 @@ export class ImportPathConverter {
             return { fullPath: pathStr, moduleName };
         }
 
-        // Dot notation: HUD.Textures becomes HUD/Textures.
         const identPattern = /[A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?/g;
         const dotSegments: string[] = [];
         let match;
@@ -269,7 +268,6 @@ export class ImportPathConverter {
             return logicalPath;
         };
 
-        // Siblings.
         if (dirSegments.length > 1) {
             const parentPath = dirSegments.slice(0, dirSegments.length - 1).join("/");
             const siblingTestPath = `${parentPath}/${modulePath}`;
@@ -282,7 +280,6 @@ export class ImportPathConverter {
             }
         }
 
-        // Ancestor directories, nearest outwards.
         for (let i = dirSegments.length - 2; i >= 0; i--) {
             const checkPath = dirSegments.slice(0, i + 1).join("/");
             const testPath = `${checkPath}/${modulePath}`;
@@ -295,7 +292,6 @@ export class ImportPathConverter {
             }
         }
 
-        // The Content root.
         const contentDirectChild = `${CONTENT_FOLDER}/${modulePath}`;
         if (await this.folderExists(workspaceFolder, getFsCheckPath(contentDirectChild))) {
             if (!locations.includes("")) locations.push("");
@@ -444,11 +440,16 @@ export class ImportPathConverter {
     /**
      * The relative form of an absolute import, in the style the author wrote,
      * or null when there is none to give: a built-in module, an import that
-     * was never absolute, or a workspace with no `.uefnproject` to take the
-     * project path from.
+     * was never absolute, a workspace with no `.uefnproject` to take the
+     * project path from, or a path that shortens to nothing.
      *
-     * Never ambiguous. Shortening a path the file already carries needs
-     * nothing looked up, unlike the other direction.
+     * Never ambiguous, because one project path shortens one import exactly one
+     * way. The other direction has a whole workspace of candidate locations to
+     * choose between.
+     *
+     * A path belonging to another project is not refused, only left whole: with
+     * no project prefix to strip, every segment survives into the dotted form,
+     * which then names a module of this project that does not exist.
      */
     async convertFromFullPath(importStatement: string, line?: number): Promise<ImportConversionResult | null> {
         if (this.isBuiltinModule(importStatement)) {
@@ -530,10 +531,13 @@ export class ImportPathConverter {
 
     /**
      * The absolute form of a relative import, in the style the author wrote,
-     * or null when the import is already absolute, names no module, or names
-     * one the workspace search cannot place. The last two also put a message
-     * in front of the user, since both are a request that failed rather than
-     * one that did not apply.
+     * or null when there is none to give: an import that is already absolute,
+     * one naming no module at all, a workspace with no `.uefnproject` to take
+     * the project path from, or a module the search cannot place.
+     *
+     * The last two also put a message in front of the user, since a lookup that
+     * came back empty is a request that failed rather than one that did not
+     * apply.
      *
      * A module resolving to several locations comes back `isAmbiguous`, with
      * the candidates in `possiblePaths` and no statement built yet - the caller

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -449,7 +449,7 @@ export class ImportPathConverter {
      *
      * A path belonging to another project is not refused, only left whole: with
      * no project prefix to strip, every segment survives into the dotted form,
-     * which then names a module of this project that does not exist.
+     * which this project cannot resolve.
      */
     async convertFromFullPath(importStatement: string, line?: number): Promise<ImportConversionResult | null> {
         if (this.isBuiltinModule(importStatement)) {


### PR DESCRIPTION
Closes #226

The comment standard applied to `ImportDocumentEditor`, `ImportPathConverter`, `ImportCodeLensProvider` and `ImportCodeActionProvider`, calibrated against the pilot that landed in #249.

Nothing but comments changed.

## What moved

**Restated signatures rewritten into contracts.** `extractExistingImports`, `addImportsToDocument`, every public method of `ImportPathConverter`, and both providers' interface methods now open with what they produce and say what they return when they fail. `@returns` is gone everywhere; `@param` survives only where it carries a fact the type cannot - the millisecond unit on the hide delay, the location contract on `buildFullVersePath`, the precondition on `applyConversion`'s `selectedPath`.

**Two comments were wrong and are now right.** `// Determine block type based on majority` described a rule the code does not implement - blocks are classified on purity, and a mixed block is deliberately neither. `convertToFullPath`'s null cases were listed short and with the user-facing messages attributed to the wrong two branches.

**Incident-shaped comments reduced to their constraint.** Past-tense accounts of defects ("pushed the header into the middle of the file", "is what let a new import be merged into one above the anchored provider", "used to leave the tab dirty") now state the rule a future editor must not break, in the present tense. Refactor history is gone: "use original behavior", "Use the new grouping method", "the defect this whole change exists to remove".

**`ImportCodeActionProvider` gained the doc comments it never had** - the class, `provideCodeActions`, and the non-mutation contract on `sortSuggestions`.

**One rationale was deleted rather than reworded.** `// Remove existing import blocks (in reverse order to maintain line numbers)`: a `WorkspaceEdit`'s ranges resolve against the original document, so the stated reason is not a constraint the code rests on, and an unverifiable rationale is worse than none.

## Follow-up refactor ticket

#257, for the two names that only exist behind a comment: `ImportConversionResult.fullPathImport`, which holds the relative statement on the relative-conversion path, and `convertAllImportsInDocument`, whose name carries no direction while its sibling `convertAllImportsFromFullPath` does. Both comments stay here, as the ticket asks.

## Review gate

Two rounds against a fresh reviewer.

Round 1 returned **FAIL** on one Critical - the `convertToFullPath` null-case list above - plus four Important findings on doc comments that over-claimed: the `ImportDocumentEditor` class doc saying "every write" when `applyConversion` also writes, `provideCodeLenses` claiming a lens per convertible import when built-ins get none, a self-contradiction in `convertFromFullPath`, and an incident-shaped comment in `ImportCodeActionProvider` whose calibrated rewrite already existed in #249. Fixed in b09dc76.

Round 2 returned **PASS_WITH_SUGGESTIONS** with no Critical and no Important, and confirmed every round-1 finding resolved. Both suggestions are taken in 954f915. The substantive one was a sentence added during round 1: an out-of-project path such as `/creator@fortnite.com/theirproject/Mod` joins to `creator@fortnite.com.theirproject.Mod`, which holds `@` and `.`, so it is a parse error rather than a reference to a module that does not exist. The claim is now only that this project cannot resolve it, which holds for both shapes.

## Verification

```
$ npm run compile
> verse-auto-imports@0.9.0 compile
> tsc -p ./


$ npm test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       595 passed, 595 total
Snapshots:   0 total
Time:        13.117 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No test file was added, removed or edited; the diff touches four files, all under `src/imports/`.

## Strip-diff gate

Both revisions compiled with comments stripped and compared. Run against `origin/main` rather than against the working tree, so it covers the whole branch:

```
$ git checkout origin/main -- src/imports
$ npx tsc -p ./ --removeComments --sourceMap false --outDir out/strip-base
$ git checkout HEAD -- src/imports
$ npx tsc -p ./ --removeComments --sourceMap false --outDir out/strip-head
$ diff -r out/strip-base out/strip-head
$ echo "exit: $?"
exit: 0
```

Empty, over 63 emitted files on each side.

No changelog fragment: this is not a user-facing change.
