### PR TITLE
chore(ci): teach both auto-labelers the module: visibility label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -57,6 +57,11 @@
           - "src/ui/**"
           - "src/commands/**"
 
+"module: visibility":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/visibility/**"
+
 "area: ci":
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -58,6 +58,8 @@ jobs:
                - "module: path-conversion" - the path conversion CodeLens
                - "module: config" - settings behavior, defaults, migration
                - "module: ui" - status bar, commands, quick fix menu appearance
+               - "module: visibility" - module visibility quick fix, declaration
+                 scanning, definitions file writing
                - "area: ci" - workflows, releases, repo automation
                - "area: docs" - README, wiki, changelog
                If the area is genuinely unclear from the report, skip this label


### PR DESCRIPTION
Closes #289

Adds a `src/visibility/**` -> `module: visibility` mapping to `.github/labeler.yml` and the matching label-vocabulary line to the `claude-issue-triage.yml` prompt, so visibility PRs and issues stop falling back to unlabeled or `module: imports`.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

Test Suites: 37 passed, 37 total
Tests:       737 passed, 737 total
Snapshots:   0 total
Time:        12.079 s
Ran all test suites.

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Both edited YAML files were also checked with `js-yaml` parse to confirm valid syntax (neither file is covered by `tsc`/`jest`/prettier).

Review gate: PASS, no findings (round 1).
