### PR TITLE
fix(services): keep a file's cached declarations when its reparse cannot read it

### DIFF
--- a/changelog.d/255.fixed.md
+++ b/changelog.d/255.fixed.md
@@ -1,0 +1,1 @@
+**Project path cache**: a .verse file that cannot be read when its change is processed keeps the declarations it already contributed, instead of dropping them until something edits the file again.

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -158,10 +158,11 @@ export class ProjectPathCache {
     /**
      * Reparses the named files and swaps their declarations into the cache.
      *
-     * A file the scanner could not read yields no nodes rather than an error,
-     * so it is committed as empty and its previous declarations are dropped;
-     * only a failure raised outside the scanner keeps the old nodes. Both cases
-     * self-correct on the file's next change event.
+     * A file that could not be read keeps the declarations it already had,
+     * rather than committing as one that declares nothing; the next change
+     * event reparses it. A file that was read and declares nothing does commit
+     * as empty, which is what makes deleting the last declaration in a file
+     * take effect.
      *
      * Parsing awaits, and `this.data` can be replaced while it does - the
      * .uefnproject watcher, watcher teardown and the Clear Project Path Cache
@@ -192,14 +193,19 @@ export class ProjectPathCache {
             try {
                 const fileUri = vscode.Uri.joinPath(workspaceFolders[0].uri, filePath);
                 const nodes = await scanner.parseVerseFile(fileUri, workspaceFolders[0]);
+
+                // Staying out of parsedResults is what keeps this file's
+                // existing nodes: the commit below only replaces files it
+                // reparsed. The scanner logged the failure already.
+                if (nodes === null) {
+                    failedFiles.push(filePath);
+                    continue;
+                }
+
                 parsedResults.set(filePath, nodes);
             } catch (error) {
                 logger.error("ProjectPathCache", `Failed to reparse ${filePath}`, error);
                 failedFiles.push(filePath);
-                // Staying out of parsedResults is what keeps this file's
-                // existing nodes: the commit below only replaces files it
-                // reparsed. Reachable only for a throw from outside
-                // parseVerseFile, which swallows its own read and parse errors.
             }
         }
 
@@ -219,7 +225,7 @@ export class ProjectPathCache {
         this.rebuildIndexes();
 
         if (failedFiles.length > 0) {
-            logger.warn("ProjectPathCache", `Kept old cache for ${failedFiles.length} failed file(s): ${failedFiles.join(", ")}`);
+            logger.warn("ProjectPathCache", `Reparse failed for ${failedFiles.length} file(s), left as cached: ${failedFiles.join(", ")}`);
         }
 
         data.generatedAt = Date.now();

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -53,7 +53,9 @@ export class ProjectPathScanner {
                 const batchResults = await Promise.all(
                     batch.map(async (fileUri) => {
                         try {
-                            return await this.parseVerseFile(fileUri, workspaceFolder, options);
+                            // A full scan has no previous declarations to keep,
+                            // so an unreadable file contributes nothing either way.
+                            return (await this.parseVerseFile(fileUri, workspaceFolder, options)) ?? [];
                         } catch (error) {
                             logger.error("ProjectPathScanner", `Error parsing ${fileUri.fsPath}`, error);
                             return [];
@@ -87,11 +89,13 @@ export class ProjectPathScanner {
     }
 
     /**
-     * The declarations in one .verse file, or [] when it could not be read or
-     * parsed. A failure here is logged and swallowed so one unreadable file
-     * cannot abandon a whole scan.
+     * The declarations in one .verse file, or null when it could not be read or
+     * parsed. Null and [] are different answers: [] is a file that was read and
+     * declares nothing, and a caller that conflates them treats an unreadable
+     * file as an emptied one. A failure here is logged and does not raise, so
+     * one unreadable file cannot abandon a whole scan.
      */
-    async parseVerseFile(fileUri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, options: ProjectScanOptions = {}): Promise<ProjectPathNode[]> {
+    async parseVerseFile(fileUri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, options: ProjectScanOptions = {}): Promise<ProjectPathNode[] | null> {
         try {
             const document = await vscode.workspace.openTextDocument(fileUri);
             const content = document.getText();
@@ -100,7 +104,7 @@ export class ProjectPathScanner {
             return this.extractDeclarations(content, relativePath, options);
         } catch (error) {
             logger.error("ProjectPathScanner", `Failed to parse ${fileUri.fsPath}`, error);
-            return [];
+            return null;
         }
     }
 

--- a/src/services/__tests__/ProjectPathCache.parseFailure.test.ts
+++ b/src/services/__tests__/ProjectPathCache.parseFailure.test.ts
@@ -1,0 +1,113 @@
+import * as vscode from "vscode";
+import { ProjectPathCache } from "../ProjectPathCache";
+
+/**
+ * Regression tests for issue #255: an unreadable file used to lose everything
+ * it had contributed to the cache.
+ *
+ * invalidateFiles commits a reparse by replacing every node the file owned, and
+ * the scanner reported a read failure as an empty declaration list - so a file
+ * held open mid-write by UEFN committed as empty and its declarations vanished
+ * until something touched the file again.
+ *
+ * These drive the cache against stub VS Code workspace APIs, so no extension
+ * host is needed.
+ */
+describe("ProjectPathCache.invalidateFiles when a file cannot be read", () => {
+    const openTextDocument = vscode.workspace.openTextDocument as unknown as jest.Mock;
+
+    const CHANGED_FILE = "Scripts/device.verse";
+
+    /** A module declaration, so a successful parse yields a node to commit. */
+    const VERSE_SOURCE = "device_module := module:\n";
+
+    /** Minimal in-memory stand-in for vscode.Memento (workspaceState). */
+    class FakeMemento {
+        private readonly store: Map<string, unknown> = new Map();
+
+        get<T>(key: string): T | undefined {
+            return this.store.get(key) as T | undefined;
+        }
+
+        async update(key: string, value: unknown): Promise<void> {
+            if (value === undefined) {
+                this.store.delete(key);
+            } else {
+                this.store.set(key, value);
+            }
+        }
+    }
+
+    /** Stands in for ProjectPathHandler; a name is all scanProject needs to succeed. */
+    class FakeProjectPathHandler {
+        async getProjectName(): Promise<string | null> {
+            return "MyGame";
+        }
+
+        async getProjectVersePath(): Promise<string | null> {
+            return "/mygame@fortnite.com/mygame";
+        }
+    }
+
+    type CacheParams = ConstructorParameters<typeof ProjectPathCache>;
+
+    /** ProjectPathCache's own storage key; kept in sync with its private static. */
+    const CACHE_KEY = "projectPathTree";
+
+    let cache: ProjectPathCache;
+    let storage: FakeMemento;
+
+    /** The node count in the payload workspace storage currently holds. */
+    const persistedNodeCount = (): number => storage.get<{ nodes: unknown[] }>(CACHE_KEY)?.nodes.length ?? -1;
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        openTextDocument.mockResolvedValue({ getText: () => VERSE_SOURCE });
+
+        setWorkspaceFolders([{ uri: { fsPath: "C:\\Project\\Content" }, name: "Content", index: 0 }]);
+
+        storage = new FakeMemento();
+        cache = new ProjectPathCache(
+            { workspaceState: storage } as unknown as CacheParams[0],
+            { appendLine: jest.fn() } as unknown as CacheParams[1],
+            new FakeProjectPathHandler() as unknown as CacheParams[2],
+        );
+
+        await cache.initialize();
+
+        // The declarations the failing reparse below must not lose.
+        await cache.invalidateFiles([CHANGED_FILE]);
+        expect(cache.getStats().identifiers).toBe(1);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        openTextDocument.mockResolvedValue({ getText: () => "" });
+    });
+
+    it("keeps the file's cached declarations when the read fails", async () => {
+        openTextDocument.mockRejectedValue(new Error("EBUSY: resource busy or locked"));
+
+        await cache.invalidateFiles([CHANGED_FILE]);
+
+        expect(cache.getStats().identifiers).toBe(1);
+        expect(cache.getStats().files).toBe(1);
+        // A later session must not load the loss either.
+        expect(persistedNodeCount()).toBe(1);
+    });
+
+    it("still drops them when the file parsed and declares nothing", async () => {
+        openTextDocument.mockResolvedValue({ getText: () => "# every declaration removed\n" });
+
+        await cache.invalidateFiles([CHANGED_FILE]);
+
+        expect(cache.getStats().identifiers).toBe(0);
+        expect(cache.getStats().files).toBe(0);
+        expect(persistedNodeCount()).toBe(0);
+    });
+});


### PR DESCRIPTION
Closes #255

## What changed

`ProjectPathScanner.parseVerseFile` returns `null` when it cannot read or parse a file, instead of `[]`. `[]` is now only what a file that was read and declares nothing produces, so `ProjectPathCache.invalidateFiles` can tell the two apart: a `null` joins `failedFiles` and stays out of `parsedResults`, which is what leaves the file's existing nodes in place through the commit.

The full scan is unaffected — it has no previous declarations to keep, so `scanProject` coalesces `null` to `[]` at the call site.

The doc comment on `invalidateFiles` described the defect rather than a transaction, since #227 documented the behaviour as it actually was. It now describes the transaction again, including the half that must still commit: a file that parsed and declares nothing does drop its nodes, which is what makes deleting the last declaration in a file take effect.

## Regression test

`src/services/__tests__/ProjectPathCache.parseFailure.test.ts` pins both halves — the read failure keeps the cached declarations (in memory and in workspace storage), and the empty-but-readable file still drops them. Written before the fix and observed failing against the unfixed code (`expected 1, received 0`), passing after.

## Review

Fresh-context review gate, opus: `PASS_WITH_SUGGESTIONS` — 0 Critical, 0 Important, 3 Suggestions. Two were applied: the new inline comment was trimmed where it restated the signature, and the `Kept old cache for N failed file(s)` warning was reworded to `Reparse failed for N file(s), left as cached`, since that path is now genuinely reachable and can fire for a file that had nothing cached to keep. The third — deleting the unreachable `catch` around `parseVerseFile` in `scanProject` — was declined as pre-existing code outside this ticket.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./
```

```
$ npm test

> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 29 passed, 29 total
Tests:       597 passed, 597 total
Snapshots:   0 total
Time:        7.882 s, estimated 12 s
Ran all test suites.
```

```
$ npm run format:check

> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
