### PR TITLE
refactor(imports): drop the hover line the code lens provider never read

### DIFF
--- a/src/imports/ImportCodeLensProvider.ts
+++ b/src/imports/ImportCodeLensProvider.ts
@@ -4,20 +4,6 @@ import { ImportPathConverter } from "./ImportPathConverter";
 import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
 /**
- * What one document's lenses are doing: the import line under the pointer, and
- * the timer that will hide them.
- *
- * An entry can exist purely to hold that timer, with no line hovered, so
- * lineNumber is optional: a hide can be scheduled for a document that was never
- * entered through the hovering branch - after a conversion, for instance, which
- * sets isHoveringImport directly.
- */
-interface HoverState {
-    lineNumber?: number;
-    timeout: NodeJS.Timeout | null;
-}
-
-/**
  * The path-conversion lenses on a document's import lines, and the hover state
  * that decides whether they are shown at all.
  *
@@ -29,7 +15,8 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
     public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
 
     private readonly importPathConverter: ImportPathConverter;
-    private readonly hoverState = new Map<string, HoverState>();
+    /** The pending hide timer per document; an entry exists only while one is armed. */
+    private readonly hideTimers = new Map<string, NodeJS.Timeout>();
     private readonly isHoveringImport = new Map<string, boolean>();
     private refreshTimeout: NodeJS.Timeout | null = null;
     private readonly disposables: vscode.Disposable[] = [];
@@ -76,48 +63,45 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
      * once the hide delay elapses. A no-op in "always" mode, where visibility
      * does not follow the pointer.
      *
-     * @param lineNumber The hovered line; required for `hovering`, since a
-     *   hover reported without one leaves the state as it was.
+     * @param lineNumber The hovered line. Only its presence is read: it is what
+     *   marks the hover as landing on an import, and a `hovering` call without
+     *   one leaves the state as it was.
      */
     setHoverState(documentUri: string, hovering: boolean, lineNumber?: number): void {
         if (this.getVisibilityMode() === "always") {
             return;
         }
 
-        const currentState = this.hoverState.get(documentUri);
-
         if (hovering && lineNumber !== undefined) {
-            if (currentState?.timeout) {
-                clearTimeout(currentState.timeout);
-            }
+            this.clearPendingHide(documentUri);
 
-            this.hoverState.set(documentUri, {
-                lineNumber,
-                timeout: null,
-            });
             this.isHoveringImport.set(documentUri, true);
             this._onDidChangeCodeLenses.fire();
         } else if (!hovering) {
-            if (currentState?.timeout) {
-                clearTimeout(currentState.timeout);
-            }
+            this.clearPendingHide(documentUri);
 
             const hideDelay = this.getHideDelay();
             const timeout = setTimeout(() => {
                 this.isHoveringImport.set(documentUri, false);
-                this.hoverState.delete(documentUri);
+                this.hideTimers.delete(documentUri);
                 this._onDidChangeCodeLenses.fire();
             }, hideDelay);
 
-            // Recorded whether or not a state already existed. The commonest
+            // An armed timer left out of the map is one nothing can clear
+            // afterwards - not clearPendingHide, and not dispose. The commonest
             // caller is the hover provider reporting a non-import line, which
-            // reaches here with nothing stored, and a timer left out of the map
-            // is one nothing can clear afterwards - not keepHoverStateActive,
-            // and not dispose.
-            this.hoverState.set(documentUri, {
-                ...currentState,
-                timeout,
-            });
+            // reaches here with nothing stored at all.
+            this.hideTimers.set(documentUri, timeout);
+        }
+    }
+
+    /** Cancels a document's pending hide, and drops the entry that held it. */
+    private clearPendingHide(documentUri: string): void {
+        const pendingHide = this.hideTimers.get(documentUri);
+
+        if (pendingHide) {
+            clearTimeout(pendingHide);
+            this.hideTimers.delete(documentUri);
         }
     }
 
@@ -126,15 +110,7 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
      * lens and which takes long enough for a pending hide to fire mid-way.
      */
     keepHoverStateActive(documentUri: string): void {
-        const currentState = this.hoverState.get(documentUri);
-
-        // Clear any pending timeout, and record that it is gone: leaving the
-        // spent handle in the map makes the stored state contradict the real
-        // timer state, and entries now exist on paths where they did not.
-        if (currentState?.timeout) {
-            clearTimeout(currentState.timeout);
-            this.hoverState.set(documentUri, { ...currentState, timeout: null });
-        }
+        this.clearPendingHide(documentUri);
 
         this.isHoveringImport.set(documentUri, true);
 
@@ -279,12 +255,10 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
             this.refreshTimeout = null;
         }
 
-        for (const state of this.hoverState.values()) {
-            if (state.timeout) {
-                clearTimeout(state.timeout);
-            }
+        for (const timeout of this.hideTimers.values()) {
+            clearTimeout(timeout);
         }
-        this.hoverState.clear();
+        this.hideTimers.clear();
         this.isHoveringImport.clear();
 
         this._onDidChangeCodeLenses.dispose();

--- a/src/imports/__tests__/ImportCodeLensProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeLensProvider.test.ts
@@ -172,6 +172,27 @@ describe("ImportCodeLensProvider hide timers and teardown", () => {
         expect(lenses).toHaveLength(1);
     });
 
+    it("clears the pending hide when a conversion holds the lenses open", async () => {
+        // A conversion is driven from a lens and takes long enough for a hide
+        // armed just before it to fire mid-way. The timer has to be cleared
+        // rather than merely outrun, so the assertion is made before the delay
+        // elapses as well as after.
+        const provider = new ImportCodeLensProvider(vscode.window.createOutputChannel("test"));
+        const document = documentWith("using { Gadgets.Tools }\n\ncode()");
+        const documentUri = document.uri.toString();
+
+        provider.setHoverState(documentUri, true, 0);
+        provider.setHoverState(documentUri, false);
+        expect(jest.getTimerCount()).toBe(1);
+
+        provider.keepHoverStateActive(documentUri);
+        expect(jest.getTimerCount()).toBe(0);
+
+        jest.advanceTimersByTime(DEFAULT_HIDE_DELAY_MS);
+
+        await expect(provider.provideCodeLenses(document, {} as vscode.CancellationToken)).resolves.toHaveLength(1);
+    });
+
     it("clears a hide timer armed without a preceding hover", () => {
         // The hover provider reports every non-import line as hovering=false,
         // so this is the path the extension takes most. The timer used to be


### PR DESCRIPTION
Closes #259

`HoverState.lineNumber` was written once per hover in `setHoverState` and read nowhere in `src/`. Every visibility decision the provider makes goes through the other map, `isHoveringImport`, so the hovered line was recorded and then dropped.

Per the maintainer decision on the issue, this takes the removal reading rather than wiring the field up. `provideCodeLenses` gains no per-line filter, so nothing a user sees changes and there is no changelog fragment.

## What changed

- `HoverState` is gone. With `lineNumber` removed it held only a timer, so the map is now `Map<string, NodeJS.Timeout>` renamed `hideTimers` for what it actually holds.
- The three sites that cancel a pending hide share one `clearPendingHide` helper. Previously each open-coded the clear, in two subtly different forms, which read like one of them was missing a `delete`.
- `setHoverState` keeps its `lineNumber` parameter. Its presence is what marks a hover as landing on an import line, and the doc comment now says that is the only thing read from it.

## Why it is behaviour-preserving

The old map could hold an entry with `timeout: null`. Such an entry was inert at every read site — `setHoverState` and `keepHoverStateActive` both tested `currentState?.timeout`, `dispose` skipped null, and nothing ever read `.has()`, `.size`, or iterated for anything but timers. Entry existence therefore never meant more than "a timer is armed", which makes deleting on cancel equivalent to storing null on every path: the hovering branch, the not-hovering branch, the hide callback, `keepHoverStateActive`, `forceRefreshAfterConversion` (which never touched the map) and `dispose`.

## Tests

The existing timer and teardown suites already pinned three of the four changed paths. `keepHoverStateActive` was pinned nowhere, and it is the one path where the old representation left an entry behind and the new one removes it, so it gets a test. The assertion is made before the hide delay elapses as well as after, so it distinguishes a timer that was cleared from one that was merely outrun.

Verified the test has power by removing the `clearPendingHide` call from `keepHoverStateActive` and re-running it:

```
  * ImportCodeLensProvider hide timers and teardown > clears the pending hide when a conversion holds the lenses open

    expect(received).toBe(expected) // Object.is equality

    Expected: 0
    Received: 1

     188 |         provider.keepHoverStateActive(documentUri);
    >189 |         expect(jest.getTimerCount()).toBe(0);
```

## Verification

`npm run compile`:

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 38 passed, 38 total
Tests:       763 passed, 763 total
Snapshots:   0 total
Time:        29.56 s
Ran all test suites.
```

`npm run format:check`:

```
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

Fresh-context review gate: `PASS_WITH_SUGGESTIONS`, no Critical and no Important findings. All three suggestions were applied — the shared `clearPendingHide` helper, a comment whose opening sentence no longer had code under it to explain, and the `keepHoverStateActive` test.
