### PR TITLE
fix(imports): accept the brace and dotted module declaration forms

### DIFF
--- a/changelog.d/275.fixed.md
+++ b/changelog.d/275.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: the "Use absolute path" lens now resolves a module declared as `Name := module { ... }` or `Name := module. ...`, which previously failed with "Could not find module".

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -97,8 +97,10 @@ export class ImportPathConverter {
 
     /**
      * A regex matching an explicit declaration of one named module, in any of
-     * the styles Verse accepts after `module`: a colon, a brace on either that
-     * line or the next, and the dotted `Name := module. Inner := ...`.
+     * the three styles Verse writes a macro body in: `module:`, `module { }`
+     * with the brace on either that line or the next, and the dotted
+     * `module. Inner := ...`. A `>` after the keyword is accepted alongside
+     * them.
      *
      * Non-global on purpose: the pattern is reused with `.test()` across many
      * files, and a global flag would carry `lastIndex` between calls and skip
@@ -301,9 +303,9 @@ export class ImportPathConverter {
     }
 
     /**
-     * Appends the locations of the `.verse` files declaring this name with
-     * `Name := module:`, which is the other way a module comes to exist and
-     * the one no folder attests to.
+     * Appends the locations of the `.verse` files explicitly declaring this
+     * name as a module, which is the other way a module comes to exist and the
+     * one no folder attests to.
      *
      * Capped at 100 files scanned, so a project larger than that resolves from
      * whichever of them the search returned.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -96,7 +96,9 @@ export class ImportPathConverter {
     }
 
     /**
-     * A regex matching an explicit `Name := module:` declaration of one module.
+     * A regex matching an explicit declaration of one named module, in any of
+     * the styles Verse accepts after `module`: a colon, a brace on either that
+     * line or the next, and the dotted `Name := module. Inner := ...`.
      *
      * Non-global on purpose: the pattern is reused with `.test()` across many
      * files, and a global flag would carry `lastIndex` between calls and skip
@@ -104,7 +106,7 @@ export class ImportPathConverter {
      */
     static buildModuleDefinitionRegex(moduleName: string): RegExp {
         const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return new RegExp(`\\b${escaped}(?:'[^']*')?\\s*(?:<\\s*(?:public|private|internal|protected)\\s*>)?\\s*:=\\s*module\\s*[:>]`, "m");
+        return new RegExp(`\\b${escaped}(?:'[^']*')?\\s*(?:<\\s*(?:public|private|internal|protected)\\s*>)?\\s*:=\\s*module\\s*[:>{.]`, "m");
     }
 
     /**
@@ -217,10 +219,10 @@ export class ImportPathConverter {
         return result.moduleName;
     }
 
-    /** The names a Verse file declares as modules with `Name := module:`. */
+    /** The names a Verse file declares as modules, in any of the colon, brace and dotted styles. */
     parseExplicitModuleDefinition(content: string): string[] {
         const modules: string[] = [];
-        const moduleDefPattern = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)\s*(?:<\s*(?:public|private|internal|protected)\s*>)?\s*:=\s*module\s*[:>]/gm;
+        const moduleDefPattern = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)\s*(?:<\s*(?:public|private|internal|protected)\s*>)?\s*:=\s*module\s*[:>{.]/gm;
         let match;
         while ((match = moduleDefPattern.exec(content)) !== null) {
             modules.push(match[1]);

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -29,11 +29,30 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
         expect(re.test("Inventory := module>")).toBe(true);
     });
 
+    it("matches the brace form, with the brace on the declaration line or the next", () => {
+        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
+        expect(re.test("Inventory := module{}")).toBe(true);
+        expect(re.test("Inventory<public> := module { }")).toBe(true);
+        expect(re.test("Inventory := module\n{\n    Count<public>:int = 0\n}")).toBe(true);
+    });
+
+    it("matches the dotted form, for the outer module and the one it heads", () => {
+        const source = "Inventory := module. Item := module{}";
+
+        expect(ImportPathConverter.buildModuleDefinitionRegex("Inventory").test(source)).toBe(true);
+        expect(ImportPathConverter.buildModuleDefinitionRegex("Item").test(source)).toBe(true);
+    });
+
     it("does not match a different module or a non-module declaration", () => {
         const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
         expect(re.test("MyInventory := module:")).toBe(false);
         expect(re.test("Inventory := class:")).toBe(false);
         expect(re.test("InventoryItem := module:")).toBe(false);
+
+        // What follows `module` is a character class, so a keyword that merely
+        // starts with it is not a declaration. Written as a bare `.` instead,
+        // the dotted style would accept any character and match this.
+        expect(re.test("Inventory := modulex")).toBe(false);
     });
 
     it("is not global, so repeated .test() calls are order-independent", () => {
@@ -56,6 +75,21 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
         const re = ImportPathConverter.buildModuleDefinitionRegex("a.b");
         expect(re.test("a.b := module:")).toBe(true);
         expect(re.test("axb := module:")).toBe(false);
+    });
+});
+
+describe("ImportPathConverter.parseExplicitModuleDefinition", () => {
+    // The parser is pure string work, so a channel is the whole of what it needs.
+    const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
+
+    it("collects the names declared in each of the three styles", () => {
+        const source = ["Colon := module:", "    Value<public>:int = 0", "Brace := module { }", "Split := module", "{", "}", "Dotted := module. Inner := module{}"].join("\n");
+
+        expect(converter.parseExplicitModuleDefinition(source)).toEqual(["Colon", "Brace", "Split", "Dotted", "Inner"]);
+    });
+
+    it("leaves a non-module declaration out of the names", () => {
+        expect(converter.parseExplicitModuleDefinition("Widget := class:\n    Count:int = 0")).toEqual([]);
     });
 });
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -36,7 +36,7 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
         expect(re.test("Inventory := module\n{\n    Count<public>:int = 0\n}")).toBe(true);
     });
 
-    it("matches the dotted form, for the outer module and the one it heads", () => {
+    it("matches the dotted form, for either name declared on the line", () => {
         const source = "Inventory := module. Item := module{}";
 
         expect(ImportPathConverter.buildModuleDefinitionRegex("Inventory").test(source)).toBe(true);


### PR DESCRIPTION
Closes #275

## What changed

Both copies of the module-declaration grammar in `ImportPathConverter` ended at `[:>]`, so only `Name := module:` was ever recognised. The terminator is now `[:>{.]`, which also admits the two forms Verse accepts and the search was missing:

- the brace form, `Name := module { ... }`, with the brace on the declaration line or the next (`\s*` already spans the newline)
- the dotted form, `Name := module. Inner := module{}`

Both sites named in the issue are fixed: `buildModuleDefinitionRegex`, which `searchExplicitModuleDefinitions` uses as a whole-file boolean gate, and its currently-uncalled twin `parseExplicitModuleDefinition`. Consolidating the two remains #260's; this only keeps them from disagreeing.

A module declared in either form and backed by no folder of the same name now resolves, instead of failing the "Use absolute path" lens with "Could not find module 'X'".

## Deliberately not in scope

`ProjectPathScanner.ts:162` feeds the declaration cache with a stricter pattern of its own (`/^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*:/`) and has the same blind spot. It is left alone: the cache is only the second of `findModuleLocations`' three phases, and the explicit search fixed here is the third, so the module is found either way. Worth its own issue rather than a wider diff.

## Regression tests

Added beside the existing `buildModuleDefinitionRegex` tests, plus a first block for `parseExplicitModuleDefinition`, which had none. Each new test was confirmed to fail against the unfixed source (`git stash push -- src/imports/ImportPathConverter.ts`, then restore):

```
  ● ImportPathConverter.buildModuleDefinitionRegex › matches the brace form, with the brace on the declaration line or the next
  ● ImportPathConverter.buildModuleDefinitionRegex › matches the dotted form, for either name declared on the line
  ● ImportPathConverter.parseExplicitModuleDefinition › collects the names declared in each of the three styles

Tests:       3 failed, 32 passed, 35 total
```

## Verification

`npm run compile`:

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 29 passed, 29 total
Tests:       609 passed, 609 total
Snapshots:   0 total
Time:        9.898 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

`PASS_WITH_SUGGESTIONS`, no Critical or Important findings. The reviewer re-derived the regex behaviour independently and confirmed that no real Verse construct newly matches, that the comment and string-literal false positives are pre-existing rather than newly opened, and that `\s*` spans the newline for the brace-on-next-line case. All three Suggestions were applied in the follow-up commit: a stale `Name := module:` in the `searchExplicitModuleDefinitions` doc, an enumeration that omitted the `>` terminator, and a test name that promised nested resolution the search does not model.
