### PR TITLE
fix(imports): split a diagnostic that carries both candidate kinds

### DIFF
--- a/changelog.d/276.fixed.md
+++ b/changelog.d/276.fixed.md
@@ -1,0 +1,1 @@
+**Import quick fix**: a compiler message that offers both same-package names and `using` paths now lists every candidate, and Optimize Imports leaves it for you to choose.

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -170,7 +170,7 @@ export class ImportSuggestionExtractor {
             .split("\n")
             .map((line) => line.trim())
             .filter((line) => line.length > 0);
-        logger.debug("ImportSuggestionExtractor", `Found ${options.length} multi-options: ${options.join(", ")}`);
+        logger.debug("ImportSuggestionExtractor", `Parsing ${options.length} suggestion options: ${options.join(", ")}`);
 
         const candidates: ImportCandidate[] = [];
         for (const option of options) {
@@ -231,9 +231,10 @@ export class ImportSuggestionExtractor {
      * matched at all, [] when one matched but no option was importable, such as
      * a list of bare identifiers.
      *
-     * The mixed pattern is tried first: a mixed message also matches the
-     * same-package pattern below, which would read the joined tail as options
-     * and drop every candidate but the first.
+     * The mixed pattern is tried first and stands in front of all three below,
+     * because a non-null result never falls back into the cascade. A mixed
+     * message also matches the same-package pattern, which would read the
+     * joined tail as options and drop every candidate but the first.
      */
     private parseMultiOptionCandidates(errorMessage: string): ImportCandidate[] | null {
         const mixed = this.parseMixedCandidates(errorMessage);

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -22,6 +22,13 @@ const PATTERNS = {
     UNKNOWN_IDENTIFIER: /Unknown identifier `([^`]+)`/,
     /** "Did you mean X" (single suggestion) */
     DID_YOU_MEAN_SINGLE: /Did you mean ([^`\n]+)/,
+    /**
+     * The " or did you forget to specify " that joins same-package suggestions
+     * to external ones inside a single message. Either case of "did" matches:
+     * the compiler composes this phrase inline rather than at a sentence start,
+     * and which case it uses there is not established.
+     */
+    MIXED_JOINER: / or [Dd]id you forget to specify /,
     /** Extracts path from "using { /Path }" */
     USING_PATH: /using \{ (\/[^}]+) \}/g,
     /** Extracts path from "(/Path:)" format */
@@ -154,39 +161,89 @@ export class ImportSuggestionExtractor {
     }
 
     /**
+     * The importable candidates among a "Did you mean" option list, one option
+     * per line. Non-importable entries are dropped rather than rejected, so a
+     * list mixing importable and bare entries still yields the importable ones.
+     */
+    private candidatesFromOptionList(optionBlock: string): ImportCandidate[] {
+        const options = optionBlock
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+        logger.debug("ImportSuggestionExtractor", `Found ${options.length} multi-options: ${options.join(", ")}`);
+
+        const candidates: ImportCandidate[] = [];
+        for (const option of options) {
+            if (option.startsWith("/")) {
+                candidates.push({ path: option, description: `Import from ${option}` });
+                continue;
+            }
+            // A fully qualified name, "Module.ClassName" or
+            // "Module.AssetClass.Member".
+            const result = this.findCorrectModulePath(option);
+            if (result && result.modulePath) {
+                candidates.push({ path: result.modulePath, description: `${result.className} from ${result.modulePath}` });
+            } else {
+                // A bare identifier, such as a local definition echoed in
+                // the option list, carries no module path to import.
+                logger.debug("ImportSuggestionExtractor", `Dropping non-importable multi-option entry: ${option}`);
+            }
+        }
+        return candidates;
+    }
+
+    /**
+     * The candidates of a message carrying both same-package suggestions and
+     * external `using` suggestions, or null when it carries only one kind.
+     *
+     * The compiler joins the two lists inline, so the last same-package path
+     * and the joiner share a line. Neither half parses while they are together:
+     * the joined line fails QUALIFIED_NAME and the using lines are not options.
+     */
+    private parseMixedCandidates(errorMessage: string): ImportCandidate[] | null {
+        const joiner = errorMessage.match(PATTERNS.MIXED_JOINER);
+        if (!joiner || joiner.index === undefined) {
+            return null;
+        }
+
+        const samePackageHalf = errorMessage.slice(0, joiner.index);
+        const usingHalf = errorMessage.slice(joiner.index + joiner[0].length);
+
+        // The single-suggestion form goes through the same option list as the
+        // "any of" form, so one menu describes both halves the same way.
+        const listed = samePackageHalf.match(PATTERNS.DID_YOU_MEAN_ANY) ?? samePackageHalf.match(PATTERNS.DID_YOU_MEAN_SINGLE);
+        const candidates = listed ? this.candidatesFromOptionList(listed[1]) : [];
+
+        // Covers both tails the joiner can introduce: "one of:" with a list, and
+        // a bare "using { /Path }".
+        for (const path of this.extractUsingPaths(usingHalf)) {
+            candidates.push({ path, description: `Import from ${path}` });
+        }
+
+        logger.debug("ImportSuggestionExtractor", `Found ${candidates.length} mixed same-package and using candidates: ${candidates.map((candidate) => candidate.path).join(", ")}`);
+        return candidates;
+    }
+
+    /**
      * The importable candidates offered by a message that lists several.
      *
      * Null and [] mean different things: null when no multi-option pattern
      * matched at all, [] when one matched but no option was importable, such as
      * a list of bare identifiers.
+     *
+     * The mixed pattern is tried first: a mixed message also matches the
+     * same-package pattern below, which would read the joined tail as options
+     * and drop every candidate but the first.
      */
     private parseMultiOptionCandidates(errorMessage: string): ImportCandidate[] | null {
+        const mixed = this.parseMixedCandidates(errorMessage);
+        if (mixed !== null) {
+            return mixed;
+        }
+
         const match1 = errorMessage.match(PATTERNS.DID_YOU_MEAN_ANY);
         if (match1) {
-            const options = match1[1]
-                .split("\n")
-                .map((line) => line.trim())
-                .filter((line) => line.length > 0);
-            logger.debug("ImportSuggestionExtractor", `Found ${options.length} multi-options (pattern 1): ${options.join(", ")}`);
-
-            const candidates: ImportCandidate[] = [];
-            for (const option of options) {
-                if (option.startsWith("/")) {
-                    candidates.push({ path: option, description: `Import from ${option}` });
-                    continue;
-                }
-                // A fully qualified name, "Module.ClassName" or
-                // "Module.AssetClass.Member".
-                const result = this.findCorrectModulePath(option);
-                if (result && result.modulePath) {
-                    candidates.push({ path: result.modulePath, description: `${result.className} from ${result.modulePath}` });
-                } else {
-                    // A bare identifier, such as a local definition echoed in
-                    // the option list, carries no module path to import.
-                    logger.debug("ImportSuggestionExtractor", `Dropping non-importable multi-option entry: ${option}`);
-                }
-            }
-            return candidates;
+            return this.candidatesFromOptionList(match1[1]);
         }
 
         const match2 = errorMessage.match(PATTERNS.FORGET_ONE_OF);

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -171,6 +171,57 @@ describe("ImportSuggestionExtractor", () => {
             expect(suggestions).toHaveLength(0);
         });
 
+        it("should offer every candidate when a message mixes an option list with a using list", async () => {
+            // The compiler joins the two lists inline, so the last same-package
+            // path shares its line with the joiner.
+            const errorMessage =
+                "Unknown identifier `Thing`.\nUsed inside module /mygame@fortnite.com/mygame/Scripts.\n Did you mean any of: \nRel1.Thing\nRel2.Thing or did you forget to specify one of:\nusing { /GameA/M }\nusing { /GameB/M }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Rel1 }", "using { Rel2 }", "using { /GameA/M }", "using { /GameB/M }"]);
+        });
+
+        it("should offer both candidates when a message mixes a single suggestion with a single using path", async () => {
+            const errorMessage = "Unknown identifier `Thing`.\nUsed inside module /mygame@fortnite.com/mygame/Scripts.\n Did you mean Rel1.Thing or did you forget to specify using { /GameA/M }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Rel1 }", "using { /GameA/M }"]);
+        });
+
+        it("should offer every candidate when an option list is mixed with a single using path", async () => {
+            const errorMessage = "Unknown identifier `Thing`. Did you mean any of: \nRel1.Thing\nRel2.Thing or did you forget to specify using { /GameA/M }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Rel1 }", "using { Rel2 }", "using { /GameA/M }"]);
+        });
+
+        it("should offer every candidate when a single suggestion is mixed with a using list", async () => {
+            const errorMessage = "Unknown identifier `Thing`. Did you mean Rel1.Thing or did you forget to specify one of:\nusing { /GameA/M }\nusing { /GameB/M }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Rel1 }", "using { /GameA/M }", "using { /GameB/M }"]);
+        });
+
+        it("should read a mixed message the same way whichever case the joiner uses", async () => {
+            const errorMessage = "Unknown identifier `Thing`. Did you mean Rel1.Thing or Did you forget to specify using { /GameA/M }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Rel1 }", "using { /GameA/M }"]);
+        });
+
+        it("should keep the using path of a mixed message whose same-package option is a bare identifier", async () => {
+            const errorMessage = "Unknown identifier `Thing`. Did you mean Thing or did you forget to specify using { /GameA/M }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { /GameA/M }"]);
+        });
+
         it("should drop prose lines trailing a 'Did you mean any of' option list", async () => {
             // Regression #130: the trailing sentence used to become an option
             const errorMessage = "Unknown identifier `Combat`. Did you mean any of: \nSystems.Combat\nFeatures.Combat\nUsed inside module /mygame@fortnite.com/mygame/Scripts.";
@@ -220,6 +271,28 @@ describe("ImportSuggestionExtractor", () => {
 
         it("should not add candidates from a 'Did you mean any of' list", () => {
             const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `thing`. Did you mean any of:\nModuleA.thing\nModuleB.thing")]);
+
+            expect(paths).toEqual([]);
+        });
+
+        it("should not bulk-add the candidates of a message mixing an option list with a using list", () => {
+            const paths = extractor.extractImportsFromDiagnostics([
+                diag("Unknown identifier `Thing`. Did you mean any of: \nRel1.Thing\nRel2.Thing or did you forget to specify one of:\nusing { /GameA/M }\nusing { /GameB/M }"),
+            ]);
+
+            expect(paths).toEqual([]);
+        });
+
+        it("should not bulk-add the candidates of a message mixing a single suggestion with a single using path", () => {
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `Thing`. Did you mean Rel1.Thing or did you forget to specify using { /GameA/M }")]);
+
+            expect(paths).toEqual([]);
+        });
+
+        it("should not bulk-add the using path of a mixed message whose joiner capitalizes 'Did'", () => {
+            // This spelling reaches UNKNOWN_WITH_SUGGESTION, which reads the
+            // joined tail as the whole message and offers the using path alone.
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `Thing`. Did you mean Rel1.Thing or Did you forget to specify using { /GameA/M }")]);
 
             expect(paths).toEqual([]);
         });

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -214,6 +214,14 @@ describe("ImportSuggestionExtractor", () => {
             expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Rel1 }", "using { /GameA/M }"]);
         });
 
+        it("should read a mixed message with both lists the same way whichever case the joiner uses", async () => {
+            const errorMessage = "Unknown identifier `Thing`. Did you mean any of: \nRel1.Thing\nRel2.Thing or Did you forget to specify one of:\nusing { /GameA/M }\nusing { /GameB/M }";
+
+            const suggestions = await extractor.extractImportSuggestions(errorMessage);
+
+            expect(suggestions.map((s) => s.importStatement)).toEqual(["using { Rel1 }", "using { Rel2 }", "using { /GameA/M }", "using { /GameB/M }"]);
+        });
+
         it("should keep the using path of a mixed message whose same-package option is a bare identifier", async () => {
             const errorMessage = "Unknown identifier `Thing`. Did you mean Thing or did you forget to specify using { /GameA/M }";
 
@@ -287,6 +295,15 @@ describe("ImportSuggestionExtractor", () => {
             const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `Thing`. Did you mean Rel1.Thing or did you forget to specify using { /GameA/M }")]);
 
             expect(paths).toEqual([]);
+        });
+
+        it("should add the one path of a mixed message whose same-package option is a bare identifier", () => {
+            // One importable candidate left is unambiguous, so Optimize adds it -
+            // the same treatment a "Did you mean any of" list gets when its only
+            // other option is a bare local definition.
+            const paths = extractor.extractImportsFromDiagnostics([diag("Unknown identifier `Thing`. Did you mean Thing or did you forget to specify using { /GameA/M }")]);
+
+            expect(paths).toEqual(["/GameA/M"]);
         });
 
         it("should not bulk-add the using path of a mixed message whose joiner capitalizes 'Did'", () => {

--- a/test-fixtures/corpus/41.10/diagnostics.json
+++ b/test-fixtures/corpus/41.10/diagnostics.json
@@ -94,6 +94,26 @@
             }
         },
         {
+            "id": "mixed-same-package-and-using-lists",
+            "source": "synthetic",
+            "context": "both candidate kinds in one message, joined inline so the last same-package path shares its line with the joiner; awaiting live capture",
+            "message": "Unknown identifier `Combat`.\nUsed inside module /vukefn@fortnite.com/VerseAutoImports/Scripts.\n Did you mean any of: \nSystems.Combat\nFeatures.Combat or did you forget to specify one of:\nusing { /GameA/Combat }\nusing { /GameB/Combat }",
+            "expected": {
+                "suggestions": ["using { Systems }", "using { Features }", "using { /GameA/Combat }", "using { /GameB/Combat }"],
+                "optimizePaths": []
+            }
+        },
+        {
+            "id": "mixed-same-package-and-using-single",
+            "source": "synthetic",
+            "context": "the single-candidate form of the mixed shape, joined the same way; awaiting live capture",
+            "message": "Unknown identifier `Combat`.\nUsed inside module /vukefn@fortnite.com/VerseAutoImports/Scripts.\n Did you mean Systems.Combat or did you forget to specify using { /GameA/Combat }",
+            "expected": {
+                "suggestions": ["using { Systems }", "using { /GameA/Combat }"],
+                "optimizePaths": []
+            }
+        },
+        {
             "id": "identifier-many-types",
             "source": "synthetic",
             "context": "ambiguous type identifier; Optimize must not bulk-add both",


### PR DESCRIPTION
Closes #276

The compiler joins same-package suggestions to external `using` suggestions inline, so the last relative path and the joiner share a line. That line fails `QUALIFIED_NAME` and the `using` lines are not options, so `parseMultiOptionCandidates` kept only the first candidate and a four-way ambiguous message classified as `singleImport` — the quick fix offered one option and Optimize Imports bulk-added it.

`parseMixedCandidates` now splits at the joiner before the same-package pattern gets a turn, parses each half with the pattern that fits it, and offers the union. The option-list loop moved into `candidatesFromOptionList` so both callers share it; the single-suggestion head goes through the same helper, which is what keeps one description shape across both halves of one menu.

## One correction to the issue

The issue says the single+single variant is milder because `UNKNOWN_WITH_SUGGESTION` wins and imports the `using` path. It does not: that pattern requires a capital `Did`, and the joined text in the issue's own example is lowercase. Pre-fix that variant matched no pattern at all — `inferFromDidYouMean` captured the whole joined tail, failed `QUALIFIED_NAME`, and the message produced **zero** suggestions rather than a deterministic one. Same defect, worse than described, same fix.

Because of that disagreement the joiner matches either case of `did`. The compiler source is unreachable here (Epic-linked account), and matching both makes the fix correct under either spelling — under the capital spelling it also stops `UNKNOWN_WITH_SUGGESTION` taking its wrong turn, since `parseMultiOptionCandidates` runs first.

## Acceptance

- A mixed message classifies as `multiOption`: every relative and every `using` candidate reaches the quick-fix menu, and Optimize skips it as ambiguous. Covered for all four join shapes.
- No candidate is lost to the joiner, for the list and single tails alike.
- Two corpus entries in `test-fixtures/corpus/41.10/diagnostics.json`, `source: "synthetic"` per the corpus README — the shape is not yet in a captured log.

One shape diverges from the acceptance text deliberately: a mixed message whose only same-package option is a bare identifier leaves one importable candidate, which is unambiguous, so Optimize adds it. That matches how a bare-option `Did you mean any of` list is already treated (`did-you-mean-any-of-bare-option` in the corpus). It is now pinned by a test rather than left implicit.

## Regression tests detect the defect

10 new unit tests. Stashing the source change and rerunning: **8 fail**, along with 3 of the 4 new corpus assertions. The two that pass vacuously pre-fix — the lowercase single+single Optimize assertion and its corpus twin — are guards on the fixed behaviour: that shape produced nothing at all before, so "adds nothing" was already true.

## Review gate

`PASS_WITH_SUGGESTIONS` — 0 Critical, 0 Important, 4 Suggestions, all applied in `bc55472`: an Optimize assertion for the one-candidate shape, a capital-joiner test with both lists, a precedence comment naming all three patterns the new branch stands in front of, and a debug-log label that fits both callers of the extracted helper.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 29 passed, 29 total
Tests:       620 passed, 620 total
Snapshots:   0 total
Time:        10.378 s, estimated 23 s
Ran all test suites.
```

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
