### PR TITLE
fix(visibility): report a narrowed module the declaration chain nests through

### DIFF
--- a/changelog.d/288.fixed.md
+++ b/changelog.d/288.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: the quick fix now reports a `scoped` or `epic_internal` module on the target's path instead of nesting a declaration through it, which wrote a `<scoped>` specifier that does not compile.

--- a/changelog.d/288.fixed.md
+++ b/changelog.d/288.fixed.md
@@ -1,1 +1,1 @@
-**Module visibility**: the quick fix now reports a `scoped` or `epic_internal` module on the target's path instead of nesting a declaration through it, which wrote a `<scoped>` specifier that does not compile.
+**Module visibility**: the quick fix now declines, and names the module to change by hand, when a `scoped`, `epic_internal`, `private` or `protected` module sits on the path to the one being made public.

--- a/changelog.d/288.fixed.md
+++ b/changelog.d/288.fixed.md
@@ -1,1 +1,1 @@
-**Module visibility**: the quick fix now declines, and names the module to change by hand, when a `scoped`, `epic_internal`, `private` or `protected` module sits on the path to the one being made public.
+**Module visibility**: the quick fix now declines, and names the module standing in the way, when a `scoped`, `epic_internal`, `private` or `protected` module sits on the path to the one being made public.

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -329,30 +329,23 @@ export class ModuleVisibilityWriter {
 }
 
 /**
- * Why a request was refused, phrased per conflict kind because the two need
- * different things from the user: one is a specifier to change, the other a
- * declaration to write inside a module the quick fix will not open up.
- *
- * The keyword is named rather than rendered as a specifier: `scoped` is
- * declared with a module list, and printing `<scoped>` would quote the file as
- * saying something it does not say - and would not compile if pasted back.
+ * Why a request was refused, naming what each conflicting module would have
+ * needed. The two kinds are phrased apart because they ask different things of
+ * the user, and one sentence carries both so a notification does not clip the
+ * second remedy before it is read.
  */
 function refusalForConflicts(moduleName: string, conflicts: readonly VisibilityConflict[]): string {
     const listed = (reason: VisibilityConflict["reason"]) =>
         conflicts
             .filter((conflict) => conflict.reason === reason)
-            .map((conflict) => `${conflict.path} is declared ${conflict.keyword}`)
-            .join(", ");
+            .map((conflict) => `${conflict.path}, declared ${conflict.keyword}`)
+            .join(" and ");
 
     const widen = listed("widen");
     const nest = listed("nest");
+    const clauses = [widen && `widening ${widen}`, nest && `declaring a module inside ${nest}`].filter(Boolean);
 
-    return [
-        widen && `making '${moduleName}' public would widen a deliberate restriction: ${widen}. Change it by hand if that is intended.`,
-        nest && `reaching '${moduleName}' would mean declaring a module inside a deliberately restricted one: ${nest}. Declare it there by hand if that is intended.`,
-    ]
-        .filter(Boolean)
-        .join(" ");
+    return `making '${moduleName}' reachable would mean ${clauses.join(", and ")}. Make the change by hand if that is intended.`;
 }
 
 /** The text with every specifier rewrite applied, taken last-first so earlier offsets stay valid. */

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -6,7 +6,7 @@ import { appendDeclarationBlock, buildDeclarationBlock } from "./definitionsCont
 import { findExplicitModuleDeclarations } from "./moduleDeclarations";
 import { ModuleVisibilityRequest } from "./ModuleVisibilityMessage";
 import { planVisibility, toContentSegments } from "./ModuleVisibilityPlanner";
-import { FoundDeclaration, resolveVisibility, SpecifierEdit } from "./visibilityResolution";
+import { FoundDeclaration, resolveVisibility, SpecifierEdit, VisibilityConflict } from "./visibilityResolution";
 
 /** The Content folder that anchors every module path, as in ImportPathConverter. */
 const CONTENT_FOLDER = "Content";
@@ -40,9 +40,10 @@ export class ModuleVisibilityWriter {
      * Makes the requested module reachable from the importing scope, and
      * reports what it did.
      *
-     * Refuses rather than half-applying: a module already narrowed to
-     * `<private>`, `<protected>` or `<scoped>` is left alone, and so is
-     * everything else the same request would have changed.
+     * Refuses rather than half-applying: a module declared anything but
+     * `<public>` or `<internal>` is left alone, whether it is the one to
+     * publicize or one a new declaration would sit inside, and so is everything
+     * else the same request would have changed.
      */
     async makeModulePublic(request: ModuleVisibilityRequest): Promise<void> {
         const outcome = await this.buildEdit(request);
@@ -105,8 +106,7 @@ export class ModuleVisibilityWriter {
         const resolved = resolveVisibility(prefix, segments, declarations);
 
         if (resolved.conflicts.length > 0) {
-            const listed = resolved.conflicts.map((conflict) => `${conflict.path} is <${conflict.keyword}>`).join(", ");
-            return { reason: `making '${request.moduleName}' public would widen a deliberate restriction: ${listed}. Change it by hand if that is intended.` };
+            return { reason: refusalForConflicts(request.moduleName, resolved.conflicts) };
         }
 
         if (resolved.edits.length === 0 && resolved.chain.length === 0) {
@@ -326,6 +326,33 @@ export class ModuleVisibilityWriter {
         }
         return `made '${moduleName}' public in the definitions file.`;
     }
+}
+
+/**
+ * Why a request was refused, phrased per conflict kind because the two need
+ * different things from the user: one is a specifier to change, the other a
+ * declaration to write inside a module the quick fix will not open up.
+ *
+ * The keyword is named rather than rendered as a specifier: `scoped` is
+ * declared with a module list, and printing `<scoped>` would quote the file as
+ * saying something it does not say - and would not compile if pasted back.
+ */
+function refusalForConflicts(moduleName: string, conflicts: readonly VisibilityConflict[]): string {
+    const listed = (reason: VisibilityConflict["reason"]) =>
+        conflicts
+            .filter((conflict) => conflict.reason === reason)
+            .map((conflict) => `${conflict.path} is declared ${conflict.keyword}`)
+            .join(", ");
+
+    const widen = listed("widen");
+    const nest = listed("nest");
+
+    return [
+        widen && `making '${moduleName}' public would widen a deliberate restriction: ${widen}. Change it by hand if that is intended.`,
+        nest && `reaching '${moduleName}' would mean declaring a module inside a deliberately restricted one: ${nest}. Declare it there by hand if that is intended.`,
+    ]
+        .filter(Boolean)
+        .join(" ");
 }
 
 /** The text with every specifier rewrite applied, taken last-first so earlier offsets stay valid. */

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -150,7 +150,20 @@ describe("ModuleVisibilityWriter", () => {
         await writer().makeModulePublic(REQUEST);
 
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("Gadgets/Tools is <private>"));
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("Gadgets/Tools is declared private"));
+    });
+
+    it("refuses to declare a module inside a scoped one, without quoting it as a specifier it is not", async () => {
+        givenProject({ "Content/systems.verse": "Gadgets<scoped{Scripts}> := module:\n    X:int = 1\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        const [warning] = (vscode.window.showWarningMessage as jest.Mock).mock.calls[0];
+        expect(warning).toContain("Gadgets is declared scoped");
+        // The declaration reads `<scoped{Scripts}>`; printing `<scoped>` would
+        // quote the file as saying something that does not compile.
+        expect(warning).not.toContain("<scoped>");
     });
 
     it("does nothing when the module is already public", async () => {

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -150,7 +150,9 @@ describe("ModuleVisibilityWriter", () => {
         await writer().makeModulePublic(REQUEST);
 
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("Gadgets/Tools is declared private"));
+        // "widening" is what separates this refusal from the nesting one below;
+        // the module name alone appears in both.
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("widening Gadgets/Tools, declared private"));
     });
 
     it("refuses to declare a module inside a scoped one, without quoting it as a specifier it is not", async () => {
@@ -160,7 +162,7 @@ describe("ModuleVisibilityWriter", () => {
 
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
         const [warning] = (vscode.window.showWarningMessage as jest.Mock).mock.calls[0];
-        expect(warning).toContain("Gadgets is declared scoped");
+        expect(warning).toContain("declaring a module inside Gadgets, declared scoped");
         // The declaration reads `<scoped{Scripts}>`; printing `<scoped>` would
         // quote the file as saying something that does not compile.
         expect(warning).not.toContain("<scoped>");

--- a/src/visibility/__tests__/moduleDeclarations.test.ts
+++ b/src/visibility/__tests__/moduleDeclarations.test.ts
@@ -37,6 +37,22 @@ describe("findExplicitModuleDeclarations", () => {
         expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<internal>");
     });
 
+    it("spans the whole of a scoped specifier, module list included", () => {
+        const content = "Tools<scoped{ModuleA, ModuleB}> := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(declaration.visibility?.keyword).toBe("scoped");
+        expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<scoped{ModuleA, ModuleB}>");
+    });
+
+    it("captures epic_internal, which read as a bare declaration would get a second specifier stacked beside it", () => {
+        const content = "Tools<epic_internal> := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(declaration.visibility?.keyword).toBe("epic_internal");
+        expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<epic_internal>");
+    });
+
     it("points the insertion point at the end of the name when there is no specifier", () => {
         const content = "Tools := module {}\n";
         const [declaration] = findExplicitModuleDeclarations(content);

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -106,8 +106,10 @@ describe("resolveVisibility", () => {
 
         const resolved = resolveVisibility([], segments(["Systems", false], ["Deep", true], ["Tools", true]), found);
 
-        // A part repeating `<private>` compiles, so this one went unnoticed, but
-        // nothing outside Systems can reach what it declares either way.
+        // A part repeating `<private>` compiles, and for an importer in the
+        // declaring scope it resolves the error too, which is why this one went
+        // unnoticed. It is refused because declaring new public modules inside
+        // a private boundary is a decision for whoever drew it.
         expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "private", reason: "nest" }]);
     });
 

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -76,7 +76,7 @@ describe("resolveVisibility", () => {
 
         const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
 
-        expect(resolved.conflicts).toEqual([{ path: "Gadgets/Tools", keyword: "private" }]);
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets/Tools", keyword: "private", reason: "widen" }]);
         expect(resolved.edits).toEqual([]);
     });
 
@@ -85,7 +85,7 @@ describe("resolveVisibility", () => {
 
         const resolved = resolveVisibility([], segments(["Systems", false], ["Deep", true], ["Tools", true]), found);
 
-        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "scoped" }]);
+        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "scoped", reason: "nest" }]);
         // `<scoped>` alone is not the declared specifier and does not compile;
         // the nesting part is written bare, and the conflict stops it anyway.
         expect(resolved.chain[0]).toEqual({ name: "Systems" });
@@ -97,8 +97,18 @@ describe("resolveVisibility", () => {
 
         const resolved = resolveVisibility([], segments(["Systems", false], ["Deep", true], ["Tools", true]), found);
 
-        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "epic_internal" }]);
+        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "epic_internal", reason: "nest" }]);
         expect(resolved.chain[0]).toEqual({ name: "Systems" });
+    });
+
+    it("reports a private module the chain would nest through, which used to be nested into silently", () => {
+        const found = declarationsIn("file://a", "", "Systems<private> := module:\n    X:int = 1\n");
+
+        const resolved = resolveVisibility([], segments(["Systems", false], ["Deep", true], ["Tools", true]), found);
+
+        // A part repeating `<private>` compiles, so this one went unnoticed, but
+        // nothing outside Systems can reach what it declares either way.
+        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "private", reason: "nest" }]);
     });
 
     it("leaves a scoped module alone when no written chain nests through it", () => {

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -80,6 +80,42 @@ describe("resolveVisibility", () => {
         expect(resolved.edits).toEqual([]);
     });
 
+    it("reports a scoped module the chain would nest through, rather than repeating a specifier it cannot reproduce", () => {
+        const found = declarationsIn("file://a", "", "Systems<scoped{ModuleA, ModuleB}> := module:\n    X:int = 1\n");
+
+        const resolved = resolveVisibility([], segments(["Systems", false], ["Deep", true], ["Tools", true]), found);
+
+        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "scoped" }]);
+        // `<scoped>` alone is not the declared specifier and does not compile;
+        // the nesting part is written bare, and the conflict stops it anyway.
+        expect(resolved.chain[0]).toEqual({ name: "Systems" });
+        expect(resolved.edits).toEqual([]);
+    });
+
+    it("reports an epic_internal module the chain would nest through", () => {
+        const found = declarationsIn("file://a", "", "Systems<epic_internal> := module:\n    X:int = 1\n");
+
+        const resolved = resolveVisibility([], segments(["Systems", false], ["Deep", true], ["Tools", true]), found);
+
+        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "epic_internal" }]);
+        expect(resolved.chain[0]).toEqual({ name: "Systems" });
+    });
+
+    it("leaves a scoped module alone when no written chain nests through it", () => {
+        const found = [
+            ...declarationsIn("file://a", "", "Systems<scoped{ModuleA, ModuleB}> := module:\n    X:int = 1\n"),
+            ...declarationsIn("file://b", "Systems", "Deep := module:\n    Tools := module {}\n"),
+        ];
+
+        const resolved = resolveVisibility([], segments(["Systems", false], ["Deep", true], ["Tools", true]), found);
+
+        // Everything below Systems is declared already, so nothing is written
+        // through it and its narrowing is nobody's business.
+        expect(resolved.conflicts).toEqual([]);
+        expect(resolved.chain).toEqual([]);
+        expect(resolved.edits.map((edit) => edit.path)).toEqual(["Systems/Deep", "Systems/Deep/Tools"]);
+    });
+
     it("addresses a segment by its full path, so a namesake elsewhere is not touched", () => {
         const found = declarationsIn("file://elsewhere", "Other", "Tools := module {}\n");
 

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -19,8 +19,16 @@
  */
 const MODULE_DECLARATION = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)((?:\s*<[^>]+>)*)\s*:=\s*module\s*[:>{.]/g;
 
-/** The visibility entry inside a stacked specifier block. */
-const VISIBILITY_SPECIFIER = /<\s*(public|protected|private|internal|scoped)\b[^>]*>/;
+/**
+ * The visibility entry inside a stacked specifier block. Group 1 is the keyword
+ * alone; the span covers the whole entry, `scoped`'s module list included.
+ *
+ * A specifier the alternation does not name reads as no specifier at all, and a
+ * caller then stacks its own beside the real one - two access specifiers on one
+ * definition, which is error 3543. That is why `epic_internal` is here despite
+ * being unreachable in user Content.
+ */
+const VISIBILITY_SPECIFIER = /<\s*(public|protected|private|internal|epic_internal|scoped)\b[^>]*>/;
 
 /** A half-open character span in the source text. */
 export interface SourceSpan {

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -30,6 +30,27 @@ export interface SpecifierEdit {
     text: string;
 }
 
+/** A module whose declared access stops the request, and what about it stops it. */
+export interface VisibilityConflict {
+    /** Content-relative path of the module, for the report to the user. */
+    path: string;
+
+    /**
+     * The declared visibility keyword alone. `scoped` carries a module list the
+     * scanner does not capture, so this is not the specifier as written and
+     * must not be reported as if it were.
+     */
+    keyword: string;
+
+    /**
+     * `widen` where the module itself has to become public, `nest` where a new
+     * part would be written inside it. The remedies differ: one is a change to
+     * this module's specifier, the other a declaration the user must make
+     * inside it by hand.
+     */
+    reason: "widen" | "nest";
+}
+
 /** Everything that has to happen for the target to become reachable. */
 export interface ResolvedVisibility {
     /** Specifier rewrites against declarations that already exist. */
@@ -41,8 +62,8 @@ export interface ResolvedVisibility {
      */
     chain: DeclarationSpec[];
 
-    /** Modules that could not be made public, with the specifier blocking each. */
-    conflicts: { path: string; keyword: string }[];
+    /** Modules that could not be made public, with what blocks each. */
+    conflicts: VisibilityConflict[];
 }
 
 const PUBLIC_SPECIFIER = "<public>";
@@ -57,13 +78,13 @@ const PUBLIC_SPECIFIER = "<public>";
  * into the definitions file, each of its modules repeats whatever specifier the
  * project already declares for that module.
  *
- * A module already declared `<private>`, `<protected>` or `<scoped>` is
- * reported as a conflict instead of being rewritten: those are deliberate
- * narrowings, and widening one silently is a decision that belongs to whoever
- * wrote it. Nesting the chain THROUGH such a module conflicts too, even where
- * the module itself needs no marking - the part that would be written repeats
- * the specifier from a keyword alone, and a keyword alone is not the specifier
- * for `scoped`, which carries a module list.
+ * A module declared anything other than `<public>` or `<internal>` is reported
+ * as a conflict rather than rewritten, and so is one the chain would merely
+ * nest a new part inside. Both are deliberate narrowings, and the second is a
+ * conflict for a mechanical reason as well: a written part has to repeat the
+ * declaration's specifier exactly, and `scoped`'s module list resolves against
+ * the scope that declared it, so it cannot be copied into a file at the Content
+ * root at all.
  *
  * @param prefix Content-relative segments above the planned ones. They are
  * already reachable, but the chain is written at the Content root, so it has to
@@ -110,9 +131,8 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
 
         if (blocking) {
             blocked.push({ chainIndex: chain.length, path: modulePath, keyword: blocking.declaration.visibility!.keyword, needsPublic: segment.needsPublic });
-            // Written bare so the chain still nests, and never carrying the
-            // blocking keyword: `<scoped>` without its module list does not
-            // compile. Whether any of this is applied is decided below.
+            // Bare so the chain still nests, and never carrying the blocking
+            // keyword: `<scoped>` without its module list does not compile.
             chain.push({ name: segment.name });
             written.push(false);
             continue;
@@ -149,7 +169,9 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     // A narrowed module blocks when it is the one to publicize, and equally
     // when the retained chain nests through it. Anything trimmed away is never
     // written, so a narrowing there is nobody's business.
-    const conflicts = blocked.filter((entry) => entry.needsPublic || entry.chainIndex <= deepestWritten).map(({ path, keyword }) => ({ path, keyword }));
+    const conflicts: VisibilityConflict[] = blocked
+        .filter((entry) => entry.needsPublic || entry.chainIndex <= deepestWritten)
+        .map(({ path, keyword, needsPublic }) => ({ path, keyword, reason: needsPublic ? "widen" : "nest" }));
 
     return {
         edits,

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -60,7 +60,10 @@ const PUBLIC_SPECIFIER = "<public>";
  * A module already declared `<private>`, `<protected>` or `<scoped>` is
  * reported as a conflict instead of being rewritten: those are deliberate
  * narrowings, and widening one silently is a decision that belongs to whoever
- * wrote it.
+ * wrote it. Nesting the chain THROUGH such a module conflicts too, even where
+ * the module itself needs no marking - the part that would be written repeats
+ * the specifier from a keyword alone, and a keyword alone is not the specifier
+ * for `scoped`, which carries a module list.
  *
  * @param prefix Content-relative segments above the planned ones. They are
  * already reachable, but the chain is written at the Content root, so it has to
@@ -78,9 +81,13 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     }
 
     const edits: SpecifierEdit[] = [];
-    const conflicts: { path: string; keyword: string }[] = [];
     const chain: DeclarationSpec[] = [];
     const written: boolean[] = [];
+
+    // Collected rather than reported on sight: whether nesting through a
+    // narrowed module matters depends on the trim below, which is not known
+    // until the walk is over.
+    const blocked: { chainIndex: number; path: string; keyword: string; needsPublic: boolean }[] = [];
 
     // The prefix modules are reachable already, so they are walked purely as
     // the nesting the chain needs - never marked, but still matched against
@@ -101,10 +108,11 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
 
         const blocking = declarations.find((entry) => entry.declaration.visibility && entry.declaration.visibility.keyword !== "public" && entry.declaration.visibility.keyword !== "internal");
 
-        if (segment.needsPublic && blocking) {
-            conflicts.push({ path: modulePath, keyword: blocking.declaration.visibility!.keyword });
-            // Written bare so the chain still nests, though the conflict means
-            // the caller will not apply any of it.
+        if (blocking) {
+            blocked.push({ chainIndex: chain.length, path: modulePath, keyword: blocking.declaration.visibility!.keyword, needsPublic: segment.needsPublic });
+            // Written bare so the chain still nests, and never carrying the
+            // blocking keyword: `<scoped>` without its module list does not
+            // compile. Whether any of this is applied is decided below.
             chain.push({ name: segment.name });
             written.push(false);
             continue;
@@ -126,7 +134,9 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
         }
 
         // Repeat what the project already declares, so a part written below
-        // this one cannot disagree with the parts that exist.
+        // this one cannot disagree with the parts that exist. Only `public` and
+        // `internal` reach here - every other keyword left through the branch
+        // above, which is what keeps a keyword-only repeat safe.
         const declaredKeyword = segment.needsPublic ? "public" : declarations[0].declaration.visibility?.keyword;
         chain.push({ name: segment.name, specifier: declaredKeyword });
         written.push(false);
@@ -135,6 +145,12 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     // The chain exists only to carry declarations that are not there yet. With
     // none to carry, the nesting above them is noise.
     const deepestWritten = written.lastIndexOf(true);
+
+    // A narrowed module blocks when it is the one to publicize, and equally
+    // when the retained chain nests through it. Anything trimmed away is never
+    // written, so a narrowing there is nobody's business.
+    const conflicts = blocked.filter((entry) => entry.needsPublic || entry.chainIndex <= deepestWritten).map(({ path, keyword }) => ({ path, keyword }));
+
     return {
         edits,
         chain: deepestWritten === -1 ? [] : chain.slice(0, deepestWritten + 1),


### PR DESCRIPTION
Closes #288

## What

`resolveVisibility` repeated a declared module's visibility keyword into the chain it writes into the definitions file. The scanner captures the keyword alone, so a `Systems<scoped{ModuleA, ModuleB}>` ancestor came back out as `Systems<scoped>` — a `scoped` clause with no module references, which `AnalyzeMacroCall_Scoped` rejects outright ("`scoped` clause must contain 1 or more module references"), and a mismatched part against the real declaration if it had parsed. The conflict guard missed it because it fired only on `needsPublic` segments, and an ancestor the chain merely nests through is not one.

Implements the issue's **second** acceptance option, per the maintainer's call: report, do not apply. Verbatim specifier repeat was rejected because a scope list is module *references* resolved against the declaring scope, so copying `<scoped{ModuleA, ModuleB}>` into a file at the Content root can fail to resolve or bind to a different `ModuleA`.

## How

- **Conflict detection moved after the chain trim.** A narrowed module conflicts when it is the one to publicize (unchanged) and now equally when the retained chain nests a new part inside it. The trim bound is what stops it over-firing: a narrowed module that no written chain passes through still gets its in-place edits.
- **A blocked segment is written bare**, never carrying the blocking keyword, so nothing but `public` or `internal` can now reach `buildDeclarationBlock`.
- **`epic_internal` joins the `VISIBILITY_SPECIFIER` alternation.** Outside it, such a declaration read as bare and got a second specifier stacked beside it (3543). The issue records it so the alternation is fixed once, not twice.
- **The refusal names which of the two problems it hit**, since the remedies differ: a specifier to change, or a declaration to write by hand inside a module the quick fix will not open up. The keyword is named rather than rendered as `<keyword>` — printing `<scoped>` quoted the file as saying something it does not say, and something that would not compile if pasted back.

One behaviour change beyond the reported symptom, deliberate and pinned by a test: a `<private>` or `<protected>` ancestor nested through used to produce a matching, *compiling* part and apply — and for an importer inside the declaring scope it resolved the error, since `<private>` limits visibility to the immediately enclosing scope rather than to the module itself. It now refuses instead. That follows the ticket's wording ("any declared ancestor whose visibility is not `public`/`internal`") and the reasoning behind it: declaring new public modules inside a boundary someone drew deliberately is their decision, not the quick fix's.

## Verification

```
$ npm run compile
> tsc -p ./
(clean)

$ npm test
Test Suites: 37 passed, 37 total
Tests:       744 passed, 744 total
Snapshots:   0 total
Time:        73.39 s

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

Regression tests proved: stashing `visibilityResolution.ts` and `moduleDeclarations.ts` and re-running fails exactly

```
● findExplicitModuleDeclarations › captures epic_internal, which read as a bare declaration would get a second specifier stacked beside it
● resolveVisibility › reports a scoped module the chain would nest through, rather than repeating a specifier it cannot reproduce
● resolveVisibility › reports an epic_internal module the chain would nest through
```

Two further new tests pass either way by design and say so: the specifier *span* was already correct before the fix (only the captured keyword was lossy), and "leaves a scoped module alone when no written chain nests through it" exists to catch over-firing.

## Review

Two rounds against a reviewer with its own context, both PASS_WITH_SUGGESTIONS, no Critical. Round 1 raised that the refusal message said "would widen a deliberate restriction" for a case where nothing is widened, and rendered the keyword as `<scoped>` — the exact invalid text this PR exists to stop being written. Round 2 caught that the two refusal phrasings were unpinned (both tests asserted fragments common to either branch) and that a test comment justified the `<private>` refusal with a claim about reachability that `docs/12_access.md:18` contradicts. Both applied.

## Not in this change

Two gaps of the same family, found while fixing this one and filed separately rather than widened into this diff:

- **#293** — a named scope alias (`SharedScope := scoped{A, B}` used as `<SharedScope>`) is an arbitrary identifier, so no keyword list can recognize it; it reads as bare and gets `<public>` stacked beside it. It needs a design decision this PR should not make.
- **#294** — `ImportPathConverter`'s sibling specifier regex lacks `scoped` and `epic_internal`, and its `\s*>` shape cannot match `<scoped{A, B}>` at all, so path conversion misses such a declaration. Pre-existing; this PR moved only the visibility scanner, which is what made the two disagree.
