### PR TITLE
fix(imports): record every statement before a using: pair

### DIFF
--- a/changelog.d/233.fixed.md
+++ b/changelog.d/233.fixed.md
@@ -1,0 +1,1 @@
+**Import scanning**: A line writing three or more `using` statements and ending in a `using:` pair now counts every path it imports, so adding one of the middle paths no longer writes a second copy of it.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -42,12 +42,12 @@ export interface ScannedImport {
      * is possible: content the statement patterns cannot lex, such as an
      * unbalanced `'`, ends the capture early, which leaves a remainder over and
      * so pins the line - the reported path is then a prefix of the real one,
-     * present but never re-emitted. `true` does not promise
-     * every path on the span was recorded either: a line ending in a `using:`
-     * pair reports the statement at its head and the path below, and none in
-     * between. The line is pinned either way, so nothing is deleted; the cost is
-     * a path that does not count as present, which lets a writer add a second
-     * copy of it.
+     * present but never re-emitted. `true` does not promise every path on the
+     * span was recorded either: a `using` glued to an identifier by a comment
+     * removed from between them, `using { /A }; Y<# note #>using { /B }`, is not
+     * a statement usingPathsOnLine offers. The line is pinned either way, so
+     * nothing is deleted; the cost is a path that does not count as present,
+     * which lets a writer add a second copy of it.
      */
     rebuildLosesText: boolean;
     /**
@@ -347,8 +347,8 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         }
 
         // The same pair, opened after a `;` rather than at the head of its line.
-        // `;` separates definitions in a scope exactly as a newline does, so a
-        // statement can precede the `using:`. Without this branch such a line
+        // `;` separates definitions in a scope exactly as a newline does, so
+        // statements can precede the `using:`. Without this branch such a line
         // falls through to the single-statement branch below, which reports the
         // path before the `;` and a span of one line - and a writer rebuilding
         // that line from that path deletes the `; using:`, stranding its path in
@@ -374,12 +374,16 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // excludes a pinned entry; a reader of the unfiltered scan gets the
         // region reported once per path it carries.
         if (/\busing\s*:\s*$/.test(code)) {
-            // The statement before the `;`, when the line writes one. A
-            // `using:` following something that is not a `using` never reaches
-            // here - isModuleImport rejects the line above and it is skipped
-            // whole.
-            const precedingPath = formatter.extractPathFromImport(code);
-            if (precedingPath) {
+            // Every statement written before the pair. The `using:` contributes
+            // no path of its own, since neither statement pattern matches it,
+            // and a `using:` following something that is not a `using` never
+            // reaches here - isModuleImport rejects the line above and it is
+            // skipped whole.
+            //
+            // Counted with usingPathsOnLine because this branch holds first
+            // refusal over the one below, so a line ending in `using:` is
+            // counted here or nowhere.
+            for (const precedingPath of usingPathsOnLine(formatter, code)) {
                 imports.push({
                     path: precedingPath,
                     startLine: i,

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -234,6 +234,19 @@ describe("scanModuleImports", () => {
         ]);
     });
 
+    // This branch has first refusal, so a line ending in `using:` never reaches
+    // the one that counts what a line writes. Reading only the head recorded
+    // `/X` and the indented path and left `/Y` out - not data loss, since the
+    // line is pinned, but a writer asked for `/Y` then writes a second copy of a
+    // path the file already imports.
+    it("records every statement written before the pair a line opens", () => {
+        expect(scanModuleImports(["using { /X }; using { /Y }; using:", "    Economy.Shop", "", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/Y", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
     // A `using:` following something that is not a `using` writes no import
     // this scanner may touch: isModuleImport rejects the line, so it is skipped
     // whole and left exactly as written.


### PR DESCRIPTION
Closes #233

## What

The branch in `scanModuleImports` keyed on `/\busing\s*:\s*$/` read a single statement from the head of the line via `extractPathFromImport`, so a line writing three or more statements and ending in a `using:` pair left every path between the head and the pair unrecorded.

It now counts the line with `usingPathsOnLine` — the same question the branch below it and `allUsingPaths` ask — and pushes one pinned entry per path. This branch holds first refusal over the branch that would otherwise have counted them, so a line ending in `using:` is counted here or nowhere; that is why the two disagreed by construction.

```
scanModuleImports(["using { /X }; using { /Y }; using:", "    Economy.Shop", "", "code()"])
```

before: `/X`, `Economy.Shop` — `/Y` missing
after:  `/X`, `/Y`, `Economy.Shop`, all pinned, matching what `allUsingPaths` reports on the same input

Not data loss: the line is pinned, so no writer rebuilds it. The residue was that `/Y` did not count as present, so a writer asked to add `/Y` wrote a second copy of a path the file already imported.

## Acceptance, against the ticket

- [x] The three-statement input reports all three paths, every one pinned.
- [x] The two-statement pair shape `using { /X }; using:` is unchanged — one entry for `/X`, one for the indented path, both pinned. `extractPathFromImport("using:")` is null (neither `DOTTED_STATEMENT` nor the braced pattern matches a `:`), so `usingPathsOnLine` returns exactly the one path the old call found. Existing tests cover it.
- [x] Regression test in `src/imports/__tests__/ImportScanner.test.ts`, running without the VS Code runtime. Confirmed failing against the unfixed code with exactly `/Y` missing.

## Also in this diff

`ScannedImport.rebuildLosesText` documented this miss as a property of the flag — the shape the ticket's filing comment points at. The claim that `true` does not promise every path on the span was recorded is still true, so the example is replaced rather than dropped: a `using` glued to an identifier by a comment removed from between them, `using { /A }; Y<# note #>using { /B }`, is not a statement `usingPathsOnLine` offers. Verified against the built code, not inferred.

## Verification

```
> verse-auto-imports@0.9.0 compile
> tsc -p ./

=== TEST ===
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 28 passed, 28 total
Tests:       596 passed, 596 total
Snapshots:   0 total
Time:        7.832 s, estimated 8 s
Ran all test suites.
=== FORMAT CHECK ===
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

`PASS_WITH_SUGGESTIONS`, fresh reviewer, opus, one round. No Critical. The one Important finding was the stale `rebuildLosesText` doc, fixed above; the suggestions were comment-length trims, applied.
