### PR TITLE
fix(imports): read a # inside a string or char literal as content

### DIFF
--- a/changelog.d/272.fixed.md
+++ b/changelog.d/272.fixed.md
@@ -1,0 +1,1 @@
+**Import scanning**: A `#` inside a string or char literal no longer ends the scan of its line, so a `using` written after one is seen and organize keeps an import it would otherwise remove.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -104,18 +104,18 @@ interface LineScan {
  * - A `#` line comment runs to the end of the line, so a `<#` inside one is
  *   text rather than an opener.
  * - A bare `#` inside a string or char literal is content, so a line is lexed
- *   far enough to tell the two apart. `<# ... #>` is the exception in both
- *   directions: it really does open a comment inside a string, so the markers
- *   are read before the literal state is consulted, and a literal survives
- *   across the comment written into it.
+ *   far enough to tell the two apart, and no further: a quote inside a string's
+ *   `{ ... }` interpolation ends the literal here, so a `#` after one still
+ *   reads as an opener. `<#` is the exception in both directions - it really
+ *   does open a comment inside a string, so it is read before the literal state
+ *   is consulted, and a literal survives across the comment written into it.
  *
- * A line that ends inside a literal is read again with literals ignored, which
- * is how this read every line before they were tracked at all. Nothing was
- * lexed past the point the literal was left open - a string may legitimately be
- * open there, since an interpolation block spans lines - so the rest of the
- * line is trivia this cannot classify, and treating it as literal content is
- * what would let a `using` written in a trailing comment read as the line's own
- * statement.
+ * A line still inside a literal at its end is read again with literals ignored.
+ * Nothing could be lexed past the point the literal was left open - a string may
+ * legitimately be open there, since an interpolation block spans lines - so the
+ * rest of that line is trivia this cannot classify, and treating it as literal
+ * content is what would let a `using` written in a trailing comment read as the
+ * line's own statement.
  */
 function scanLine(line: string, depth: number): LineScan {
     return lexLine(line, depth, true) ?? lexLine(line, depth, false)!;
@@ -170,7 +170,6 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
             // closes at the quote it escapes and the rest of the line is read
             // as code.
             if (quote !== "" && line[i] === "\\") {
-                hasCode = true;
                 code += line.slice(i, i + 2);
                 i += 2;
                 continue;

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -103,15 +103,39 @@ interface LineScan {
  *   The rest of its line is comment text.
  * - A `#` line comment runs to the end of the line, so a `<#` inside one is
  *   text rather than an opener.
+ * - A bare `#` inside a string or char literal is content, so a line is lexed
+ *   far enough to tell the two apart. `<# ... #>` is the exception in both
+ *   directions: it really does open a comment inside a string, so the markers
+ *   are read before the literal state is consulted, and a literal survives
+ *   across the comment written into it.
  *
- * Inside a block comment nothing else is special: a `<#` in a string literal
- * really does open a comment in Verse, so no string tracking is needed.
+ * A line that ends inside a literal is read again with literals ignored, which
+ * is how this read every line before they were tracked at all. Nothing was
+ * lexed past the point the literal was left open - a string may legitimately be
+ * open there, since an interpolation block spans lines - so the rest of the
+ * line is trivia this cannot classify, and treating it as literal content is
+ * what would let a `using` written in a trailing comment read as the line's own
+ * statement.
  */
 function scanLine(line: string, depth: number): LineScan {
+    return lexLine(line, depth, true) ?? lexLine(line, depth, false)!;
+}
+
+/**
+ * One pass of scanLine, or null when literal tracking was asked for and the
+ * line ended inside a literal.
+ *
+ * @param trackLiterals false reads a `#` as a comment opener wherever it sits.
+ */
+function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan | null {
     let nesting = depth;
     let hasCode = false;
     let code = "";
     let i = 0;
+    // The quote that opened the literal being read, or "" outside one. Kept
+    // across the `nesting > 0` branch, because a block comment written inside a
+    // string does not end it: `"a<#c#>#b"` is the string `"a#b"`.
+    let quote = "";
 
     while (i < line.length) {
         if (nesting > 0) {
@@ -131,7 +155,7 @@ function scanLine(line: string, depth: number): LineScan {
             return { depth: nesting, hasCode, code, opensIndentedComment: true };
         }
 
-        if (line[i] === "#") {
+        if (line[i] === "#" && quote === "") {
             return { depth: nesting, hasCode, code, opensIndentedComment: false };
         }
 
@@ -141,6 +165,26 @@ function scanLine(line: string, depth: number): LineScan {
             continue;
         }
 
+        if (trackLiterals) {
+            // An escape and the character it escapes are one unit, or `"a\"b"`
+            // closes at the quote it escapes and the rest of the line is read
+            // as code.
+            if (quote !== "" && line[i] === "\\") {
+                hasCode = true;
+                code += line.slice(i, i + 2);
+                i += 2;
+                continue;
+            }
+
+            if (quote === "") {
+                if (line[i] === '"' || line[i] === "'") {
+                    quote = line[i];
+                }
+            } else if (line[i] === quote) {
+                quote = "";
+            }
+        }
+
         if (!/\s/.test(line[i])) {
             hasCode = true;
         }
@@ -148,7 +192,7 @@ function scanLine(line: string, depth: number): LineScan {
         i += 1;
     }
 
-    return { depth: nesting, hasCode, code, opensIndentedComment: false };
+    return quote === "" ? { depth: nesting, hasCode, code, opensIndentedComment: false } : null;
 }
 
 function indentWidth(line: string): number {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -282,6 +282,14 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A }", "", "<# note #> using { Economy.Shop }", "using { /A } <#> anchor", "    body", "code()"].join("\n"));
     });
 
+    // The same miss, made by a string literal rather than by comment trivia: a
+    // bare `#` inside one is content, so the `using` after it is live code the
+    // guard has to see.
+    it("keeps a duplicate when a using behind a string literal could resolve against it", () => {
+        const input = ['X := "a#b"; using { Economy.Shop }', "using { /A }", "using { /A } <#> anchor", "    body", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A }", "", 'X := "a#b"; using { Economy.Shop }', "using { /A } <#> anchor", "    body", "code()"].join("\n"));
+    });
+
     // scanModuleImports skips indented lines, so a module-body `using` is
     // invisible to it - a guard reading only the scanned imports would drop the
     // provider and leave this file with its consumer above it.

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -180,8 +180,8 @@ describe("allUsingPaths", () => {
 
     // A line may legitimately end inside a string, because an interpolation
     // block spans lines. Nothing can be lexed past that point, so such a line is
-    // read as it was before literals were tracked at all - which is what keeps a
-    // `using` named after its `#` the comment text it is.
+    // read with literals ignored - which is what keeps a `using` named after its
+    // `#` the comment text it is.
     it("does not read a using out of the trailing comment of a line whose literal never closes", () => {
         expect(allUsingPaths(['X := "ab{ # see using { /B }', "using { /A }"])).toEqual(["/A"]);
     });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -155,6 +155,36 @@ describe("allUsingPaths", () => {
     it("reports a using whose token a comment splits, rather than risking a miss", () => {
         expect(allUsingPaths(["us<# c #>ing { /B }", "using { /A }"])).toEqual(["/B", "/A"]);
     });
+
+    // A bare `#` inside a literal is content, not a comment opener: both
+    // `" # "` and `'#'` are literals the language's own test suite compiles.
+    // Ending the scan there hides every statement written after it on the line.
+    it("collects a using written after a string literal holding a #", () => {
+        expect(allUsingPaths(['X := "a#b"; using { Economy.Shop }', "using { /A }", "code()"])).toEqual(["Economy.Shop", "/A"]);
+    });
+
+    it("collects a using written after a char literal holding a #", () => {
+        expect(allUsingPaths(["C := '#'; using { Features }", "using { /A }"])).toEqual(["Features", "/A"]);
+    });
+
+    it("does not end a string literal at an escaped quote", () => {
+        expect(allUsingPaths(['X := "a\\"#b"; using { Economy.Shop }', "using { /A }"])).toEqual(["Economy.Shop", "/A"]);
+    });
+
+    // The other half of the rule, and the one that was already right: a
+    // `<# ... #>` written inside a string really is a comment there, since
+    // "abc<#def#>ghi" is the string "abcghi".
+    it("still reads a block comment written inside a string literal as a comment", () => {
+        expect(allUsingPaths(['X := "a<# using { /B } #>c"', "using { /A }"])).toEqual(["/A"]);
+    });
+
+    // A line may legitimately end inside a string, because an interpolation
+    // block spans lines. Nothing can be lexed past that point, so such a line is
+    // read as it was before literals were tracked at all - which is what keeps a
+    // `using` named after its `#` the comment text it is.
+    it("does not read a using out of the trailing comment of a line whose literal never closes", () => {
+        expect(allUsingPaths(['X := "ab{ # see using { /B }', "using { /A }"])).toEqual(["/A"]);
+    });
 });
 
 describe("scanModuleImports", () => {
@@ -692,6 +722,20 @@ describe("classifyLines", () => {
 
     it("does not mistake a block opener inside a line comment for one", () => {
         expect(kinds(["# see <# below", "code()"])).toEqual(["comment", "code"]);
+    });
+
+    it("keeps a # inside a string literal in the line's code", () => {
+        expect(classifyLines(['X := "a#b"; using { /A }'])[0].code).toBe('X := "a#b"; using { /A }');
+    });
+
+    it("keeps a # inside a char literal in the line's code", () => {
+        expect(classifyLines(["C := '#'; using { /A }"])[0].code).toBe("C := '#'; using { /A }");
+    });
+
+    // A block comment opened inside a string does not end the string:
+    // "a<#c#>#b" is the string "a#b", so the `#` after the `#>` is content too.
+    it("keeps a string open across a block comment written inside it", () => {
+        expect(classifyLines(['X := "a<#c#>#b"; using { /A }'])[0].code).toBe('X := "a#b"; using { /A }');
     });
 
     it("marks only the lines a block comment was opened above", () => {


### PR DESCRIPTION
Closes #272

`scanLine` ended its scan at any `#` outside a block comment, with no literal tracking, so a `#` written inside a string or char literal truncated the line and hid every statement after it. A live `using` behind one went uncounted, which can flip `withholdIsSafe` and let organize remove an import the hidden `using` was resolving against.

Literals are now tracked far enough to tell content from a comment opener:

- `<#` keeps first refusal, because a `<# ... #>` written inside a string really is a comment there (`"abc<#def#>ghi"` is `"abcghi"`), and the literal survives across it — `"a<#c#>#b"` is the string `"a#b"`.
- Backslash escapes are consumed, so `"a\"b#c"` and `'\''` do not close early.
- A line still inside a literal at its end is read again with literals ignored, which is byte-identical to the previous behaviour. A string may legitimately be open at end of line, since an interpolation block spans lines, and nothing can be lexed past that point — treating the remainder as literal content is what would let a `using` written in a trailing comment read as the line's own statement. This bounds the change to lines whose literals balance, so no input that behaves correctly today can regress.

Verified against the language's own suite in `verselang/book`: `assert{" {0o23} " = " # "}` (`Tests/Literals/String.versetest`), `option{'#'}` (`Tests/Literals/Char.versetest`), and `assert{"abc<#def#>ghi" = "abcghi"}` for the `<#` half.

## Known limit, unchanged by this PR

A quote inside a string's `{ ... }` interpolation ends the literal here, so `X := "a{F("#")}b"; using { /A }` still misses the `using`. That is the same miss narrowed rather than closed; `main` behaves identically, and interpolation-aware lexing is beyond what the ticket asks. Recorded in the function's doc comment.

## Tests

Seven new assertions, each proved to fail against the unfixed `scanLine` by stashing it:

```
  ● allUsingPaths › collects a using written after a char literal holding a #
  ● allUsingPaths › collects a using written after a string literal holding a #
  ● allUsingPaths › does not end a string literal at an escaped quote
  ● classifyLines › keeps a # inside a char literal in the line's code
  ● classifyLines › keeps a # inside a string literal in the line's code
  ● classifyLines › keeps a string open across a block comment written inside it
  ● ImportDocumentEditor.buildOrganizedContent › keeps a duplicate when a using behind a string literal could resolve against it
Tests:       7 failed, 265 passed, 272 total
```

Two further assertions pin the halves that were already right — a `<#` inside a string still opening a comment, and an unterminated literal keeping the old reading — and pass in both directions.

Review gate: PASS_WITH_SUGGESTIONS, 0 Critical, 0 Important, 5 Suggestions. Four were applied: the marker exception is narrowed to `<#` (the shipped grammar starts a block comment at `<#(?!>)`, so `<#>` is not one and its precedence inside a string is a separate question), the interpolation limit is documented, a redundant `hasCode` assignment in the escape branch is removed, and two comments explaining the fallback by reference to the previous implementation are rewritten as the constraint itself.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 29 passed, 29 total
Tests:       640 passed, 640 total
Snapshots:   0 total
Time:        7.731 s
Ran all test suites.
```

`npm run format:check`

```
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
