### PR TITLE
fix(services): serve digest lookups from the precompiled data alone

### DIFF
--- a/changelog.d/143.fixed.md
+++ b/changelog.d/143.fixed.md
@@ -1,0 +1,1 @@
+**Digest lookup**: An unknown identifier now resolves only to the entry with that exact name instead of every entry containing it, and unreadable bundled digest data reports an error instead of silently disabling lookups for the session.

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -360,8 +360,8 @@ export class ImportSuggestionExtractor {
      * unless `experimental.useDigestFiles` is on, and empty rather than
      * throwing when the lookup fails.
      *
-     * Confidence is high only for an exact identifier match; a near match is
-     * medium.
+     * Always high confidence: the lookup matches the identifier exactly, so an
+     * entry it returns declares the name the compiler could not resolve.
      */
     private async lookupIdentifierInDigest(identifier: string): Promise<ImportSuggestion[]> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -382,10 +382,9 @@ export class ImportSuggestionExtractor {
                 }
 
                 const importStatement = this.formatter.formatImportStatement(entry.modulePath, preferDotSyntax);
-                const confidence: ImportConfidence = entry.identifier === identifier ? "high" : "medium";
                 const description = `${entry.type} from ${entry.modulePath}`;
 
-                suggestions.push(this.createImportSuggestion(importStatement, "digest_lookup", confidence, description));
+                suggestions.push(this.createImportSuggestion(importStatement, "digest_lookup", "high", description));
             }
 
             if (suggestions.length > 0) {

--- a/src/services/DigestParser.ts
+++ b/src/services/DigestParser.ts
@@ -1,182 +1,100 @@
 import * as vscode from "vscode";
-import * as path from "path";
-import * as fs from "fs";
 import { logger } from "../utils";
 import { PrecompiledDigestLoader } from "./PrecompiledDigestLoader";
-import { DigestEntry, parseDigestContent, rootDomainForDigestFile } from "./digestParsing";
+import { DigestEntry } from "./digestParsing";
 
 export { DigestEntry } from "./digestParsing";
 
 /**
- * The index of importable Verse API identifiers, served from precompiled JSON
- * where possible and parsed from the bundled `.digest.verse` files where not.
+ * The index of importable Verse API identifiers, served from the precompiled
+ * JSON in `src/data`.
  *
- * The fallback is one-way: the first failure to load the precompiled data
- * latches precompiled use off for the lifetime of the instance, so a transient
- * failure costs runtime parsing for the rest of the session rather than
- * retrying on every lookup. {@link forceReparse} is the only way back to
- * runtime parsing by choice, and nothing returns to precompiled data short of a
- * new instance.
+ * There is no second source. A load failure is reported to the user and leaves
+ * the index empty rather than degrading quietly, and every later call retries,
+ * so an install repaired mid-session recovers on the next lookup.
+ *
+ * Constructed without an `ExtensionContext` it holds nothing and serves nothing,
+ * which is how the unit tests get an instance without a packaged extension.
  */
 export class DigestParser {
-    private digestCache: Map<string, DigestEntry> = new Map();
-    private lastParsed: number = 0;
-    private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
     private precompiledLoader: PrecompiledDigestLoader | null = null;
-    private usePrecompiled: boolean = true;
+    private loadFailureReported: boolean = false;
 
     constructor(
         private outputChannel: vscode.OutputChannel,
-        private extensionContext?: vscode.ExtensionContext,
+        extensionContext?: vscode.ExtensionContext,
     ) {
         if (extensionContext) {
             this.precompiledLoader = new PrecompiledDigestLoader(extensionContext);
         }
     }
 
+    /** The identifier index, empty when the digest data could not be loaded. */
     async getDigestIndex(): Promise<Map<string, DigestEntry>> {
-        if (this.usePrecompiled && this.precompiledLoader) {
-            try {
-                if (!this.precompiledLoader.isLoaded()) {
-                    await this.precompiledLoader.loadPrecompiledDigests();
-                }
-                if (this.precompiledLoader.isLoaded()) {
-                    logger.debug("DigestParser", "Using pre-compiled digest index");
-                    return this.precompiledLoader.getAllEntries();
-                }
-            } catch (error) {
-                logger.warn("DigestParser", "Pre-compiled digests not available, falling back to runtime parsing");
-                this.usePrecompiled = false;
+        if (!this.precompiledLoader) {
+            return new Map();
+        }
+
+        try {
+            if (!this.precompiledLoader.isLoaded()) {
+                await this.precompiledLoader.loadPrecompiledDigests();
             }
+            return this.precompiledLoader.getAllEntries();
+        } catch (error) {
+            this.reportLoadFailure(error);
+            return new Map();
         }
-
-        const now = Date.now();
-        if (this.digestCache.size > 0 && now - this.lastParsed < this.CACHE_DURATION) {
-            logger.debug("DigestParser", "Using cached digest index (runtime parsed)");
-            return this.digestCache;
-        }
-
-        logger.debug("DigestParser", "Parsing digest files at runtime...");
-        await this.parseDigestFiles();
-        this.lastParsed = now;
-        return this.digestCache;
     }
 
     /**
-     * Entries whose identifier matches, the exact one first and then every
-     * case-insensitive substring match. Ranking beyond that order is the
-     * caller's: the quick-fix menu re-sorts alphabetically when
-     * `quickFix.sortAlphabetically` is on.
+     * Tells the user once per instance that the digest data is unusable.
+     *
+     * Once, because the caller is a per-diagnostic lookup: reporting every
+     * failure would put a modal on every keystroke that produces an unknown
+     * identifier.
+     */
+    private reportLoadFailure(error: unknown): void {
+        logger.error("DigestParser", "Pre-compiled digest data could not be loaded; identifier lookups will return nothing", error);
+
+        if (this.loadFailureReported) {
+            return;
+        }
+        this.loadFailureReported = true;
+
+        const detail = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Verse Auto Imports could not read its bundled digest data, so identifier lookups are unavailable. Reinstalling the extension should restore it. (${detail})`);
+    }
+
+    /**
+     * The entry declaring this exact identifier, as a list so the caller can
+     * treat "none" and "one" alike.
+     *
+     * The match is exact on purpose. Matching by substring returned every entry
+     * whose name merely contained the identifier - 226 of them for `device` -
+     * and the diagnostics handler reads more than one suggestion as a choice to
+     * offer, or under an `auto_*` multi-option strategy to make on the user's
+     * behalf.
      */
     async lookupIdentifier(identifier: string): Promise<DigestEntry[]> {
         const index = await this.getDigestIndex();
-        const results: DigestEntry[] = [];
-
-        const exactMatch = index.get(identifier);
-        if (exactMatch) {
-            results.push(exactMatch);
-        }
-
-        const lowerIdentifier = identifier.toLowerCase();
-        for (const [key, entry] of index) {
-            if (key.toLowerCase().includes(lowerIdentifier) && key !== identifier) {
-                results.push(entry);
-            }
-        }
-
-        return results;
+        const match = index.get(identifier);
+        return match ? [match] : [];
     }
 
-    private async parseDigestFiles(): Promise<void> {
-        this.digestCache.clear();
-
-        try {
-            const digestFiles = ["Fortnite.digest.verse", "UnrealEngine.digest.verse", "Verse.digest.verse"];
-
-            const extensionPath = vscode.extensions.getExtension("vukefn.verse-auto-imports")?.extensionPath;
-            if (!extensionPath) {
-                logger.warn("DigestParser", "Extension path not found, using relative path");
-                return;
-            }
-
-            const utilsPath = path.join(extensionPath, "src", "utils");
-
-            for (const fileName of digestFiles) {
-                const filePath = path.join(utilsPath, fileName);
-                if (fs.existsSync(filePath)) {
-                    logger.trace("DigestParser", `Parsing digest file: ${fileName}`);
-                    this.parseDigestFile(filePath);
-                } else {
-                    logger.trace("DigestParser", `Digest file not found: ${filePath}`);
-                }
-            }
-
-            logger.info("DigestParser", `Parsed ${this.digestCache.size} identifiers from digest files`);
-        } catch (error) {
-            logger.error("DigestParser", "Error parsing digest files", error);
-        }
-    }
-
-    /**
-     * Merges one digest file's entries into the runtime cache, keeping the entry
-     * already there on a collision. First occurrence therefore wins across the
-     * Fortnite, UnrealEngine and Verse files in that iteration order, which is
-     * what the precompiled loader does too - the two must agree, or the same
-     * identifier resolves differently depending on which path served it.
-     */
-    private parseDigestFile(filePath: string): void {
-        try {
-            const content = fs.readFileSync(filePath, "utf8");
-            const rootDomain = rootDomainForDigestFile(path.basename(filePath));
-            const { entries } = parseDigestContent(content, rootDomain);
-
-            for (const entry of Object.values(entries)) {
-                if (!this.digestCache.has(entry.identifier)) {
-                    this.digestCache.set(entry.identifier, entry);
-                }
-            }
-        } catch (error) {
-            logger.error("DigestParser", `Error reading digest file ${filePath}`, error);
-        }
-    }
-
+    /** Drops the loaded index, so the next lookup re-reads it from disk. */
     clearCache(): void {
-        this.digestCache.clear();
-        this.lastParsed = 0;
         if (this.precompiledLoader) {
             this.precompiledLoader.clear();
         }
         logger.debug("DigestParser", "Digest cache cleared");
     }
 
-    /**
-     * Reparses the bundled `.verse` files and switches this instance to runtime
-     * parsing for good, for when the precompiled data is suspected stale.
-     * Nothing switches it back.
-     */
-    async forceReparse(): Promise<void> {
-        logger.info("DigestParser", "Forcing runtime reparse of digest files...");
-        this.usePrecompiled = false;
-        this.digestCache.clear();
-        await this.parseDigestFiles();
-        this.lastParsed = Date.now();
-        logger.info("DigestParser", `Runtime reparse complete: ${this.digestCache.size} entries`);
-    }
-
-    /** Which of the two sources is currently serving lookups, and how much it holds. */
-    getStats(): { entries: number; source: "precompiled" | "runtime"; loaded: boolean } {
-        if (this.usePrecompiled && this.precompiledLoader?.isLoaded()) {
-            const stats = this.precompiledLoader.getStats();
-            return {
-                entries: stats.entries,
-                source: "precompiled",
-                loaded: stats.loaded,
-            };
+    /** How much the index holds, and whether it loaded at all. */
+    getStats(): { entries: number; loaded: boolean } {
+        if (!this.precompiledLoader) {
+            return { entries: 0, loaded: false };
         }
-        return {
-            entries: this.digestCache.size,
-            source: "runtime",
-            loaded: this.digestCache.size > 0,
-        };
+        const stats = this.precompiledLoader.getStats();
+        return { entries: stats.entries, loaded: stats.loaded };
     }
 }

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -23,9 +23,9 @@ export interface PrecompiledDigest {
  * `src/scripts/parseDigestFiles.ts` generates at build time rather than parsed
  * from Verse source at startup.
  *
- * This is DigestParser's fast path. It reports failure by throwing from
- * {@link loadPrecompiledDigests} and by leaving {@link isLoaded} false, which is
- * the signal DigestParser falls back on.
+ * This is DigestParser's only source. It reports failure by throwing from
+ * {@link loadPrecompiledDigests} and by leaving {@link isLoaded} false; there is
+ * no second source to fall back to, so DigestParser surfaces that to the user.
  */
 export class PrecompiledDigestLoader {
     private digestCache: Map<string, DigestEntry> = new Map();
@@ -43,8 +43,7 @@ export class PrecompiledDigestLoader {
      *
      * One file is enough to count as loaded, so a caller that sees
      * {@link isLoaded} true may still be holding a partial index. Only a total
-     * failure leaves it false and sends DigestParser to runtime parsing.
-     * Calling again after success is a no-op.
+     * failure leaves it false. Calling again after success is a no-op.
      */
     async loadPrecompiledDigests(): Promise<void> {
         if (this.loaded) {
@@ -101,9 +100,8 @@ export class PrecompiledDigestLoader {
                 const content = fs.readFileSync(filePath, "utf8");
                 const digest: PrecompiledDigest = JSON.parse(content);
 
-                // First file to declare an identifier wins, matching
-                // DigestParser's runtime merge. DIGEST_FILES order is therefore
-                // the precedence between the three domains.
+                // First file to declare an identifier wins, so DIGEST_FILES
+                // order is the precedence between the three domains.
                 for (const [identifier, entry] of Object.entries(digest.entries)) {
                     if (!this.digestCache.has(identifier)) {
                         this.digestCache.set(identifier, entry);

--- a/src/services/__tests__/DigestParser.test.ts
+++ b/src/services/__tests__/DigestParser.test.ts
@@ -1,0 +1,153 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { DigestParser } from "../DigestParser";
+import { DigestEntry } from "../digestParsing";
+
+/**
+ * Regression tests for issue #143.
+ *
+ * Two defects, both in how DigestParser behaved when it could not serve a good
+ * answer. It fell back to parsing `src/utils/*.digest.verse`, which
+ * `.vscodeignore` keeps out of the `.vsix`, and it latched that unreachable
+ * fallback on permanently after one load failure - so a single bad
+ * `src/data/*.digest.json` cost the session every lookup while the log claimed
+ * a successful fallback. Separately, lookups matched by substring, so `device`
+ * answered with every identifier containing it.
+ *
+ * These drive the real PrecompiledDigestLoader through a mocked `fs`, because
+ * both defects were in the load-and-fall-back wiring rather than in parsing.
+ */
+describe("DigestParser", () => {
+    const EXTENSION_PATH = path.join("C:", "extensions", "vukefn.verse-auto-imports");
+    const DATA_DIR = path.join(EXTENSION_PATH, "src", "data");
+
+    const entry = (identifier: string, modulePath: string): DigestEntry => ({
+        identifier,
+        modulePath,
+        type: "class",
+        isPublic: true,
+    });
+
+    /**
+     * Identifiers chosen so that one is a strict substring of the others - the
+     * shape that produced a 226-entry quick-fix list for `device`.
+     */
+    const FORTNITE_ENTRIES: Record<string, DigestEntry> = {
+        device: entry("device", "/Fortnite.com/Devices"),
+        button_device: entry("button_device", "/Fortnite.com/Devices"),
+        trigger_device: entry("trigger_device", "/Fortnite.com/Devices"),
+    };
+
+    /** Whether the data directory and its files can be read this test. */
+    let dataReadable: boolean;
+    let parser: DigestParser;
+
+    const showErrorMessage = vscode.window.showErrorMessage as unknown as jest.Mock;
+
+    const newParser = (withContext = true): DigestParser => {
+        const context = { extensionPath: EXTENSION_PATH } as unknown as vscode.ExtensionContext;
+        return new DigestParser(vscode.window.createOutputChannel("test"), withContext ? context : undefined);
+    };
+
+    beforeEach(() => {
+        dataReadable = true;
+        showErrorMessage.mockClear();
+
+        jest.spyOn(fs, "existsSync").mockImplementation((target) => {
+            if (!dataReadable) {
+                return false;
+            }
+            const asString = String(target);
+            return asString === DATA_DIR || asString === path.join(DATA_DIR, "Fortnite.digest.json");
+        });
+
+        jest.spyOn(fs, "readFileSync").mockImplementation((() =>
+            JSON.stringify({ version: "1", generatedAt: "", sourceFile: "", sourceBuild: "", entries: FORTNITE_ENTRIES, moduleIndex: {} })) as unknown as typeof fs.readFileSync);
+
+        parser = newParser();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("lookupIdentifier", () => {
+        it("returns only the entry bearing the identifier, not every one containing it", async () => {
+            const results = await parser.lookupIdentifier("device");
+
+            expect(results.map((result) => result.identifier)).toEqual(["device"]);
+        });
+
+        it("returns nothing for a string that is only ever a substring of an identifier", async () => {
+            expect(await parser.lookupIdentifier("evice")).toEqual([]);
+        });
+
+        it("still resolves an identifier that contains another", async () => {
+            const results = await parser.lookupIdentifier("button_device");
+
+            expect(results.map((result) => result.identifier)).toEqual(["button_device"]);
+        });
+
+        it("returns nothing for an identifier the digests do not declare", async () => {
+            expect(await parser.lookupIdentifier("no_such_identifier")).toEqual([]);
+        });
+    });
+
+    describe("when the digest data cannot be read", () => {
+        beforeEach(() => {
+            dataReadable = false;
+        });
+
+        it("tells the user once however many lookups fail", async () => {
+            await parser.lookupIdentifier("device");
+            await parser.lookupIdentifier("button_device");
+            await parser.lookupIdentifier("trigger_device");
+
+            expect(showErrorMessage).toHaveBeenCalledTimes(1);
+            expect(showErrorMessage.mock.calls[0][0]).toMatch(/digest data/);
+        });
+
+        it("returns an empty result rather than throwing", async () => {
+            expect(await parser.lookupIdentifier("device")).toEqual([]);
+        });
+
+        it("serves lookups again once the data becomes readable", async () => {
+            expect(await parser.lookupIdentifier("device")).toEqual([]);
+
+            dataReadable = true;
+
+            const results = await parser.lookupIdentifier("device");
+            expect(results.map((result) => result.identifier)).toEqual(["device"]);
+        });
+
+        it("reports nothing loaded", async () => {
+            await parser.lookupIdentifier("device");
+
+            expect(parser.getStats()).toEqual({ entries: 0, loaded: false });
+        });
+    });
+
+    describe("without an ExtensionContext", () => {
+        it("serves an empty index without reading the disk or alarming the user", async () => {
+            const contextless = newParser(false);
+
+            expect(await contextless.lookupIdentifier("device")).toEqual([]);
+            expect(await contextless.getDigestIndex()).toEqual(new Map());
+            expect(showErrorMessage).not.toHaveBeenCalled();
+            expect(contextless.getStats()).toEqual({ entries: 0, loaded: false });
+        });
+    });
+
+    describe("clearCache", () => {
+        it("makes the next lookup re-read the data", async () => {
+            await parser.lookupIdentifier("device");
+            const readsBefore = (fs.readFileSync as unknown as jest.Mock).mock.calls.length;
+
+            parser.clearCache();
+            await parser.lookupIdentifier("device");
+
+            expect((fs.readFileSync as unknown as jest.Mock).mock.calls.length).toBeGreaterThan(readsBefore);
+        });
+    });
+});

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -3,10 +3,9 @@
  * `Verse.digest.verse`, `UnrealEngine.digest.verse`) into a module-scoped
  * identifier index.
  *
- * This module is shared by the build-time precompiler
- * (`src/scripts/parseDigestFiles.ts`, run under ts-node) and the runtime fallback
- * parser (`DigestParser.parseDigestFile`). It must never import `vscode` so it can
- * run outside the extension host.
+ * The build-time precompiler (`src/scripts/parseDigestFiles.ts`, run under
+ * ts-node) is the only caller; its output in `src/data` is what the extension
+ * reads. It must never import `vscode` so it can run outside the extension host.
  *
  * The parser tracks indentation like `AssetsDigestParser.parseDigestContent`:
  * modules form a stack scoped by indent, and class/struct/interface/enum bodies

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,8 +1,8 @@
 // From outside this module, take DigestParser for Verse API lookups and
 // ProjectPathCache for project-declaration lookups; both own the caching their
-// collaborators do not. PrecompiledDigestLoader is DigestParser's fast path and
-// ProjectPathScanner is what ProjectPathCache rebuilds from - reach for either
-// directly only to bypass a cache on purpose. AssetsDigestParser is separate
+// collaborators do not. PrecompiledDigestLoader is where DigestParser's entries
+// come from and ProjectPathScanner is what ProjectPathCache rebuilds from -
+// reach for either directly only to bypass a cache on purpose. AssetsDigestParser is separate
 // from the other two: it reads the project's generated assets, not the API.
 export { DigestParser, DigestEntry } from "./DigestParser";
 export { AssetsDigestParser } from "./AssetsDigestParser";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,8 +2,9 @@
 // ProjectPathCache for project-declaration lookups; both own the caching their
 // collaborators do not. PrecompiledDigestLoader is where DigestParser's entries
 // come from and ProjectPathScanner is what ProjectPathCache rebuilds from -
-// reach for either directly only to bypass a cache on purpose. AssetsDigestParser is separate
-// from the other two: it reads the project's generated assets, not the API.
+// reach for either directly only to bypass a cache on purpose. AssetsDigestParser
+// is separate from the other two: it reads the project's generated assets, not
+// the API.
 export { DigestParser, DigestEntry } from "./DigestParser";
 export { AssetsDigestParser } from "./AssetsDigestParser";
 export { PrecompiledDigestLoader, PrecompiledDigest } from "./PrecompiledDigestLoader";


### PR DESCRIPTION
Closes #143

`DigestParser`'s runtime fallback read `<extensionPath>/src/utils/*.digest.verse`. `.vscodeignore` excludes `src/**` and re-includes only `!src/data/**`, so those files are not in the `.vsix` and the fallback could never run in a packaged install.

Dead code, except that it was load-bearing in the failure path: a throw from `loadPrecompiledDigests()` set `usePrecompiled = false` for the lifetime of the instance with nothing to reset it, then handed over to a fallback that found no files. One unreadable `src/data/*.digest.json` therefore cost a user every digest lookup for the session, while the log said it had fallen back to runtime parsing.

## What changed

**The fallback is gone.** `parseDigestFiles`, `parseDigestFile`, `forceReparse`, `digestCache`, `CACHE_DURATION` and `usePrecompiled` are deleted. `getDigestIndex` now loads from `PrecompiledDigestLoader` or reports failure.

**A load failure is surfaced**, once per instance, via `showErrorMessage` naming the install as the thing to repair. Once because the caller is a per-diagnostic lookup; reporting each failure would fire on every keystroke producing an unknown identifier.

**The latch is fixed by deletion.** With no flag to latch, each lookup retries, so an install repaired mid-session recovers on the next lookup.

**`lookupIdentifier` matches exactly.** It was `key.toLowerCase().includes(...)` over the 2427-entry index, so `device` returned 226 entries. [DiagnosticsHandler.ts:169](../blob/main/src/diagnostics/DiagnosticsHandler.ts#L169) reads more than one suggestion as a multi-option diagnostic — and under an `auto_*` `behavior.multiOptionStrategy`, `selectBestSuggestion` picks one of the 226 and inserts it. That is worse than the filed symptom, which described only a long quick-fix list.

## Maintainer decisions this was built to

- **Delete rather than ship the sources.** Adding `!src/utils/**.digest.verse` was the alternative: ~865 KB packaged to enable a slower path that only runs once the 553 KB of JSON has already failed. `.vscodeignore` is untouched.
- **Stay narrow with respect to #46.** No lowercased index is built at load time (item 3) and no availability flag is reset on cache clear (item 5) — both targets cease to exist here instead. I will comment on #46 with what this made moot.
- **Fix the substring matching here**, opted in explicitly rather than split out.

## Behaviour delta worth knowing

With `experimental.useDigestFiles` and `general.autoImport` on, an exact digest hit is now a lone high-confidence suggestion, so it auto-inserts where 226 suggestions previously forced the quick-fix path. That is the fix working.

The second commit follows from the first: `lookupIdentifierInDigest` still documented and coded for near matches (`entry.identifier === identifier ? "high" : "medium"`), a branch the exact match can no longer take.

## Tests

`src/services/__tests__/DigestParser.test.ts` is new — the class had no test file. It drives the real `PrecompiledDigestLoader` through a mocked `fs`, because both defects were in the load-and-fall-back wiring rather than in parsing.

Proved to detect the defect: with `HEAD~1`'s `DigestParser` swapped back in, 6 of 10 fail, including both pins — the substring cases and `serves lookups again once the data becomes readable`, which is the latch.

## Verification

```
$ npm run compile

> verse-auto-imports@0.10.0 compile
> tsc -p ./

```

```
$ npm test

> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       792 passed, 792 total
Snapshots:   0 total
Time:        10.059 s
Ran all test suites.
```

```
$ npm run format:check

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

One caveat on that run: the worktree also held an unrelated uncommitted change to `ImportScanner.ts` belonging to another session, which is not in this diff. It touches import scanning, not digest lookup, and CI builds from the committed diff.

## Review gate

`PASS_WITH_SUGGESTIONS`, no Critical findings. The one Important finding was the stale near-match confidence in `ImportSuggestionExtractor`, fixed in the second commit.

Suggestions left deliberately, for the maintainer rather than this PR:

- `DigestParser` still takes an `outputChannel` it never reads. Pre-existing; removing it costs a caller edit.
- A failing lookup logs one `logger.error` per call, so a broken install floods the output channel. The user-facing message is deduped; the log is not. A time-bounded retry guard would fix both without reinstating a latch.
- `lookupIdentifier` returns `DigestEntry[]` that can only hold 0 or 1.
- `clearCache()` and `getStats()` have no production caller; `getStats` lost its now-meaningless `source` discriminant rather than being deleted outright.
