### PR TITLE
refactor(commands): split the command table into seven named group tables

### DIFF
--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -38,6 +38,9 @@ interface PathConversionResult {
     line?: number;
 }
 
+/** A command id paired with the method that runs it. */
+type CommandEntry = [string, (...args: any[]) => any];
+
 /**
  * The body of every command the extension contributes, and the one place they
  * are registered.
@@ -56,41 +59,31 @@ export class CommandsHandler {
      * `contributes.commands`, and the five that take caller-supplied arguments
      * must stay hidden from the Command Palette there - invoking one from the
      * palette dereferences an undefined document. Both halves are pinned:
-     * commandManifest.test.ts checks the manifest, and the integration suite
-     * checks every id is registered once the extension has activated.
+     * commandManifest.test.ts checks the manifest, CommandsHandler.test.ts
+     * checks this method registers every id once, and the integration suite
+     * checks they are registered once the extension has activated.
      */
     registerAll(context: vscode.ExtensionContext): void {
-        const commands: Array<[string, (...args: any[]) => any]> = [
-            ["verseAutoImports.addSingleImport", this.addSingleImport.bind(this)],
-            ["verseAutoImports.optimizeImports", this.optimizeImports.bind(this)],
-
-            ["verseAutoImports.showStatusMenu", this.showStatusMenu.bind(this)],
-
-            ["verseAutoImports.toggleAutoImport", this.toggleAutoImport.bind(this)],
-            ["verseAutoImports.togglePreserveLocations", this.togglePreserveLocations.bind(this)],
-            ["verseAutoImports.toggleImportSyntax", this.toggleImportSyntax.bind(this)],
-            ["verseAutoImports.toggleDigestFiles", this.toggleDigestFiles.bind(this)],
-            ["verseAutoImports.toggleFullPathCodeLens", this.toggleFullPathCodeLens.bind(this)],
-
-            ["verseAutoImports.snoozeAutoImport", this.snoozeAutoImport.bind(this)],
-            ["verseAutoImports.cancelSnooze", this.cancelSnooze.bind(this)],
-
-            ["verseAutoImports.exportDebugLogs", this.exportDebugLogs.bind(this)],
-            ["verseAutoImports.captureDiagnosticsCorpus", this.captureDiagnosticsCorpus.bind(this)],
-
-            ["verseAutoImports.rebuildPathCache", this.rebuildPathCache.bind(this)],
-            ["verseAutoImports.clearPathCache", this.clearPathCache.bind(this)],
-            ["verseAutoImports.showCacheStatus", this.showCacheStatus.bind(this)],
-
-            ["verseAutoImports.convertToFullPath", this.convertToFullPath.bind(this)],
-            ["verseAutoImports.convertAllToFullPath", this.convertAllToFullPath.bind(this)],
-            ["verseAutoImports.convertToRelativePath", this.convertToRelativePath.bind(this)],
-            ["verseAutoImports.convertAllToRelativePath", this.convertAllToRelativePath.bind(this)],
+        const commands: CommandEntry[] = [
+            ...this.importCommands(),
+            ...this.menuCommands(),
+            ...this.toggleCommands(),
+            ...this.snoozeCommands(),
+            ...this.debugCommands(),
+            ...this.pathCacheCommands(),
+            ...this.pathConversionCommands(),
         ];
 
         for (const [commandId, handler] of commands) {
             context.subscriptions.push(vscode.commands.registerCommand(commandId, handler));
         }
+    }
+
+    private importCommands(): CommandEntry[] {
+        return [
+            ["verseAutoImports.addSingleImport", this.addSingleImport.bind(this)],
+            ["verseAutoImports.optimizeImports", this.optimizeImports.bind(this)],
+        ];
     }
 
     async addSingleImport(document: vscode.TextDocument, importStatement: string): Promise<void> {
@@ -160,8 +153,22 @@ export class CommandsHandler {
         }
     }
 
+    private menuCommands(): CommandEntry[] {
+        return [["verseAutoImports.showStatusMenu", this.showStatusMenu.bind(this)]];
+    }
+
     async showStatusMenu(): Promise<void> {
         await this.deps.statusBarHandler.showMenu();
+    }
+
+    private toggleCommands(): CommandEntry[] {
+        return [
+            ["verseAutoImports.toggleAutoImport", this.toggleAutoImport.bind(this)],
+            ["verseAutoImports.togglePreserveLocations", this.togglePreserveLocations.bind(this)],
+            ["verseAutoImports.toggleImportSyntax", this.toggleImportSyntax.bind(this)],
+            ["verseAutoImports.toggleDigestFiles", this.toggleDigestFiles.bind(this)],
+            ["verseAutoImports.toggleFullPathCodeLens", this.toggleFullPathCodeLens.bind(this)],
+        ];
     }
 
     /**
@@ -199,12 +206,26 @@ export class CommandsHandler {
         await this.toggleConfig<boolean>("pathConversion.enableCodeLens");
     }
 
+    private snoozeCommands(): CommandEntry[] {
+        return [
+            ["verseAutoImports.snoozeAutoImport", this.snoozeAutoImport.bind(this)],
+            ["verseAutoImports.cancelSnooze", this.cancelSnooze.bind(this)],
+        ];
+    }
+
     async snoozeAutoImport(): Promise<void> {
         this.deps.statusBarHandler.startSnooze(CommandsHandler.SNOOZE_DURATION_MINUTES);
     }
 
     async cancelSnooze(): Promise<void> {
         this.deps.statusBarHandler.cancelSnooze();
+    }
+
+    private debugCommands(): CommandEntry[] {
+        return [
+            ["verseAutoImports.exportDebugLogs", this.exportDebugLogs.bind(this)],
+            ["verseAutoImports.captureDiagnosticsCorpus", this.captureDiagnosticsCorpus.bind(this)],
+        ];
     }
 
     async exportDebugLogs(): Promise<void> {
@@ -273,6 +294,14 @@ export class CommandsHandler {
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to capture diagnostics: ${error instanceof Error ? error.message : String(error)}`);
         }
+    }
+
+    private pathCacheCommands(): CommandEntry[] {
+        return [
+            ["verseAutoImports.rebuildPathCache", this.rebuildPathCache.bind(this)],
+            ["verseAutoImports.clearPathCache", this.clearPathCache.bind(this)],
+            ["verseAutoImports.showCacheStatus", this.showCacheStatus.bind(this)],
+        ];
     }
 
     async rebuildPathCache(): Promise<void> {
@@ -349,6 +378,15 @@ export class CommandsHandler {
             logger.error("CommandsHandler", "Error showing cache status", error);
             vscode.window.showErrorMessage(`Failed to show cache status: ${error instanceof Error ? error.message : String(error)}`);
         }
+    }
+
+    private pathConversionCommands(): CommandEntry[] {
+        return [
+            ["verseAutoImports.convertToFullPath", this.convertToFullPath.bind(this)],
+            ["verseAutoImports.convertAllToFullPath", this.convertAllToFullPath.bind(this)],
+            ["verseAutoImports.convertToRelativePath", this.convertToRelativePath.bind(this)],
+            ["verseAutoImports.convertAllToRelativePath", this.convertAllToRelativePath.bind(this)],
+        ];
     }
 
     /**

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -42,6 +42,52 @@ afterEach(() => {
     setActiveEditor(undefined);
 });
 
+/** Every id registerAll registers, in the order its seven groups are spread. */
+const REGISTERED_COMMAND_IDS = [
+    "verseAutoImports.addSingleImport",
+    "verseAutoImports.optimizeImports",
+    "verseAutoImports.showStatusMenu",
+    "verseAutoImports.toggleAutoImport",
+    "verseAutoImports.togglePreserveLocations",
+    "verseAutoImports.toggleImportSyntax",
+    "verseAutoImports.toggleDigestFiles",
+    "verseAutoImports.toggleFullPathCodeLens",
+    "verseAutoImports.snoozeAutoImport",
+    "verseAutoImports.cancelSnooze",
+    "verseAutoImports.exportDebugLogs",
+    "verseAutoImports.captureDiagnosticsCorpus",
+    "verseAutoImports.rebuildPathCache",
+    "verseAutoImports.clearPathCache",
+    "verseAutoImports.showCacheStatus",
+    "verseAutoImports.convertToFullPath",
+    "verseAutoImports.convertAllToFullPath",
+    "verseAutoImports.convertToRelativePath",
+    "verseAutoImports.convertAllToRelativePath",
+];
+
+// The integration suite asserts the same ids are registered, but only with an
+// extension host running - so nothing in this suite would catch a command lost
+// from one of registerAll's group tables.
+describe("CommandsHandler.registerAll", () => {
+    it("registers every command id once, in group order", () => {
+        const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+        makeHandler({}).registerAll(context);
+
+        const registered = (vscode.commands.registerCommand as jest.Mock).mock.calls.map(([commandId]) => commandId);
+
+        expect(registered).toEqual(REGISTERED_COMMAND_IDS);
+    });
+
+    it("hands every registration to the context for disposal", () => {
+        const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+        makeHandler({}).registerAll(context);
+
+        expect(context.subscriptions).toHaveLength(REGISTERED_COMMAND_IDS.length);
+    });
+});
+
 describe("CommandsHandler.addSingleImport", () => {
     it("warns and reports no success when the edit is rejected", async () => {
         const handler = makeHandler({ addImportsToDocument: jest.fn().mockResolvedValue(false) });

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -42,41 +42,53 @@ afterEach(() => {
     setActiveEditor(undefined);
 });
 
-/** Every id registerAll registers, in the order its seven groups are spread. */
-const REGISTERED_COMMAND_IDS = [
-    "verseAutoImports.addSingleImport",
-    "verseAutoImports.optimizeImports",
-    "verseAutoImports.showStatusMenu",
-    "verseAutoImports.toggleAutoImport",
-    "verseAutoImports.togglePreserveLocations",
-    "verseAutoImports.toggleImportSyntax",
-    "verseAutoImports.toggleDigestFiles",
-    "verseAutoImports.toggleFullPathCodeLens",
-    "verseAutoImports.snoozeAutoImport",
-    "verseAutoImports.cancelSnooze",
-    "verseAutoImports.exportDebugLogs",
-    "verseAutoImports.captureDiagnosticsCorpus",
-    "verseAutoImports.rebuildPathCache",
-    "verseAutoImports.clearPathCache",
-    "verseAutoImports.showCacheStatus",
-    "verseAutoImports.convertToFullPath",
-    "verseAutoImports.convertAllToFullPath",
-    "verseAutoImports.convertToRelativePath",
-    "verseAutoImports.convertAllToRelativePath",
+/** Every command registerAll registers, with the method it binds, in the order its groups are spread. */
+const REGISTERED_COMMANDS: Array<[string, string]> = [
+    ["verseAutoImports.addSingleImport", "addSingleImport"],
+    ["verseAutoImports.optimizeImports", "optimizeImports"],
+    ["verseAutoImports.showStatusMenu", "showStatusMenu"],
+    ["verseAutoImports.toggleAutoImport", "toggleAutoImport"],
+    ["verseAutoImports.togglePreserveLocations", "togglePreserveLocations"],
+    ["verseAutoImports.toggleImportSyntax", "toggleImportSyntax"],
+    ["verseAutoImports.toggleDigestFiles", "toggleDigestFiles"],
+    ["verseAutoImports.toggleFullPathCodeLens", "toggleFullPathCodeLens"],
+    ["verseAutoImports.snoozeAutoImport", "snoozeAutoImport"],
+    ["verseAutoImports.cancelSnooze", "cancelSnooze"],
+    ["verseAutoImports.exportDebugLogs", "exportDebugLogs"],
+    ["verseAutoImports.captureDiagnosticsCorpus", "captureDiagnosticsCorpus"],
+    ["verseAutoImports.rebuildPathCache", "rebuildPathCache"],
+    ["verseAutoImports.clearPathCache", "clearPathCache"],
+    ["verseAutoImports.showCacheStatus", "showCacheStatus"],
+    ["verseAutoImports.convertToFullPath", "convertToFullPath"],
+    ["verseAutoImports.convertAllToFullPath", "convertAllToFullPath"],
+    ["verseAutoImports.convertToRelativePath", "convertToRelativePath"],
+    ["verseAutoImports.convertAllToRelativePath", "convertAllToRelativePath"],
 ];
+
+function registeredCommands(): Array<[string, string]> {
+    return (vscode.commands.registerCommand as jest.Mock).mock.calls.map(([commandId, handler]) => [commandId, handler.name]);
+}
 
 // The integration suite asserts the same ids are registered, but only with an
 // extension host running - so nothing in this suite would catch a command lost
-// from one of registerAll's group tables.
+// from one of registerAll's group tables, or bound to the wrong method.
 describe("CommandsHandler.registerAll", () => {
     it("registers every command id once, in group order", () => {
         const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
 
         makeHandler({}).registerAll(context);
 
-        const registered = (vscode.commands.registerCommand as jest.Mock).mock.calls.map(([commandId]) => commandId);
+        expect(registeredCommands().map(([commandId]) => commandId)).toEqual(REGISTERED_COMMANDS.map(([commandId]) => commandId));
+    });
 
-        expect(registered).toEqual(REGISTERED_COMMAND_IDS);
+    it("binds each id to its own method", () => {
+        const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+        makeHandler({}).registerAll(context);
+
+        // bind() names its result "bound <method>", which is the only trace of
+        // the original method left on a registered handler.
+        expect(registeredCommands()).toEqual(REGISTERED_COMMANDS.map(([commandId, method]) => [commandId, `bound ${method}`]));
     });
 
     it("hands every registration to the context for disposal", () => {
@@ -84,7 +96,7 @@ describe("CommandsHandler.registerAll", () => {
 
         makeHandler({}).registerAll(context);
 
-        expect(context.subscriptions).toHaveLength(REGISTERED_COMMAND_IDS.length);
+        expect(context.subscriptions).toHaveLength(REGISTERED_COMMANDS.length);
     });
 });
 


### PR DESCRIPTION
Closes #250

`registerAll` held a flat 19-entry `[id, handler]` array whose grouping lived in blank lines alone, after #228 removed the section-header comments that had carried it. Each of the seven groups is now a private method returning its own entries, placed at the head of the methods it registers, so the class layout carries the same grouping the banner comments used to. `registerAll` spreads the seven and keeps its loop, staying the only `registerCommand` call site.

No behaviour change: the 19 ids register in the same order as before, each bound to the same method.

## What moved

| Group method | Commands |
| --- | --- |
| `importCommands` | `addSingleImport`, `optimizeImports` |
| `menuCommands` | `showStatusMenu` |
| `toggleCommands` | the five `toggle*` |
| `snoozeCommands` | `snoozeAutoImport`, `cancelSnooze` |
| `debugCommands` | `exportDebugLogs`, `captureDiagnosticsCorpus` |
| `pathCacheCommands` | `rebuildPathCache`, `clearPathCache`, `showCacheStatus` |
| `pathConversionCommands` | the four `convert*` |

No command body or private helper moved, and nothing was renamed.

## Tests

Three unit tests on `registerAll`, because the integration suite that asserts the same ids needs an extension host — the jest suite alone could not otherwise catch a command lost from a group table, or bound to the wrong method. Both new failure modes were proved detectable by introducing them and watching the suite fail:

- dropping `clearPathCache` from `pathCacheCommands` fails the id-order test
- pointing `toggleAutoImport`'s entry at `toggleDigestFiles` fails only the pairing test, since the ids are unchanged

## Out of scope

`package.json` `contributes.commands` and the integration suite's id list are untouched. Their order disagrees with `registerAll`'s, which the issue notes as motivation rather than as work; reconciling the three is a separate change. The `PathConversionResult` duplicate is left alone, as the issue directs.

No changelog fragment: a structural move with no user-visible effect.

## Verification

```
$ npm run compile

> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test

> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 29 passed, 29 total
Tests:       608 passed, 608 total
Snapshots:   0 total
Time:        8.82 s, estimated 21 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Review gate: PASS_WITH_SUGGESTIONS, 0 Critical, 0 Important, 2 Suggestions — both applied in the follow-up commit.
