### PR TITLE
fix(imports): ship an empty behavior.ambiguousImports default

### DIFF
--- a/changelog.d/266.changed.md
+++ b/changelog.d/266.changed.md
@@ -1,0 +1,1 @@
+**Ambiguous import mappings**: `behavior.ambiguousImports` now defaults to no mappings, so a configured mapping is applied exactly as you set it.

--- a/package.json
+++ b/package.json
@@ -228,11 +228,7 @@
         },
         "verseAutoImports.behavior.ambiguousImports": {
           "type": "object",
-          "default": {
-            "vector3": "/UnrealEngine.com/Temporary/SpatialMath",
-            "vector2": "/UnrealEngine.com/Temporary/SpatialMath",
-            "rotation": "/UnrealEngine.com/Temporary/SpatialMath"
-          },
+          "default": {},
           "description": "Mappings for class names that appear in multiple modules. Format: {\"className\": \"preferredModulePath\"}",
           "order": 15
         },

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -44,15 +44,11 @@ const QUALIFIED_NAME = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 
 /**
  * Fallback for behavior.ambiguousImports. package.json is the source of truth
- * and registers exactly these three mappings; keep the two in step. Only a
- * caller with no registered setting behind it, such as a test, ever sees this
- * value - config.get returns the registered default otherwise.
+ * and registers {} as the default; keep the two in step. Only a caller with
+ * no registered setting behind it, such as a test, ever sees this value -
+ * config.get returns the registered default otherwise.
  */
-export const DEFAULT_AMBIGUOUS_IMPORTS: Record<string, string> = {
-    vector3: "/UnrealEngine.com/Temporary/SpatialMath",
-    vector2: "/UnrealEngine.com/Temporary/SpatialMath",
-    rotation: "/UnrealEngine.com/Temporary/SpatialMath",
-};
+export const DEFAULT_AMBIGUOUS_IMPORTS: Record<string, string> = {};
 
 /** A resolvable import extracted from a compiler message. */
 interface ImportCandidate {

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -123,17 +123,28 @@ describe("ImportSuggestionExtractor", () => {
             expect(suggestions[0].description).toBe("Configured import for player");
         });
 
-        // Regression for #135: the fallback passed for behavior.ambiguousImports
-        // was {} where package.json registers three mappings. config.get returns
-        // the registered default for a registered setting, so production always
-        // had them - but the vscode mock returns the passed fallback, so the
-        // suite ran against no mappings at all.
-        it("should apply the registered ambiguous mappings when the user has set none", async () => {
+        it("should resolve a bare unknown identifier from a configured ambiguous mapping", async () => {
+            (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+                get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                    if (key === "behavior.ambiguousImports") {
+                        return { vector3: "/UnrealEngine.com/Temporary/SpatialMath" };
+                    }
+                    return defaultValue;
+                }),
+                update: jest.fn().mockResolvedValue(undefined),
+            });
+
             const suggestions = await extractor.extractImportSuggestions("Unknown identifier `vector3`");
 
             expect(suggestions).toHaveLength(1);
             expect(suggestions[0].importStatement).toBe("using { /UnrealEngine.com/Temporary/SpatialMath }");
             expect(suggestions[0].description).toBe("Configured import for vector3");
+        });
+
+        it("should return nothing for a bare unknown identifier when no ambiguous mapping is configured", async () => {
+            const suggestions = await extractor.extractImportSuggestions("Unknown identifier `vector3`");
+
+            expect(suggestions).toHaveLength(0);
         });
 
         it("should return nothing for messages without import-related content", async () => {

--- a/src/imports/__tests__/diagnosticsCorpus.test.ts
+++ b/src/imports/__tests__/diagnosticsCorpus.test.ts
@@ -9,6 +9,13 @@ interface CorpusEntry {
     source: "captured" | "book" | "synthetic";
     context?: string;
     message: string;
+    /**
+     * Per-entry config overrides, keyed the way config.get() is called (e.g.
+     * "behavior.ambiguousImports"). Applied only to suggestion extraction -
+     * extractImportsFromDiagnostics never reads configuration, so a settings
+     * override has no effect on the optimize-path assertion below.
+     */
+    settings?: Record<string, unknown>;
     expected: {
         suggestions: string[];
         optimizePaths: string[];
@@ -47,6 +54,13 @@ describe("diagnostics corpus", () => {
             });
 
             it.each(corpus.entries.map((entry) => [entry.id, entry] as const))("%s: suggestion extraction", async (_id, entry) => {
+                if (entry.settings) {
+                    const settings = entry.settings;
+                    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+                        get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key in settings ? settings[key] : defaultValue)),
+                        update: jest.fn().mockResolvedValue(undefined),
+                    });
+                }
                 const suggestions = await extractor.extractImportSuggestions(entry.message);
                 expect(suggestions.map((suggestion) => suggestion.importStatement)).toEqual(entry.expected.suggestions);
             });

--- a/src/test-integration/suite/regressionsConfig.itest.ts
+++ b/src/test-integration/suite/regressionsConfig.itest.ts
@@ -28,9 +28,11 @@ describe("configuration resolution regressions (issues #76/#77)", () => {
         // the fixture's own workspace value) and clear any legacy override.
         await setWorkspaceSetting("general.autoImportDebounceDelay", FIXTURE_DEBOUNCE_MS);
         await setWorkspaceSetting("general.diagnosticDelay", undefined);
+        await setWorkspaceSetting("behavior.ambiguousImports", undefined);
     });
 
-    it("#77: the default behavior.ambiguousImports mapping drives auto-import for a bare unknown identifier", async () => {
+    it("#77: a configured behavior.ambiguousImports mapping drives auto-import for a bare unknown identifier", async () => {
+        await setWorkspaceSetting("behavior.ambiguousImports", { vector3: "/UnrealEngine.com/Temporary/SpatialMath" });
         const document = await openFixture("r77_ambiguous_mapping.verse");
         injector.inject(document, [corpusMessage("unknown-identifier-bare-ambiguous")], "vector3");
 

--- a/test-fixtures/corpus/41.10/diagnostics.json
+++ b/test-fixtures/corpus/41.10/diagnostics.json
@@ -126,8 +126,11 @@
         {
             "id": "unknown-identifier-bare-ambiguous",
             "source": "synthetic",
-            "context": "bare unknown identifier with no inline suggestion; the registered behavior.ambiguousImports default maps vector3 to /UnrealEngine.com/Temporary/SpatialMath, so extraction resolves it without any inline hint (issue #77 regression, also asserted by the integration suite). Before issue #135 this entry expected nothing, because the extractor's code-side fallback was {} and the test mock returned that fallback rather than the registered default.",
+            "context": "bare unknown identifier with no inline suggestion; settings configures a behavior.ambiguousImports mapping for vector3, so extraction resolves it without any inline hint (issue #77 regression, also asserted by the integration suite, which sets the same mapping explicitly rather than relying on a shipped default).",
             "message": "Unknown identifier `vector3`.\nUsed inside module /vukefn@fortnite.com/VerseAutoImports/Scripts.",
+            "settings": {
+                "behavior.ambiguousImports": { "vector3": "/UnrealEngine.com/Temporary/SpatialMath" }
+            },
             "expected": {
                 "suggestions": ["using { /UnrealEngine.com/Temporary/SpatialMath }"],
                 "optimizePaths": []

--- a/test-fixtures/corpus/README.md
+++ b/test-fixtures/corpus/README.md
@@ -34,6 +34,9 @@ and asserts, for each entry, the output of both extraction paths.
             "source": "captured | book | synthetic",
             "context": "optional: where the message came from",
             "message": "verbatim compiler message, newlines preserved",
+            "settings": {
+                "behavior.ambiguousImports": { "className": "/preferred/module/path" }
+            },
             "expected": {
                 "suggestions": ["using { /Fortnite.com/Devices }"],
                 "optimizePaths": ["/Fortnite.com/Devices"]
@@ -48,6 +51,12 @@ and asserts, for each entry, the output of both extraction paths.
 - `expected.optimizePaths`: paths `extractImportsFromDiagnostics` must return
   (the Optimize Imports path). Ambiguous multi-option messages expect `[]`
   here by design.
+- `settings`: optional, per-entry config overrides keyed the way `config.get`
+  is called (e.g. `"behavior.ambiguousImports"`). Applies only to the
+  suggestion-extraction assertion - `extractImportsFromDiagnostics` never
+  reads configuration, so a `settings` override has no effect on
+  `expected.optimizePaths`. Omit it entirely when an entry should run against
+  the real registered defaults.
 - `source`: `captured` = recorded from a live UEFN session (highest value),
   `book` = preserved compiler output from the Book of Verse, `synthetic` =
   hand-written shape awaiting live capture. Replace synthetic entries with

--- a/test-fixtures/integration-workspace/Project/Content/r77_ambiguous_mapping.verse
+++ b/test-fixtures/integration-workspace/Project/Content/r77_ambiguous_mapping.verse
@@ -1,5 +1,5 @@
-# Config regression (issue #77): a bare unknown identifier covered by the
-# default behavior.ambiguousImports mapping must auto-import the mapped path.
+# Config regression (issue #77): a bare unknown identifier covered by a
+# configured behavior.ambiguousImports mapping must auto-import the mapped path.
 
 r77_probe := class:
     var Position:vector3 = vector3{}


### PR DESCRIPTION
Closes #266

## What

Registers `{}` as the default for `verseAutoImports.behavior.ambiguousImports` instead of the three shipped `vector3`/`vector2`/`rotation` -> `/UnrealEngine.com/Temporary/SpatialMath` mappings. The setting stays - a user who hits a real bare-identifier ambiguity can still configure a mapping.

## Why

The shipped mappings never fire on the diagnostic that actually reports these names as ambiguous (`Identifier vector3 could be one of many types: ...` classifies as `multiOption`, not the bare-identifier `identifier` kind the mapping reads), and no captured diagnostic in the corpus exercises the path the mapping does fire on. They were also the one place the extension resolved an ambiguity silently, where the two comparable mechanisms (`multiOptionStrategy`, digest lookup) both ask the user.

## Changes

- `package.json` / `DEFAULT_AMBIGUOUS_IMPORTS`: default becomes `{}`.
- `src/imports/__tests__/ImportSuggestionExtractor.test.ts`: reframed the old #135 regression test to configure the mapping explicitly (matching its neighbor test) rather than relying on the shipped default, and added a new test covering the empty-default path itself (no suggestions when nothing is configured).
- `src/imports/__tests__/diagnosticsCorpus.test.ts` + `test-fixtures/corpus/41.10/diagnostics.json` + `test-fixtures/corpus/README.md`: added an optional per-entry `settings` field to the corpus schema so `unknown-identifier-bare-ambiguous` can configure the mapping explicitly instead of depending on the shipped default (documented as suggestion-extraction-only, since `extractImportsFromDiagnostics` never reads config).
- `src/test-integration/suite/regressionsConfig.itest.ts`: the `#77` test now sets `behavior.ambiguousImports` via workspace settings before injecting the diagnostic, and restores it in the shared `afterEach`.
- Wiki [Configuration](https://github.com/vukefn/verse-auto-imports/wiki/Configuration) page's "Full Configuration Reference" block updated to show the new `{}` default.
- `changelog.d/266.changed.md`.

## Out of scope (per the issue)

- The resolution order in `extractImportSuggestions` (configured mapping vs. digest lookup).
- Removing the `behavior.ambiguousImports` setting itself.

## Verification

```
npm run compile
```
Clean, no output.

```
npm test
```
```
Test Suites: 37 passed, 37 total
Tests:       738 passed, 738 total
Snapshots:   0 total
```

```
npm run format:check
```
```
Checking formatting...
All matched files use Prettier code style!
```

`npm run test:integration` covers the reframed `#77` test; not run locally (requires a live VS Code instance), gated in CI on `windows-latest`.

## Review

A fresh reviewer subagent reviewed the diff against the ticket's scope and acceptance criteria and the repo's Fowler smell baseline: `PASS_WITH_SUGGESTIONS`, 0 Critical, 1 Important, 1 Suggestion. Both addressed before this PR was opened:

- Important: the changelog entry originally asserted an unverified VS Code object-setting merge behavior as the cause; reworded to state only the verified, observable effect.
- Suggestion: added the missing regression test for the new empty-default path (no suggestion for an unconfigured bare ambiguous identifier).
