### PR TITLE
fix(imports): classify a dotted import by the statement at its head

### DIFF
--- a/changelog.d/247.fixed.md
+++ b/changelog.d/247.fixed.md
@@ -1,0 +1,1 @@
+**Import scanning**: A dotted import of a same-directory module sharing its line with another statement now counts as imported, so nothing writes a second copy of an import the file already makes.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -90,14 +90,13 @@ export class ImportFormatter {
      *   at file scope a bare `using { X }` can only be the former. Pass this
      *   only when you know the line is not inside a function body.
      *
-     * Every style answers from the statement at the head of the line rather
-     * than from the whole of it, since a line may write more than one and a
-     * definition after a `;` belongs to none of the `using` before it. The
-     * dotted form reads matchImport's DOTTED_STATEMENT for that: its content is
-     * what ends it, and a second copy of the pattern is a second opinion about
-     * where it ended. A bare folder-module name is where the two answers differ:
-     * `Features; MyVal := 5` is neither a path nor an identifier, so a line
-     * read whole classifies as no import and is skipped rather than counted.
+     * The dotted and braced styles answer from the statement at the head of the
+     * line rather than from the whole of it, since a line may write more than
+     * one and a definition after a `;` belongs to none of the `using` before
+     * it. The dotted form reads matchImport's DOTTED_STATEMENT to do that: its
+     * content is what ends it, and a second copy of that pattern is a second
+     * opinion about where it ended. The indented style is the exception and
+     * classifies from the whole of nextLine.
      *
      * @param nextLine The following line, which carries the content for the
      *   indented style. When it is not given and the line is `using:`, this

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -90,6 +90,15 @@ export class ImportFormatter {
      *   at file scope a bare `using { X }` can only be the former. Pass this
      *   only when you know the line is not inside a function body.
      *
+     * Every style answers from the statement at the head of the line rather
+     * than from the whole of it, since a line may write more than one and a
+     * definition after a `;` belongs to none of the `using` before it. The
+     * dotted form reads matchImport's DOTTED_STATEMENT for that: its content is
+     * what ends it, and a second copy of the pattern is a second opinion about
+     * where it ended. A bare folder-module name is where the two answers differ:
+     * `Features; MyVal := 5` is neither a path nor an identifier, so a line
+     * read whole classifies as no import and is skipped rather than counted.
+     *
      * @param nextLine The following line, which carries the content for the
      *   indented style. When it is not given and the line is `using:`, this
      *   conservatively returns `true`.
@@ -123,7 +132,7 @@ export class ImportFormatter {
         }
 
         // Dotted style.
-        const dotMatch = trimmed.match(/^using\.\s+(.+)/);
+        const dotMatch = trimmed.match(ImportFormatter.DOTTED_STATEMENT);
         if (dotMatch) {
             return isModuleImportContent(ImportFormatter.stripTrailingComment(dotMatch[1]));
         }
@@ -148,6 +157,10 @@ export class ImportFormatter {
 
     /**
      * A dotted `using` statement, capturing its content.
+     *
+     * Matched by isModuleImport as well as matchImport, so the classifier and
+     * the reader cannot disagree about how much of a line the statement
+     * occupies. Widening the class widens both.
      *
      * The class covers every character Verse's path production admits outside a
      * quoted suffix - a label may hold `.` and `-`, `@` introduces the account,

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -228,6 +228,20 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Economy.Shop"], curlySorted)).toBeNull();
     });
 
+    // A bare folder-module name is the one dotted content the swallowed
+    // definition stopped classifying as an import, so the line was skipped and
+    // the path went unrecorded - and a writer asked for Features added a second
+    // copy of an import the line was already making.
+    it("does not write a second copy of a bare path a dotted statement provides beside a definition", () => {
+        const input = ["using. Features; MyVal := 5", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Features"], curlySorted)).toBeNull();
+    });
+
+    it("leaves a line that writes a definition after its bare dotted import alone", () => {
+        const input = ["using. Features; MyVal := 5", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
     // A module whose name merely ends in those five letters writes one
     // statement, and organizing has to keep treating it as one. Counted by
     // every occurrence of `using`, this line reads as two, and the file stops

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -40,6 +40,23 @@ describe("ImportFormatter.isModuleImport", () => {
         expect(ImportFormatter.isModuleImport("using. Features", undefined, { atFileScope: true })).toBe(true);
         expect(ImportFormatter.isModuleImport("using:", "    Features", { atFileScope: true })).toBe(true);
     });
+
+    // A bare identifier is the only dotted content the swallowed definition
+    // changes the answer for: read to end of line the content was
+    // `Features; MyVal := 5`, which is neither a path nor an identifier, so the
+    // line classified as no import at all and the scanner skipped it whole. The
+    // absolute and dot-notation forms keep the `/` or the `.` that decides them.
+    it("atFileScope: a bare dotted import sharing its line with a definition is a module import", () => {
+        expect(ImportFormatter.isModuleImport("using. Features; MyVal := 5", undefined, { atFileScope: true })).toBe(true);
+        expect(ImportFormatter.isModuleImport("using. /Verse.org/Simulation; MyVal := 5", undefined, { atFileScope: true })).toBe(true);
+        expect(ImportFormatter.isModuleImport("using. Economy.Shop; MyVal := 5", undefined, { atFileScope: true })).toBe(true);
+    });
+
+    // Ending the capture at the statement must not promote a local-scope using:
+    // outside file scope a bare identifier is an instance, whatever follows it.
+    it("default mode: a local-scope dotted using sharing its line stays a local-scope using", () => {
+        expect(ImportFormatter.isModuleImport("using. Instance; MyVal := 5")).toBe(false);
+    });
 });
 
 describe("ImportFormatter.stripTrailingComment", () => {

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -52,10 +52,19 @@ describe("ImportFormatter.isModuleImport", () => {
         expect(ImportFormatter.isModuleImport("using. Economy.Shop; MyVal := 5", undefined, { atFileScope: true })).toBe(true);
     });
 
-    // Ending the capture at the statement must not promote a local-scope using:
-    // outside file scope a bare identifier is an instance, whatever follows it.
+    // Outside file scope a bare identifier is an instance, whatever follows it.
+    // Read to end of line, a dot anywhere in that leftover answered the content
+    // test instead and promoted the local-scope using to a module import.
     it("default mode: a local-scope dotted using sharing its line stays a local-scope using", () => {
         expect(ImportFormatter.isModuleImport("using. Instance; MyVal := 5")).toBe(false);
+        expect(ImportFormatter.isModuleImport("using. Instance; MyVal := Foo.Bar")).toBe(false);
+    });
+
+    // The shared pattern needs no space after the `.`, where the classifier's
+    // own copy required one - so this line read as an import to everything
+    // going through matchImport and as no import at all to the scanner.
+    it("atFileScope: a dotted import written without a space after the dot is a module import", () => {
+        expect(ImportFormatter.isModuleImport("using.Features", undefined, { atFileScope: true })).toBe(true);
     });
 });
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -170,6 +170,17 @@ describe("scanModuleImports", () => {
         ]);
     });
 
+    // The classification read the dotted content to end of line, so this one
+    // was `Features; MyVal := 5` - no path, no identifier, no import. The line
+    // was skipped whole and nothing recorded that the file imports Features, so
+    // a diagnostic asking for it wrote a second copy above a line already
+    // making that import.
+    it("records a bare dotted import that shares its line with a definition, pinned", () => {
+        expect(scanModuleImports(["using. Features; MyVal := 5", "", "code()"])).toEqual([
+            { path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
     it("consumes the indented using: pair as one two-line entry", () => {
         expect(scanModuleImports(["using:", "    /Verse.org/Simulation", "code()"])).toEqual([
             { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
@@ -184,6 +195,17 @@ describe("scanModuleImports", () => {
     it("consumes a using: pair opened after a semicolon, pinning both paths", () => {
         expect(scanModuleImports(["using { /X }; using:", "    Economy.Shop", "", "code()"])).toEqual([
             { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The same pair opened after a bare dotted import, which the classification
+    // has to admit before this branch can see it: gated on the line read whole,
+    // the opener was skipped and its indented path was left in the body as a
+    // bare expression, imported by nothing.
+    it("consumes a using: pair opened after a bare dotted import, pinning both paths", () => {
+        expect(scanModuleImports(["using. Features; using:", "    Economy.Shop", "", "code()"])).toEqual([
+            { path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
     });


### PR DESCRIPTION
Closes #247

`isModuleImport` kept its own copy of the dotted pattern, `/^using\.\s+(.+)/`, greedy to end of line, while `matchImport` ends the capture where the path ends. A bare folder-module import sharing its line with a definition was therefore handed `Features; MyVal := 5` to classify: no leading `/`, no `.`, not an identifier, so no import at all. `scanModuleImports` skipped the line whole, nothing recorded that the file imports `Features`, and a diagnostic asking for it wrote a second `using { Features }` above a line already making that import.

The dotted branch now reads `DOTTED_STATEMENT`, so the classifier and the reader answer from the same statement rather than from two opinions about where it ended.

## What changed

- `ImportFormatter.isModuleImport` matches `DOTTED_STATEMENT` in its dotted branch instead of a second, looser copy of it.
- Doc comments carry the two constraints that fall out: `isModuleImport` classifies from the head statement (the indented style excepted, which still reads the whole of `nextLine`), and `DOTTED_STATEMENT` now has two readers, so widening the class widens both.

The ticket's open question - whether `isModuleImport` should answer from the statement at the head of the line at all - is answered yes, and documented on the method.

## Deliberate consequences, beyond the reported symptom

Both follow from sharing the pattern rather than copying it, and both are pinned by tests:

- `DOTTED_STATEMENT` needs no space after the `.`, where the replaced copy required one. `using.Features` now classifies as a module import at file scope. Everything reading through `matchImport` (`allUsingPaths`, `usingPathsOnLine`) already reported a path there, so this closes the same two-readers-disagree gap one form over rather than opening a new one.
- In default mode a dotted local-scope `using` sharing its line no longer gets promoted by a dot in the leftover: `using. Instance; MyVal := Foo.Bar` was a module import and is now correctly a local-scope using.

## Out of scope, needs its own issue

`ImportPathConverter.extractPathFromImport` (`src/imports/ImportPathConverter.ts:122`) holds a third copy of the dotted pattern, `/^using\.\s*(.+)/`, still greedy to end of line. It is safe today only because `scanConvertibleImports` feeds it rewritable single-statement lines, so leftover text never reaches it - an invariant nothing states next to either copy. Not touched here.

## Tests

Regression tests in `src/imports/__tests__/`, each verified to fail against the unfixed regex:

- `ImportScanner`: `scanModuleImports(["using. Features; MyVal := 5", "", "code()"])` records `Features`, pinned - `[]` before.
- `ImportScanner`: a `using:` pair opened after a bare dotted import records both paths, pinned - `[]` before, which stranded the indented path in the body, imported by nothing.
- `ImportDocumentEditor`: organizing with `["Features"]` against that line adds nothing - before, it emitted `using { Features }` above the line, reproducing the reported harm exactly.
- `ImportFormatter`: the three classification flips (bare dotted sharing its line, the no-space form, the local-scope promotion).

Plus a guard that organizing leaves the line as written, and the pre-existing pin on `using. Instance # see Foo.Bar` as a local-scope using, which still passes.

## Review

Fresh-context review gate, `opus`: **PASS_WITH_SUGGESTIONS**, 0 Critical, 0 Important, 4 Suggestions. Three were applied in the second commit (the head-statement doc claim was too broad, one comment narrated the incident the commit already carries, and the default-mode assertion named a promotion it never exercised). The fourth is the third pattern copy, recorded above rather than folded into this diff.

## Verification

```
$ npm run compile

> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm test

Test Suites: 28 passed, 28 total
Tests:       602 passed, 602 total
Snapshots:   0 total
Time:        7.433 s, estimated 9 s
Ran all test suites.

$ npm run format:check

Checking formatting...
All matched files use Prettier code style!
```
