### PR TITLE
fix(services): accept every module declaration form in the project scan

### DIFF
--- a/changelog.d/282.fixed.md
+++ b/changelog.d/282.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: a module declared as `Name := module { ... }`, with the brace on the next line, or as `Name := module. ...` now enters the project's declaration cache, so module lookups and quick fixes see it.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -160,12 +160,12 @@ export class ProjectPathScanner {
         // rather than captured - except by modulePattern, which allows none
         // there and so does not match a module carrying them.
         //
-        // A module body is written in any of the three styles Verse gives a
-        // macro, so the keyword ends at `:`, `{` or `.`, and at the line end
-        // when the brace opens on the next line. `>` matches the terminators
-        // ImportPathConverter.buildModuleDefinitionRegex accepts. This line is
-        // matched trimmed, so the alternative is what reaches a next-line
-        // brace that regex reads through `\s*` over the whole file.
+        // A module body takes any of the three styles Verse gives a macro, so
+        // the keyword ends at `:`, `{` or `.` - or at the line end, which is
+        // how a next-line brace reaches a scan that sees one line at a time.
+        // `>` holds parity with the two other spellings of this grammar,
+        // ImportPathConverter.buildModuleDefinitionRegex and
+        // moduleDeclarations' MODULE_DECLARATION.
         const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*(?:[:>{.]|$)/;
         const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\s*(?:<[^>]+>)*\s*[\(:]?/;
         const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\s*(?:<[^>]+>)*\s*[\(:]?/;

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -159,7 +159,14 @@ export class ProjectPathScanner {
         // right of `:=` belong to the type, not the name, and are skipped
         // rather than captured - except by modulePattern, which allows none
         // there and so does not match a module carrying them.
-        const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*:/;
+        //
+        // A module body is written in any of the three styles Verse gives a
+        // macro, so the keyword ends at `:`, `{` or `.`, and at the line end
+        // when the brace opens on the next line. `>` matches the terminators
+        // ImportPathConverter.buildModuleDefinitionRegex accepts. This line is
+        // matched trimmed, so the alternative is what reaches a next-line
+        // brace that regex reads through `\s*` over the whole file.
+        const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*(?:[:>{.]|$)/;
         const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\s*(?:<[^>]+>)*\s*[\(:]?/;
         const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\s*(?:<[^>]+>)*\s*[\(:]?/;
         const interfacePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*interface\s*(?:<[^>]+>)*\s*[\(:]?/;

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -1,0 +1,64 @@
+import { ProjectPathScanner } from "../ProjectPathScanner";
+import { ProjectPathNode } from "../../types";
+
+/**
+ * Regression tests for issue #282: the scanner's module pattern ended at `:`,
+ * so a module written in either of the other two styles Verse gives a macro
+ * body was dropped from the declaration cache entirely - the fall-through
+ * variable pattern matched the `:` of `:=` and its guard then skipped the line
+ * for naming `module`, leaving every reader of the cache blind to it.
+ *
+ * extractDeclarations is pure, so these run without the VS Code runtime.
+ */
+describe("ProjectPathScanner.extractDeclarations module forms", () => {
+    type ScannerParams = ConstructorParameters<typeof ProjectPathScanner>;
+
+    const scanner = new ProjectPathScanner({ appendLine: jest.fn() } as unknown as ScannerParams[0], {} as unknown as ScannerParams[1]);
+
+    const declare = (source: string): ProjectPathNode[] => scanner.extractDeclarations(source, "Content/Inventory.verse");
+
+    const moduleNames = (source: string): string[] =>
+        declare(source)
+            .filter((node) => node.type === "module")
+            .map((node) => node.name);
+
+    it("records a module whose brace opens on the declaration line", () => {
+        expect(moduleNames("Inventory := module{}\n")).toEqual(["Inventory"]);
+        expect(moduleNames("Inventory := module { }\n")).toEqual(["Inventory"]);
+    });
+
+    it("records a module whose brace opens on the following line", () => {
+        expect(moduleNames("Inventory := module\n{\n    Count<public>:int = 0\n}\n")).toEqual(["Inventory"]);
+    });
+
+    it("records the module at the head of a dotted declaration", () => {
+        // Only the head: the scan is line-anchored, so the second declaration
+        // on the line is out of its reach either way.
+        expect(moduleNames("Inventory := module. Item := module{}\n")).toEqual(["Inventory"]);
+    });
+
+    it("accepts the `>` terminator its sibling in ImportPathConverter accepts", () => {
+        expect(moduleNames("Inventory := module>\n")).toEqual(["Inventory"]);
+    });
+
+    it("still records the colon form, and nests what a braced module contains", () => {
+        expect(moduleNames("Inventory := module:\n    Count:int = 0\n")).toEqual(["Inventory"]);
+
+        const nested = declare("Inventory := module {\n    Item := class {}\n}\n");
+        expect(nested.map((node) => [node.type, node.fullPath])).toEqual([
+            ["module", "Inventory"],
+            ["class", "Inventory.Item"],
+        ]);
+    });
+
+    it("keeps reading the visibility specifier attached to the name", () => {
+        const [declared] = declare("Inventory<public> := module {}\n");
+        expect(declared).toMatchObject({ name: "Inventory", type: "module", isPublic: true, sourceLine: 1 });
+
+        expect(moduleNames("Hidden<private> := module {}\n")).toEqual([]);
+    });
+
+    it("does not read a keyword that merely starts with module as a declaration", () => {
+        expect(moduleNames("Inventory := modulex\n")).toEqual([]);
+    });
+});

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -51,6 +51,17 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
         ]);
     });
 
+    it("leaves the members of a next-line brace module unnested", () => {
+        // Pins the limit rather than endorsing it: indentation alone closes a
+        // module, and the bare brace sits at the declaration's own indent, so
+        // it pops the module before the body is read.
+        const nested = declare("Inventory := module\n{\n    Item := class {}\n}\n");
+        expect(nested.map((node) => [node.type, node.fullPath])).toEqual([
+            ["module", "Inventory"],
+            ["class", "Item"],
+        ]);
+    });
+
     it("keeps reading the visibility specifier attached to the name", () => {
         const [declared] = declare("Inventory<public> := module {}\n");
         expect(declared).toMatchObject({ name: "Inventory", type: "module", isPublic: true, sourceLine: 1 });

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -5,7 +5,8 @@
  *
  * This overlaps ImportPathConverter's declaration regexes, which answer only
  * "does this file declare a module of this name", and ProjectPathScanner's,
- * which records a position but matches the colon form alone.
+ * which records a position but matches one line at a time and reads no
+ * quoted suffix.
  */
 
 /**


### PR DESCRIPTION
Closes #282

`ProjectPathScanner`'s module row ended at `module\s*:`, so only the colon form was recorded. The other forms were not merely mistyped — the fall-through `variablePattern` matched the `:` of `:=`, and its guard then skipped the line for naming `module`, so the declaration left no node at all and every reader of the cache was blind to it.

```diff
-const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*:/;
+const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*(?:[:>{.]|$)/;
```

`[:>{.]` is the terminator set `ImportPathConverter.buildModuleDefinitionRegex` already accepts. The `|$` alternative is what this site needs and the siblings do not: they match whole file text, so their `\s*` crosses the newline to a next-line brace, while this scan sees one trimmed line at a time. Both capture groups are unchanged — `[1]` the name, `[2]` the specifiers attached to it — which is the constraint the issue sets.

## On the approach

Widened in place, as the issue's stopgap option. The alternative it names — calling `buildModuleDefinitionRegex` with a wildcard — is not viable as written: that function escapes backslashes in its argument, captures neither the name nor the specifier block, and anchors on `\b` rather than line start.

One correction to the issue's premise: it says this is "the one remaining site in `src/` that spells the module-declaration grammar independently". #286 landed `MODULE_DECLARATION` in `src/visibility/moduleDeclarations.ts` after the issue was filed, so there are now three spellings, not two. Sharing that one here would still mean composing rather than reusing (the `|$` again), would invert the layering, and would silently widen the name grammar to quoted suffixes. Unifying them stays #45's job; the comment above the pattern now names both siblings so the triplication is findable when it lands.

## Known limits, unchanged by this PR

- A trailing comment after the keyword (`X := module # opens below`) still defeats the match. `buildModuleDefinitionRegex` has the identical gap.
- The scanner masks no comments, so a brace-form module inside a `<# ... #>` block is now recorded as one — the same pre-existing hole that already swallowed the colon form.
- Members of a next-line-brace module are not nested: the bare `{` sits at the declaration's own indent and indentation alone closes a module. Pinned by a test rather than left to be discovered.

## Tests

`src/services/__tests__/ProjectPathScanner.test.ts` is new — the class had no test file. One test per form; 6 of the 7 form tests fail against the unfixed pattern (`git stash push -- src/services/ProjectPathScanner.ts`), the seventh being the `modulex` negative, which must hold in both directions.

## Review

Fresh-context reviewer, opus: **PASS_WITH_SUGGESTIONS** — 0 Critical, 2 Important, 4 Suggestions. Both Important findings are applied here: the missing changelog fragment, and the now-false sentence in `moduleDeclarations.ts` describing this scanner as colon-only.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

Test Suites: 38 passed, 38 total
Tests:       745 passed, 745 total
Snapshots:   0 total
Time:        229.001 s
Ran all test suites.

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
