### PR TITLE
chore(deps): patch the dev-scope advisories and pin serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1904,9 +1904,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3612,9 +3612,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3942,9 +3942,9 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4474,16 +4474,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -4614,13 +4604,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {
@@ -4959,9 +4949,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -341,6 +341,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "publisher": "vukefn",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #265

Clears all six open Dependabot alerts. Every one is development scope; `package.json` declares no runtime `dependencies`, so none of them ever shipped in the .vsix, and what this actually buys is a readable alert page.

## What changed

`npm audit fix --package-lock-only` lifts four of the six with no manifest change:

| package | via | before | after |
| --- | --- | --- | --- |
| `brace-expansion` | mocha > minimatch@9 | 2.1.1 | 2.1.4 |
| `brace-expansion` | ts-jest > ... > test-exclude > minimatch@3 | 1.1.15 | 1.1.18 |
| `js-yaml` | ts-jest > ... > @istanbuljs/load-nyc-config | 3.15.0 | 3.15.1 |
| `js-yaml` | mocha | 4.3.0 | 4.3.1 |

Both `brace-expansion` rows landed independently on `main` as #267 while this branch was in flight, so they will not appear in the diff below — they are listed because they are two of the six alerts, not because this PR moves them. The merge is clean and a no-op on that file: `git merge-tree --write-tree origin/main HEAD` produces tree `9f5b9dd`, byte-identical to this branch's tree, so the verification below holds for the post-merge content.

`serialize-javascript` has no in-range fix, so it needs the one manifest line. mocha@11.8.0, the current latest, declares `serialize-javascript: ^6.0.2`; the first patched release is 7.0.3. No mocha version clears alerts #2 and #3, so:

```json
"overrides": {
  "serialize-javascript": "^7.0.5"
}
```

resolves it to 7.1.0. `randombytes` drops out of the lockfile because 7.x no longer depends on it.

The alternative for #2/#3 was dismissal as not-reachable — the RCE needs mocha's parallel mode, and neither integration suite passes `parallel`. The maintainer chose the override.

## Notes for review

- **Node floor.** `serialize-javascript@7.1.0` adds `engines: {"node": ">=20.0.0"}`, which 6.0.2 did not have. Every workflow in `.github/workflows/` pins `node-version: "20"`, so the floor is satisfied with nothing to spare.
- **The override's blast radius is mocha only.** mocha is the sole consumer of `serialize-javascript` in the tree.
- **No changelog fragment.** `changelog.d/README` scopes fragments to user-facing change — "what changed in the editor experience" — and with no runtime dependencies nothing here reaches a user. Past `deps:` PRs (#220, #118, #115, #116, #114, #111, #109, #39) carry none either.
- **The other half of #265 is already done and is not in this PR.** Repo-level Dependabot security updates were switched off, which is why these accumulated; a PR cannot change a repo setting. The maintainer enabled it directly — `GET /repos/vukefn/verse-auto-imports/automated-security-fixes` now returns `{"enabled":true,"paused":false}` (it returned `{"enabled":false}` when the issue was filed). #267 is the result: a security update Dependabot raised on its own, which it could not have raised before. `dependabot-automerge.yml` already handles those.

## Review

Reviewed on a fresh context: **PASS_WITH_SUGGESTIONS**, no Critical and no spec findings. One suggestion, not taken here to keep the diff to what the ticket asked: the override is declared at root scope, so it applies to every consumer of `serialize-javascript` present and future, where the nested form `{"mocha": {"serialize-javascript": "^7.0.5"}}` would pin only the package the ticket names. Both resolve identically today since mocha is the sole consumer; the root form is the shape npm's own advisory-remediation docs use. Worth revisiting only if a second consumer appears that needs 6.x.

## Verification

`npm ci` against the refreshed lockfile, then:

```
$ npm run compile
> verse-auto-imports@0.9.0 compile
> tsc -p ./

$ npm run format:check
> verse-auto-imports@0.9.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!

$ npm test
> verse-auto-imports@0.9.0 test
> jest --verbose

Test Suites: 29 passed, 29 total
Tests:       605 passed, 605 total
Snapshots:   0 total
Time:        9.07 s
Ran all test suites.
```

The integration suite is the check that matters here, since it is the only mocha consumer:

```
$ npm run test:integration
  ...
  configuration resolution regressions (issues #76/#77)
    #77: the default behavior.ambiguousImports mapping drives auto-import for a bare unknown identifier (638ms)
    #76: autoImportDebounceDelay governs the debounce when diagnosticDelay is unset (3435ms)
    #76: an explicit legacy diagnosticDelay is honored while the new key is unset (1368ms)

  30 passing (31s)

Extension host with pid 47196 exited with code: 0, signal: unknown.
Exit code:   0
```

Resolved versions and the remaining audit surface:

```
$ npm ls serialize-javascript js-yaml brace-expansion --all
          brace-expansion@1.1.18
      js-yaml@3.15.1
    brace-expansion@2.1.4
    serialize-javascript@7.1.0
    js-yaml@4.3.1

$ npm audit
# npm audit report

diff  6.0.0 - 8.0.2
jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch - https://github.com/advisories/GHSA-73rr-hh4g-fpgx
fix available via `npm audit fix --force`
Will install mocha@11.3.0, which is a breaking change
node_modules/mocha/node_modules/diff
  mocha  11.4.0 - 12.0.0-beta-3
  Depends on vulnerable versions of diff
  node_modules/mocha

2 low severity vulnerabilities
```

Those two low findings are jsdiff via mocha, which GitHub has already auto-dismissed as alert #1. Clearing them means holding mocha back to 11.3.0, which is not worth it. No open alert survives this PR.
