### PR TITLE
refactor(services): load precompiled digests from src/data only

### DIFF
--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -58,9 +58,9 @@ export class PrecompiledDigestLoader {
             const extensionPath = this.extensionContext.extensionPath;
             const dataDir = path.join(extensionPath, "src", "data");
 
-            // The .vsix carries src/data only because .vscodeignore re-includes
-            // it with `!src/data/**` after excluding src/**. Remove that
-            // negation and the packaged extension ships no digest data at all.
+            // The .vsix carries src/data only because .vscodeignore negates it
+            // with `!src/data/**`. Drop that negation and the packaged
+            // extension ships no digest data at all.
             if (!fs.existsSync(dataDir)) {
                 throw new Error(`Pre-compiled digest directory not found: ${dataDir}`);
             }

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -57,22 +57,15 @@ export class PrecompiledDigestLoader {
         try {
             const extensionPath = this.extensionContext.extensionPath;
             const dataDir = path.join(extensionPath, "src", "data");
-            let successCount = 0;
 
-            // src/data is the live location in both a checkout and a .vsix -
-            // .vscodeignore excludes src/** but re-includes src/data/**, and
-            // nothing copies the JSON into out/. The out/data branch below is
-            // dormant, and stays only against a build that starts copying.
+            // The .vsix carries src/data only because .vscodeignore re-includes
+            // it with `!src/data/**` after excluding src/**. Remove that
+            // negation and the packaged extension ships no digest data at all.
             if (!fs.existsSync(dataDir)) {
-                const outDataDir = path.join(extensionPath, "out", "data");
-                if (fs.existsSync(outDataDir)) {
-                    successCount = await this.loadFromDirectory(outDataDir);
-                } else {
-                    throw new Error(`Pre-compiled digest directory not found: ${dataDir}`);
-                }
-            } else {
-                successCount = await this.loadFromDirectory(dataDir);
+                throw new Error(`Pre-compiled digest directory not found: ${dataDir}`);
             }
+
+            const successCount = await this.loadFromDirectory(dataDir);
 
             if (successCount > 0) {
                 this.loaded = true;


### PR DESCRIPTION
Closes #256

`PrecompiledDigestLoader.loadPrecompiledDigests` now loads from `src/data` and throws directly when it is missing. The `out/data` fallback is gone, and the comment above the guard records the one fact that keeps the packaged extension working.

## Why the removed branch could not run

Confirmed on `origin/main` rather than taken from the issue:

- No script writes `out/data`. `vscode:prepublish` is `parse-digest && compile`; `compile` is bare `tsc -p ./`, and `tsconfig.json` sets no `resolveJsonModule`, so `tsc` cannot emit the JSON. Nothing in the workflows copies it either.
- `out/data` is absent after a clean compile.
- `src/data/{Fortnite,UnrealEngine,Verse}.digest.json` are tracked, so a checkout always has them.
- `vsce ls` on this branch lists exactly those three files under `src/`, so the `.vsix` always has them too.

Behaviour is therefore unchanged for every caller. The thrown message is identical, and `DigestParser.getDigestIndex` still catches it, warns, and falls back to runtime parsing.

## The comment

The first draft said the negation works because it comes *after* `src/**`. It does not: `vsce` partitions the file into ignore and negate lists and applies every negation last, whatever its position. The review gate caught that and checked it against a scratch fixture, so the wording now names the negation's presence and says nothing about order.

## Not done, deliberately

- **No changelog fragment.** Nothing about the editor experience changes, and `changelog.d/README` scopes fragments to user-facing change. `refactor(imports): delete the uncalled second module-declaration parser (#283)` landed the same way.
- **No new test.** This is dead-code removal, not a bug fix, and the loader is `fs`- and `ExtensionContext`-bound rather than the pure logic `CLAUDE.md` asks tests for. `precompiledDigestData.test.ts` reads `src/data` directly and is untouched by the change.

## Verification

```
$ npm run compile

> verse-auto-imports@0.10.0 compile
> tsc -p ./

```

```
$ npm test

> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 38 passed, 38 total
Tests:       762 passed, 762 total
Snapshots:   0 total
Time:        18.954 s, estimated 36 s
Ran all test suites.
```

```
$ npm run format:check

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review gate

`PASS_WITH_SUGGESTIONS`, no Critical findings. Two suggestions: the comment's ordering claim, fixed here; and a note that CI could assert the negation mechanically instead of relying on a comment, which is outside this ticket and left for a follow-up.
