### PR TITLE
fix(services): mask comments and strings before the project scan records a declaration

### DIFF
--- a/changelog.d/292.fixed.md
+++ b/changelog.d/292.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: A declaration commented out with a block comment, a `<#>` marker or a mid-line `#` is no longer recorded in the project declaration cache as live code.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
-import { maskCommentsAndStrings } from "../utils/verseText";
+import { indentOf, maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 
@@ -124,8 +124,12 @@ export class ProjectPathScanner {
      */
     extractDeclarations(content: string, filePath: string, options: ProjectScanOptions = {}): ProjectPathNode[] {
         const nodes: ProjectPathNode[] = [];
-        // Masking is space-for-character and keeps newlines, so a line's index,
-        // its length and its indentation all still address the original file.
+        // Masking is space-for-character and keeps newlines, so a masked line
+        // holds the index and the length of the line it replaces. It does not
+        // hold the indentation: a comment in the leading columns masks to
+        // spaces and reads as indentation, which is why the module stack
+        // measures the unmasked line instead.
+        const sourceLines = content.split("\n");
         const lines = maskCommentsAndStrings(content).split("\n");
 
         let currentModulePath = "";
@@ -185,8 +189,7 @@ export class ProjectPathScanner {
         const variablePattern = /^(\w+)((?:<[^>]+>)*)\s*:/;
 
         for (let i = 0; i < lines.length; i++) {
-            const rawLine = lines[i];
-            const line = rawLine.trim();
+            const line = lines[i].trim();
 
             // A comment is blank by the time it arrives here, so the empty test
             // is what skips one. `//` is not a Verse comment form and masking
@@ -199,10 +202,7 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // Each tab counts as four spaces so mixed indentation compares
-            // consistently.
-            const indentMatch = rawLine.match(/^(\s*)/);
-            const indent = indentMatch ? indentMatch[1].replace(/\t/g, "    ").length : 0;
+            const indent = indentOf(sourceLines[i], 0);
 
             // Indentation alone closes a module: a line at or left of the open
             // module's own indent is outside it.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
+import { maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 
@@ -116,10 +117,16 @@ export class ProjectPathScanner {
      * modules, so it equals `name` only at file scope. Declarations nested in a
      * class or struct body are not filtered out here; only indentation-scoped
      * module nesting is tracked.
+     *
+     * Comments and string literals are masked before the scan, so a
+     * commented-out declaration is neither recorded nor pushed onto the module
+     * stack, where it would prefix the `fullPath` of everything below it.
      */
     extractDeclarations(content: string, filePath: string, options: ProjectScanOptions = {}): ProjectPathNode[] {
         const nodes: ProjectPathNode[] = [];
-        const lines = content.split("\n");
+        // Masking is space-for-character and keeps newlines, so a line's index,
+        // its length and its indentation all still address the original file.
+        const lines = maskCommentsAndStrings(content).split("\n");
 
         let currentModulePath = "";
         const moduleStack: { name: string; indent: number }[] = [];
@@ -181,7 +188,10 @@ export class ProjectPathScanner {
             const rawLine = lines[i];
             const line = rawLine.trim();
 
-            if (line === "" || line.startsWith("#") || line.startsWith("//")) {
+            // A comment is blank by the time it arrives here, so the empty test
+            // is what skips one. `//` is not a Verse comment form and masking
+            // leaves it alone, so its own test stays.
+            if (line === "" || line.startsWith("//")) {
                 continue;
             }
 

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -191,9 +191,9 @@ export class ProjectPathScanner {
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i].trim();
 
-            // A comment is blank by the time it arrives here, so the empty test
-            // is what skips one. `//` is not a Verse comment form and masking
-            // leaves it alone, so its own test stays.
+            // A Verse comment is already blank here, so the empty test is what
+            // skips one; `//` is not a Verse comment form and masking leaves it
+            // alone.
             if (line === "" || line.startsWith("//")) {
                 continue;
             }

--- a/src/services/__tests__/ProjectPathScannerMasking.test.ts
+++ b/src/services/__tests__/ProjectPathScannerMasking.test.ts
@@ -65,6 +65,14 @@ describe("ProjectPathScanner.extractDeclarations comment and string masking", ()
         expect(declared.map((node) => [node.type, node.fullPath])).toEqual([["class", "Item"]]);
     });
 
+    it("measures indentation on the unmasked line, so a comment before a declaration does not nest it", () => {
+        // A comment in the leading columns masks to spaces. Read as
+        // indentation it puts the declaration inside the module above.
+        const declared = declare("Outer := module:\n    Inner := module:\n        Count:int = 0\n    <# note #> Sibling := module {}\n");
+
+        expect(declared.map((node) => node.fullPath)).toContain("Outer.Sibling");
+    });
+
     it("keeps the source line of a declaration below a block comment", () => {
         // Masking is space-for-character and keeps every newline. Anything
         // that blanked a comment wholesale would pass every test above and

--- a/src/services/__tests__/ProjectPathScannerMasking.test.ts
+++ b/src/services/__tests__/ProjectPathScannerMasking.test.ts
@@ -54,6 +54,9 @@ describe("ProjectPathScanner.extractDeclarations comment and string masking", ()
     });
 
     it("does not let a `#` inside a string literal hide the declaration on that line", () => {
+        // The default's closing `)` and the `:` after it are what the function
+        // pattern matches on, and a `#` read as a line comment takes both.
+        expect(names('Greet(Name:string = "a#b")<transacts>:void =\nInventory := module {}\n')).toEqual(["Greet", "Inventory"]);
         expect(names('Tag:string = "a#b"\nInventory := module {}\n')).toEqual(["Tag", "Inventory"]);
     });
 
@@ -70,7 +73,7 @@ describe("ProjectPathScanner.extractDeclarations comment and string masking", ()
         // indentation it puts the declaration inside the module above.
         const declared = declare("Outer := module:\n    Inner := module:\n        Count:int = 0\n    <# note #> Sibling := module {}\n");
 
-        expect(declared.map((node) => node.fullPath)).toContain("Outer.Sibling");
+        expect(declared.map((node) => node.fullPath)).toEqual(["Outer", "Outer.Inner", "Outer.Inner.Count", "Outer.Sibling"]);
     });
 
     it("keeps the source line of a declaration below a block comment", () => {

--- a/src/services/__tests__/ProjectPathScannerMasking.test.ts
+++ b/src/services/__tests__/ProjectPathScannerMasking.test.ts
@@ -1,0 +1,76 @@
+import { ProjectPathScanner } from "../ProjectPathScanner";
+import { ProjectPathNode } from "../../types";
+
+/**
+ * Both directions matter to the cache's readers. A declaration recorded where
+ * none exists resolves a module path the compiler never sees, and a phantom
+ * module also prefixes the `fullPath` of every real declaration below it; a
+ * real declaration hidden by a `#` inside a string is the same bug with the
+ * sign flipped.
+ *
+ * extractDeclarations is pure, so these run without the VS Code runtime.
+ */
+describe("ProjectPathScanner.extractDeclarations comment and string masking", () => {
+    type ScannerParams = ConstructorParameters<typeof ProjectPathScanner>;
+
+    const scanner = new ProjectPathScanner({ appendLine: jest.fn() } as unknown as ScannerParams[0], {} as unknown as ScannerParams[1]);
+
+    const declare = (source: string): ProjectPathNode[] => scanner.extractDeclarations(source, "Content/Inventory.verse");
+
+    const names = (source: string): string[] => declare(source).map((node) => node.name);
+
+    // The three single-line cases below already held before masking, because
+    // every pattern is anchored and none of them starts with a word character.
+    // They pin that, so a later scan that stops being line-anchored cannot
+    // reopen the hole quietly.
+    it("ignores a declaration commented out on one line with a block comment", () => {
+        expect(names("<# Ghost := module {} #>\nInventory := module {}\n")).toEqual(["Inventory"]);
+    });
+
+    it("ignores declarations inside a multi-line block comment", () => {
+        expect(names("<#\nGhost := module {}\nLegacy := class {}\n#>\nInventory := module {}\n")).toEqual(["Inventory"]);
+    });
+
+    it("ignores a declaration inside a nested block comment, which Verse allows", () => {
+        expect(names("<# outer <# Ghost := class {} #> still comment #>\nInventory := module {}\n")).toEqual(["Inventory"]);
+    });
+
+    it("ignores a declaration after a `<#>` marker on the marker's own line", () => {
+        // `<#>` opens the indented comment; it is not a block that closes on
+        // the `#>` inside it, and read as one it leaves the declaration live.
+        expect(names("<#> Ghost := module {}\nInventory := module {}\n")).toEqual(["Inventory"]);
+    });
+
+    it("ignores declarations in the indented body of a `<#>` marker, blank lines included", () => {
+        expect(names("<#>\n    Ghost := module {}\n\n    Legacy := class {}\nInventory := module {}\n")).toEqual(["Inventory"]);
+    });
+
+    it("ends a `<#>` body at the first line back at the marker's indent", () => {
+        expect(names("    <#>\n        Ghost := class {}\n    Inventory := module {}\n")).toEqual(["Inventory"]);
+    });
+
+    it("ignores a declaration after a `#` that does not start the line", () => {
+        expect(names("Count:int = 0 # Ghost := class {}\nInventory := module {}\n")).toEqual(["Count", "Inventory"]);
+    });
+
+    it("does not let a `#` inside a string literal hide the declaration on that line", () => {
+        expect(names('Tag:string = "a#b"\nInventory := module {}\n')).toEqual(["Tag", "Inventory"]);
+    });
+
+    it("keeps a commented-out module out of the enclosing-module chain", () => {
+        // The phantom is pushed onto the module stack as well as recorded, so
+        // an unmasked scan reports the real class as `Ghost.Item`.
+        const declared = declare("<#\nGhost := module:\n#>\n    Item := class {}\n");
+
+        expect(declared.map((node) => [node.type, node.fullPath])).toEqual([["class", "Item"]]);
+    });
+
+    it("keeps the source line of a declaration below a block comment", () => {
+        // Masking is space-for-character and keeps every newline. Anything
+        // that blanked a comment wholesale would pass every test above and
+        // still report this declaration on the wrong line.
+        const declared = declare("<#\nGhost := module {}\n#>\nInventory := module {}\n").find((node) => node.name === "Inventory");
+
+        expect(declared).toMatchObject({ sourceLine: 4 });
+    });
+});

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -1,0 +1,161 @@
+/**
+ * Reading Verse source as text, for the scans that match declarations against
+ * it. No VS Code dependencies, so importing this from a pure module is safe -
+ * take it by file path rather than through the utils barrel, which re-exports
+ * the logger and with it vscode.
+ */
+
+/**
+ * The text with every comment replaced by spaces, so offsets still address the
+ * original.
+ *
+ * Verse has three comment forms and they do not compose the way a reader
+ * expects, so the order of the tests below is the whole of this function:
+ *
+ * - `<#>` is the INDENTED comment marker, not a block that closes on the `#>`
+ *   inside it. The rest of its line is comment text, and so is every line
+ *   indented past it, blank lines included. It must therefore be tested before
+ *   `<#`, or a declaration commented out this way reads as live code. A `<#`
+ *   written inside its body is still a real opener, and outlives the body.
+ * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string
+ *   really does open a comment there. Both digraphs are consumed whole, so the
+ *   `#` of a `<#` cannot also be read as closing one.
+ * - `#` runs to the end of the line, but inside a string it is content. This
+ *   is the one place string tracking is needed, and the only reason it is
+ *   here.
+ *
+ * ImportScanner encodes the same three rules for its own line scan. The single
+ * quote is deliberately not tracked: it opens a char literal and an
+ * identifier's quoted suffix alike, and nothing here can tell the two apart.
+ */
+export function maskCommentsAndStrings(content: string): string {
+    const masked = content.split("");
+    const lines = content.split("\n");
+    let blockDepth = 0;
+    let markerIndent: number | null = null;
+    let lineStart = 0;
+
+    for (const line of lines) {
+        const lineEnd = lineStart + line.length;
+        const indent = indentOf(content, lineStart);
+
+        // The marker's body runs while lines stay indented past it; a blank
+        // line does not end it. The body is still scanned rather than blanked
+        // wholesale, because a block comment opened inside it survives the
+        // body's end and swallows what follows.
+        if (markerIndent !== null) {
+            if (line.trim().length === 0 || indent > markerIndent) {
+                blockDepth = blankCommentRange(masked, content, lineStart, lineEnd, blockDepth);
+                lineStart = lineEnd + 1;
+                continue;
+            }
+            markerIndent = null;
+        }
+
+        let inString = false;
+
+        for (let i = lineStart; i < lineEnd; i++) {
+            if (blockDepth > 0) {
+                if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
+                    blockDepth += content[i] === "<" ? 1 : -1;
+                    blank(masked, content, i);
+                    blank(masked, content, i + 1);
+                    i++;
+                    continue;
+                }
+                blank(masked, content, i);
+                continue;
+            }
+
+            if (content.startsWith("<#>", i)) {
+                markerIndent = indent;
+                blankRange(masked, content, i, lineEnd);
+                break;
+            }
+
+            if (content.startsWith("<#", i)) {
+                blockDepth++;
+                blank(masked, content, i);
+                blank(masked, content, i + 1);
+                i++;
+                continue;
+            }
+
+            if (inString) {
+                if (content[i] === "\\") {
+                    blank(masked, content, i);
+                    i++;
+                    if (i < lineEnd) blank(masked, content, i);
+                    continue;
+                }
+                if (content[i] === '"') {
+                    inString = false;
+                }
+                blank(masked, content, i);
+                continue;
+            }
+
+            if (content[i] === '"') {
+                inString = true;
+                blank(masked, content, i);
+                continue;
+            }
+
+            if (content[i] === "#") {
+                blankRange(masked, content, i, lineEnd);
+                break;
+            }
+        }
+
+        lineStart = lineEnd + 1;
+    }
+
+    return masked.join("");
+}
+
+/** Leading whitespace of a line, each tab counted as four spaces so mixed indentation compares. */
+export function indentOf(content: string, lineStart: number): number {
+    let width = 0;
+    for (let i = lineStart; i < content.length; i++) {
+        if (content[i] === " ") {
+            width += 1;
+        } else if (content[i] === "\t") {
+            width += 4;
+        } else {
+            break;
+        }
+    }
+    return width;
+}
+
+/** Replaces one character with a space, keeping newlines so line numbers still hold. */
+function blank(masked: string[], content: string, index: number): void {
+    if (content[index] !== "\n") {
+        masked[index] = " ";
+    }
+}
+
+/** Blanks a half-open range. */
+function blankRange(masked: string[], content: string, start: number, end: number): void {
+    for (let i = start; i < end; i++) {
+        blank(masked, content, i);
+    }
+}
+
+/** Blanks a half-open range that is comment text, returning the block-comment depth it leaves behind. */
+function blankCommentRange(masked: string[], content: string, start: number, end: number, depth: number): number {
+    let blockDepth = depth;
+
+    for (let i = start; i < end; i++) {
+        if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
+            blockDepth = Math.max(0, blockDepth + (content[i] === "<" ? 1 : -1));
+            blank(masked, content, i);
+            blank(masked, content, i + 1);
+            i++;
+            continue;
+        }
+        blank(masked, content, i);
+    }
+
+    return blockDepth;
+}

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -9,6 +9,8 @@
  * quoted suffix.
  */
 
+import { indentOf, maskCommentsAndStrings } from "../utils/verseText";
+
 /**
  * A declaration in any of the three styles a macro body is written in:
  * `module:`, `module { }` with the brace on that line or the next, and the
@@ -122,146 +124,6 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
     return declarations;
 }
 
-/**
- * The text with every comment replaced by spaces, so offsets still address the
- * original.
- *
- * Verse has three comment forms and they do not compose the way a reader
- * expects, so the order of the tests below is the whole of this function:
- *
- * - `<#>` is the INDENTED comment marker, not a block that closes on the `#>`
- *   inside it. The rest of its line is comment text, and so is every line
- *   indented past it, blank lines included. It must therefore be tested before
- *   `<#`, or a declaration commented out this way reads as live code. A `<#`
- *   written inside its body is still a real opener, and outlives the body.
- * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string
- *   really does open a comment there. Both digraphs are consumed whole, so the
- *   `#` of a `<#` cannot also be read as closing one.
- * - `#` runs to the end of the line, but inside a string it is content. This
- *   is the one place string tracking is needed, and the only reason it is
- *   here.
- *
- * ImportScanner encodes the same three rules for its own line scan. The single
- * quote is deliberately not tracked: it opens a char literal and an
- * identifier's quoted suffix alike, and nothing here can tell the two apart.
- */
-function maskCommentsAndStrings(content: string): string {
-    const masked = content.split("");
-    const lines = content.split("\n");
-    let blockDepth = 0;
-    let markerIndent: number | null = null;
-    let lineStart = 0;
-
-    for (const line of lines) {
-        const lineEnd = lineStart + line.length;
-        const indent = indentOf(content, lineStart);
-
-        // The marker's body runs while lines stay indented past it; a blank
-        // line does not end it. The body is still scanned rather than blanked
-        // wholesale, because a block comment opened inside it survives the
-        // body's end and swallows what follows.
-        if (markerIndent !== null) {
-            if (line.trim().length === 0 || indent > markerIndent) {
-                blockDepth = blankCommentRange(masked, content, lineStart, lineEnd, blockDepth);
-                lineStart = lineEnd + 1;
-                continue;
-            }
-            markerIndent = null;
-        }
-
-        let inString = false;
-
-        for (let i = lineStart; i < lineEnd; i++) {
-            if (blockDepth > 0) {
-                if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
-                    blockDepth += content[i] === "<" ? 1 : -1;
-                    blank(masked, content, i);
-                    blank(masked, content, i + 1);
-                    i++;
-                    continue;
-                }
-                blank(masked, content, i);
-                continue;
-            }
-
-            if (content.startsWith("<#>", i)) {
-                markerIndent = indent;
-                blankRange(masked, content, i, lineEnd);
-                break;
-            }
-
-            if (content.startsWith("<#", i)) {
-                blockDepth++;
-                blank(masked, content, i);
-                blank(masked, content, i + 1);
-                i++;
-                continue;
-            }
-
-            if (inString) {
-                if (content[i] === "\\") {
-                    blank(masked, content, i);
-                    i++;
-                    if (i < lineEnd) blank(masked, content, i);
-                    continue;
-                }
-                if (content[i] === '"') {
-                    inString = false;
-                }
-                blank(masked, content, i);
-                continue;
-            }
-
-            if (content[i] === '"') {
-                inString = true;
-                blank(masked, content, i);
-                continue;
-            }
-
-            if (content[i] === "#") {
-                blankRange(masked, content, i, lineEnd);
-                break;
-            }
-        }
-
-        lineStart = lineEnd + 1;
-    }
-
-    return masked.join("");
-}
-
-/** Replaces one character with a space, keeping newlines so line numbers still hold. */
-function blank(masked: string[], content: string, index: number): void {
-    if (content[index] !== "\n") {
-        masked[index] = " ";
-    }
-}
-
-/** Blanks a half-open range. */
-function blankRange(masked: string[], content: string, start: number, end: number): void {
-    for (let i = start; i < end; i++) {
-        blank(masked, content, i);
-    }
-}
-
-/** Blanks a half-open range that is comment text, returning the block-comment depth it leaves behind. */
-function blankCommentRange(masked: string[], content: string, start: number, end: number, depth: number): number {
-    let blockDepth = depth;
-
-    for (let i = start; i < end; i++) {
-        if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
-            blockDepth = Math.max(0, blockDepth + (content[i] === "<" ? 1 : -1));
-            blank(masked, content, i);
-            blank(masked, content, i + 1);
-            i++;
-            continue;
-        }
-        blank(masked, content, i);
-    }
-
-    return blockDepth;
-}
-
 /** Offset of the first character of every line, so a line number is a binary search. */
 function buildLineStarts(content: string): number[] {
     const starts = [0];
@@ -286,19 +148,4 @@ function lineOf(lineStarts: readonly number[], offset: number): number {
         }
     }
     return low + 1;
-}
-
-/** Leading whitespace of a line, each tab counted as four spaces so mixed indentation compares. */
-function indentOf(content: string, lineStart: number): number {
-    let width = 0;
-    for (let i = lineStart; i < content.length; i++) {
-        if (content[i] === " ") {
-            width += 1;
-        } else if (content[i] === "\t") {
-            width += 4;
-        } else {
-            break;
-        }
-    }
-    return width;
 }


### PR DESCRIPTION
Closes #292

`ProjectPathScanner.extractDeclarations` skipped a line only when the trimmed line started with `#` or `//`, so a declaration inside `<# ... #>`, inside a `<#>` marker's body, or after a mid-line `#` was recorded in the project declaration cache as live code. A commented-out module was also pushed onto the module stack, prefixing the `fullPath` of every real declaration below it.

## Approach

The ticket named the choice: move the masking helper somewhere both callers reach, or grow the scanner its own line-state scan. This takes the first. `maskCommentsAndStrings` and the `indentOf` it uses move unchanged out of `src/visibility/moduleDeclarations.ts` into a new pure `src/utils/verseText.ts`, and the scanner splits the masked text. A third hand-rolled encoding of the three Verse comment rules is what #45 exists to remove, so this shrinks the duplication rather than adding to it.

Imported by file path rather than through the `src/utils` barrel: the barrel re-exports `logger`, which imports `vscode`, and `moduleDeclarations.ts` is documented as VS Code free.

`ImportScanner`'s own encoding is deliberately untouched — a third caller is #45's job.

Masking is space-for-character and keeps newlines, so `sourceLine` and the file's line indices survive it. Indentation does not: a comment in the leading columns masks to spaces and reads as indent, so the module stack measures the unmasked line, as `findExplicitModuleDeclarations` already did.

## Tests

`src/services/__tests__/ProjectPathScannerMasking.test.ts`, 11 cases. Six fail against `origin/main`'s scanner: the multi-line block comment, the `<#>` indented body, the `<#>` body ending at the marker's indent, the mid-line `#`, the commented-out module in the enclosing chain, and the same-line comment inflating the indent.

Five pass either way and are guards rather than regressions: three single-line `<#`-prefixed cases that the anchored patterns already survived, the `#`-in-a-string case, and the `sourceLine` case. The string case was rewritten after review because its first input did not discriminate — a parameter default now puts the `)` and the `:` the function pattern needs behind the `#`, and it fails if string tracking is removed from the mask.

## Review

Two rounds, both `PASS_WITH_SUGGESTIONS`, each with a fresh reviewer.

Round 1 found the indentation defect described above (Important) plus three suggestions: a comment asserting an invariant the code did not provide, the duplicated tab-counting indent rule, and a wrong count of failing-unfixed tests. Round 2 found that the `#`-in-a-string test pinned nothing (Important) plus two suggestions: refactor history in a comment, and `toContain` where `toEqual` on the full path list was knowable. All acted on.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

Test Suites: 39 passed, 39 total
Tests:       773 passed, 773 total
Snapshots:   0 total
Time:        9.562 s
Ran all test suites.

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
