### PR TITLE
fix(imports): bound the organized block against the imports pinned below it

### DIFF
--- a/changelog.d/232.fixed.md
+++ b/changelog.d/232.fixed.md
@@ -1,0 +1,1 @@
+**Organize Imports**: an import is no longer hoisted above the import pinned to its line that brings its first segment into scope, so organizing a file holding one leaves it compiling

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -351,6 +351,34 @@ export class ImportDocumentEditor {
     }
 
     /**
+     * The last line a pinned import forbids `path` from being hoisted above, or
+     * -1 where none does.
+     *
+     * A rebuilt block is written above every pinned line, so a pinned import
+     * that has to precede `path` rules the block out for it altogether. The
+     * floor is therefore read as a yes or no first, and only then as the line a
+     * path with none of its own is written below.
+     *
+     * Taken from pinnedBounds so that the writer that rebuilds a block and the
+     * writer that adds a single import cannot disagree about what precedes
+     * what: the same floor, from the same belongsAbove. The ceiling that comes
+     * with it says nothing here - a block above every pinned line already
+     * satisfies one, and a path written directly below this floor is above
+     * every pinned import further down.
+     *
+     * A pinned import never bounds its own path. Nothing needs itself in scope,
+     * and the duplicate of a pinned path the withhold rules deliberately keep
+     * would otherwise be stranded in the body instead of being organized.
+     */
+    private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string): number {
+        return this.pinnedBounds(
+            pinned.filter((imp) => imp.path !== path),
+            classifications,
+            path,
+        ).floor;
+    }
+
+    /**
      * Where the imports pinned to their line allow a new `path` to be written.
      * See PinnedBounds.
      */
@@ -849,6 +877,12 @@ export class ImportDocumentEditor {
      * first segment against the copy being removed; see the withholdIsSafe
      * check.
      *
+     * A pinned import also bounds the block the file is organized around: a
+     * path it may have to precede is not hoisted above it. An import already
+     * written keeps its line, untidy but compiling; an additional path, which
+     * has no line to keep, is written directly below the pinned statement that
+     * constrains it. See hoistFloor.
+     *
      * The result keeps the text's own line ending, so rebuilding an already
      * organized document reproduces it byte for byte and organizeImports can
      * skip the edit.
@@ -866,6 +900,8 @@ export class ImportDocumentEditor {
     ): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
         const lines = text.split(LINE_SPLIT);
+        const classifications = classifyLines(lines);
+        const headerEnd = headerLineCount(classifications);
         // A pinned import - one anchored by a comment marker, or one sharing its
         // span with another statement - is neither hoisted nor removed from the
         // body: its line stays exactly where it is, and the rest of the file is
@@ -876,9 +912,23 @@ export class ImportDocumentEditor {
         // why it does; see ScannedImport.rebuildLosesText.
         const allImports = scanModuleImports(lines);
         const movableImports = rewritableImports(allImports);
-        const pinnedPaths = new Set(pinnedImports(allImports).map((imp) => imp.path));
+        const pinned = pinnedImports(allImports);
+        const pinnedPaths = new Set(pinned.map((imp) => imp.path));
 
-        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0 && !pinnedPaths.has(p));
+        // The block goes above every pinned line, so an import a pinned one may
+        // have to precede is left on the line it was written on rather than
+        // hoisted into it. Untidy, and the alternative is a file that no longer
+        // compiles: a `using` resolves its own path top-down, so a path whose
+        // first segment the pinned import brings into scope has to stay below
+        // it. See hoistFloor.
+        const groundedImports = movableImports.filter((imp) => this.hoistFloor(pinned, classifications, imp.path) !== -1);
+        const groundedPaths = new Set(groundedImports.map((imp) => imp.path));
+        const hoistableImports = movableImports.filter((imp) => !groundedPaths.has(imp.path));
+
+        // A grounded import is a statement the file keeps, so a path one of them
+        // already covers is dropped here as a pinned path is. The block's own
+        // deduplication cannot do it: the grounded statement is not in the block.
+        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0 && !pinnedPaths.has(p) && !groundedPaths.has(p));
 
         // Module imports have file scope, so the names an anchored import brings
         // in are available to code anywhere in the file, however far down its
@@ -916,7 +966,7 @@ export class ImportDocumentEditor {
         // direction: the duplicate left behind is legal Verse, and a stranded
         // provider is a file that stops compiling.
         const withholdIsSafe = [...allUsingPaths(lines), ...extraPaths].every((path) => this.formatter.importRank(path) === 0);
-        const blockImports = withholdIsSafe ? movableImports.filter((imp) => !pinnedPaths.has(imp.path)) : movableImports;
+        const blockImports = withholdIsSafe ? hoistableImports.filter((imp) => !pinnedPaths.has(imp.path)) : hoistableImports;
 
         const paths = blockImports.map((imp) => imp.path);
         // Keyed on the unfiltered set: a file whose only rewritable import is
@@ -926,15 +976,29 @@ export class ImportDocumentEditor {
             return null;
         }
 
-        const classifications = classifyLines(lines);
-        const headerEnd = headerLineCount(classifications);
+        // An additional path the block cannot take is written on its own line
+        // directly below the pinned statement that constrains it, since it has
+        // no line of its own to keep. Declining to write it at all would make
+        // organizing a file with such an import silently add nothing.
+        const topExtraPaths: string[] = [];
+        const groundedExtrasByLine = new Map<number, string[]>();
+        for (const path of extraPaths) {
+            const floor = this.hoistFloor(pinned, classifications, path);
+            if (floor === -1) {
+                topExtraPaths.push(path);
+                continue;
+            }
+            groundedExtrasByLine.set(floor, [...(groundedExtrasByLine.get(floor) ?? []), path]);
+        }
 
         // Every line the rebuilt block accounts for: the import statements
         // themselves, and the comment lines written above them, which are part
-        // of the statement they annotate rather than of the body.
+        // of the statement they annotate rather than of the body. A grounded
+        // import is in neither list - its statement and its comments stay in
+        // the body, where they already read correctly.
         const hoistedLines = new Set<number>();
         const commentsByPath = new Map<string, string[]>();
-        for (const imp of movableImports) {
+        for (const imp of hoistableImports) {
             for (let line = imp.startLine; line <= imp.endLine; line++) {
                 hoistedLines.add(line);
             }
@@ -954,9 +1018,22 @@ export class ImportDocumentEditor {
         }
 
         const header = lines.slice(0, headerEnd);
-        const body = lines.filter((_, index) => index >= headerEnd && !hoistedLines.has(index));
+        const body: string[] = [];
+        for (let index = headerEnd; index < lines.length; index++) {
+            if (!hoistedLines.has(index)) {
+                body.push(lines[index]);
+            }
+            const groundedExtras = groundedExtrasByLine.get(index);
+            if (groundedExtras) {
+                // Grouping is a property of the block at the top, so a run
+                // written between two body lines is emitted ungrouped: the
+                // separator a strategy puts between its two groups would read
+                // as a gap in the code around it.
+                body.push(...this.formatter.groupAndFormatImports(groundedExtras, options.preferDotSyntax, options.sortAlphabetically, "none"));
+            }
+        }
 
-        const uniquePaths = Array.from(new Set([...paths, ...extraPaths]));
+        const uniquePaths = Array.from(new Set([...paths, ...topExtraPaths]));
         const formatted = this.formatter.groupAndFormatImports(uniquePaths, options.preferDotSyntax, options.sortAlphabetically, options.importGrouping);
 
         // Put each comment back above the statement it was written for,

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -373,9 +373,9 @@ export class ImportDocumentEditor {
 
     /**
      * The last line a pinned import forbids `path` from being hoisted above, or
-     * -1 where none does. For a path with no line of its own, so any pinned
-     * import that must precede it rules out the block and names where the path
-     * goes instead.
+     * -1 where none does. `path` has no line of its own to keep, so a pinned
+     * import that must precede it both rules the block out and names the line
+     * the path is written below instead.
      *
      * The floor is pinnedBounds', from the same belongsAbove, so a rebuilt
      * block and a singly added import read one rule rather than two. Only the
@@ -893,11 +893,13 @@ export class ImportDocumentEditor {
      * first segment against the copy being removed; see the withholdIsSafe
      * check.
      *
-     * A pinned import also bounds the block the file is organized around: a
-     * path it may have to precede is not hoisted above it. An import already
-     * written keeps its line, untidy but compiling; an additional path, which
-     * has no line to keep, is written directly below the pinned statement that
-     * constrains it. See hoistFloor.
+     * A pinned import also bounds the block the file is organized around:
+     * nothing is carried across a pinned import that has to precede it. One
+     * written above such a line is hoisted like any other, the block being
+     * above that line as well; one written below it keeps its line, untidy but
+     * compiling. An additional path has no line to keep, so it is written
+     * directly below the pinned statement that constrains it. See
+     * crossesPinnedProvider and hoistFloor.
      *
      * The result keeps the text's own line ending, so rebuilding an already
      * organized document reproduces it byte for byte and organizeImports can
@@ -940,11 +942,13 @@ export class ImportDocumentEditor {
         const groundedPaths = new Set(movableImports.filter((imp) => this.crossesPinnedProvider(pinned, imp)).map((imp) => imp.path));
         const hoistableImports = movableImports.filter((imp) => !groundedPaths.has(imp.path));
 
-        // A grounded import is a statement the file keeps, so a path one of them
-        // already covers is dropped here as a pinned path is. The block's own
-        // deduplication cannot do it: the grounded statement is not in the
-        // block, and neither is an additional path written below a pinned line.
-        const extraPaths = Array.from(new Set(additionalPaths.map((p) => p.trim()))).filter((p) => p.length > 0 && !pinnedPaths.has(p) && !groundedPaths.has(p));
+        // A path the file already imports is not written again, whichever
+        // statement holds it - pinned, grounded, or hoisted into the block. The
+        // block's own deduplication answers for none of them once a path can be
+        // written below a pinned line instead of into the block: what lands
+        // there is compared against nothing.
+        const importedPaths = new Set(allImports.map((imp) => imp.path));
+        const extraPaths = Array.from(new Set(additionalPaths.map((p) => p.trim()))).filter((p) => p.length > 0 && !importedPaths.has(p));
 
         // Module imports have file scope, so the names an anchored import brings
         // in are available to code anywhere in the file, however far down its

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -351,24 +351,40 @@ export class ImportDocumentEditor {
     }
 
     /**
+     * Whether hoisting `imp` into a block at the top of the file would carry it
+     * above a pinned import that has to precede it.
+     *
+     * Position is the whole question, not the presence of such an import. The
+     * block is written above every pinned line, so an import already above
+     * every pinned one that must precede it lands in the same relation to them
+     * afterwards and can be sorted freely; one written below such a line would
+     * cross it, and a `using` that crosses the import bringing its first
+     * segment into scope stops resolving. Holding back an import that was never
+     * at risk would leave a file the sort could have repaired unrepaired.
+     *
+     * A pinned import never constrains its own path: nothing needs itself in
+     * scope, and the duplicate of a pinned path the withhold rules deliberately
+     * keep would be stranded in the body rather than organized.
+     */
+    private crossesPinnedProvider(pinned: ScannedImport[], imp: ScannedImport): boolean {
+        const rank = this.formatter.importRank(imp.path);
+        return pinned.some((other) => other.path !== imp.path && other.startLine < imp.startLine && this.belongsAbove(this.formatter.importRank(other.path), rank));
+    }
+
+    /**
      * The last line a pinned import forbids `path` from being hoisted above, or
-     * -1 where none does.
+     * -1 where none does. For a path with no line of its own, so any pinned
+     * import that must precede it rules out the block and names where the path
+     * goes instead.
      *
-     * A rebuilt block is written above every pinned line, so a pinned import
-     * that has to precede `path` rules the block out for it altogether. The
-     * floor is therefore read as a yes or no first, and only then as the line a
-     * path with none of its own is written below.
+     * The floor is pinnedBounds', from the same belongsAbove, so a rebuilt
+     * block and a singly added import read one rule rather than two. Only the
+     * floor: the ceiling pinnedBounds returns with it answers a question this
+     * caller has already answered, since a block above every pinned line, and a
+     * path written directly below this floor, both precede every pinned import
+     * further down.
      *
-     * Taken from pinnedBounds so that the writer that rebuilds a block and the
-     * writer that adds a single import cannot disagree about what precedes
-     * what: the same floor, from the same belongsAbove. The ceiling that comes
-     * with it says nothing here - a block above every pinned line already
-     * satisfies one, and a path written directly below this floor is above
-     * every pinned import further down.
-     *
-     * A pinned import never bounds its own path. Nothing needs itself in scope,
-     * and the duplicate of a pinned path the withhold rules deliberately keep
-     * would otherwise be stranded in the body instead of being organized.
+     * Exempts the path from itself for the reason crossesPinnedProvider does.
      */
     private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string): number {
         return this.pinnedBounds(
@@ -915,20 +931,20 @@ export class ImportDocumentEditor {
         const pinned = pinnedImports(allImports);
         const pinnedPaths = new Set(pinned.map((imp) => imp.path));
 
-        // The block goes above every pinned line, so an import a pinned one may
-        // have to precede is left on the line it was written on rather than
-        // hoisted into it. Untidy, and the alternative is a file that no longer
+        // The block goes above every pinned line, so an import that hoisting
+        // would carry above a pinned one it needs is left on the line it was
+        // written on. Untidy, and the alternative is a file that no longer
         // compiles: a `using` resolves its own path top-down, so a path whose
         // first segment the pinned import brings into scope has to stay below
-        // it. See hoistFloor.
-        const groundedImports = movableImports.filter((imp) => this.hoistFloor(pinned, classifications, imp.path) !== -1);
-        const groundedPaths = new Set(groundedImports.map((imp) => imp.path));
+        // it. See crossesPinnedProvider.
+        const groundedPaths = new Set(movableImports.filter((imp) => this.crossesPinnedProvider(pinned, imp)).map((imp) => imp.path));
         const hoistableImports = movableImports.filter((imp) => !groundedPaths.has(imp.path));
 
         // A grounded import is a statement the file keeps, so a path one of them
         // already covers is dropped here as a pinned path is. The block's own
-        // deduplication cannot do it: the grounded statement is not in the block.
-        const extraPaths = additionalPaths.map((p) => p.trim()).filter((p) => p.length > 0 && !pinnedPaths.has(p) && !groundedPaths.has(p));
+        // deduplication cannot do it: the grounded statement is not in the
+        // block, and neither is an additional path written below a pinned line.
+        const extraPaths = Array.from(new Set(additionalPaths.map((p) => p.trim()))).filter((p) => p.length > 0 && !pinnedPaths.has(p) && !groundedPaths.has(p));
 
         // Module imports have file scope, so the names an anchored import brings
         // in are available to code anywhere in the file, however far down its
@@ -980,6 +996,11 @@ export class ImportDocumentEditor {
         // directly below the pinned statement that constrains it, since it has
         // no line of its own to keep. Declining to write it at all would make
         // organizing a file with such an import silently add nothing.
+        //
+        // Grouped by line as groupByPlacementLine groups the add path's, and
+        // deliberately not through it: that one places a run against a document
+        // being edited, honouring a ceiling as well, while these are spliced
+        // into text being rebuilt and hoistFloor says why no ceiling binds.
         const topExtraPaths: string[] = [];
         const groundedExtrasByLine = new Map<number, string[]>();
         for (const path of extraPaths) {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -259,12 +259,15 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
     // holds a bare or dotted import anywhere.
     it("keeps a duplicate when a dotted import could resolve against it", () => {
         const input = ["using { /A } <#> note", "    body", "using { /A }", "using { Economy.Shop }", "code()"].join("\n");
-        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A }", "using { Economy.Shop }", "", "using { /A } <#> note", "    body", "code()"].join("\n"));
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A }", "", "using { /A } <#> note", "    body", "using { Economy.Shop }", "code()"].join("\n"));
     });
 
-    it("keeps a duplicate of a bare anchored path when its dotted consumer is in the block", () => {
+    // The duplicate is hoisted rather than withheld, because a path cannot be
+    // resolving against itself. Its dotted consumer stays below the anchored
+    // line, which is a different question - see the hoisting tests below.
+    it("keeps a duplicate of a bare anchored path, leaving its dotted consumer below the anchor", () => {
         const input = ["using { Features }", "using { Economy.Shop }", "using { Features } <#> note", "    body", "code()"].join("\n");
-        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "using { Economy.Shop }", "", "using { Features } <#> note", "    body", "code()"].join("\n"));
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "", "using { Economy.Shop }", "using { Features } <#> note", "    body", "code()"].join("\n"));
     });
 
     it("keeps a duplicate when the consumer is itself anchored above the provider", () => {
@@ -367,6 +370,51 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
     it("returns null when the only import carries an indented comment marker", () => {
         const input = ["using { /A } <#> why this is here", "    it brings the module into scope", "code()"].join("\n");
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
+    });
+
+    // The block is rebuilt above every pinned line, so hoisting a path a pinned
+    // import brings into scope puts the consumer above its provider and the
+    // file stops compiling. Both pin reasons reach it, so both are pinned here.
+    describe("hoisting past an import pinned to its line", () => {
+        it("leaves a dotted consumer below the pinned import opening a block comment over it", () => {
+            const input = ["using { Features } <# note", "using { Old }", "#>", "using { Economy.Other }", "", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
+        });
+
+        it("leaves a bare consumer below the pinned import carrying an indented comment marker", () => {
+            const input = ["using { /game/TestUsing } <#> pinned", "    note", "using { WithASubmodule }", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
+        });
+
+        // The other pin reason: a `;` puts two statements on one span, so the
+        // line may not be rebuilt from any one path.
+        it("leaves a dotted consumer below the pinned import sharing its span with another statement", () => {
+            const input = ["using { Features }; using:", "    Economy.Shop", "using { Economy.Other }", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
+        });
+
+        // An added path has no line of its own to keep, so it is written below
+        // the statement that constrains it - past the body of the comment that
+        // pins it, which is where the marker's own body ends.
+        it("writes an added consumer below the pinned provider instead of into the block", () => {
+            const input = ["using { Features } <#> note", "    body", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, ["Economy.Other"], curlySorted)).toBe(["using { Features } <#> note", "    body", "using { Economy.Other }", "code()"].join("\n"));
+        });
+
+        // Only the paths the pinned import could provide are held back. An
+        // absolute path needs nothing in scope, so the file is still organized
+        // around what stays.
+        it("still hoists the absolute imports past a pinned bare provider", () => {
+            const input = ["using { Features } <#> note", "    body", "using { Economy.Other }", "using { /Zebra }", "using { /Apple }", "code()"].join("\n");
+            const organized = ["using { /Apple }", "using { /Zebra }", "", "using { Features } <#> note", "    body", "using { Economy.Other }", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(organized);
+            expect(editor.buildOrganizedContent(organized, [], curlySorted)).toBe(organized);
+        });
+
+        it("sorts a provider above its consumer as before when no import is pinned", () => {
+            const input = ["using { Economy.Other }", "using { Features }", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "using { Economy.Other }", "", "code()"].join("\n"));
+        });
     });
 
     // Excluding an import with an ordinary trailing comment from rewriting

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -420,6 +420,14 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "using { Economy.Shop }", "", "using { /A }; X := 1", "code()"].join("\n"));
         });
 
+        // A stale diagnostic naming a path the buffer already imports is the
+        // ordinary case, and what lands below a pinned line is compared against
+        // nothing once it is out of the block.
+        it("does not write an additional path the file already imports below a pinned line", () => {
+            const input = ["using { Features }", "using { /A }; X := 1", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted)).toBe(["using { Features }", "", "using { /A }; X := 1", "code()"].join("\n"));
+        });
+
         it("writes a repeated additional path below the pinned provider once", () => {
             const input = ["using { Features } <#> note", "    body", "code()"].join("\n");
             expect(editor.buildOrganizedContent(input, ["Economy.Other", "Economy.Other"], curlySorted)).toBe(

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -262,12 +262,9 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A }", "", "using { /A } <#> note", "    body", "using { Economy.Shop }", "code()"].join("\n"));
     });
 
-    // The duplicate is hoisted rather than withheld, because a path cannot be
-    // resolving against itself. Its dotted consumer stays below the anchored
-    // line, which is a different question - see the hoisting tests below.
-    it("keeps a duplicate of a bare anchored path, leaving its dotted consumer below the anchor", () => {
+    it("keeps a duplicate of a bare anchored path when its dotted consumer is in the block", () => {
         const input = ["using { Features }", "using { Economy.Shop }", "using { Features } <#> note", "    body", "code()"].join("\n");
-        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "", "using { Economy.Shop }", "using { Features } <#> note", "    body", "code()"].join("\n"));
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "using { Economy.Shop }", "", "using { Features } <#> note", "    body", "code()"].join("\n"));
     });
 
     it("keeps a duplicate when the consumer is itself anchored above the provider", () => {
@@ -381,8 +378,11 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
         });
 
+        // An absolute import exposes the public member modules of what it
+        // imports under their bare names, so a bare reference below one can be
+        // resolving through it.
         it("leaves a bare consumer below the pinned import carrying an indented comment marker", () => {
-            const input = ["using { /game/TestUsing } <#> pinned", "    note", "using { WithASubmodule }", "code()"].join("\n");
+            const input = ["using { /A } <#> pinned", "    note", "using { Features }", "code()"].join("\n");
             expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(input);
         });
 
@@ -409,6 +409,22 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             const organized = ["using { /Apple }", "using { /Zebra }", "", "using { Features } <#> note", "    body", "using { Economy.Other }", "code()"].join("\n");
             expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(organized);
             expect(editor.buildOrganizedContent(organized, [], curlySorted)).toBe(organized);
+        });
+
+        // Hoisting only carries an import across the pinned lines above it, so
+        // one already written above them all is sorted as it always was. Held
+        // back on the presence of a pinned provider rather than on crossing it,
+        // this file would keep an order that does not compile.
+        it("still sorts the imports written above the pinned line", () => {
+            const input = ["using { Economy.Shop }", "using { Features }", "using { /A }; X := 1", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "using { Economy.Shop }", "", "using { /A }; X := 1", "code()"].join("\n"));
+        });
+
+        it("writes a repeated additional path below the pinned provider once", () => {
+            const input = ["using { Features } <#> note", "    body", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, ["Economy.Other", "Economy.Other"], curlySorted)).toBe(
+                ["using { Features } <#> note", "    body", "using { Economy.Other }", "code()"].join("\n"),
+            );
         });
 
         it("sorts a provider above its consumer as before when no import is pinned", () => {


### PR DESCRIPTION
Closes #232

`buildOrganizedContent` hoisted every rewritable import into one block at the top and left each pinned line in the body, without ever asking whether a pinned import brings the first segment of a hoisted path into scope. A `using` resolves its own path top-down, so the rebuilt file stopped compiling.

## What changed

Nothing is carried across a pinned import that has to precede it.

- **An import already written above such a line is hoisted as before.** The block goes above that line too, so its relation to the pinned import is unchanged and the sort still repairs the order. Holding these back would leave a file the sort could have fixed unrepaired.
- **One written below it keeps its line** — not hoisted, not rebuilt, its comments left with it. Untidy rather than uncompilable, which is how the neighbouring `withholdIsSafe` errs and the answer the issue proposed to its own open question.
- **An additional path has no line to keep**, so it is written directly below the pinned statement that constrains it. Declining to write it would make "organize, then add the missing imports" silently add nothing.

The bound is the floor `pinnedBounds` already computes for the add path (#196, #270), from the same `belongsAbove`, so the two writers read one rule rather than two — the divergence #221 warns about. No ceiling is needed: the block precedes every pinned line already, and so does a path written directly below the floor.

Both pin reasons are covered — `anchorsCommentBelow` (under both markers) and `rebuildLosesText`.

## Acceptance

- Organizing a file whose pinned import provides the first segment of a path in the rebuilt block does not place that path above the pinned line — `src/imports/__tests__/ImportDocumentEditor.test.ts`, five cases including the issue's own reproduction.
- A file with no pinned import is unaffected and the sort is unchanged — pinned empty means `crossesPinnedProvider` is always false, so `hoistableImports === movableImports`; pinned by a test.
- Regression tests live in `src/imports/__tests__/` and run without the VS Code runtime.

One existing expectation changed: "keeps a duplicate when a dotted import could resolve against it". Its `Economy.Shop` sits below the anchored line, so it now stays there; the duplicate the test was written to pin is still kept, which is what it asserts.

Each new test was run against `origin/main` and fails there — 6 of the 9 in the group, the other three being the guards that must hold before and after.

## Not in scope

`addImportsToDocument`'s `preserveImportLocations: false` branch, the other half of #221, which is untouched and still open.

`placementLine`'s doc calls the rank-0-above-rank-1 floor a "preference, raised by a pinned absolute path that brings nothing into scope". An absolute import does bring names into scope — it exposes the public member modules of what it imports under their bare names, which is why a pinned `using { /A }` genuinely constrains a bare reference below it, as the new test asserts. That sentence is #270's and reopening its ceiling-wins reasoning belongs with #221, so it is left alone here and flagged rather than edited.

## Verification

```
$ npm run compile
> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 37 passed, 37 total
Tests:       746 passed, 746 total
Snapshots:   0 total
Time:        7.84 s

$ npm run format:check
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Two review rounds, both `PASS_WITH_SUGGESTIONS`, four Important findings between them, all fixed:

1. Grounding ignored position, holding back imports already above the pinned line and losing a repair the sort used to make.
2. `extraPaths` was no longer deduplicated on the branch that bypasses the block's set, so a path asked for twice was written twice.
3. The same branch also missed a path an import in the block already carried, which emitted it in both places — a regression introduced by the fix for (1), now pinned by its own test.
4. The method doc still stated the superseded rule after (1) landed.
