### PR TITLE
refactor(imports): delete the uncalled second module-declaration parser

### DIFF
--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -221,17 +221,6 @@ export class ImportPathConverter {
         return result.moduleName;
     }
 
-    /** The names a Verse file declares as modules, in any of the colon, brace and dotted styles. */
-    parseExplicitModuleDefinition(content: string): string[] {
-        const modules: string[] = [];
-        const moduleDefPattern = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)\s*(?:<\s*(?:public|private|internal|protected)\s*>)?\s*:=\s*module\s*[:>{.]/gm;
-        let match;
-        while ((match = moduleDefPattern.exec(content)) !== null) {
-            modules.push(match[1]);
-        }
-        return modules;
-    }
-
     /**
      * Appends the locations where a folder of this name sits, searched outwards
      * from the current file: siblings first, then each ancestor directory, then

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -78,21 +78,6 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
     });
 });
 
-describe("ImportPathConverter.parseExplicitModuleDefinition", () => {
-    // The parser is pure string work, so a channel is the whole of what it needs.
-    const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
-
-    it("collects the names declared in each of the three styles", () => {
-        const source = ["Colon := module:", "    Value<public>:int = 0", "Brace := module { }", "Split := module", "{", "}", "Dotted := module. Inner := module{}"].join("\n");
-
-        expect(converter.parseExplicitModuleDefinition(source)).toEqual(["Colon", "Brace", "Split", "Dotted", "Inner"]);
-    });
-
-    it("leaves a non-module declaration out of the names", () => {
-        expect(converter.parseExplicitModuleDefinition("Widget := class:\n    Count:int = 0")).toEqual([]);
-    });
-});
-
 interface RecordedOperation {
     kind: "insert" | "delete" | "replace";
     range?: { start: { line: number; character: number }; end: { line: number; character: number } };


### PR DESCRIPTION
Closes #260

## What changed

`ImportPathConverter.parseExplicitModuleDefinition` is deleted, along with its tests. `buildModuleDefinitionRegex` is now the only spelling of the module-declaration grammar in the file, so there is nothing left there to keep in sync.

Two files, no behaviour change, no changelog fragment - nothing here is user-facing.

## Why delete rather than unify behind one builder

The issue leaves the choice open and makes keeping it conditional on an outside caller. There is none, and there cannot be one: `activate` (`src/extension.ts:56-298`) returns nothing, so the extension publishes no API object. A `grep` across `src/`, `src/test-integration/`, scripts, markdown and `package.json` finds the method's own definition and its own tests, and nothing else.

Deleting also leaves #45 - which plans one shared declaration parser across five consumers - with four to unify instead of five. A local two-site builder here would be work #45 then has to absorb or tear out.

## Three statements in the issue are stale

#281 merged shortly before this branch was cut, so a reader comparing the diff against the issue will hit these:

1. The body quotes the regex ending `[:>]`. Both patterns ended `[:>{.]` as of #281.
2. "has no test" - #281 added a `describe` block, which this change removes with the method.
3. "`buildModuleDefinitionRegex` ... is also used by `ProjectPathScanner`" - it is not. `ProjectPathScanner.ts:162` carries its own separate pattern and calls nothing in `ImportPathConverter`.

None of them changes the decision. #281 having to widen both copies in lockstep is the cost the issue predicted, and is the argument for closing it.

## Deliberately not in scope

`ProjectPathScanner.ts:162` is a third, independent spelling of the grammar, still colon-only and so blind to the brace and dotted forms. #281 left it alone and called it "worth its own issue"; nothing tracked it, so it is now #282. Not fixed here.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

```

`npm test`:

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 29 passed, 29 total
Tests:       629 passed, 629 total
Snapshots:   0 total
Time:        13.76 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

629 is the previous 631 less the two deleted cases. Confirmed at suite level rather than inferred - `ImportPathConverter.test.ts` alone runs 33, against 35 on `origin/main`:

```
=== after (this branch) ===
Tests:       33 passed, 33 total
=== before (origin/main) ===
Tests:       35 passed, 35 total
```

No new regression test and no stash-test proof: this is a deletion with no behaviour change, so there is no defect for a test to detect. Every form the deleted tests pinned - colon, brace, brace on the next line, dotted, and the class-is-not-a-module negative - is already covered by the surviving `buildModuleDefinitionRegex` block, which is the pattern actually in use.

## Review

Fresh-context review gate, opus: **PASS**, no findings.
