### PR TITLE
fix(imports): accept any stacked specifier on a module declaration

### DIFF
--- a/changelog.d/294.fixed.md
+++ b/changelog.d/294.fixed.md
@@ -1,0 +1,1 @@
+**Import path conversion**: A module declared with a `scoped` list, `epic_internal`, or several stacked specifiers is now found by the fallback scan, so its path converts instead of being left unresolved.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -102,13 +102,21 @@ export class ImportPathConverter {
      * `module. Inner := ...`. A `>` after the keyword is accepted alongside
      * them.
      *
+     * The declared name may carry any number of stacked specifiers, and no
+     * keyword list appears here: the answer is only whether this file declares
+     * the module, never which specifier it carries, and a list is a standing
+     * invitation to drift from the spellings in moduleDeclarations'
+     * MODULE_DECLARATION and ProjectPathScanner. Accepting any `<...>` entry
+     * also covers a `scoped{A, B}` scope list, whose specifier does not end at
+     * its keyword.
+     *
      * Non-global on purpose: the pattern is reused with `.test()` across many
      * files, and a global flag would carry `lastIndex` between calls and skip
      * valid definitions depending on the order the files are read in.
      */
     static buildModuleDefinitionRegex(moduleName: string): RegExp {
         const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return new RegExp(`\\b${escaped}(?:'[^']*')?\\s*(?:<\\s*(?:public|private|internal|protected)\\s*>)?\\s*:=\\s*module\\s*[:>{.]`, "m");
+        return new RegExp(`\\b${escaped}(?:'[^']*')?(?:\\s*<[^>]+>)*\\s*:=\\s*module\\s*[:>{.]`, "m");
     }
 
     /**

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -111,6 +111,8 @@ export class ImportPathConverter {
      * whole-file content, so a body free to span lines lets a comparison
      * operator or a `<` in a comment run on to the `>` of a LATER
      * declaration's specifier, reporting a file that declares no such module.
+     * MODULE_DECLARATION affords the wider `[^>]` because it masks comments
+     * and strings first; this does not, so the two cannot be synchronized.
      *
      * Non-global on purpose: the pattern is reused with `.test()` across many
      * files, and a global flag would carry `lastIndex` between calls and skip

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -102,13 +102,15 @@ export class ImportPathConverter {
      * `module. Inner := ...`. A `>` after the keyword is accepted alongside
      * them.
      *
-     * The declared name may carry any number of stacked specifiers, and no
-     * keyword list appears here: the answer is only whether this file declares
-     * the module, never which specifier it carries, and a list is a standing
-     * invitation to drift from the spellings in moduleDeclarations'
-     * MODULE_DECLARATION and ProjectPathScanner. Accepting any `<...>` entry
-     * also covers a `scoped{A, B}` scope list, whose specifier does not end at
-     * its keyword.
+     * No visibility keyword list appears here: nothing reads which specifier
+     * was found, only whether this file declares the module, so any `<...>`
+     * entry is accepted - a `scoped{A, B}` list included, whose specifier does
+     * not end at its keyword.
+     *
+     * A specifier body must exclude `<` and newlines. Callers test unmasked
+     * whole-file content, so a body free to span lines lets a comparison
+     * operator or a `<` in a comment run on to the `>` of a LATER
+     * declaration's specifier, reporting a file that declares no such module.
      *
      * Non-global on purpose: the pattern is reused with `.test()` across many
      * files, and a global flag would carry `lastIndex` between calls and skip
@@ -116,7 +118,7 @@ export class ImportPathConverter {
      */
     static buildModuleDefinitionRegex(moduleName: string): RegExp {
         const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return new RegExp(`\\b${escaped}(?:'[^']*')?(?:\\s*<[^>]+>)*\\s*:=\\s*module\\s*[:>{.]`, "m");
+        return new RegExp(`\\b${escaped}(?:'[^']*')?(?:\\s*<[^<>\\n]+>)*\\s*:=\\s*module\\s*[:>{.]`, "m");
     }
 
     /**

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -43,11 +43,30 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
         expect(ImportPathConverter.buildModuleDefinitionRegex("Item").test(source)).toBe(true);
     });
 
+    it("matches any specifier the language allows, not a fixed keyword list", () => {
+        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
+
+        // A scope list holds module references, so the specifier does not end
+        // at the keyword.
+        expect(re.test("Inventory<scoped{ModuleA, ModuleB}> := module:")).toBe(true);
+        expect(re.test("Inventory<epic_internal> := module:")).toBe(true);
+    });
+
+    it("matches a stacked specifier block, not one specifier", () => {
+        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
+        expect(re.test("Inventory<internal><final> := module:")).toBe(true);
+        expect(re.test("Inventory<public><scoped{ModuleA}> := module { }")).toBe(true);
+    });
+
     it("does not match a different module or a non-module declaration", () => {
         const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
         expect(re.test("MyInventory := module:")).toBe(false);
         expect(re.test("Inventory := class:")).toBe(false);
         expect(re.test("InventoryItem := module:")).toBe(false);
+
+        // A specifier block is not what makes a declaration a module, so one
+        // must not carry a non-module declaration into a match.
+        expect(re.test("Inventory<public> := class:")).toBe(false);
 
         // What follows `module` is a character class, so a keyword that merely
         // starts with it is not a declaration. Written as a bare `.` instead,

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -58,6 +58,18 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
         expect(re.test("Inventory<public><scoped{ModuleA}> := module { }")).toBe(true);
     });
 
+    it("does not let a stray < reach the specifier of a later declaration", () => {
+        // The whole file is tested unmasked, so a `<` that opens nothing - a
+        // comparison, or one written in a comment - sits between the name and
+        // the next declaration's specifier. A specifier body that could span
+        // that far would report this file as declaring Inventory.
+        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
+
+        expect(re.test("if (Inventory < MaxSlots):\n\nHelpers<public> := module:")).toBe(false);
+        expect(re.test("# Inventory <-- rename before ship\nHelpers<internal> := module:")).toBe(false);
+        expect(re.test("Count := Inventory < 3\nOther<final><public> := module {}")).toBe(false);
+    });
+
     it("does not match a different module or a non-module declaration", () => {
         const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
         expect(re.test("MyInventory := module:")).toBe(false);

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -50,6 +50,11 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
         // at the keyword.
         expect(re.test("Inventory<scoped{ModuleA, ModuleB}> := module:")).toBe(true);
         expect(re.test("Inventory<epic_internal> := module:")).toBe(true);
+
+        // A named scope is an arbitrary identifier, qualified or not, which no
+        // keyword list could cover.
+        expect(re.test("Inventory<scoped_X> := module:")).toBe(true);
+        expect(re.test("Inventory<Systems.scoped_to_A> := module:")).toBe(true);
     });
 
     it("matches a stacked specifier block, not one specifier", () => {


### PR DESCRIPTION
Closes #294

## What

`buildModuleDefinitionRegex` spelled its own visibility keyword list, which had drifted from the two sibling spellings in `moduleDeclarations.ts` and `ProjectPathScanner.ts`. It could not match a `scoped{A, B}` module list at all, since the clause ended in `\s*>`, and it handled one specifier rather than a stacked block. A real declaration therefore read as absent, and the fallback scan behind a path conversion fell through instead of resolving.

## How

**The keyword list is deleted, not synchronized.** This site only answers "does this file declare a module of this name" — `searchExplicitModuleDefinitions` is the one caller, and it reads no specifier. Accepting any `<...>` entry covers all three shapes the issue names at once, and leaves no visibility vocabulary in `src/imports/` to fall out of step again. It also covers a shape the issue did not name and no alternation ever could: a **named scope**, `Inventory<scoped_X> := module:`, which the compiler's own versetests use (`Tests/Attributes/scoped.versetest`).

**The specifier body excludes `<` and newlines.** The first draft used `[^>]+`, matching `MODULE_DECLARATION`. Review caught that this regresses harder than the bug it fixes: `[^>]` admits `<` and newlines, so a `<` that opens nothing — a comparison, or one inside a comment — runs across lines and closes on the `>` of a *later* declaration's specifier. Callers `.test()` unmasked whole-file content, so that reports a file declaring no such module, and `searchExplicitModuleDefinitions` pushes its directory into `locations`: a wrong location rather than a missing one. `[^<>\n]` rejects it while still accepting every legal body — a sweep of the Book of Verse corpus found 1464 module declarations, none with `<`, `>` or a newline inside a specifier.

This is why the two regexes cannot simply be made identical, and the doc comment now says so: `MODULE_DECLARATION` affords the wider class because `findExplicitModuleDeclarations` masks comments and strings before matching. This site does not.

**The issue's shared-source option was ruled out on dependency direction**, as it asked. Nothing outside `src/visibility/` imports from it — only `src/extension.ts` and `src/commands/CommandsHandler.ts` wire it up — so `src/imports/` reaching in would add a sideways edge into a leaf feature module.

## Coverage

The three shapes the issue asked for, plus named scopes, plus the false-positive class the narrowing exists to stop. Every new positive assertion was proven to fail against the old regex, and the negative one against the intermediate `[^>]+` draft, by stashing the fix and running the file.

## Found while here, filed separately

- **#305** — `ProjectPathScanner.extractVisibility` carries the same two flaws, so a `scoped{A, B}` or `epic_internal` module reads as having no specifier and is kept as an import candidate rather than skipped.
- **#306** — this same call site tests unmasked content, so a commented-out declaration still reports its file as declaring the module. Same wrong-location class, reachable with no `<` involved.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 39 passed, 39 total
Tests:       785 passed, 785 total
Snapshots:   0 total
Time:        8.706 s
Ran all test suites.

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

Two rounds, fresh reviewer each time, opus. Round 1 `FAIL` — 1 Critical (the `[^>]` cross-line false positive), 2 Suggestions. Round 2 `PASS_WITH_SUGGESTIONS` — 0 Critical, 4 Suggestions; two taken (pin a named scope, document why the sibling regexes differ), one filed as #306, one declined: the `Inventory<public> := class:` assertion does not flip against the old code, but it guards a boundary worth holding.
