### PR TITLE
feat(visibility): declare a module public from its inaccessible-module error

### DIFF
--- a/changelog.d/61.added.md
+++ b/changelog.d/61.added.md
@@ -1,0 +1,1 @@
+**Module visibility**: a quick fix on the compiler's inaccessible-internal-module error declares the module `<public>`, editing an existing declaration where there is one and otherwise writing a definitions file at the Content root.

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
         "command": "verseAutoImports.showCacheStatus",
         "title": "Show Cache Status",
         "category": "Verse Auto Imports"
+      },
+      {
+        "command": "verseAutoImports.makeModulePublic",
+        "title": "Make Module Public",
+        "category": "Verse Auto Imports"
       }
     ],
     "menus": {
@@ -140,6 +145,10 @@
         },
         {
           "command": "verseAutoImports.convertAllToRelativePath",
+          "when": "false"
+        },
+        {
+          "command": "verseAutoImports.makeModulePublic",
           "when": "false"
         }
       ]
@@ -287,6 +296,12 @@
           "maximum": 10000,
           "description": "Milliseconds to wait before hiding CodeLens after cursor leaves import (only applies when visibility is 'hover')",
           "order": 32
+        },
+        "verseAutoImports.moduleVisibility.definitionsFileName": {
+          "type": "string",
+          "default": "definitions.verse",
+          "description": "Name of the file at the Content root that the 'Make Module Public' quick fix writes <public> module declarations into. Existing declarations elsewhere in the project are edited in place instead, whatever this is set to.",
+          "order": 35
         },
         "verseAutoImports.experimental.useDigestFiles": {
           "type": "boolean",

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -73,11 +73,12 @@ class EventEmitter<T> {
 }
 
 interface RecordedEditOperation {
-    kind: "insert" | "delete" | "replace";
+    kind: "insert" | "delete" | "replace" | "createFile";
     uri: unknown;
     position?: Position;
     range?: Range;
     text?: string;
+    options?: { overwrite?: boolean; ignoreIfExists?: boolean };
 }
 
 /** Records edit operations so tests can assert on them. */
@@ -94,6 +95,10 @@ class WorkspaceEdit {
 
     replace(uri: unknown, range: Range, text: string): void {
         this.operations.push({ kind: "replace", uri, range, text });
+    }
+
+    createFile(uri: unknown, options?: { overwrite?: boolean; ignoreIfExists?: boolean }): void {
+        this.operations.push({ kind: "createFile", uri, options });
     }
 
     /**
@@ -246,6 +251,14 @@ const workspace = {
     // undefined - which is how the environment snapshot tells the two apart.
     workspaceFile: undefined as { fsPath: string } | undefined,
     findFiles: jest.fn().mockResolvedValue([]),
+    // Rejecting is the "no such file" answer, which is what production code
+    // reads a missing file as. A resolving default would make an absent
+    // definitions file look like an empty existing one.
+    fs: {
+        readFile: jest.fn().mockRejectedValue(new Error("ENOENT")),
+        stat: jest.fn().mockRejectedValue(new Error("ENOENT")),
+        writeFile: jest.fn().mockResolvedValue(undefined),
+    },
     createFileSystemWatcher: jest.fn().mockImplementation((globPattern: unknown) => new FileSystemWatcher(globPattern)),
     // Empty by default so a test that only needs the scan to complete does not
     // have to stub it; tests that care about parse timing replace it.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -363,6 +363,13 @@ const EndOfLine = {
     CRLF: 2,
 };
 
+const FileType = {
+    Unknown: 0,
+    File: 1,
+    Directory: 2,
+    SymbolicLink: 64,
+};
+
 /**
  * A code action kind, as vscode.CodeActionKind models one: a dotted string
  * that append() extends. Only the value matters to the providers; nothing
@@ -407,6 +414,7 @@ export {
     ConfigurationTarget,
     ProgressLocation,
     EndOfLine,
+    FileType,
     Position,
     Range,
     TextEdit,

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -101,7 +101,7 @@ export class CommandsHandler {
      * diagnostic, which is why the command is hidden from the Command Palette.
      */
     async makeModulePublic(request: ModuleVisibilityRequest): Promise<void> {
-        logger.info("CommandsHandler", `Make module public command triggered for ${request?.targetPath}`);
+        logger.info("CommandsHandler", `Make module public command triggered for ${request.targetPath}`);
         await this.deps.moduleVisibilityWriter.makeModulePublic(request);
     }
 

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -3,6 +3,7 @@ import { logger } from "../utils";
 import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../imports";
 import { StatusBarHandler } from "../ui";
 import { ProjectPathCache } from "../services";
+import { ModuleVisibilityRequest, ModuleVisibilityWriter } from "../visibility";
 
 /** The collaborators the commands act on, wired once during activation. */
 export interface CommandsDependencies {
@@ -10,6 +11,7 @@ export interface CommandsDependencies {
     statusBarHandler: StatusBarHandler;
     importPathConverter: ImportPathConverter;
     importCodeLensProvider: ImportCodeLensProvider;
+    moduleVisibilityWriter: ModuleVisibilityWriter;
     /**
      * Absent when the cache setting is off, so the dependency is missing in
      * fact and not only in type. The commands that would build one refuse
@@ -72,6 +74,7 @@ export class CommandsHandler {
             ...this.debugCommands(),
             ...this.pathCacheCommands(),
             ...this.pathConversionCommands(),
+            ...this.moduleVisibilityCommands(),
         ];
 
         for (const [commandId, handler] of commands) {
@@ -84,6 +87,22 @@ export class CommandsHandler {
             ["verseAutoImports.addSingleImport", this.addSingleImport.bind(this)],
             ["verseAutoImports.optimizeImports", this.optimizeImports.bind(this)],
         ];
+    }
+
+    private moduleVisibilityCommands(): CommandEntry[] {
+        return [["verseAutoImports.makeModulePublic", this.makeModulePublic.bind(this)]];
+    }
+
+    /**
+     * Declares the module an import could not reach `<public>`, so the import
+     * compiles.
+     *
+     * The argument comes from the quick fix that parsed it out of the compiler
+     * diagnostic, which is why the command is hidden from the Command Palette.
+     */
+    async makeModulePublic(request: ModuleVisibilityRequest): Promise<void> {
+        logger.info("CommandsHandler", `Make module public command triggered for ${request?.targetPath}`);
+        await this.deps.moduleVisibilityWriter.makeModulePublic(request);
     }
 
     async addSingleImport(document: vscode.TextDocument, importStatement: string): Promise<void> {

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -63,6 +63,7 @@ const REGISTERED_COMMANDS: Array<[string, string]> = [
     ["verseAutoImports.convertAllToFullPath", "convertAllToFullPath"],
     ["verseAutoImports.convertToRelativePath", "convertToRelativePath"],
     ["verseAutoImports.convertAllToRelativePath", "convertAllToRelativePath"],
+    ["verseAutoImports.makeModulePublic", "makeModulePublic"],
 ];
 
 function registeredCommands(): Array<[string, string]> {

--- a/src/commands/__tests__/commandManifest.test.ts
+++ b/src/commands/__tests__/commandManifest.test.ts
@@ -1,11 +1,12 @@
 import * as fs from "fs";
 import * as path from "path";
 
-// Regression for #136: five commands need caller-supplied arguments - the quick
-// fix passes them to addSingleImport, the CodeLens passes them to the four
-// conversion commands. Without a commandPalette entry hiding them, every
-// declared command is palette-visible, and invoking one of these from the
-// palette dereferences an undefined document.
+// Regression for #136: six commands need caller-supplied arguments - the import
+// quick fix passes them to addSingleImport, the CodeLens passes them to the four
+// conversion commands, and the module-visibility quick fix passes the parsed
+// diagnostic to makeModulePublic. Without a commandPalette entry hiding them,
+// every declared command is palette-visible, and invoking one of these from the
+// palette dereferences an undefined argument.
 
 interface CommandContribution {
     command: string;
@@ -30,6 +31,7 @@ const ARGUMENT_REQUIRING_COMMANDS = [
     "verseAutoImports.convertAllToFullPath",
     "verseAutoImports.convertToRelativePath",
     "verseAutoImports.convertAllToRelativePath",
+    "verseAutoImports.makeModulePublic",
 ];
 
 const manifest: Manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json"), "utf8"));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { CommandsHandler, CommandsDependencies } from "./commands";
 import { StatusBarHandler } from "./ui";
 import { ProjectPathHandler } from "./project";
 import { AssetsDigestParser, ProjectPathCache } from "./services";
+import { ModuleVisibilityCodeActionProvider, ModuleVisibilityWriter } from "./visibility";
 
 /**
  * The project path cache toggle, and the default the two reads of it must
@@ -90,12 +91,14 @@ export function activate(context: vscode.ExtensionContext) {
     const diagnosticsHandler = new DiagnosticsHandler(outputChannel, importHandler, () => statusBarHandler.isSnoozeActive());
     const importPathConverter = new ImportPathConverter(outputChannel, projectPathCache);
     const importCodeLensProvider = new ImportCodeLensProvider(outputChannel);
+    const moduleVisibilityWriter = new ModuleVisibilityWriter(outputChannel, projectPathHandler);
 
     const commandsDeps: CommandsDependencies = {
         importHandler,
         statusBarHandler,
         importPathConverter,
         importCodeLensProvider,
+        moduleVisibilityWriter,
         projectPathCache,
     };
     const commandsHandler = new CommandsHandler(commandsDeps);
@@ -136,6 +139,7 @@ export function activate(context: vscode.ExtensionContext) {
     // the provider's own listeners and hide timers live after deactivation.
     context.subscriptions.push(
         vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ImportCodeActionProvider(outputChannel, importHandler)),
+        vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ModuleVisibilityCodeActionProvider()),
         vscode.languages.registerCodeLensProvider({ language: "verse" }, importCodeLensProvider),
         importCodeLensProvider,
     );

--- a/src/visibility/ModuleVisibilityCodeActionProvider.ts
+++ b/src/visibility/ModuleVisibilityCodeActionProvider.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+import { logger } from "../utils";
+import { parseModuleVisibilityMessage } from "./ModuleVisibilityMessage";
+
+/**
+ * Offers a quick fix on the compiler error a `<public>` module declaration
+ * fixes: an import that reaches an implicit folder module across project
+ * branches, which is internal by default.
+ *
+ * The action carries no edit of its own. Which files change depends on what
+ * the project already declares, which is a workspace scan, and a provider must
+ * answer fast enough for a lightbulb.
+ */
+export class ModuleVisibilityCodeActionProvider implements vscode.CodeActionProvider {
+    /**
+     * One action per diagnostic that names an inaccessible internal module, or
+     * undefined when none does.
+     */
+    provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext): vscode.CodeAction[] | undefined {
+        const actions: vscode.CodeAction[] = [];
+
+        for (const diagnostic of context.diagnostics) {
+            const request = parseModuleVisibilityMessage(diagnostic.message);
+            if (!request) {
+                continue;
+            }
+
+            logger.debug("ModuleVisibilityCodeActionProvider", `Offering visibility fix for ${request.targetPath}`);
+
+            const action = new vscode.CodeAction(`Make module '${request.moduleName}' public`, vscode.CodeActionKind.QuickFix);
+            action.kind = vscode.CodeActionKind.QuickFix.append("verse.moduleVisibility");
+            action.diagnostics = [diagnostic];
+            action.command = {
+                title: "Make Module Public",
+                command: "verseAutoImports.makeModulePublic",
+                arguments: [request],
+            };
+
+            actions.push(action);
+        }
+
+        return actions.length > 0 ? actions : undefined;
+    }
+}

--- a/src/visibility/ModuleVisibilityMessage.ts
+++ b/src/visibility/ModuleVisibilityMessage.ts
@@ -1,0 +1,69 @@
+/**
+ * Recognizes the one compiler message that a `<public>` module declaration
+ * fixes, and pulls the two Verse paths out of it. No VS Code dependencies.
+ */
+
+/**
+ * The help sentence the compiler appends only when the inaccessible definition
+ * is a module whose derived access level is internal. Every other shape of
+ * error 3593 - an inaccessible class, a private field, the "All references to
+ * `X` are inaccessible" sibling - lacks it, so matching this is what keeps the
+ * quick fix off diagnostics a `<public>` module part would not fix.
+ *
+ * Keyed on the tail rather than on the `<public>` token: the token is rendered
+ * backticked in some captures and bare in others, and which one a given UEFN
+ * build emits is not established.
+ */
+const INTERNAL_MODULE_HELP = /to make it accessible from other modules within your project/;
+
+/**
+ * The inaccessible module, written as a parenthesized parent path followed by
+ * the module's own name: "`(/Account@fortnite.com/Project/Gadgets:)Tools`".
+ */
+const TARGET_QUALIFIED = /`\((\/[^:)]+):\)([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)`/;
+
+/**
+ * The referencing scope: the second backticked path, introduced by "from".
+ * Its kind word varies (module, class, function), so the pattern does not
+ * pin it.
+ */
+const IMPORTER_PATH = /\bfrom\s+\w+\s+`(\/[^`]+)`/;
+
+/** An inaccessible-module diagnostic, reduced to the two paths that decide the fix. */
+export interface ModuleVisibilityRequest {
+    /** Absolute Verse path of the module that must become public. */
+    targetPath: string;
+
+    /** Absolute Verse path of the scope that failed to reach it. */
+    importerPath: string;
+
+    /** Final segment of `targetPath`, for the quick fix title. */
+    moduleName: string;
+}
+
+/**
+ * The request a compiler message describes, or null when the message is not an
+ * internal-module access error.
+ *
+ * Returning null is the common case by a wide margin: this runs against every
+ * diagnostic the editor reports.
+ */
+export function parseModuleVisibilityMessage(message: string): ModuleVisibilityRequest | null {
+    if (!INTERNAL_MODULE_HELP.test(message)) {
+        return null;
+    }
+
+    const target = message.match(TARGET_QUALIFIED);
+    const importer = message.match(IMPORTER_PATH);
+    if (!target || !importer) {
+        return null;
+    }
+
+    const [, parentPath, moduleName] = target;
+
+    return {
+        targetPath: `${parentPath}/${moduleName}`,
+        importerPath: importer[1],
+        moduleName,
+    };
+}

--- a/src/visibility/ModuleVisibilityMessage.ts
+++ b/src/visibility/ModuleVisibilityMessage.ts
@@ -18,7 +18,7 @@ const INTERNAL_MODULE_HELP = /to make it accessible from other modules within yo
 
 /**
  * The inaccessible module, written as a parenthesized parent path followed by
- * the module's own name: "`(/Account@fortnite.com/Project/Gadgets:)Tools`".
+ * the module's own name: "`(/vukefn@fortnite.com/MyGame/Gadgets:)Tools`".
  */
 const TARGET_QUALIFIED = /`\((\/[^:)]+):\)([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)`/;
 

--- a/src/visibility/ModuleVisibilityPlanner.ts
+++ b/src/visibility/ModuleVisibilityPlanner.ts
@@ -1,0 +1,88 @@
+/**
+ * Decides which modules on a target's path have to be declared `<public>` for
+ * one importer to reach it. No VS Code dependencies.
+ */
+
+/** One segment of the target path, and whether it has to carry `<public>`. */
+export interface VisibilitySegment {
+    /** The module's own name. */
+    name: string;
+
+    /**
+     * Whether this segment must be declared `<public>`. A false segment is
+     * written only as the nesting a deeper declaration needs, and carries no
+     * specifier of its own.
+     */
+    needsPublic: boolean;
+}
+
+/** The split of a target's path into the part already reachable and the part that is not. */
+export interface VisibilityPlan {
+    /** Content-relative segments the importer already reaches, outermost first. */
+    prefix: string[];
+
+    /** The segments below that, in root-to-target order. */
+    segments: VisibilitySegment[];
+}
+
+/**
+ * The Content-relative segments of a Verse path, or null when the path does not
+ * sit under the project.
+ *
+ * @param versePath absolute, e.g. "/vukefn@fortnite.com/MyGame/Gadgets/Tools"
+ * @param projectVersePath the project prefix exactly as UEFN wrote it, without a trailing slash
+ */
+export function toContentSegments(versePath: string, projectVersePath: string): string[] | null {
+    const path = splitPath(versePath);
+    const project = splitPath(projectVersePath);
+
+    if (path.length < project.length) {
+        return null;
+    }
+    for (let i = 0; i < project.length; i++) {
+        if (path[i] !== project[i]) {
+            return null;
+        }
+    }
+
+    return path.slice(project.length);
+}
+
+/**
+ * Which of the target's modules must become public for the importer to reach
+ * it, given both paths relative to the Content root.
+ *
+ * `<internal>` grants access to the module a definition lives in and to every
+ * child of that module. So a segment is reachable exactly when the importer
+ * sits at or under the segment's PARENT. Walking the target path down from the
+ * common prefix: the first divergent segment's parent is the common ancestor,
+ * which the importer is under by construction, so that segment is already
+ * reachable - only the ones below it are not. Marking it anyway compiles, but
+ * publishes a module the importer never needed.
+ *
+ * `segments` is empty when the importer already sits inside the target's own
+ * branch, which is a pair the compiler cannot have raised this error for.
+ */
+export function planVisibility(targetSegments: readonly string[], importerSegments: readonly string[]): VisibilityPlan {
+    let common = 0;
+    while (common < targetSegments.length && common < importerSegments.length && targetSegments[common] === importerSegments[common]) {
+        common++;
+    }
+
+    if (common >= targetSegments.length) {
+        return { prefix: [...targetSegments], segments: [] };
+    }
+
+    return {
+        prefix: targetSegments.slice(0, common),
+        segments: targetSegments.slice(common).map((name, index) => ({
+            name,
+            needsPublic: index > 0,
+        })),
+    };
+}
+
+/** Path segments with the leading slash and any empty segments dropped. */
+function splitPath(path: string): string[] {
+    return path.split("/").filter((segment) => segment.length > 0);
+}

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -94,7 +94,7 @@ export class ModuleVisibilityWriter {
 
         const definitionsUri = this.definitionsUri(contentRoot);
         if (!definitionsUri) {
-            return { reason: "the configured definitions file name is not a plain file name." };
+            return { reason: "verseAutoImports.moduleVisibility.definitionsFileName must be a plain file name ending in .verse." };
         }
         const definitionsKey = definitionsUri.toString();
 
@@ -179,15 +179,17 @@ export class ModuleVisibilityWriter {
      * The configured definitions file, at the Content root, or null when the
      * setting does not name one.
      *
-     * The setting is a file NAME, so a value carrying a separator is refused
-     * rather than resolved: `Uri.joinPath` would happily place the file in
-     * another directory, or outside Content entirely, and an empty value would
-     * address the Content directory itself.
+     * The setting is a file NAME, so anything carrying a path is refused rather
+     * than resolved: `Uri.joinPath` would place the file in another directory,
+     * or outside Content entirely, and an empty value would address the Content
+     * directory itself. The `.verse` suffix is required because a file the
+     * compiler does not read would leave the error standing while the quick fix
+     * reported success.
      */
     private definitionsUri(contentRoot: vscode.Uri): vscode.Uri | null {
         const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "definitions.verse").trim();
 
-        if (fileName.length === 0 || /[\\/]/.test(fileName) || fileName === "." || fileName === "..") {
+        if (!/^[^\\/:*?"<>|]+\.verse$/.test(fileName)) {
             return null;
         }
 

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -93,6 +93,9 @@ export class ModuleVisibilityWriter {
         }
 
         const definitionsUri = this.definitionsUri(contentRoot);
+        if (!definitionsUri) {
+            return { reason: "the configured definitions file name is not a plain file name." };
+        }
         const definitionsKey = definitionsUri.toString();
 
         // Every module on the path is looked up, the reachable prefix included:
@@ -148,10 +151,11 @@ export class ModuleVisibilityWriter {
                 continue;
             }
 
-            if (specifierEdit.span) {
-                edit.replace(file.uri, new vscode.Range(positionAt(file.text, specifierEdit.span.start), positionAt(file.text, specifierEdit.span.end)), specifierEdit.text);
+            const { start, end } = specifierEdit.span;
+            if (start === end) {
+                edit.insert(file.uri, positionAt(file.text, start), specifierEdit.text);
             } else {
-                edit.insert(file.uri, positionAt(file.text, specifierEdit.offset), specifierEdit.text);
+                edit.replace(file.uri, new vscode.Range(positionAt(file.text, start), positionAt(file.text, end)), specifierEdit.text);
             }
         }
     }
@@ -171,9 +175,22 @@ export class ModuleVisibilityWriter {
         }
     }
 
-    /** The configured definitions file, at the Content root. */
-    private definitionsUri(contentRoot: vscode.Uri): vscode.Uri {
-        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "definitions.verse");
+    /**
+     * The configured definitions file, at the Content root, or null when the
+     * setting does not name one.
+     *
+     * The setting is a file NAME, so a value carrying a separator is refused
+     * rather than resolved: `Uri.joinPath` would happily place the file in
+     * another directory, or outside Content entirely, and an empty value would
+     * address the Content directory itself.
+     */
+    private definitionsUri(contentRoot: vscode.Uri): vscode.Uri | null {
+        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "definitions.verse").trim();
+
+        if (fileName.length === 0 || /[\\/]/.test(fileName) || fileName === "." || fileName === "..") {
+            return null;
+        }
+
         return vscode.Uri.joinPath(contentRoot, fileName);
     }
 
@@ -208,7 +225,9 @@ export class ModuleVisibilityWriter {
      * rather than what is currently on disk.
      *
      * @param definitionsKey the definitions file, whose text is kept even when
-     * it declares nothing, because the caller appends to it
+     * it declares none of these modules, because the caller appends to it. A
+     * file holding no module declaration at all is skipped before that, and
+     * reaches the caller through readDefinitions instead.
      */
     private async findDeclarations(
         workspaceFolder: vscode.WorkspaceFolder,
@@ -309,13 +328,7 @@ export class ModuleVisibilityWriter {
 
 /** The text with every specifier rewrite applied, taken last-first so earlier offsets stay valid. */
 function applySpecifierEdits(text: string, edits: readonly SpecifierEdit[]): string {
-    const ordered = [...edits].sort((a, b) => (b.span?.start ?? b.offset) - (a.span?.start ?? a.offset));
-
-    return ordered.reduce((current, edit) => {
-        const start = edit.span?.start ?? edit.offset;
-        const end = edit.span?.end ?? edit.offset;
-        return current.slice(0, start) + edit.text + current.slice(end);
-    }, text);
+    return [...edits].sort((a, b) => b.span.start - a.span.start).reduce((current, edit) => current.slice(0, edit.span.start) + edit.text + current.slice(edit.span.end), text);
 }
 
 /** The position an offset falls at in the text the offset was taken from. */

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -17,6 +17,12 @@ const SCAN_CONCURRENCY = 8;
 /** Why an attempt to publicize a module produced no edit. */
 type Refusal = { reason: string };
 
+/** A scanned file, and the exact text every offset taken from it addresses. */
+interface ScannedFile {
+    uri: vscode.Uri;
+    text: string;
+}
+
 /**
  * Applies the `<public>` declarations that make an internal module reachable.
  *
@@ -81,10 +87,18 @@ export class ModuleVisibilityWriter {
             return { reason: `'${request.moduleName}' is already reachable from the importing module.` };
         }
 
-        const { declarations, files } = await this.findDeclarations(
-            workspaceFolder,
-            segments.map((segment) => segment.name),
-        );
+        const contentRoot = await this.findContentRoot(workspaceFolder);
+        if (!contentRoot) {
+            return { reason: `no '${CONTENT_FOLDER}' folder was found in the workspace, so there is nowhere to declare the module.` };
+        }
+
+        const definitionsUri = this.definitionsUri(contentRoot);
+        const definitionsKey = definitionsUri.toString();
+
+        // Every module on the path is looked up, the reachable prefix included:
+        // the chain written into the definitions file has to nest through them,
+        // and a part it writes must repeat whatever they already declare.
+        const { declarations, scanned } = await this.findDeclarations(workspaceFolder, [...prefix, ...segments.map((segment) => segment.name)], definitionsKey);
         const resolved = resolveVisibility(prefix, segments, declarations);
 
         if (resolved.conflicts.length > 0) {
@@ -97,138 +111,165 @@ export class ModuleVisibilityWriter {
         }
 
         const edit = new vscode.WorkspaceEdit();
-        await this.addSpecifierEdits(edit, resolved.edits, files);
 
-        let wroteDefinitions = false;
+        // A specifier edit inside the definitions file would overlap the
+        // whole-file replace below, which VS Code rejects, so it is folded into
+        // that replacement's text instead of being applied separately.
+        const inDefinitions = resolved.chain.length > 0 ? resolved.edits.filter((specifierEdit) => specifierEdit.file === definitionsKey) : [];
+        const elsewhere = resolved.edits.filter((specifierEdit) => !inDefinitions.includes(specifierEdit));
+
+        this.addSpecifierEdits(edit, elsewhere, scanned);
+
         if (resolved.chain.length > 0) {
-            wroteDefinitions = await this.addDefinitionsEdit(edit, workspaceFolder, buildDeclarationBlock(resolved.chain));
-            if (!wroteDefinitions) {
+            const existing = scanned.get(definitionsKey)?.text ?? (await this.readDefinitions(definitionsUri));
+            if (existing === undefined) {
                 return { reason: "the definitions file could not be read." };
             }
+
+            const withEdits = applySpecifierEdits(existing, inDefinitions);
+            const content = appendDeclarationBlock(withEdits, buildDeclarationBlock(resolved.chain));
+
+            if (existing.length === 0 && !scanned.has(definitionsKey)) {
+                edit.createFile(definitionsUri, { ignoreIfExists: true });
+                edit.insert(definitionsUri, new vscode.Position(0, 0), content);
+            } else {
+                edit.replace(definitionsUri, new vscode.Range(new vscode.Position(0, 0), positionAt(existing, existing.length)), content);
+            }
         }
 
-        return { edit, summary: this.summarize(request.moduleName, resolved.edits.length, wroteDefinitions) };
+        return { edit, summary: this.summarize(request.moduleName, resolved.edits, resolved.chain.length > 0) };
     }
 
-    /** Adds one specifier rewrite per existing declaration, resolving each file's offsets to positions. */
-    private async addSpecifierEdits(edit: vscode.WorkspaceEdit, specifierEdits: readonly SpecifierEdit[], files: ReadonlyMap<string, vscode.Uri>): Promise<void> {
-        const byFile = new Map<string, SpecifierEdit[]>();
+    /** Adds one specifier rewrite per existing declaration, resolving offsets against the text they came from. */
+    private addSpecifierEdits(edit: vscode.WorkspaceEdit, specifierEdits: readonly SpecifierEdit[], scanned: ReadonlyMap<string, ScannedFile>): void {
         for (const specifierEdit of specifierEdits) {
-            const existing = byFile.get(specifierEdit.file);
-            if (existing) {
-                existing.push(specifierEdit);
-            } else {
-                byFile.set(specifierEdit.file, [specifierEdit]);
-            }
-        }
-
-        for (const [file, fileEdits] of byFile) {
-            const uri = files.get(file);
-            if (!uri) {
+            const file = scanned.get(specifierEdit.file);
+            if (!file) {
                 continue;
             }
-            const document = await vscode.workspace.openTextDocument(uri);
 
-            for (const fileEdit of fileEdits) {
-                if (fileEdit.span) {
-                    edit.replace(uri, new vscode.Range(document.positionAt(fileEdit.span.start), document.positionAt(fileEdit.span.end)), fileEdit.text);
-                } else {
-                    edit.insert(uri, document.positionAt(fileEdit.offset), fileEdit.text);
-                }
+            if (specifierEdit.span) {
+                edit.replace(file.uri, new vscode.Range(positionAt(file.text, specifierEdit.span.start), positionAt(file.text, specifierEdit.span.end)), specifierEdit.text);
+            } else {
+                edit.insert(file.uri, positionAt(file.text, specifierEdit.offset), specifierEdit.text);
             }
         }
+    }
+
+    /** The Content folder the project's modules hang off, or null when the workspace has none. */
+    private async findContentRoot(workspaceFolder: vscode.WorkspaceFolder): Promise<vscode.Uri | null> {
+        if (path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER) {
+            return workspaceFolder.uri;
+        }
+
+        const candidate = vscode.Uri.joinPath(workspaceFolder.uri, CONTENT_FOLDER);
+        try {
+            const stat = await vscode.workspace.fs.stat(candidate);
+            return stat.type === vscode.FileType.Directory ? candidate : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /** The configured definitions file, at the Content root. */
+    private definitionsUri(contentRoot: vscode.Uri): vscode.Uri {
+        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "definitions.verse");
+        return vscode.Uri.joinPath(contentRoot, fileName);
     }
 
     /**
-     * Adds the definitions-file write, creating the file when it does not exist
-     * yet. False when an existing file could not be read, which must not be
-     * treated as an empty one - that would discard whatever it holds.
+     * The definitions file's text, "" when it does not exist, or undefined when
+     * it exists but could not be read - which must not be treated as empty,
+     * since that would discard whatever it holds.
      */
-    private async addDefinitionsEdit(edit: vscode.WorkspaceEdit, workspaceFolder: vscode.WorkspaceFolder, block: string): Promise<boolean> {
-        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "definitions.verse");
-        const contentRoot = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER ? workspaceFolder.uri : vscode.Uri.joinPath(workspaceFolder.uri, CONTENT_FOLDER);
-        const uri = vscode.Uri.joinPath(contentRoot, fileName);
-
-        const existing = await vscode.workspace.fs.readFile(uri).then(
-            (buffer) => Buffer.from(buffer).toString("utf8"),
-            () => null,
-        );
-
-        if (existing === null) {
-            edit.createFile(uri, { ignoreIfExists: true });
-            edit.insert(uri, new vscode.Position(0, 0), appendDeclarationBlock("", block));
-            return true;
+    private async readDefinitions(uri: vscode.Uri): Promise<string | undefined> {
+        try {
+            await vscode.workspace.fs.stat(uri);
+        } catch {
+            return "";
         }
 
-        const document = await vscode.workspace.openTextDocument(uri).then(
-            (opened) => opened,
-            () => null,
-        );
-        if (!document) {
-            return false;
+        try {
+            return (await vscode.workspace.openTextDocument(uri)).getText();
+        } catch {
+            return undefined;
         }
-
-        edit.replace(uri, new vscode.Range(new vscode.Position(0, 0), document.positionAt(document.getText().length)), appendDeclarationBlock(existing, block));
-        return true;
     }
 
     /**
      * Every explicit declaration of any of these module names in the project,
-     * bound to its Content-relative path.
+     * bound to its Content-relative path, with the text each was read from.
      *
      * The whole project is read rather than a capped sample: a declaration
      * missed here becomes a second, possibly conflicting part written into the
      * definitions file, which is a compile error rather than a worse
-     * suggestion.
+     * suggestion. Text comes from openTextDocument, as ProjectPathScanner's
+     * does, so an offset addresses the buffer the edit will be applied to
+     * rather than what is currently on disk.
+     *
+     * @param definitionsKey the definitions file, whose text is kept even when
+     * it declares nothing, because the caller appends to it
      */
-    private async findDeclarations(workspaceFolder: vscode.WorkspaceFolder, names: readonly string[]): Promise<{ declarations: FoundDeclaration[]; files: Map<string, vscode.Uri> }> {
+    private async findDeclarations(
+        workspaceFolder: vscode.WorkspaceFolder,
+        names: readonly string[],
+        definitionsKey: string,
+    ): Promise<{ declarations: FoundDeclaration[]; scanned: Map<string, ScannedFile> }> {
         const workspaceIsContent = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER;
         const searchPattern = workspaceIsContent ? "**/*.verse" : `${CONTENT_FOLDER}/**/*.verse`;
         const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, searchPattern), "**/*.digest.verse");
         const wanted = new Set(names);
         const declarations: FoundDeclaration[] = [];
-        const files = new Map<string, vscode.Uri>();
+        const scanned = new Map<string, ScannedFile>();
 
         for (let i = 0; i < verseFiles.length; i += SCAN_CONCURRENCY) {
             const batch = await Promise.all(verseFiles.slice(i, i + SCAN_CONCURRENCY).map((file) => this.readDeclarations(file, workspaceFolder, workspaceIsContent, wanted)));
-            for (const [index, fileDeclarations] of batch.entries()) {
-                if (fileDeclarations.length > 0) {
-                    const file = verseFiles[i + index];
-                    files.set(file.toString(), file);
-                    declarations.push(...fileDeclarations);
+            for (const result of batch) {
+                if (!result) {
+                    continue;
+                }
+                const key = result.file.uri.toString();
+                if (result.declarations.length > 0 || key === definitionsKey) {
+                    scanned.set(key, result.file);
+                    declarations.push(...result.declarations);
                 }
             }
         }
 
         logger.debug("ModuleVisibilityWriter", `Scanned ${verseFiles.length} file(s), found ${declarations.length} matching declaration(s)`);
-        return { declarations, files };
+        return { declarations, scanned };
     }
 
-    /** The wanted declarations in one file, or none when it cannot be read or sits outside Content. */
-    private async readDeclarations(file: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, workspaceIsContent: boolean, wanted: ReadonlySet<string>): Promise<FoundDeclaration[]> {
-        const content = await vscode.workspace.fs.readFile(file).then(
-            (buffer) => Buffer.from(buffer).toString("utf8"),
-            () => null,
-        );
-
-        if (!content || !content.includes("module")) {
-            return [];
+    /** The wanted declarations in one file, or null when it holds none, cannot be read, or sits outside Content. */
+    private async readDeclarations(
+        uri: vscode.Uri,
+        workspaceFolder: vscode.WorkspaceFolder,
+        workspaceIsContent: boolean,
+        wanted: ReadonlySet<string>,
+    ): Promise<{ file: ScannedFile; declarations: FoundDeclaration[] } | null> {
+        const directory = this.contentRelativeDirectory(uri, workspaceFolder, workspaceIsContent);
+        if (directory === null) {
+            return null;
         }
 
-        const directory = this.contentRelativeDirectory(file, workspaceFolder, workspaceIsContent);
-        if (directory === null) {
-            return [];
+        const text = await vscode.workspace.openTextDocument(uri).then(
+            (document) => document.getText(),
+            () => null,
+        );
+        if (text === null || !text.includes("module")) {
+            return null;
         }
 
         const prefix = directory.length > 0 ? directory.split("/") : [];
-
-        return findExplicitModuleDeclarations(content)
+        const declarations = findExplicitModuleDeclarations(text)
             .filter((declaration) => wanted.has(declaration.name))
             .map((declaration) => ({
                 path: [...prefix, ...declaration.chain].join("/"),
-                file: file.toString(),
+                file: uri.toString(),
                 declaration,
             }));
+
+        return { file: { uri, text }, declarations };
     }
 
     /**
@@ -237,7 +278,7 @@ export class ModuleVisibilityWriter {
      * ImportPathConverter's declaration scan.
      */
     private contentRelativeDirectory(file: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, workspaceIsContent: boolean): string | null {
-        let directory = path.dirname(path.relative(workspaceFolder.uri.fsPath, file.fsPath)).replace(/\\/g, "/");
+        const directory = path.dirname(path.relative(workspaceFolder.uri.fsPath, file.fsPath)).replace(/\\/g, "/");
 
         if (workspaceIsContent) {
             return directory === "" || directory === "." ? "" : directory;
@@ -247,20 +288,38 @@ export class ModuleVisibilityWriter {
             return "";
         }
         if (directory.startsWith(`${CONTENT_FOLDER}/`)) {
-            directory = directory.substring(CONTENT_FOLDER.length + 1);
-            return directory;
+            return directory.substring(CONTENT_FOLDER.length + 1);
         }
         return null;
     }
 
-    /** What the user is told happened, which differs by whether an existing declaration was edited. */
-    private summarize(moduleName: string, editCount: number, wroteDefinitions: boolean): string {
-        if (editCount > 0 && wroteDefinitions) {
-            return `made '${moduleName}' public: updated ${editCount} existing declaration(s) and wrote the definitions file.`;
+    /** What the user is told happened, naming the declarations that were rewritten. */
+    private summarize(moduleName: string, edits: readonly SpecifierEdit[], wroteDefinitions: boolean): string {
+        const rewritten = [...new Set(edits.map((edit) => edit.path))];
+
+        if (rewritten.length > 0 && wroteDefinitions) {
+            return `made '${moduleName}' public: declared ${rewritten.join(", ")} public in place and wrote the definitions file.`;
         }
-        if (editCount > 0) {
-            return `made '${moduleName}' public by updating ${editCount} existing declaration(s).`;
+        if (rewritten.length > 0) {
+            return `made '${moduleName}' public by declaring ${rewritten.join(", ")} public in place.`;
         }
         return `made '${moduleName}' public in the definitions file.`;
     }
+}
+
+/** The text with every specifier rewrite applied, taken last-first so earlier offsets stay valid. */
+function applySpecifierEdits(text: string, edits: readonly SpecifierEdit[]): string {
+    const ordered = [...edits].sort((a, b) => (b.span?.start ?? b.offset) - (a.span?.start ?? a.offset));
+
+    return ordered.reduce((current, edit) => {
+        const start = edit.span?.start ?? edit.offset;
+        const end = edit.span?.end ?? edit.offset;
+        return current.slice(0, start) + edit.text + current.slice(end);
+    }, text);
+}
+
+/** The position an offset falls at in the text the offset was taken from. */
+function positionAt(text: string, offset: number): vscode.Position {
+    const before = text.slice(0, offset).split("\n");
+    return new vscode.Position(before.length - 1, before[before.length - 1].length);
 }

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -1,0 +1,266 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { logger } from "../utils";
+import { ProjectPathHandler } from "../project";
+import { appendDeclarationBlock, buildDeclarationBlock } from "./definitionsContent";
+import { findExplicitModuleDeclarations } from "./moduleDeclarations";
+import { ModuleVisibilityRequest } from "./ModuleVisibilityMessage";
+import { planVisibility, toContentSegments } from "./ModuleVisibilityPlanner";
+import { FoundDeclaration, resolveVisibility, SpecifierEdit } from "./visibilityResolution";
+
+/** The Content folder that anchors every module path, as in ImportPathConverter. */
+const CONTENT_FOLDER = "Content";
+
+/** Files read at a time while scanning for existing declarations, as in ProjectPathScanner. */
+const SCAN_CONCURRENCY = 8;
+
+/** Why an attempt to publicize a module produced no edit. */
+type Refusal = { reason: string };
+
+/**
+ * Applies the `<public>` declarations that make an internal module reachable.
+ *
+ * The whole project is scanned before anything is written, because a second
+ * explicit part of a module that disagrees with the first is a compile error
+ * rather than a no-op - see resolveVisibility for the two rules that avoid it.
+ */
+export class ModuleVisibilityWriter {
+    constructor(
+        private readonly outputChannel: vscode.OutputChannel,
+        private readonly projectPathHandler: ProjectPathHandler,
+    ) {}
+
+    /**
+     * Makes the requested module reachable from the importing scope, and
+     * reports what it did.
+     *
+     * Refuses rather than half-applying: a module already narrowed to
+     * `<private>`, `<protected>` or `<scoped>` is left alone, and so is
+     * everything else the same request would have changed.
+     */
+    async makeModulePublic(request: ModuleVisibilityRequest): Promise<void> {
+        const outcome = await this.buildEdit(request);
+
+        if ("reason" in outcome) {
+            logger.warn("ModuleVisibilityWriter", `Cannot publicize ${request.targetPath}: ${outcome.reason}`);
+            vscode.window.showWarningMessage(`Verse Auto Imports: ${outcome.reason}`);
+            return;
+        }
+
+        const applied = await vscode.workspace.applyEdit(outcome.edit);
+        if (!applied) {
+            logger.warn("ModuleVisibilityWriter", `Edit rejected for ${request.targetPath}`);
+            vscode.window.showWarningMessage(`Verse Auto Imports: could not write the module visibility change for '${request.moduleName}'.`);
+            return;
+        }
+
+        logger.info("ModuleVisibilityWriter", `Made ${request.targetPath} public`, { summary: outcome.summary });
+        vscode.window.showInformationMessage(`Verse Auto Imports: ${outcome.summary}`);
+    }
+
+    /** The single edit that satisfies a request, or why there is none. */
+    private async buildEdit(request: ModuleVisibilityRequest): Promise<{ edit: vscode.WorkspaceEdit; summary: string } | Refusal> {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return { reason: "no workspace folder is open." };
+        }
+
+        const projectVersePath = await this.projectPathHandler.getProjectVersePath();
+        if (!projectVersePath) {
+            return { reason: "no .uefnproject file was found, so module paths cannot be resolved." };
+        }
+
+        const targetSegments = toContentSegments(request.targetPath, projectVersePath);
+        const importerSegments = toContentSegments(request.importerPath, projectVersePath);
+        if (!targetSegments || !importerSegments) {
+            return { reason: `'${request.targetPath}' is outside the project '${projectVersePath}'.` };
+        }
+
+        const { prefix, segments } = planVisibility(targetSegments, importerSegments);
+        if (segments.length === 0) {
+            return { reason: `'${request.moduleName}' is already reachable from the importing module.` };
+        }
+
+        const { declarations, files } = await this.findDeclarations(
+            workspaceFolder,
+            segments.map((segment) => segment.name),
+        );
+        const resolved = resolveVisibility(prefix, segments, declarations);
+
+        if (resolved.conflicts.length > 0) {
+            const listed = resolved.conflicts.map((conflict) => `${conflict.path} is <${conflict.keyword}>`).join(", ");
+            return { reason: `making '${request.moduleName}' public would widen a deliberate restriction: ${listed}. Change it by hand if that is intended.` };
+        }
+
+        if (resolved.edits.length === 0 && resolved.chain.length === 0) {
+            return { reason: `'${request.moduleName}' is already declared public.` };
+        }
+
+        const edit = new vscode.WorkspaceEdit();
+        await this.addSpecifierEdits(edit, resolved.edits, files);
+
+        let wroteDefinitions = false;
+        if (resolved.chain.length > 0) {
+            wroteDefinitions = await this.addDefinitionsEdit(edit, workspaceFolder, buildDeclarationBlock(resolved.chain));
+            if (!wroteDefinitions) {
+                return { reason: "the definitions file could not be read." };
+            }
+        }
+
+        return { edit, summary: this.summarize(request.moduleName, resolved.edits.length, wroteDefinitions) };
+    }
+
+    /** Adds one specifier rewrite per existing declaration, resolving each file's offsets to positions. */
+    private async addSpecifierEdits(edit: vscode.WorkspaceEdit, specifierEdits: readonly SpecifierEdit[], files: ReadonlyMap<string, vscode.Uri>): Promise<void> {
+        const byFile = new Map<string, SpecifierEdit[]>();
+        for (const specifierEdit of specifierEdits) {
+            const existing = byFile.get(specifierEdit.file);
+            if (existing) {
+                existing.push(specifierEdit);
+            } else {
+                byFile.set(specifierEdit.file, [specifierEdit]);
+            }
+        }
+
+        for (const [file, fileEdits] of byFile) {
+            const uri = files.get(file);
+            if (!uri) {
+                continue;
+            }
+            const document = await vscode.workspace.openTextDocument(uri);
+
+            for (const fileEdit of fileEdits) {
+                if (fileEdit.span) {
+                    edit.replace(uri, new vscode.Range(document.positionAt(fileEdit.span.start), document.positionAt(fileEdit.span.end)), fileEdit.text);
+                } else {
+                    edit.insert(uri, document.positionAt(fileEdit.offset), fileEdit.text);
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds the definitions-file write, creating the file when it does not exist
+     * yet. False when an existing file could not be read, which must not be
+     * treated as an empty one - that would discard whatever it holds.
+     */
+    private async addDefinitionsEdit(edit: vscode.WorkspaceEdit, workspaceFolder: vscode.WorkspaceFolder, block: string): Promise<boolean> {
+        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "definitions.verse");
+        const contentRoot = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER ? workspaceFolder.uri : vscode.Uri.joinPath(workspaceFolder.uri, CONTENT_FOLDER);
+        const uri = vscode.Uri.joinPath(contentRoot, fileName);
+
+        const existing = await vscode.workspace.fs.readFile(uri).then(
+            (buffer) => Buffer.from(buffer).toString("utf8"),
+            () => null,
+        );
+
+        if (existing === null) {
+            edit.createFile(uri, { ignoreIfExists: true });
+            edit.insert(uri, new vscode.Position(0, 0), appendDeclarationBlock("", block));
+            return true;
+        }
+
+        const document = await vscode.workspace.openTextDocument(uri).then(
+            (opened) => opened,
+            () => null,
+        );
+        if (!document) {
+            return false;
+        }
+
+        edit.replace(uri, new vscode.Range(new vscode.Position(0, 0), document.positionAt(document.getText().length)), appendDeclarationBlock(existing, block));
+        return true;
+    }
+
+    /**
+     * Every explicit declaration of any of these module names in the project,
+     * bound to its Content-relative path.
+     *
+     * The whole project is read rather than a capped sample: a declaration
+     * missed here becomes a second, possibly conflicting part written into the
+     * definitions file, which is a compile error rather than a worse
+     * suggestion.
+     */
+    private async findDeclarations(workspaceFolder: vscode.WorkspaceFolder, names: readonly string[]): Promise<{ declarations: FoundDeclaration[]; files: Map<string, vscode.Uri> }> {
+        const workspaceIsContent = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER;
+        const searchPattern = workspaceIsContent ? "**/*.verse" : `${CONTENT_FOLDER}/**/*.verse`;
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, searchPattern), "**/*.digest.verse");
+        const wanted = new Set(names);
+        const declarations: FoundDeclaration[] = [];
+        const files = new Map<string, vscode.Uri>();
+
+        for (let i = 0; i < verseFiles.length; i += SCAN_CONCURRENCY) {
+            const batch = await Promise.all(verseFiles.slice(i, i + SCAN_CONCURRENCY).map((file) => this.readDeclarations(file, workspaceFolder, workspaceIsContent, wanted)));
+            for (const [index, fileDeclarations] of batch.entries()) {
+                if (fileDeclarations.length > 0) {
+                    const file = verseFiles[i + index];
+                    files.set(file.toString(), file);
+                    declarations.push(...fileDeclarations);
+                }
+            }
+        }
+
+        logger.debug("ModuleVisibilityWriter", `Scanned ${verseFiles.length} file(s), found ${declarations.length} matching declaration(s)`);
+        return { declarations, files };
+    }
+
+    /** The wanted declarations in one file, or none when it cannot be read or sits outside Content. */
+    private async readDeclarations(file: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, workspaceIsContent: boolean, wanted: ReadonlySet<string>): Promise<FoundDeclaration[]> {
+        const content = await vscode.workspace.fs.readFile(file).then(
+            (buffer) => Buffer.from(buffer).toString("utf8"),
+            () => null,
+        );
+
+        if (!content || !content.includes("module")) {
+            return [];
+        }
+
+        const directory = this.contentRelativeDirectory(file, workspaceFolder, workspaceIsContent);
+        if (directory === null) {
+            return [];
+        }
+
+        const prefix = directory.length > 0 ? directory.split("/") : [];
+
+        return findExplicitModuleDeclarations(content)
+            .filter((declaration) => wanted.has(declaration.name))
+            .map((declaration) => ({
+                path: [...prefix, ...declaration.chain].join("/"),
+                file: file.toString(),
+                declaration,
+            }));
+    }
+
+    /**
+     * A file's directory relative to the Content root, "" at the root itself,
+     * or null when the file sits outside Content. Mirrors the normalization in
+     * ImportPathConverter's declaration scan.
+     */
+    private contentRelativeDirectory(file: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, workspaceIsContent: boolean): string | null {
+        let directory = path.dirname(path.relative(workspaceFolder.uri.fsPath, file.fsPath)).replace(/\\/g, "/");
+
+        if (workspaceIsContent) {
+            return directory === "" || directory === "." ? "" : directory;
+        }
+
+        if (directory === CONTENT_FOLDER) {
+            return "";
+        }
+        if (directory.startsWith(`${CONTENT_FOLDER}/`)) {
+            directory = directory.substring(CONTENT_FOLDER.length + 1);
+            return directory;
+        }
+        return null;
+    }
+
+    /** What the user is told happened, which differs by whether an existing declaration was edited. */
+    private summarize(moduleName: string, editCount: number, wroteDefinitions: boolean): string {
+        if (editCount > 0 && wroteDefinitions) {
+            return `made '${moduleName}' public: updated ${editCount} existing declaration(s) and wrote the definitions file.`;
+        }
+        if (editCount > 0) {
+            return `made '${moduleName}' public by updating ${editCount} existing declaration(s).`;
+        }
+        return `made '${moduleName}' public in the definitions file.`;
+    }
+}

--- a/src/visibility/__tests__/ModuleVisibilityCodeActionProvider.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityCodeActionProvider.test.ts
@@ -1,0 +1,58 @@
+import * as vscode from "vscode";
+import { ModuleVisibilityCodeActionProvider } from "../ModuleVisibilityCodeActionProvider";
+
+const INACCESSIBLE =
+    "Invalid access of internal module `(/mygame@fortnite.com/mygame/Gadgets:)Tools` from module `/mygame@fortnite.com/mygame/Scripts`. Consider setting the module's access specifier to <public> to make it accessible from other modules within your project.";
+
+const diagnostic = (message: string) => ({ message }) as vscode.Diagnostic;
+
+const provide = (...messages: string[]) => {
+    const provider = new ModuleVisibilityCodeActionProvider();
+    const context = { diagnostics: messages.map(diagnostic) } as unknown as vscode.CodeActionContext;
+    return provider.provideCodeActions({} as vscode.TextDocument, {} as vscode.Range, context);
+};
+
+describe("ModuleVisibilityCodeActionProvider", () => {
+    it("offers one action naming the module", () => {
+        const actions = provide(INACCESSIBLE);
+
+        expect(actions).toHaveLength(1);
+        expect(actions![0].title).toBe("Make module 'Tools' public");
+    });
+
+    it("sends the parsed request to the command rather than the raw message", () => {
+        const actions = provide(INACCESSIBLE);
+
+        expect(actions![0].command).toEqual({
+            title: "Make Module Public",
+            command: "verseAutoImports.makeModulePublic",
+            arguments: [
+                {
+                    targetPath: "/mygame@fortnite.com/mygame/Gadgets/Tools",
+                    importerPath: "/mygame@fortnite.com/mygame/Scripts",
+                    moduleName: "Tools",
+                },
+            ],
+        });
+    });
+
+    it("attaches the diagnostic it answers", () => {
+        const actions = provide(INACCESSIBLE);
+
+        expect(actions![0].diagnostics?.[0].message).toBe(INACCESSIBLE);
+    });
+
+    it("offers nothing for a diagnostic an import would fix", () => {
+        expect(provide("Unknown identifier `button_device`. Did you forget to specify using { /Fortnite.com/Devices }")).toBeUndefined();
+    });
+
+    it("offers nothing when there are no diagnostics", () => {
+        expect(provide()).toBeUndefined();
+    });
+
+    it("answers only the matching diagnostic when several are reported at once", () => {
+        const actions = provide("Unknown identifier `button_device`.", INACCESSIBLE);
+
+        expect(actions).toHaveLength(1);
+    });
+});

--- a/src/visibility/__tests__/ModuleVisibilityMessage.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityMessage.test.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parseModuleVisibilityMessage } from "../ModuleVisibilityMessage";
+
+/** The corpus entry with this id, so no compiler message is hand-written here. */
+const corpusMessage = (id: string): string => {
+    const corpusPath = path.join(__dirname, "..", "..", "..", "test-fixtures", "corpus", "41.10", "diagnostics.json");
+    const corpus = JSON.parse(fs.readFileSync(corpusPath, "utf8")) as { entries: { id: string; message: string }[] };
+    const entry = corpus.entries.find((candidate) => candidate.id === id);
+    if (!entry) {
+        throw new Error(`No corpus entry '${id}'`);
+    }
+    return entry.message;
+};
+
+describe("parseModuleVisibilityMessage", () => {
+    it("parses both paths out of the captured inaccessible-module message", () => {
+        expect(parseModuleVisibilityMessage(corpusMessage("inaccessible-internal-module"))).toEqual({
+            targetPath: "/vukefn@fortnite.com/VerseAutoImports/Gadgets/Tools",
+            importerPath: "/vukefn@fortnite.com/VerseAutoImports/Scripts",
+            moduleName: "Tools",
+        });
+    });
+
+    it("ignores the sibling 3593 shape, which no <public> part fixes", () => {
+        expect(parseModuleVisibilityMessage(corpusMessage("inaccessible-all-references"))).toBeNull();
+    });
+
+    it("accepts the help sentence with the specifier backticked", () => {
+        const message =
+            "Invalid access of internal module `(/mygame@fortnite.com/mygame/Gadgets:)Tools` from module `/mygame@fortnite.com/mygame/Scripts`. Consider setting the module's access specifier to `<public>` to make it accessible from other modules within your project.";
+
+        expect(parseModuleVisibilityMessage(message)?.moduleName).toBe("Tools");
+    });
+
+    it("ignores an inaccessible definition that is not an internal module", () => {
+        const message = "Invalid access of private function `(/mygame@fortnite.com/mygame/Gadgets:)Fire` from module `/mygame@fortnite.com/mygame/Scripts`.";
+
+        expect(parseModuleVisibilityMessage(message)).toBeNull();
+    });
+
+    it("ignores an unrelated diagnostic", () => {
+        expect(parseModuleVisibilityMessage("Unknown identifier `button_device`. Did you forget to specify using { /Fortnite.com/Devices }")).toBeNull();
+    });
+
+    it("reads a scope of any kind as the importer", () => {
+        const message =
+            "Invalid access of internal module `(/mygame@fortnite.com/mygame/Gadgets:)Tools` from class `/mygame@fortnite.com/mygame/Scripts/hud_device`. Consider setting the module's access specifier to <public> to make it accessible from other modules within your project.";
+
+        expect(parseModuleVisibilityMessage(message)?.importerPath).toBe("/mygame@fortnite.com/mygame/Scripts/hud_device");
+    });
+
+    it("keeps a quoted suffix, which the module's path carries too", () => {
+        const message =
+            "Invalid access of internal module `(/mygame@fortnite.com/mygame/Gadgets:)Tools'v2'` from module `/mygame@fortnite.com/mygame/Scripts`. Consider setting the module's access specifier to <public> to make it accessible from other modules within your project.";
+
+        expect(parseModuleVisibilityMessage(message)?.moduleName).toBe("Tools'v2'");
+    });
+
+    it("returns null when the help sentence is present but the paths are not", () => {
+        expect(parseModuleVisibilityMessage("Consider setting the module's access specifier to <public> to make it accessible from other modules within your project.")).toBeNull();
+    });
+});

--- a/src/visibility/__tests__/ModuleVisibilityPlanner.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityPlanner.test.ts
@@ -1,0 +1,89 @@
+import { planVisibility, toContentSegments } from "../ModuleVisibilityPlanner";
+
+const PROJECT = "/mygame@fortnite.com/mygame";
+
+describe("toContentSegments", () => {
+    it("strips the project prefix", () => {
+        expect(toContentSegments(`${PROJECT}/Gadgets/Tools`, PROJECT)).toEqual(["Gadgets", "Tools"]);
+    });
+
+    it("returns an empty list for the project root itself", () => {
+        expect(toContentSegments(PROJECT, PROJECT)).toEqual([]);
+    });
+
+    it("rejects a path outside the project", () => {
+        expect(toContentSegments("/Fortnite.com/Devices", PROJECT)).toBeNull();
+    });
+
+    it("rejects a path shorter than the project prefix", () => {
+        expect(toContentSegments("/mygame@fortnite.com", PROJECT)).toBeNull();
+    });
+});
+
+describe("planVisibility", () => {
+    it("leaves the first divergent segment alone and marks the rest", () => {
+        // Gadgets is internal to the Content root, and the importer is a child
+        // of that root, so Gadgets is already reachable. Only Tools is not.
+        expect(planVisibility(["Gadgets", "Tools"], ["Scripts"])).toEqual({
+            prefix: [],
+            segments: [
+                { name: "Gadgets", needsPublic: false },
+                { name: "Tools", needsPublic: true },
+            ],
+        });
+    });
+
+    it("marks every segment below the first divergent one", () => {
+        expect(planVisibility(["Gadgets", "Deep", "Tools"], ["Scripts"])).toEqual({
+            prefix: [],
+            segments: [
+                { name: "Gadgets", needsPublic: false },
+                { name: "Deep", needsPublic: true },
+                { name: "Tools", needsPublic: true },
+            ],
+        });
+    });
+
+    it("keeps the shared ancestors as the prefix", () => {
+        expect(planVisibility(["A", "B", "C", "D"], ["A", "B", "Other"])).toEqual({
+            prefix: ["A", "B"],
+            segments: [
+                { name: "C", needsPublic: false },
+                { name: "D", needsPublic: true },
+            ],
+        });
+    });
+
+    it("marks nothing when the target is a direct sibling of the importer", () => {
+        // Tools is internal to the Content root and the importer is a child of
+        // it, so the compiler cannot have raised this for the pair.
+        expect(planVisibility(["Tools"], ["Scripts"])).toEqual({
+            prefix: [],
+            segments: [{ name: "Tools", needsPublic: false }],
+        });
+    });
+
+    it("marks nothing when the importer already sits inside the target branch", () => {
+        expect(planVisibility(["Gadgets"], ["Gadgets", "Inner"])).toEqual({
+            prefix: ["Gadgets"],
+            segments: [],
+        });
+    });
+
+    it("marks nothing when the importer is the target", () => {
+        expect(planVisibility(["Gadgets", "Tools"], ["Gadgets", "Tools"])).toEqual({
+            prefix: ["Gadgets", "Tools"],
+            segments: [],
+        });
+    });
+
+    it("treats an importer at the Content root as reaching the first segment", () => {
+        expect(planVisibility(["Gadgets", "Tools"], [])).toEqual({
+            prefix: [],
+            segments: [
+                { name: "Gadgets", needsPublic: false },
+                { name: "Tools", needsPublic: true },
+            ],
+        });
+    });
+});

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -178,6 +178,39 @@ describe("ModuleVisibilityWriter", () => {
         expect(appliedOperations()[0]).toMatchObject({ kind: "createFile" });
     });
 
+    it("refuses a configured file name that is not a plain file name", async () => {
+        givenProject({ "Content/Scripts/main.verse": "" });
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn().mockImplementation((key: string, fallback?: unknown) => (key === "moduleVisibility.definitionsFileName" ? "../outside.verse" : fallback)),
+            update: jest.fn(),
+        });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("not a plain file name"));
+    });
+
+    it("refuses an empty configured file name, which would address the Content folder", async () => {
+        givenProject({ "Content/Scripts/main.verse": "" });
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn().mockImplementation((key: string, fallback?: unknown) => (key === "moduleVisibility.definitionsFileName" ? "   " : fallback)),
+            update: jest.fn(),
+        });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+    });
+
+    it("ignores a declaration commented out with the `<#>` marker", async () => {
+        givenProject({ "Content/Gadgets/tools.verse": "<#> Tools := module {}\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(appliedOperations()[0]).toMatchObject({ kind: "createFile" });
+    });
+
     it("refuses when no project file resolves the module paths", async () => {
         givenProject({ "Content/Scripts/main.verse": "" });
         const handler = { getProjectVersePath: jest.fn().mockResolvedValue(null) } as unknown as ProjectPathHandler;

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -1,0 +1,166 @@
+import * as vscode from "vscode";
+import { ProjectPathHandler } from "../../project";
+import { ModuleVisibilityWriter } from "../ModuleVisibilityWriter";
+
+const PROJECT = "/mygame@fortnite.com/mygame";
+const ROOT = "/repo";
+
+const REQUEST = {
+    targetPath: `${PROJECT}/Gadgets/Tools`,
+    importerPath: `${PROJECT}/Scripts`,
+    moduleName: "Tools",
+};
+
+/** The workspace as one map of workspace-relative path to file text. */
+const givenProject = (files: Record<string, string>): void => {
+    (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file(ROOT), name: "repo", index: 0 }];
+
+    const uris = Object.keys(files).map((relative) => vscode.Uri.file(`${ROOT}/${relative}`));
+    const byUri = new Map(uris.map((uri, index) => [uri.toString(), files[Object.keys(files)[index]]]));
+
+    (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(uris);
+    (vscode.workspace.fs.readFile as jest.Mock).mockImplementation((uri: vscode.Uri) => {
+        const content = byUri.get(uri.toString());
+        return content === undefined ? Promise.reject(new Error("ENOENT")) : Promise.resolve(Buffer.from(content, "utf8"));
+    });
+    (vscode.workspace.openTextDocument as jest.Mock).mockImplementation((uri: vscode.Uri) => {
+        const content = byUri.get(uri.toString()) ?? "";
+        return Promise.resolve({
+            getText: () => content,
+            positionAt: (offset: number) => {
+                const before = content.slice(0, offset).split("\n");
+                return new vscode.Position(before.length - 1, before[before.length - 1].length);
+            },
+        });
+    });
+};
+
+const writer = (): ModuleVisibilityWriter => {
+    const handler = { getProjectVersePath: jest.fn().mockResolvedValue(PROJECT) } as unknown as ProjectPathHandler;
+    return new ModuleVisibilityWriter({} as vscode.OutputChannel, handler);
+};
+
+/** The operations of the edit that was applied, or [] when none was. */
+const appliedOperations = (): any[] => {
+    const calls = (vscode.workspace.applyEdit as jest.Mock).mock.calls;
+    return calls.length === 0 ? [] : calls[calls.length - 1][0].operations;
+};
+
+describe("ModuleVisibilityWriter", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (vscode.workspace.applyEdit as jest.Mock).mockResolvedValue(true);
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn().mockImplementation((_key: string, fallback?: unknown) => fallback),
+            update: jest.fn(),
+        });
+    });
+
+    it("creates the definitions file when the target is a plain folder module", async () => {
+        givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        const operations = appliedOperations();
+        expect(operations[0]).toMatchObject({ kind: "createFile" });
+        expect(String(operations[0].uri.fsPath).replace(/\\/g, "/")).toBe(`${ROOT}/Content/definitions.verse`);
+        expect(operations[1]).toMatchObject({ kind: "insert", text: "Gadgets := module:\n    Tools<public> := module {}\n" });
+    });
+
+    it("honours the configured definitions file name", async () => {
+        givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn().mockImplementation((key: string, fallback?: unknown) => (key === "moduleVisibility.definitionsFileName" ? "visibility.verse" : fallback)),
+            update: jest.fn(),
+        });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(String(appliedOperations()[0].uri.fsPath).replace(/\\/g, "/")).toBe(`${ROOT}/Content/visibility.verse`);
+    });
+
+    it("extends an existing definitions file rather than replacing it", async () => {
+        givenProject({
+            "Content/definitions.verse": "Other<public> := module {}\n",
+            "Content/Scripts/main.verse": "using { Gadgets.Tools }\n",
+        });
+
+        await writer().makeModulePublic(REQUEST);
+
+        const replace = appliedOperations().find((operation) => operation.kind === "replace");
+        expect(replace.text).toBe("Other<public> := module {}\n\nGadgets := module:\n    Tools<public> := module {}\n");
+    });
+
+    it("edits an existing declaration instead of writing a second part", async () => {
+        givenProject({ "Content/Gadgets/tools.verse": "Tools := module:\n    X:int = 1\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        const operations = appliedOperations();
+        expect(operations).toHaveLength(1);
+        expect(operations[0]).toMatchObject({ kind: "insert", text: "<public>" });
+        expect(operations[0].position).toEqual(new vscode.Position(0, 5));
+    });
+
+    it("refuses to widen a module the project deliberately narrowed", async () => {
+        givenProject({ "Content/Gadgets/tools.verse": "Tools<private> := module {}\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("Gadgets/Tools is <private>"));
+    });
+
+    it("does nothing when the module is already public", async () => {
+        givenProject({ "Content/Gadgets/tools.verse": "Tools<public> := module {}\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("already declared public"));
+    });
+
+    it("ignores a namesake module in another branch", async () => {
+        givenProject({ "Content/Other/tools.verse": "Tools := module {}\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(appliedOperations()[0]).toMatchObject({ kind: "createFile" });
+    });
+
+    it("refuses when no project file resolves the module paths", async () => {
+        givenProject({ "Content/Scripts/main.verse": "" });
+        const handler = { getProjectVersePath: jest.fn().mockResolvedValue(null) } as unknown as ProjectPathHandler;
+
+        await new ModuleVisibilityWriter({} as vscode.OutputChannel, handler).makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining(".uefnproject"));
+    });
+
+    it("warns when the edit is rejected", async () => {
+        givenProject({ "Content/Scripts/main.verse": "" });
+        (vscode.workspace.applyEdit as jest.Mock).mockResolvedValue(false);
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("could not write"));
+    });
+
+    it("resolves paths without the Content prefix when the workspace is Content itself", async () => {
+        (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file("/repo/Content"), name: "Content", index: 0 }];
+        const uri = vscode.Uri.file("/repo/Content/Gadgets/tools.verse");
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([uri]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockImplementation((target: vscode.Uri) =>
+            target.toString() === uri.toString() ? Promise.resolve(Buffer.from("Tools := module {}\n", "utf8")) : Promise.reject(new Error("ENOENT")),
+        );
+        (vscode.workspace.openTextDocument as jest.Mock).mockResolvedValue({
+            getText: () => "Tools := module {}\n",
+            positionAt: (offset: number) => new vscode.Position(0, offset),
+        });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(appliedOperations()[0]).toMatchObject({ kind: "insert", text: "<public>" });
+    });
+});

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -188,7 +188,19 @@ describe("ModuleVisibilityWriter", () => {
         await writer().makeModulePublic(REQUEST);
 
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("not a plain file name"));
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("definitionsFileName must be a plain file name"));
+    });
+
+    it("refuses a configured file name the compiler would not read", async () => {
+        givenProject({ "Content/Scripts/main.verse": "" });
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn().mockImplementation((key: string, fallback?: unknown) => (key === "moduleVisibility.definitionsFileName" ? "definitions.txt" : fallback)),
+            update: jest.fn(),
+        });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
     });
 
     it("refuses an empty configured file name, which would address the Content folder", async () => {

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -11,27 +11,28 @@ const REQUEST = {
     moduleName: "Tools",
 };
 
-/** The workspace as one map of workspace-relative path to file text. */
-const givenProject = (files: Record<string, string>): void => {
-    (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file(ROOT), name: "repo", index: 0 }];
+/**
+ * Stands the workspace up from one map of workspace-relative path to file text.
+ *
+ * Text is served through openTextDocument, which is where production reads it,
+ * so an offset a test asserts on addresses the same string the writer parsed.
+ */
+const givenProject = (files: Record<string, string>, root = ROOT): void => {
+    (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file(root), name: root.split("/").pop(), index: 0 }];
 
-    const uris = Object.keys(files).map((relative) => vscode.Uri.file(`${ROOT}/${relative}`));
+    const uris = Object.keys(files).map((relative) => vscode.Uri.file(`${root}/${relative}`));
     const byUri = new Map(uris.map((uri, index) => [uri.toString(), files[Object.keys(files)[index]]]));
 
     (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(uris);
-    (vscode.workspace.fs.readFile as jest.Mock).mockImplementation((uri: vscode.Uri) => {
-        const content = byUri.get(uri.toString());
-        return content === undefined ? Promise.reject(new Error("ENOENT")) : Promise.resolve(Buffer.from(content, "utf8"));
+    (vscode.workspace.fs.stat as jest.Mock).mockImplementation((uri: vscode.Uri) => {
+        if (uri.fsPath.replace(/\\/g, "/").endsWith("/Content")) {
+            return Promise.resolve({ type: vscode.FileType.Directory });
+        }
+        return byUri.has(uri.toString()) ? Promise.resolve({ type: vscode.FileType.File }) : Promise.reject(new Error("ENOENT"));
     });
     (vscode.workspace.openTextDocument as jest.Mock).mockImplementation((uri: vscode.Uri) => {
-        const content = byUri.get(uri.toString()) ?? "";
-        return Promise.resolve({
-            getText: () => content,
-            positionAt: (offset: number) => {
-                const before = content.slice(0, offset).split("\n");
-                return new vscode.Position(before.length - 1, before[before.length - 1].length);
-            },
-        });
+        const content = byUri.get(uri.toString());
+        return content === undefined ? Promise.reject(new Error("ENOENT")) : Promise.resolve({ getText: () => content });
     });
 };
 
@@ -45,6 +46,8 @@ const appliedOperations = (): any[] => {
     const calls = (vscode.workspace.applyEdit as jest.Mock).mock.calls;
     return calls.length === 0 ? [] : calls[calls.length - 1][0].operations;
 };
+
+const forwardSlashed = (uri: { fsPath: string }): string => String(uri.fsPath).replace(/\\/g, "/");
 
 describe("ModuleVisibilityWriter", () => {
     beforeEach(() => {
@@ -63,8 +66,22 @@ describe("ModuleVisibilityWriter", () => {
 
         const operations = appliedOperations();
         expect(operations[0]).toMatchObject({ kind: "createFile" });
-        expect(String(operations[0].uri.fsPath).replace(/\\/g, "/")).toBe(`${ROOT}/Content/definitions.verse`);
+        expect(forwardSlashed(operations[0].uri)).toBe(`${ROOT}/Content/definitions.verse`);
         expect(operations[1]).toMatchObject({ kind: "insert", text: "Gadgets := module:\n    Tools<public> := module {}\n" });
+    });
+
+    it("nests the block through the ancestors the target shares with the importer", async () => {
+        // Written at the Content root, so a block that skipped Systems would
+        // declare an unrelated /proj/Gadgets/Tools and fix nothing.
+        givenProject({ "Content/Systems/Scripts/main.verse": "" });
+
+        await writer().makeModulePublic({
+            targetPath: `${PROJECT}/Systems/Gadgets/Tools`,
+            importerPath: `${PROJECT}/Systems/Scripts`,
+            moduleName: "Tools",
+        });
+
+        expect(appliedOperations()[1].text).toBe("Systems := module:\n    Gadgets := module:\n        Tools<public> := module {}\n");
     });
 
     it("honours the configured definitions file name", async () => {
@@ -76,7 +93,7 @@ describe("ModuleVisibilityWriter", () => {
 
         await writer().makeModulePublic(REQUEST);
 
-        expect(String(appliedOperations()[0].uri.fsPath).replace(/\\/g, "/")).toBe(`${ROOT}/Content/visibility.verse`);
+        expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${ROOT}/Content/visibility.verse`);
     });
 
     it("extends an existing definitions file rather than replacing it", async () => {
@@ -91,6 +108,23 @@ describe("ModuleVisibilityWriter", () => {
         expect(replace.text).toBe("Other<public> := module {}\n\nGadgets := module:\n    Tools<public> := module {}\n");
     });
 
+    it("folds a specifier edit inside the definitions file into the same replacement", async () => {
+        // Two operations on one file would overlap, which VS Code rejects, and
+        // half-applying would leave two parts of Deep disagreeing.
+        givenProject({ "Content/definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
+
+        await writer().makeModulePublic({
+            targetPath: `${PROJECT}/Gadgets/Deep/Tools`,
+            importerPath: `${PROJECT}/Scripts`,
+            moduleName: "Tools",
+        });
+
+        const operations = appliedOperations();
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("replace");
+        expect(operations[0].text).toBe("Gadgets := module:\n    Deep<public> := module {}\n\nGadgets := module:\n    Deep<public> := module:\n        Tools<public> := module {}\n");
+    });
+
     it("edits an existing declaration instead of writing a second part", async () => {
         givenProject({ "Content/Gadgets/tools.verse": "Tools := module:\n    X:int = 1\n" });
 
@@ -100,6 +134,14 @@ describe("ModuleVisibilityWriter", () => {
         expect(operations).toHaveLength(1);
         expect(operations[0]).toMatchObject({ kind: "insert", text: "<public>" });
         expect(operations[0].position).toEqual(new vscode.Position(0, 5));
+    });
+
+    it("names the declaration it rewrote", async () => {
+        givenProject({ "Content/Gadgets/tools.verse": "Tools := module {}\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("declaring Gadgets/Tools public in place"));
     });
 
     it("refuses to widen a module the project deliberately narrowed", async () => {
@@ -128,6 +170,14 @@ describe("ModuleVisibilityWriter", () => {
         expect(appliedOperations()[0]).toMatchObject({ kind: "createFile" });
     });
 
+    it("ignores a declaration that is only inside a block comment", async () => {
+        givenProject({ "Content/Gadgets/tools.verse": "<# Tools := module {} #>\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(appliedOperations()[0]).toMatchObject({ kind: "createFile" });
+    });
+
     it("refuses when no project file resolves the module paths", async () => {
         givenProject({ "Content/Scripts/main.verse": "" });
         const handler = { getProjectVersePath: jest.fn().mockResolvedValue(null) } as unknown as ProjectPathHandler;
@@ -136,6 +186,16 @@ describe("ModuleVisibilityWriter", () => {
 
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
         expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining(".uefnproject"));
+    });
+
+    it("refuses rather than creating a Content folder the workspace does not have", async () => {
+        givenProject({ "Scripts/main.verse": "" });
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("no 'Content' folder"));
     });
 
     it("warns when the edit is rejected", async () => {
@@ -148,16 +208,7 @@ describe("ModuleVisibilityWriter", () => {
     });
 
     it("resolves paths without the Content prefix when the workspace is Content itself", async () => {
-        (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file("/repo/Content"), name: "Content", index: 0 }];
-        const uri = vscode.Uri.file("/repo/Content/Gadgets/tools.verse");
-        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([uri]);
-        (vscode.workspace.fs.readFile as jest.Mock).mockImplementation((target: vscode.Uri) =>
-            target.toString() === uri.toString() ? Promise.resolve(Buffer.from("Tools := module {}\n", "utf8")) : Promise.reject(new Error("ENOENT")),
-        );
-        (vscode.workspace.openTextDocument as jest.Mock).mockResolvedValue({
-            getText: () => "Tools := module {}\n",
-            positionAt: (offset: number) => new vscode.Position(0, offset),
-        });
+        givenProject({ "Gadgets/tools.verse": "Tools := module {}\n" }, "/repo/Content");
 
         await writer().makeModulePublic(REQUEST);
 

--- a/src/visibility/__tests__/definitionsContent.test.ts
+++ b/src/visibility/__tests__/definitionsContent.test.ts
@@ -1,0 +1,44 @@
+import { appendDeclarationBlock, buildDeclarationBlock } from "../definitionsContent";
+
+describe("buildDeclarationBlock", () => {
+    it("writes a single module in the brace style, which needs no body", () => {
+        expect(buildDeclarationBlock([{ name: "Tools", specifier: "public" }])).toBe("Tools<public> := module {}");
+    });
+
+    it("nests each module in the one above it", () => {
+        expect(buildDeclarationBlock([{ name: "Gadgets" }, { name: "Deep", specifier: "public" }, { name: "Tools", specifier: "public" }])).toBe(
+            "Gadgets := module:\n    Deep<public> := module:\n        Tools<public> := module {}",
+        );
+    });
+
+    it("leaves a scaffolding parent bare, so it stays internal", () => {
+        expect(buildDeclarationBlock([{ name: "Gadgets" }, { name: "Tools", specifier: "public" }])).toBe("Gadgets := module:\n    Tools<public> := module {}");
+    });
+
+    it("writes whatever specifier it is given, not only public", () => {
+        expect(
+            buildDeclarationBlock([
+                { name: "Gadgets", specifier: "internal" },
+                { name: "Tools", specifier: "public" },
+            ]),
+        ).toBe("Gadgets<internal> := module:\n    Tools<public> := module {}");
+    });
+});
+
+describe("appendDeclarationBlock", () => {
+    it("writes the block alone into an empty file", () => {
+        expect(appendDeclarationBlock("", "Tools<public> := module {}")).toBe("Tools<public> := module {}\n");
+    });
+
+    it("separates the block from existing content with one blank line", () => {
+        expect(appendDeclarationBlock("A := module {}\n", "B<public> := module {}")).toBe("A := module {}\n\nB<public> := module {}\n");
+    });
+
+    it("collapses whatever trailing whitespace the file had", () => {
+        expect(appendDeclarationBlock("A := module {}\n\n\n\n", "B<public> := module {}")).toBe("A := module {}\n\nB<public> := module {}\n");
+    });
+
+    it("keeps the file's CRLF line endings", () => {
+        expect(appendDeclarationBlock("A := module {}\r\n", "B := module:\n    C<public> := module {}")).toBe("A := module {}\r\n\r\nB := module:\r\n    C<public> := module {}\r\n");
+    });
+});

--- a/src/visibility/__tests__/moduleDeclarations.test.ts
+++ b/src/visibility/__tests__/moduleDeclarations.test.ts
@@ -1,0 +1,78 @@
+import { findExplicitModuleDeclarations } from "../moduleDeclarations";
+
+describe("findExplicitModuleDeclarations", () => {
+    it("finds the colon form", () => {
+        const declarations = findExplicitModuleDeclarations("Tools := module:\n    X:int = 1\n");
+
+        expect(declarations).toHaveLength(1);
+        expect(declarations[0]).toMatchObject({ name: "Tools", chain: ["Tools"], line: 1 });
+        expect(declarations[0].visibility).toBeUndefined();
+    });
+
+    it("finds the brace form, opened on the same line or the next", () => {
+        const declarations = findExplicitModuleDeclarations("A := module {}\nB := module\n{\n}\n");
+
+        expect(declarations.map((declaration) => declaration.name)).toEqual(["A", "B"]);
+    });
+
+    it("finds the dotted form and nests what follows it on the line", () => {
+        const declarations = findExplicitModuleDeclarations("Inventory := module. Item := module {}\n");
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Inventory"], ["Inventory", "Item"]]);
+    });
+
+    it("captures a visibility specifier and its span", () => {
+        const content = "Tools<public> := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(declaration.visibility).toEqual({ start: 5, end: 13, keyword: "public" });
+        expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<public>");
+    });
+
+    it("picks the visibility out of a stacked specifier block", () => {
+        const content = "Tools<internal><final> := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(declaration.visibility?.keyword).toBe("internal");
+        expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<internal>");
+    });
+
+    it("points the insertion point at the end of the name when there is no specifier", () => {
+        const content = "Tools := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(content.slice(0, declaration.insertionPoint)).toBe("Tools");
+    });
+
+    it("keeps a quoted suffix, which is part of the identifier and of the path", () => {
+        const [declaration] = findExplicitModuleDeclarations("Tools'v2' := module {}\n");
+
+        expect(declaration.name).toBe("Tools'v2'");
+    });
+
+    it("nests by indentation", () => {
+        const declarations = findExplicitModuleDeclarations("Outer := module:\n    Inner := module:\n        Deep := module {}\nSibling := module {}\n");
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Outer"], ["Outer", "Inner"], ["Outer", "Inner", "Deep"], ["Sibling"]]);
+    });
+
+    it("closes a module when indentation returns to its level", () => {
+        const declarations = findExplicitModuleDeclarations("Outer := module:\n    Inner := module {}\n    Other := module {}\n");
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Outer"], ["Outer", "Inner"], ["Outer", "Other"]]);
+    });
+
+    it("skips a declaration inside a line comment", () => {
+        expect(findExplicitModuleDeclarations("# Ghost := module {}\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("reports one-based lines", () => {
+        const declarations = findExplicitModuleDeclarations("\n\nTools := module {}\n");
+
+        expect(declarations[0].line).toBe(3);
+    });
+
+    it("does not match a name that only starts with module", () => {
+        expect(findExplicitModuleDeclarations("Inventory := modulex\n")).toEqual([]);
+    });
+});

--- a/src/visibility/__tests__/moduleDeclarationsMasking.test.ts
+++ b/src/visibility/__tests__/moduleDeclarationsMasking.test.ts
@@ -61,6 +61,16 @@ describe("findExplicitModuleDeclarations comment and string masking", () => {
         expect(findExplicitModuleDeclarations("<# open\nTools := module {}\n")).toEqual([]);
     });
 
+    it("lets a block comment opened inside a `<#>` body outlive the body", () => {
+        expect(findExplicitModuleDeclarations("<#>\n    see <# note\nTools := module {} #>\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("finds a declaration with a block comment between its name and the keyword", () => {
+        // The `#` of `<#` must not also be read as closing the comment it opens,
+        // or the block never ends and the declaration is lost.
+        expect(findExplicitModuleDeclarations("Tools<# note #> := module {}\n").map((declaration) => declaration.name)).toEqual(["Tools"]);
+    });
+
     it("ignores a declaration inside a string literal", () => {
         expect(findExplicitModuleDeclarations('Snippet:string = "Tools := module {}"\n')).toEqual([]);
     });

--- a/src/visibility/__tests__/moduleDeclarationsMasking.test.ts
+++ b/src/visibility/__tests__/moduleDeclarationsMasking.test.ts
@@ -1,0 +1,48 @@
+import { findExplicitModuleDeclarations } from "../moduleDeclarations";
+
+// Both directions matter to the caller. A declaration reported where none
+// exists makes it edit dead text and believe the module is declared, so the
+// compiler error stands; one missed makes it write a second part that can
+// disagree with the real one.
+describe("findExplicitModuleDeclarations comment and string masking", () => {
+    it("ignores a declaration commented out with a block comment", () => {
+        expect(findExplicitModuleDeclarations("<# Tools := module {} #>\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("ignores a declaration inside a multi-line block comment", () => {
+        expect(findExplicitModuleDeclarations("<#\nTools := module {}\n#>\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("handles a nested block comment, which Verse allows", () => {
+        expect(findExplicitModuleDeclarations("<# outer <# Tools := module {} #> still comment #>\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("still finds a declaration after a `#` inside a string literal", () => {
+        const declarations = findExplicitModuleDeclarations('Tag:string = "a#b"\nTools := module {}\n');
+
+        expect(declarations.map((declaration) => declaration.name)).toEqual(["Tools"]);
+    });
+
+    it("does not let a `#` inside a string on the declaration's own line hide it", () => {
+        const content = 'Label:string = "#" ; Tools := module {}\n';
+        const declarations = findExplicitModuleDeclarations(content);
+
+        expect(declarations.map((declaration) => declaration.name)).toContain("Tools");
+    });
+
+    it("ignores a declaration inside a string literal", () => {
+        expect(findExplicitModuleDeclarations('Snippet:string = "Tools := module {}"\n')).toEqual([]);
+    });
+
+    it("keeps offsets addressing the original text", () => {
+        const content = "# a comment\nTools := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(content.slice(0, declaration.insertionPoint)).toBe("# a comment\nTools");
+        expect(declaration.line).toBe(2);
+    });
+
+    it("does not treat an escaped quote as closing a string", () => {
+        expect(findExplicitModuleDeclarations('Quote:string = "he said \\" Tools := module {} "\n')).toEqual([]);
+    });
+});

--- a/src/visibility/__tests__/moduleDeclarationsMasking.test.ts
+++ b/src/visibility/__tests__/moduleDeclarationsMasking.test.ts
@@ -17,6 +17,29 @@ describe("findExplicitModuleDeclarations comment and string masking", () => {
         expect(findExplicitModuleDeclarations("<# outer <# Tools := module {} #> still comment #>\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
     });
 
+    it("ignores a declaration commented out with the `<#>` marker", () => {
+        // `<#>` is the indented-comment marker, not a block that closes on the
+        // `#>` inside it. Read as a block, it opens and shuts on itself and
+        // leaves the declaration looking live.
+        expect(findExplicitModuleDeclarations("<#> Tools := module {}\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("ignores the indented body of a `<#>` marker", () => {
+        expect(findExplicitModuleDeclarations("<#>\n    Tools := module {}\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("keeps a blank line inside a `<#>` body", () => {
+        expect(findExplicitModuleDeclarations("<#>\n    still comment\n\n    Tools := module {}\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("ends a `<#>` body at the first line back at the marker's indent", () => {
+        expect(findExplicitModuleDeclarations("    <#>\n        hidden\n    Tools := module {}\n").map((declaration) => declaration.name)).toEqual(["Tools"]);
+    });
+
+    it("lets a `<#` inside a string open a comment, which Verse says it does", () => {
+        expect(findExplicitModuleDeclarations('Note:string = "a<#b"\nTools := module {}\n')).toEqual([]);
+    });
+
     it("still finds a declaration after a `#` inside a string literal", () => {
         const declarations = findExplicitModuleDeclarations('Tag:string = "a#b"\nTools := module {}\n');
 
@@ -28,6 +51,14 @@ describe("findExplicitModuleDeclarations comment and string masking", () => {
         const declarations = findExplicitModuleDeclarations(content);
 
         expect(declarations.map((declaration) => declaration.name)).toContain("Tools");
+    });
+
+    it("does not carry an unterminated string past its line", () => {
+        expect(findExplicitModuleDeclarations('Broken:string = "oops\nTools := module {}\n').map((declaration) => declaration.name)).toEqual(["Tools"]);
+    });
+
+    it("treats an unterminated block comment as running to the end", () => {
+        expect(findExplicitModuleDeclarations("<# open\nTools := module {}\n")).toEqual([]);
     });
 
     it("ignores a declaration inside a string literal", () => {

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -30,7 +30,7 @@ describe("resolveVisibility", () => {
         const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
 
         expect(resolved.chain).toEqual([]);
-        expect(resolved.edits).toEqual([{ file: "file://a", span: undefined, offset: 5, text: "<public>" }]);
+        expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: undefined, offset: 5, text: "<public>" }]);
     });
 
     it("rewrites every part of a module, since later parts must repeat the specifier", () => {
@@ -46,7 +46,7 @@ describe("resolveVisibility", () => {
 
         const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
 
-        expect(resolved.edits).toEqual([{ file: "file://a", span: { start: 5, end: 15 }, offset: 5, text: "<public>" }]);
+        expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: { start: 5, end: 15 }, offset: 5, text: "<public>" }]);
     });
 
     it("does nothing for a module already declared public", () => {
@@ -96,6 +96,36 @@ describe("resolveVisibility", () => {
         const resolved = resolveVisibility(["A", "B"], segments(["C", false], ["D", true]), found);
 
         expect(resolved.edits.map((edit) => edit.file)).toEqual(["file://a"]);
+    });
+
+    it("carries the shared prefix into the chain, which is written at the Content root", () => {
+        // Without the prefix the block would declare /proj/Gadgets/Tools, a
+        // module unrelated to the target under Systems.
+        const resolved = resolveVisibility(["Systems"], segments(["Gadgets", false], ["Tools", true]), []);
+
+        expect(resolved.chain).toEqual([
+            { name: "Systems", specifier: undefined },
+            { name: "Gadgets", specifier: undefined },
+            { name: "Tools", specifier: "public" },
+        ]);
+    });
+
+    it("repeats a prefix module's declared specifier, so the nesting part cannot disagree", () => {
+        const found = declarationsIn("file://a", "", "Systems<public> := module:\n    X:int = 1\n");
+
+        const resolved = resolveVisibility(["Systems"], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.chain[0]).toEqual({ name: "Systems", specifier: "public" });
+        // The prefix is reachable already, so nothing about it is rewritten.
+        expect(resolved.edits).toEqual([]);
+    });
+
+    it("names the module path on each edit, for the report to the user", () => {
+        const found = declarationsIn("file://a", "Gadgets", "Tools := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.edits.map((edit) => edit.path)).toEqual(["Gadgets/Tools"]);
     });
 
     it("trims the chain to the deepest module it actually has to write", () => {

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -30,7 +30,9 @@ describe("resolveVisibility", () => {
         const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
 
         expect(resolved.chain).toEqual([]);
-        expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: undefined, offset: 5, text: "<public>" }]);
+        // An empty span at the end of the name is the insertion of a specifier
+        // where the declaration carries none.
+        expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: { start: 5, end: 5 }, text: "<public>" }]);
     });
 
     it("rewrites every part of a module, since later parts must repeat the specifier", () => {
@@ -46,7 +48,7 @@ describe("resolveVisibility", () => {
 
         const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
 
-        expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: { start: 5, end: 15 }, offset: 5, text: "<public>" }]);
+        expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: { start: 5, end: 15 }, text: "<public>" }]);
     });
 
     it("does nothing for a module already declared public", () => {

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -1,0 +1,114 @@
+import { findExplicitModuleDeclarations } from "../moduleDeclarations";
+import { VisibilitySegment } from "../ModuleVisibilityPlanner";
+import { FoundDeclaration, resolveVisibility } from "../visibilityResolution";
+
+/** The declarations one file's text carries, bound to the directory it sits in. */
+const declarationsIn = (file: string, directory: string, content: string): FoundDeclaration[] =>
+    findExplicitModuleDeclarations(content).map((declaration) => ({
+        path: [...(directory ? directory.split("/") : []), ...declaration.chain].join("/"),
+        file,
+        declaration,
+    }));
+
+const segments = (...names: [string, boolean][]): VisibilitySegment[] => names.map(([name, needsPublic]) => ({ name, needsPublic }));
+
+describe("resolveVisibility", () => {
+    it("writes the whole chain when nothing is declared yet", () => {
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), []);
+
+        expect(resolved.edits).toEqual([]);
+        expect(resolved.chain).toEqual([
+            { name: "Gadgets", specifier: undefined },
+            { name: "Tools", specifier: "public" },
+        ]);
+        expect(resolved.conflicts).toEqual([]);
+    });
+
+    it("edits an existing declaration instead of writing a second part", () => {
+        const found = declarationsIn("file://a", "Gadgets", "Tools := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.chain).toEqual([]);
+        expect(resolved.edits).toEqual([{ file: "file://a", span: undefined, offset: 5, text: "<public>" }]);
+    });
+
+    it("rewrites every part of a module, since later parts must repeat the specifier", () => {
+        const found = [...declarationsIn("file://a", "Gadgets", "Tools := module {}\n"), ...declarationsIn("file://b", "Gadgets", "Tools := module:\n    X:int = 1\n")];
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.edits.map((edit) => edit.file)).toEqual(["file://a", "file://b"]);
+    });
+
+    it("replaces a non-public specifier rather than stacking another", () => {
+        const found = declarationsIn("file://a", "Gadgets", "Tools<internal> := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.edits).toEqual([{ file: "file://a", span: { start: 5, end: 15 }, offset: 5, text: "<public>" }]);
+    });
+
+    it("does nothing for a module already declared public", () => {
+        const found = declarationsIn("file://a", "Gadgets", "Tools<public> := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.edits).toEqual([]);
+        expect(resolved.chain).toEqual([]);
+    });
+
+    it("repeats an existing parent specifier in the written chain, so the parts cannot disagree", () => {
+        const found = declarationsIn("file://a", "", "Gadgets<internal> := module:\n    X:int = 1\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.chain).toEqual([
+            { name: "Gadgets", specifier: "internal" },
+            { name: "Tools", specifier: "public" },
+        ]);
+    });
+
+    it("reports a deliberate narrowing as a conflict rather than widening it", () => {
+        const found = declarationsIn("file://a", "Gadgets", "Tools<private> := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets/Tools", keyword: "private" }]);
+        expect(resolved.edits).toEqual([]);
+    });
+
+    it("addresses a segment by its full path, so a namesake elsewhere is not touched", () => {
+        const found = declarationsIn("file://elsewhere", "Other", "Tools := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.edits).toEqual([]);
+        expect(resolved.chain).toEqual([
+            { name: "Gadgets", specifier: undefined },
+            { name: "Tools", specifier: "public" },
+        ]);
+    });
+
+    it("addresses segments below a shared prefix", () => {
+        const found = declarationsIn("file://a", "A/B/C", "D := module {}\n");
+
+        const resolved = resolveVisibility(["A", "B"], segments(["C", false], ["D", true]), found);
+
+        expect(resolved.edits.map((edit) => edit.file)).toEqual(["file://a"]);
+    });
+
+    it("trims the chain to the deepest module it actually has to write", () => {
+        const found = declarationsIn("file://a", "Gadgets/Deep", "Tools := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Deep", true], ["Tools", true]), found);
+
+        // Deep still needs writing, Tools is edited in place, so the chain stops
+        // at Deep rather than carrying a redundant Tools part.
+        expect(resolved.chain).toEqual([
+            { name: "Gadgets", specifier: undefined },
+            { name: "Deep", specifier: "public" },
+        ]);
+        expect(resolved.edits.map((edit) => edit.text)).toEqual(["<public>"]);
+    });
+});

--- a/src/visibility/definitionsContent.ts
+++ b/src/visibility/definitionsContent.ts
@@ -1,0 +1,54 @@
+/**
+ * Renders module declarations into the text of a definitions file. Pure string
+ * in, string out - no VS Code dependencies.
+ */
+
+/** One module in a chain about to be written, and the specifier it carries. */
+export interface DeclarationSpec {
+    name: string;
+
+    /**
+     * Visibility keyword to declare, or undefined for none. A bare declaration
+     * is internal, which is the default anyway: parents are written bare so the
+     * file commits nothing beyond the module the importer actually needs.
+     */
+    specifier?: string;
+}
+
+const INDENT = "    ";
+
+/**
+ * A nested declaration chain, outermost first, as Verse source without a
+ * trailing newline.
+ *
+ * Every module but the last opens a colon body holding the next one. The last
+ * has no body to hold, so it is written in the brace style: `module:` with
+ * nothing indented under it does not parse.
+ */
+export function buildDeclarationBlock(segments: readonly DeclarationSpec[]): string {
+    return segments
+        .map((segment, depth) => {
+            const specifier = segment.specifier ? `<${segment.specifier}>` : "";
+            const body = depth === segments.length - 1 ? "module {}" : "module:";
+            return `${INDENT.repeat(depth)}${segment.name}${specifier} := ${body}`;
+        })
+        .join("\n");
+}
+
+/**
+ * The definitions file's new text, with the block appended and one blank line
+ * separating it from whatever was already there.
+ *
+ * @param existingContent "" when the file does not exist yet
+ */
+export function appendDeclarationBlock(existingContent: string, block: string): string {
+    const eol = existingContent.includes("\r\n") ? "\r\n" : "\n";
+    const normalized = block.split("\n").join(eol);
+    const existing = existingContent.replace(/\s+$/, "");
+
+    if (existing.length === 0) {
+        return `${normalized}${eol}`;
+    }
+
+    return `${existing}${eol}${eol}${normalized}${eol}`;
+}

--- a/src/visibility/index.ts
+++ b/src/visibility/index.ts
@@ -1,0 +1,12 @@
+// From outside this module, take the provider and the writer: the provider
+// recognizes the diagnostic and the writer applies the change. Everything else
+// here is their pure collaborators - the message parser, the marking rule, the
+// declaration finder, the resolution step and the definitions renderer - and is
+// exported for its own tests, not for callers.
+export { ModuleVisibilityCodeActionProvider } from "./ModuleVisibilityCodeActionProvider";
+export { ModuleVisibilityWriter } from "./ModuleVisibilityWriter";
+export { parseModuleVisibilityMessage, ModuleVisibilityRequest } from "./ModuleVisibilityMessage";
+export { planVisibility, toContentSegments, VisibilityPlan, VisibilitySegment } from "./ModuleVisibilityPlanner";
+export { findExplicitModuleDeclarations, ModuleDeclaration } from "./moduleDeclarations";
+export { resolveVisibility, FoundDeclaration, ResolvedVisibility } from "./visibilityResolution";
+export { buildDeclarationBlock, appendDeclarationBlock, DeclarationSpec } from "./definitionsContent";

--- a/src/visibility/index.ts
+++ b/src/visibility/index.ts
@@ -1,12 +1,8 @@
 // From outside this module, take the provider and the writer: the provider
-// recognizes the diagnostic and the writer applies the change. Everything else
-// here is their pure collaborators - the message parser, the marking rule, the
-// declaration finder, the resolution step and the definitions renderer - and is
-// exported for its own tests, not for callers.
+// recognizes the diagnostic and the writer applies the change. Their pure
+// collaborators - the message parser, the marking rule, the declaration finder,
+// the resolution step and the definitions renderer - have no caller outside
+// them, and their tests import them directly.
 export { ModuleVisibilityCodeActionProvider } from "./ModuleVisibilityCodeActionProvider";
 export { ModuleVisibilityWriter } from "./ModuleVisibilityWriter";
-export { parseModuleVisibilityMessage, ModuleVisibilityRequest } from "./ModuleVisibilityMessage";
-export { planVisibility, toContentSegments, VisibilityPlan, VisibilitySegment } from "./ModuleVisibilityPlanner";
-export { findExplicitModuleDeclarations, ModuleDeclaration } from "./moduleDeclarations";
-export { resolveVisibility, FoundDeclaration, ResolvedVisibility } from "./visibilityResolution";
-export { buildDeclarationBlock, appendDeclarationBlock, DeclarationSpec } from "./definitionsContent";
+export { ModuleVisibilityRequest } from "./ModuleVisibilityMessage";

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -5,8 +5,7 @@
  *
  * This overlaps ImportPathConverter's declaration regexes, which answer only
  * "does this file declare a module of this name", and ProjectPathScanner's,
- * which records a position but matches the colon form alone. #45 is where the
- * three should converge on one parser.
+ * which records a position but matches the colon form alone.
  */
 
 /**
@@ -60,28 +59,26 @@ export interface ModuleDeclaration {
  * otherwise indentation decides, as it does for the colon style and for a
  * brace opened on the following line. A one-line `module {}` followed by a
  * MORE indented sibling is therefore read as nesting - invalid Verse anyway,
- * and the alternative is tracking brace depth through strings and comments.
+ * and the alternative is tracking brace depth as well.
  *
- * Declarations inside a line comment are skipped. One inside a `<# #>` block
- * comment is not: block comments are not tracked here, and the cost of
- * matching a commented-out declaration is a specifier edit inside dead text.
+ * Text inside comments and string literals is masked before matching, so a
+ * commented-out declaration is not reported and a `#` inside a string does not
+ * hide a real one. Both directions matter to the caller: a declaration
+ * reported where none exists makes it edit dead text and believe the module is
+ * declared, and one missed makes it write a second, possibly conflicting part.
  */
 export function findExplicitModuleDeclarations(content: string): ModuleDeclaration[] {
     const declarations: ModuleDeclaration[] = [];
+    const searchable = maskCommentsAndStrings(content);
     const pattern = new RegExp(MODULE_DECLARATION.source, "g");
     const lineStarts = buildLineStarts(content);
     const open: { chain: string[]; indent: number; line: number }[] = [];
 
     let match: RegExpExecArray | null;
-    while ((match = pattern.exec(content)) !== null) {
+    while ((match = pattern.exec(searchable)) !== null) {
         const [, name, specifierBlock] = match;
         const nameStart = match.index;
         const line = lineOf(lineStarts, nameStart);
-
-        if (isInLineComment(content, lineStarts[line - 1], nameStart)) {
-            continue;
-        }
-
         const indent = indentOf(content, lineStarts[line - 1]);
         while (open.length > 0 && open[open.length - 1].line !== line && indent <= open[open.length - 1].indent) {
             open.pop();
@@ -114,6 +111,82 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
     }
 
     return declarations;
+}
+
+/**
+ * The text with every comment and string literal replaced by spaces, so
+ * offsets still address the original.
+ *
+ * Handles the `#` line comment, the nesting `<# #>` block comment and the
+ * double-quoted string, which is where `#` is content rather than a comment.
+ * Two shapes are deliberately not tracked: the `<#>` indented comment, whose
+ * body is indented under the marker where a declaration reads as nested
+ * anyway, and the single-quoted char literal, because a single quote also
+ * opens an identifier's quoted suffix and the two cannot be told apart here.
+ */
+function maskCommentsAndStrings(content: string): string {
+    const masked = content.split("");
+    let blockDepth = 0;
+    let inString = false;
+
+    for (let i = 0; i < content.length; i++) {
+        const character = content[i];
+
+        if (blockDepth > 0) {
+            if (content.startsWith("<#", i)) {
+                blockDepth++;
+            } else if (content.startsWith("#>", i)) {
+                blockDepth--;
+            }
+            blank(masked, content, i);
+            continue;
+        }
+
+        if (inString) {
+            if (character === "\\") {
+                blank(masked, content, i);
+                i++;
+                if (i < content.length) blank(masked, content, i);
+                continue;
+            }
+            if (character === '"') {
+                inString = false;
+            }
+            blank(masked, content, i);
+            continue;
+        }
+
+        if (content.startsWith("<#", i)) {
+            blockDepth++;
+            blank(masked, content, i);
+            continue;
+        }
+
+        if (character === '"') {
+            inString = true;
+            blank(masked, content, i);
+            continue;
+        }
+
+        // A line comment is a `#` not preceded by `<` and not followed by `>`;
+        // the other two shapes are the block and indented comment openers.
+        if (character === "#" && content[i + 1] !== ">") {
+            while (i < content.length && content[i] !== "\n") {
+                blank(masked, content, i);
+                i++;
+            }
+            i--;
+        }
+    }
+
+    return masked.join("");
+}
+
+/** Replaces one character with a space, keeping newlines so line numbers still hold. */
+function blank(masked: string[], content: string, index: number): void {
+    if (content[index] !== "\n") {
+        masked[index] = " ";
+    }
 }
 
 /** Offset of the first character of every line, so a line number is a binary search. */
@@ -155,9 +228,4 @@ function indentOf(content: string, lineStart: number): number {
         }
     }
     return width;
-}
-
-/** Whether an offset sits after a `#` on its own line. */
-function isInLineComment(content: string, lineStart: number, offset: number): boolean {
-    return content.slice(lineStart, offset).includes("#");
 }

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -123,9 +123,11 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
  * - `<#>` is the INDENTED comment marker, not a block that closes on the `#>`
  *   inside it. The rest of its line is comment text, and so is every line
  *   indented past it, blank lines included. It must therefore be tested before
- *   `<#`, or a declaration commented out this way reads as live code.
+ *   `<#`, or a declaration commented out this way reads as live code. A `<#`
+ *   written inside its body is still a real opener, and outlives the body.
  * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string
- *   really does open a comment there.
+ *   really does open a comment there. Both digraphs are consumed whole, so the
+ *   `#` of a `<#` cannot also be read as closing one.
  * - `#` runs to the end of the line, but inside a string it is content. This
  *   is the one place string tracking is needed, and the only reason it is
  *   here.
@@ -146,10 +148,12 @@ function maskCommentsAndStrings(content: string): string {
         const indent = indentOf(content, lineStart);
 
         // The marker's body runs while lines stay indented past it; a blank
-        // line does not end it.
+        // line does not end it. The body is still scanned rather than blanked
+        // wholesale, because a block comment opened inside it survives the
+        // body's end and swallows what follows.
         if (markerIndent !== null) {
             if (line.trim().length === 0 || indent > markerIndent) {
-                blankRange(masked, content, lineStart, lineEnd);
+                blockDepth = blankCommentRange(masked, content, lineStart, lineEnd, blockDepth);
                 lineStart = lineEnd + 1;
                 continue;
             }
@@ -160,10 +164,12 @@ function maskCommentsAndStrings(content: string): string {
 
         for (let i = lineStart; i < lineEnd; i++) {
             if (blockDepth > 0) {
-                if (content.startsWith("<#", i)) {
-                    blockDepth++;
-                } else if (content.startsWith("#>", i)) {
-                    blockDepth--;
+                if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
+                    blockDepth += content[i] === "<" ? 1 : -1;
+                    blank(masked, content, i);
+                    blank(masked, content, i + 1);
+                    i++;
+                    continue;
                 }
                 blank(masked, content, i);
                 continue;
@@ -178,6 +184,8 @@ function maskCommentsAndStrings(content: string): string {
             if (content.startsWith("<#", i)) {
                 blockDepth++;
                 blank(masked, content, i);
+                blank(masked, content, i + 1);
+                i++;
                 continue;
             }
 
@@ -225,6 +233,24 @@ function blankRange(masked: string[], content: string, start: number, end: numbe
     for (let i = start; i < end; i++) {
         blank(masked, content, i);
     }
+}
+
+/** Blanks a half-open range that is comment text, returning the block-comment depth it leaves behind. */
+function blankCommentRange(masked: string[], content: string, start: number, end: number, depth: number): number {
+    let blockDepth = depth;
+
+    for (let i = start; i < end; i++) {
+        if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
+            blockDepth = Math.max(0, blockDepth + (content[i] === "<" ? 1 : -1));
+            blank(masked, content, i);
+            blank(masked, content, i + 1);
+            i++;
+            continue;
+        }
+        blank(masked, content, i);
+    }
+
+    return blockDepth;
 }
 
 /** Offset of the first character of every line, so a line number is a binary search. */

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -114,69 +114,100 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
 }
 
 /**
- * The text with every comment and string literal replaced by spaces, so
- * offsets still address the original.
+ * The text with every comment replaced by spaces, so offsets still address the
+ * original.
  *
- * Handles the `#` line comment, the nesting `<# #>` block comment and the
- * double-quoted string, which is where `#` is content rather than a comment.
- * Two shapes are deliberately not tracked: the `<#>` indented comment, whose
- * body is indented under the marker where a declaration reads as nested
- * anyway, and the single-quoted char literal, because a single quote also
- * opens an identifier's quoted suffix and the two cannot be told apart here.
+ * Verse has three comment forms and they do not compose the way a reader
+ * expects, so the order of the tests below is the whole of this function:
+ *
+ * - `<#>` is the INDENTED comment marker, not a block that closes on the `#>`
+ *   inside it. The rest of its line is comment text, and so is every line
+ *   indented past it, blank lines included. It must therefore be tested before
+ *   `<#`, or a declaration commented out this way reads as live code.
+ * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string
+ *   really does open a comment there.
+ * - `#` runs to the end of the line, but inside a string it is content. This
+ *   is the one place string tracking is needed, and the only reason it is
+ *   here.
+ *
+ * ImportScanner encodes the same three rules for its own line scan. The single
+ * quote is deliberately not tracked: it opens a char literal and an
+ * identifier's quoted suffix alike, and nothing here can tell the two apart.
  */
 function maskCommentsAndStrings(content: string): string {
     const masked = content.split("");
+    const lines = content.split("\n");
     let blockDepth = 0;
-    let inString = false;
+    let markerIndent: number | null = null;
+    let lineStart = 0;
 
-    for (let i = 0; i < content.length; i++) {
-        const character = content[i];
+    for (const line of lines) {
+        const lineEnd = lineStart + line.length;
+        const indent = indentOf(content, lineStart);
 
-        if (blockDepth > 0) {
-            if (content.startsWith("<#", i)) {
-                blockDepth++;
-            } else if (content.startsWith("#>", i)) {
-                blockDepth--;
-            }
-            blank(masked, content, i);
-            continue;
-        }
-
-        if (inString) {
-            if (character === "\\") {
-                blank(masked, content, i);
-                i++;
-                if (i < content.length) blank(masked, content, i);
+        // The marker's body runs while lines stay indented past it; a blank
+        // line does not end it.
+        if (markerIndent !== null) {
+            if (line.trim().length === 0 || indent > markerIndent) {
+                blankRange(masked, content, lineStart, lineEnd);
+                lineStart = lineEnd + 1;
                 continue;
             }
-            if (character === '"') {
-                inString = false;
-            }
-            blank(masked, content, i);
-            continue;
+            markerIndent = null;
         }
 
-        if (content.startsWith("<#", i)) {
-            blockDepth++;
-            blank(masked, content, i);
-            continue;
-        }
+        let inString = false;
 
-        if (character === '"') {
-            inString = true;
-            blank(masked, content, i);
-            continue;
-        }
-
-        // A line comment is a `#` not preceded by `<` and not followed by `>`;
-        // the other two shapes are the block and indented comment openers.
-        if (character === "#" && content[i + 1] !== ">") {
-            while (i < content.length && content[i] !== "\n") {
+        for (let i = lineStart; i < lineEnd; i++) {
+            if (blockDepth > 0) {
+                if (content.startsWith("<#", i)) {
+                    blockDepth++;
+                } else if (content.startsWith("#>", i)) {
+                    blockDepth--;
+                }
                 blank(masked, content, i);
-                i++;
+                continue;
             }
-            i--;
+
+            if (content.startsWith("<#>", i)) {
+                markerIndent = indent;
+                blankRange(masked, content, i, lineEnd);
+                break;
+            }
+
+            if (content.startsWith("<#", i)) {
+                blockDepth++;
+                blank(masked, content, i);
+                continue;
+            }
+
+            if (inString) {
+                if (content[i] === "\\") {
+                    blank(masked, content, i);
+                    i++;
+                    if (i < lineEnd) blank(masked, content, i);
+                    continue;
+                }
+                if (content[i] === '"') {
+                    inString = false;
+                }
+                blank(masked, content, i);
+                continue;
+            }
+
+            if (content[i] === '"') {
+                inString = true;
+                blank(masked, content, i);
+                continue;
+            }
+
+            if (content[i] === "#") {
+                blankRange(masked, content, i, lineEnd);
+                break;
+            }
         }
+
+        lineStart = lineEnd + 1;
     }
 
     return masked.join("");
@@ -186,6 +217,13 @@ function maskCommentsAndStrings(content: string): string {
 function blank(masked: string[], content: string, index: number): void {
     if (content[index] !== "\n") {
         masked[index] = " ";
+    }
+}
+
+/** Blanks a half-open range. */
+function blankRange(masked: string[], content: string, start: number, end: number): void {
+    for (let i = start; i < end; i++) {
+        blank(masked, content, i);
     }
 }
 

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -1,0 +1,163 @@
+/**
+ * Finds explicit `X := module` declarations in Verse source, resolved to their
+ * in-file module chain and located precisely enough to edit their access
+ * specifier in place. No VS Code dependencies.
+ *
+ * This overlaps ImportPathConverter's declaration regexes, which answer only
+ * "does this file declare a module of this name", and ProjectPathScanner's,
+ * which records a position but matches the colon form alone. #45 is where the
+ * three should converge on one parser.
+ */
+
+/**
+ * A declaration in any of the three styles a macro body is written in:
+ * `module:`, `module { }` with the brace on that line or the next, and the
+ * dotted `module. Inner := ...`. `>` is accepted after the keyword alongside
+ * them, matching ImportPathConverter.
+ *
+ * Group 1 is the declared name with any quoted suffix; group 2 is the whole
+ * stacked specifier block, of which at most one entry is a visibility.
+ */
+const MODULE_DECLARATION = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)((?:\s*<[^>]+>)*)\s*:=\s*module\s*[:>{.]/g;
+
+/** The visibility entry inside a stacked specifier block. */
+const VISIBILITY_SPECIFIER = /<\s*(public|protected|private|internal|scoped)\b[^>]*>/;
+
+/** A half-open character span in the source text. */
+export interface SourceSpan {
+    start: number;
+    end: number;
+}
+
+/** One explicit module declaration, located precisely enough to rewrite. */
+export interface ModuleDeclaration {
+    /**
+     * Declared name, quoted suffix included. The suffix is part of the
+     * identifier and appears in the module's Verse path, so stripping it here
+     * would stop a declaration matching the path a diagnostic names.
+     */
+    name: string;
+
+    /** Enclosing module names in this file, outermost first, ending with this one. */
+    chain: string[];
+
+    /** One-based line of the declaration, matching ProjectPathNode.sourceLine. */
+    line: number;
+
+    /** Where a specifier is inserted when the declaration carries none. */
+    insertionPoint: number;
+
+    /** The visibility specifier's span and keyword, absent when the declaration carries none. */
+    visibility?: SourceSpan & { keyword: string };
+}
+
+/**
+ * Every explicit module declaration in the text, in source order.
+ *
+ * Nesting is read two ways, because the three declaration styles do not agree
+ * on how a body opens. A declaration on the same line as the one before it is
+ * nested in it, which is what the dotted and same-line brace chains mean;
+ * otherwise indentation decides, as it does for the colon style and for a
+ * brace opened on the following line. A one-line `module {}` followed by a
+ * MORE indented sibling is therefore read as nesting - invalid Verse anyway,
+ * and the alternative is tracking brace depth through strings and comments.
+ *
+ * Declarations inside a line comment are skipped. One inside a `<# #>` block
+ * comment is not: block comments are not tracked here, and the cost of
+ * matching a commented-out declaration is a specifier edit inside dead text.
+ */
+export function findExplicitModuleDeclarations(content: string): ModuleDeclaration[] {
+    const declarations: ModuleDeclaration[] = [];
+    const pattern = new RegExp(MODULE_DECLARATION.source, "g");
+    const lineStarts = buildLineStarts(content);
+    const open: { chain: string[]; indent: number; line: number }[] = [];
+
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(content)) !== null) {
+        const [, name, specifierBlock] = match;
+        const nameStart = match.index;
+        const line = lineOf(lineStarts, nameStart);
+
+        if (isInLineComment(content, lineStarts[line - 1], nameStart)) {
+            continue;
+        }
+
+        const indent = indentOf(content, lineStarts[line - 1]);
+        while (open.length > 0 && open[open.length - 1].line !== line && indent <= open[open.length - 1].indent) {
+            open.pop();
+        }
+
+        const chain = open.length > 0 ? [...open[open.length - 1].chain, name] : [name];
+        open.push({ chain, indent, line });
+
+        const nameEnd = nameStart + name.length;
+        const declaration: ModuleDeclaration = {
+            name,
+            chain,
+            line,
+            insertionPoint: nameEnd,
+        };
+
+        // The specifier block starts exactly at the name's end, so an offset
+        // inside it is an offset from there.
+        const visibility = specifierBlock.match(VISIBILITY_SPECIFIER);
+        if (visibility && visibility.index !== undefined) {
+            const start = nameEnd + visibility.index;
+            declaration.visibility = {
+                start,
+                end: start + visibility[0].length,
+                keyword: visibility[1],
+            };
+        }
+
+        declarations.push(declaration);
+    }
+
+    return declarations;
+}
+
+/** Offset of the first character of every line, so a line number is a binary search. */
+function buildLineStarts(content: string): number[] {
+    const starts = [0];
+    for (let i = 0; i < content.length; i++) {
+        if (content[i] === "\n") {
+            starts.push(i + 1);
+        }
+    }
+    return starts;
+}
+
+/** The one-based line an offset falls on. */
+function lineOf(lineStarts: readonly number[], offset: number): number {
+    let low = 0;
+    let high = lineStarts.length - 1;
+    while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+        if (lineStarts[mid] <= offset) {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return low + 1;
+}
+
+/** Leading whitespace of a line, each tab counted as four spaces so mixed indentation compares. */
+function indentOf(content: string, lineStart: number): number {
+    let width = 0;
+    for (let i = lineStart; i < content.length; i++) {
+        if (content[i] === " ") {
+            width += 1;
+        } else if (content[i] === "\t") {
+            width += 4;
+        } else {
+            break;
+        }
+    }
+    return width;
+}
+
+/** Whether an offset sits after a `#` on its own line. */
+function isInLineComment(content: string, lineStart: number, offset: number): boolean {
+    return content.slice(lineStart, offset).includes("#");
+}

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -19,15 +19,14 @@ export interface FoundDeclaration {
     declaration: ModuleDeclaration;
 }
 
-/** One specifier rewrite: replacing `span` when present, inserting at `offset` when not. */
+/** One specifier rewrite. An empty span is an insertion at that offset. */
 export interface SpecifierEdit {
     file: string;
 
     /** Content-relative path of the module being rewritten, for the report to the user. */
     path: string;
 
-    span?: SourceSpan;
-    offset: number;
+    span: SourceSpan;
     text: string;
 }
 
@@ -120,8 +119,7 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
                 edits.push({
                     file: entry.file,
                     path: modulePath,
-                    span: visibility ? { start: visibility.start, end: visibility.end } : undefined,
-                    offset: visibility ? visibility.start : insertionPoint,
+                    span: visibility ? { start: visibility.start, end: visibility.end } : { start: insertionPoint, end: insertionPoint },
                     text: PUBLIC_SPECIFIER,
                 });
             }

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -1,0 +1,136 @@
+/**
+ * Turns a visibility plan plus the declarations a project already carries into
+ * the concrete edits that make the target public. Pure - no VS Code
+ * dependencies.
+ */
+
+import { DeclarationSpec } from "./definitionsContent";
+import { ModuleDeclaration, SourceSpan } from "./moduleDeclarations";
+import { VisibilitySegment } from "./ModuleVisibilityPlanner";
+
+/** An explicit declaration found in the project, bound to the module it declares. */
+export interface FoundDeclaration {
+    /** Content-relative module path, slash-separated, e.g. "Gadgets/Tools". */
+    path: string;
+
+    /** Opaque file identifier, passed back on any edit against this declaration. */
+    file: string;
+
+    declaration: ModuleDeclaration;
+}
+
+/** One specifier rewrite: replacing `span` when present, inserting at `offset` when not. */
+export interface SpecifierEdit {
+    file: string;
+    span?: SourceSpan;
+    offset: number;
+    text: string;
+}
+
+/** Everything that has to happen for the target to become reachable. */
+export interface ResolvedVisibility {
+    /** Specifier rewrites against declarations that already exist. */
+    edits: SpecifierEdit[];
+
+    /**
+     * The chain to write into the definitions file, outermost first, or empty
+     * when every module that needed publicizing was already declared.
+     */
+    chain: DeclarationSpec[];
+
+    /** Modules that could not be made public, with the specifier blocking each. */
+    conflicts: { path: string; keyword: string }[];
+}
+
+const PUBLIC_SPECIFIER = "<public>";
+
+/**
+ * The edits and the declaration chain that make the planned segments reachable.
+ *
+ * Two rules keep this from producing `ErrSemantic_MismatchedPartialAttributes`,
+ * which is what sank the 0.4.x attempt at this feature. A module's access level
+ * comes from its first explicit part, and every later part must repeat the same
+ * specifier - so where a module is already declared, EVERY part of it is
+ * rewritten rather than one, and where a chain is written into the definitions
+ * file, each of its modules repeats whatever specifier the project already
+ * declares for that module.
+ *
+ * A module already declared `<private>`, `<protected>` or `<scoped>` is
+ * reported as a conflict instead of being rewritten: those are deliberate
+ * narrowings, and widening one silently is a decision that belongs to whoever
+ * wrote it.
+ *
+ * @param prefix Content-relative segments above the planned ones, needed to
+ * address a planned segment by its full path
+ */
+export function resolveVisibility(prefix: readonly string[], segments: readonly VisibilitySegment[], found: readonly FoundDeclaration[]): ResolvedVisibility {
+    const byPath = new Map<string, FoundDeclaration[]>();
+    for (const entry of found) {
+        const existing = byPath.get(entry.path);
+        if (existing) {
+            existing.push(entry);
+        } else {
+            byPath.set(entry.path, [entry]);
+        }
+    }
+
+    const edits: SpecifierEdit[] = [];
+    const conflicts: { path: string; keyword: string }[] = [];
+    const chain: DeclarationSpec[] = [];
+    const written: boolean[] = [];
+
+    const pathSegments = [...prefix];
+
+    for (const segment of segments) {
+        pathSegments.push(segment.name);
+        const modulePath = pathSegments.join("/");
+        const declarations = byPath.get(modulePath) ?? [];
+
+        if (declarations.length === 0) {
+            chain.push({ name: segment.name, specifier: segment.needsPublic ? "public" : undefined });
+            written.push(segment.needsPublic);
+            continue;
+        }
+
+        const blocking = declarations.find((entry) => entry.declaration.visibility && entry.declaration.visibility.keyword !== "public" && entry.declaration.visibility.keyword !== "internal");
+
+        if (segment.needsPublic && blocking) {
+            conflicts.push({ path: modulePath, keyword: blocking.declaration.visibility!.keyword });
+            // Written bare so the chain still nests, though the conflict means
+            // the caller will not apply any of it.
+            chain.push({ name: segment.name });
+            written.push(false);
+            continue;
+        }
+
+        if (segment.needsPublic) {
+            for (const entry of declarations) {
+                const { visibility, insertionPoint } = entry.declaration;
+                if (visibility?.keyword === "public") {
+                    continue;
+                }
+                edits.push({
+                    file: entry.file,
+                    span: visibility ? { start: visibility.start, end: visibility.end } : undefined,
+                    offset: visibility ? visibility.start : insertionPoint,
+                    text: PUBLIC_SPECIFIER,
+                });
+            }
+        }
+
+        // Repeat what the project already declares, so a part written below
+        // this one cannot disagree with the parts that exist.
+        const declaredKeyword = segment.needsPublic ? "public" : declarations[0].declaration.visibility?.keyword;
+        chain.push({ name: segment.name, specifier: declaredKeyword });
+        written.push(false);
+    }
+
+    // The chain exists only to carry declarations that are not there yet. With
+    // none to carry, the nesting above them is noise.
+    const deepestWritten = written.lastIndexOf(true);
+    return {
+        edits,
+        chain: deepestWritten === -1 ? [] : chain.slice(0, deepestWritten + 1),
+        conflicts,
+    };
+}

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -22,6 +22,10 @@ export interface FoundDeclaration {
 /** One specifier rewrite: replacing `span` when present, inserting at `offset` when not. */
 export interface SpecifierEdit {
     file: string;
+
+    /** Content-relative path of the module being rewritten, for the report to the user. */
+    path: string;
+
     span?: SourceSpan;
     offset: number;
     text: string;
@@ -47,21 +51,21 @@ const PUBLIC_SPECIFIER = "<public>";
 /**
  * The edits and the declaration chain that make the planned segments reachable.
  *
- * Two rules keep this from producing `ErrSemantic_MismatchedPartialAttributes`,
- * which is what sank the 0.4.x attempt at this feature. A module's access level
- * comes from its first explicit part, and every later part must repeat the same
- * specifier - so where a module is already declared, EVERY part of it is
- * rewritten rather than one, and where a chain is written into the definitions
- * file, each of its modules repeats whatever specifier the project already
- * declares for that module.
+ * Two rules keep this from producing `ErrSemantic_MismatchedPartialAttributes`.
+ * A module's access level comes from its first explicit part, and every later
+ * part must repeat the same specifier - so where a module is already declared,
+ * EVERY part of it is rewritten rather than one, and where a chain is written
+ * into the definitions file, each of its modules repeats whatever specifier the
+ * project already declares for that module.
  *
  * A module already declared `<private>`, `<protected>` or `<scoped>` is
  * reported as a conflict instead of being rewritten: those are deliberate
  * narrowings, and widening one silently is a decision that belongs to whoever
  * wrote it.
  *
- * @param prefix Content-relative segments above the planned ones, needed to
- * address a planned segment by its full path
+ * @param prefix Content-relative segments above the planned ones. They are
+ * already reachable, but the chain is written at the Content root, so it has to
+ * carry them or the declaration it nests would name a different module.
  */
 export function resolveVisibility(prefix: readonly string[], segments: readonly VisibilitySegment[], found: readonly FoundDeclaration[]): ResolvedVisibility {
     const byPath = new Map<string, FoundDeclaration[]>();
@@ -79,9 +83,13 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     const chain: DeclarationSpec[] = [];
     const written: boolean[] = [];
 
-    const pathSegments = [...prefix];
+    // The prefix modules are reachable already, so they are walked purely as
+    // the nesting the chain needs - never marked, but still matched against
+    // what the project declares so a written part cannot disagree with one.
+    const walk: VisibilitySegment[] = [...prefix.map((name) => ({ name, needsPublic: false })), ...segments];
+    const pathSegments: string[] = [];
 
-    for (const segment of segments) {
+    for (const segment of walk) {
         pathSegments.push(segment.name);
         const modulePath = pathSegments.join("/");
         const declarations = byPath.get(modulePath) ?? [];
@@ -111,6 +119,7 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
                 }
                 edits.push({
                     file: entry.file,
+                    path: modulePath,
                     span: visibility ? { start: visibility.start, end: visibility.end } : undefined,
                     offset: visibility ? visibility.start : insertionPoint,
                     text: PUBLIC_SPECIFIER,

--- a/test-fixtures/corpus/41.10/diagnostics.json
+++ b/test-fixtures/corpus/41.10/diagnostics.json
@@ -132,6 +132,26 @@
                 "suggestions": ["using { /UnrealEngine.com/Temporary/SpatialMath }"],
                 "optimizePaths": []
             }
+        },
+        {
+            "id": "inaccessible-internal-module",
+            "source": "captured",
+            "context": "error 3593 from a cross-branch import of an implicit folder module. No import fixes it, so extraction must stay empty; the module-visibility quick fix keys on the help sentence, which the compiler appends only for an internal module.",
+            "message": "Invalid access of internal module `(/vukefn@fortnite.com/VerseAutoImports/Gadgets:)Tools` from module `/vukefn@fortnite.com/VerseAutoImports/Scripts`. Consider setting the module's access specifier to <public> to make it accessible from other modules within your project.",
+            "expected": {
+                "suggestions": [],
+                "optimizePaths": []
+            }
+        },
+        {
+            "id": "inaccessible-all-references",
+            "source": "synthetic",
+            "context": "the sibling shape under the same error code 3593, composed at a different call site and carrying no help sentence; awaiting live capture. Neither the import extractor nor the module-visibility quick fix may act on it.",
+            "message": "All references to `Tools` are inaccessible from context `/vukefn@fortnite.com/VerseAutoImports/Scripts/main` in module `/vukefn@fortnite.com/VerseAutoImports/Gadgets`.",
+            "expected": {
+                "suggestions": [],
+                "optimizePaths": []
+            }
         }
     ]
 }


### PR DESCRIPTION
Closes #61

Adds a quick fix on error 3593's internal-module shape: it declares the module the importer could not reach `<public>`, editing an existing declaration where the project has one and otherwise writing a `definitions.verse` at the Content root.

The feature lives in a new `src/visibility/` directory rather than in `ImportSuggestionExtractor`. 3593 is an access error, not an import suggestion — `classifyMessage` correctly returns `none` for it today — and that cascade's precedence is documented as load-bearing, so adding an access pattern there would put visibility parsing behind a facade named for imports and risk shadowing an existing rung.

## Decisions taken with the maintainer before implementing

**Marking rule: strictly below the divergence**, which is one segment tighter than the issue's wording. `<internal>` grants access to the module a definition lives in and every child of it, so the first segment where importer and target diverge has the common ancestor as its parent — and the importer is already a child of that ancestor. Only the segments below it need marking. The issue's own rationale, that every `<public>` is a published-API commitment, is the reason to take the tighter reading. Scaffolding parents are written bare, so they stay internal and commit nothing.

**The definitions file name is configurable** — `verseAutoImports.moduleVisibility.definitionsFileName`, default `definitions.verse`. It must be a plain file name ending in `.verse`; a value carrying a path is refused rather than resolved, since joining one would place the file outside the Content root.

**Tier 2 is out of scope.** The optional project-wide "Publicize Cross-Branch Imports" sweep is not covered by any acceptance criterion. Follow-ups are listed at the bottom.

## How the MismatchedPartialAttributes trap is avoided

This is what sank the 0.4.x attempt, so it is worth stating what stops it here. A module's access level comes from its first explicit part and every later part must repeat the same specifier, so:

- Where a module is already declared, **every** part of it is rewritten, not one.
- Where a chain is written into the definitions file, **each of its modules repeats whatever specifier the project already declares** for that module — including the ancestors above the marked segments, which the chain has to nest through.
- A module already narrowed to `<private>`, `<protected>` or `<scoped>` is reported as a conflict rather than widened, and nothing else in that request is applied either.

Declarations are matched by full Content-relative path, so a namesake module in another branch is never touched.

## Acceptance criteria

- [x] The quick fix appears only on 3593 diagnostics carrying the internal-module help suffix. It keys on the tail `to make it accessible from other modules within your project`, not on the `<public>` token, because the captured 41.10 text and the compiler-source template disagree on whether that token is backticked. The sibling `All references to ... are inaccessible` shape produces nothing.
- [x] Applying it when the target already has an explicit declaration edits that declaration, and never produces `MismatchedPartialAttributes`.
- [x] Applying it on a plain folder module creates or extends the definitions file with `<public>` on exactly the segments below the divergence.
- [x] Corpus entries for both 3593 message shapes, asserting the import extractor still ignores them. The visibility matcher's expectations read the same two entries, so there is one source of message truth.

## Review gate

Three rounds, each with a fresh reviewer.

| Round | Verdict | Critical | Important | Suggestion |
|---|---|---|---|---|
| 1 | FAIL | 2 | 4 | 5 |
| 2 | FAIL | 1 | 2 | 4 |
| 3 | PASS_WITH_SUGGESTIONS | 0 | 1 | 2 |

The four defects that mattered, all now fixed and each pinned by a test verified to fail when its fix is reverted:

1. The shared ancestors never entered the written chain, so a target sharing a prefix with the importer got its block written at the wrong nesting level — declaring an unrelated module and fixing nothing.
2. When the declaration being edited lived in the definitions file itself, one `WorkspaceEdit` carried an insert inside a range it also replaced. VS Code rejects that; half-applied it would have left two parts of one module disagreeing.
3. `<#>` is the indented-comment marker, not a block comment that closes on the `#>` inside it. Read as one, it opened and shut on itself, so a declaration commented out that way looked live: the writer edited comment text, suppressed the real fix, and reported success.
4. Scanning a block comment one character at a time let the `#` of a `<#` also read as closing one, so `Tools<# note #> := module {}` was missed — and a missed declaration is what produces a second, conflicting part.

Rounds 1 and 2 also moved offsets onto `openTextDocument` (they came from the raw disk bytes while positions came from the buffer), added a Content-root check so nothing is written into a folder the workspace does not have, and validated the file-name setting.

## Verification

```
$ npm run compile
> tsc -p ./

$ npm test
Test Suites: 37 passed, 37 total
Tests:       730 passed, 730 total
Snapshots:   0 total
Time:        6.874 s

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

Not smoke-tested in the Extension Development Host yet.

## Follow-ups, not in this PR

- `ProjectPathScanner.modulePattern` still matches only the colon form, so a brace- or dotted-declared module never enters `ProjectPathCache`. #275 fixed this for `ImportPathConverter` but not for the scanner.
- Three parsers now cover the same declaration grammar. #45 is the natural home for one shared parser; this feature's needs offsets and a specifier, which neither existing parser provides.
- Verse comment structure is encoded twice — here and in `ImportScanner.scanLine`. The masker needs offset preservation, which `scanLine` does not provide, but the rules should have one owner.
- Tier 2, the project-wide sweep command.
