### PR TITLE
fix(imports): count a using written after a definition on its line as present

### DIFF
--- a/changelog.d/273.fixed.md
+++ b/changelog.d/273.fixed.md
@@ -1,1 +1,1 @@
-**Imports**: A `using` written after another statement on the same line now counts as already imported, so a quick fix no longer adds a second copy of it.
+**Import scanning**: A `using` written after another statement on the same line now counts as already imported, and a `using` written inside a string is no longer read as one at all.

--- a/changelog.d/273.fixed.md
+++ b/changelog.d/273.fixed.md
@@ -1,0 +1,1 @@
+**Imports**: A `using` written after another statement on the same line now counts as already imported, so a quick fix no longer adds a second copy of it.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -84,24 +84,32 @@ interface LineScan {
      */
     code: string;
     /**
-     * `code` with the contents of every string and char literal replaced by
-     * spaces, so a `using` written as string text is not offered as a statement
-     * the line makes.
+     * `code` with the contents of every `"` string replaced by spaces, so a
+     * `using` written as string text is not offered as a statement the line
+     * makes.
      *
      * Read this wherever a path is going to count as imported. The text of a
-     * literal is data, not a statement, and recording a path from it both
+     * string is data, not a statement, and recording a path from it both
      * suppresses an import the file needs and - because a path that counts as
      * pinned withholds the movable import of the same path from the rebuilt
      * block - deletes the real `using` the author wrote.
      *
-     * Spaces rather than nothing, so the text on either side of a literal does
+     * A `'` is deliberately not masked, though the lexer opens a char literal
+     * on one. The same character closes a path's quoted segment suffix,
+     * `Economy.Shop'Loc'`, and masking it truncates the path to `Economy.Shop`,
+     * a different module that exists; see ImportFormatter.DOTTED_STATEMENT.
+     * Nothing is lost by that, because a char literal holds one character and a
+     * `using` cannot fit in one.
+     *
+     * Spaces rather than nothing, so the text on either side of a string does
      * not join into a token neither side wrote. `code` removes comments without
      * replacement on purpose, for the opposite reason; the two differ because a
-     * comment can splice a token apart and a literal cannot.
+     * comment can splice a token apart and a string cannot.
      *
-     * Equal to `code` on a line that ended inside an open literal, which the
-     * second lexing pass reads with literal tracking off: nothing there can be
-     * classified, so nothing is masked.
+     * Equal to `code` on a line that ended inside an open literal or
+     * interpolation, which the second lexing pass reads with literal tracking
+     * off. Nothing there can be classified, so nothing is masked, and a `using`
+     * written in an unterminated string on such a line still counts as present.
      */
     codeOutsideLiterals: string;
     /**
@@ -217,7 +225,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
             // from opening an interpolation.
             if (line[i] === "\\") {
                 code += line.slice(i, i + 2);
-                codeOutsideLiterals += "  ";
+                codeOutsideLiterals += innermost.quote === '"' ? "  " : line.slice(i, i + 2);
                 i += 2;
                 continue;
             }
@@ -249,7 +257,12 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
             hasCode = true;
         }
         code += line[i];
-        codeOutsideLiterals += innermost?.kind === "literal" ? " " : line[i];
+        // Only a `"` string. A `'` opens a char literal here, but the same
+        // character ends a path's quoted segment suffix, `Economy.Shop'Loc'`,
+        // and masking that truncates the path to `Economy.Shop` - a different
+        // module that exists. Nothing is lost by leaving `'` alone: a char
+        // literal holds one character, which cannot be a `using`.
+        codeOutsideLiterals += innermost?.kind === "literal" && innermost.quote === '"' ? " " : line[i];
         i += 1;
     }
 

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -84,6 +84,27 @@ interface LineScan {
      */
     code: string;
     /**
+     * `code` with the contents of every string and char literal replaced by
+     * spaces, so a `using` written as string text is not offered as a statement
+     * the line makes.
+     *
+     * Read this wherever a path is going to count as imported. The text of a
+     * literal is data, not a statement, and recording a path from it both
+     * suppresses an import the file needs and - because a path that counts as
+     * pinned withholds the movable import of the same path from the rebuilt
+     * block - deletes the real `using` the author wrote.
+     *
+     * Spaces rather than nothing, so the text on either side of a literal does
+     * not join into a token neither side wrote. `code` removes comments without
+     * replacement on purpose, for the opposite reason; the two differ because a
+     * comment can splice a token apart and a literal cannot.
+     *
+     * Equal to `code` on a line that ended inside an open literal, which the
+     * second lexing pass reads with literal tracking off: nothing there can be
+     * classified, so nothing is masked.
+     */
+    codeOutsideLiterals: string;
+    /**
      * Whether the line holds a `<#>` marker, which makes every line below it
      * indented past it part of the comment it opens.
      */
@@ -144,6 +165,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
     let nesting = depth;
     let hasCode = false;
     let code = "";
+    let codeOutsideLiterals = "";
     let i = 0;
     // What is open at this point, innermost last, and empty at code scope. A
     // stack rather than one quote because interpolation alternates the two:
@@ -168,7 +190,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
         }
 
         if (line.startsWith("<#>", i)) {
-            return { depth: nesting, hasCode, code, opensIndentedComment: true };
+            return { depth: nesting, hasCode, code, codeOutsideLiterals, opensIndentedComment: true };
         }
 
         const innermost = trackLiterals ? open[open.length - 1] : undefined;
@@ -179,7 +201,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
         // pass ends at the first `#` on the line, which may sit further back
         // inside string text this pass has already read as content.
         if (line[i] === "#" && innermost?.kind !== "literal") {
-            return { depth: nesting, hasCode, code, opensIndentedComment: false };
+            return { depth: nesting, hasCode, code, codeOutsideLiterals, opensIndentedComment: false };
         }
 
         if (line.startsWith("<#", i)) {
@@ -195,6 +217,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
             // from opening an interpolation.
             if (line[i] === "\\") {
                 code += line.slice(i, i + 2);
+                codeOutsideLiterals += "  ";
                 i += 2;
                 continue;
             }
@@ -226,10 +249,11 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
             hasCode = true;
         }
         code += line[i];
+        codeOutsideLiterals += innermost?.kind === "literal" ? " " : line[i];
         i += 1;
     }
 
-    return open.length === 0 ? { depth: nesting, hasCode, code, opensIndentedComment: false } : null;
+    return open.length === 0 ? { depth: nesting, hasCode, code, codeOutsideLiterals, opensIndentedComment: false } : null;
 }
 
 function indentWidth(line: string): number {
@@ -261,6 +285,12 @@ export interface LineClassification {
      * `using` written in its trivia reads as the line's own statement.
      */
     code: string;
+    /**
+     * `code` with every literal's contents masked. Read this, not `code`,
+     * wherever a path found on the line is going to count as imported; see
+     * LineScan.codeOutsideLiterals.
+     */
+    codeOutsideLiterals: string;
 }
 
 /**
@@ -303,6 +333,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
             insideBlockComment,
             continuesCommentAbove: insideBlockComment || insideIndentedComment,
             code: scan.code,
+            codeOutsideLiterals: scan.codeOutsideLiterals,
         };
 
         if (!insideBlockComment && !insideIndentedComment && scan.opensIndentedComment) {
@@ -343,8 +374,12 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   can never be a legal local-scope using.
  *   That classification reads the line from its head, so it rejects a line
  *   whose `using` follows a definition. Such a line is not skipped: every
- *   `using` it writes is recorded, pinned, because the path is imported and
- *   writing it again would duplicate it.
+ *   complete `using` statement it writes is recorded, pinned, because the path
+ *   is imported and writing it again would duplicate it. A `using:` opening an
+ *   indented pair is not one of them - the path below it stays unrecorded, as
+ *   it is for any `using:` the classification rejects.
+ * - A path is only ever read from the line's statements, never from the text of
+ *   a string or char literal it writes. See LineScan.codeOutsideLiterals.
  * - A collected import that itself opens a comment over the lines below it is
  *   flagged with `anchorsCommentBelow`. It is a real import and still counts
  *   as present, but no writer may rebuild or move its line, because where the
@@ -401,6 +436,12 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
 
         const trimmed = line.trim();
         const code = classifications[i].code.trim();
+        // Every path recorded below is read from this rather than from `code`,
+        // because every one of them counts as imported. See
+        // LineScan.codeOutsideLiterals for what a path read out of string text
+        // costs. `code` still answers what text the line holds, which is a
+        // question about the whole line and not about its statements.
+        const statements = classifications[i].codeOutsideLiterals.trim();
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
 
         if (!ImportFormatter.isModuleImport(trimmed, nextLine, { atFileScope: true })) {
@@ -420,7 +461,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // than widened to admit them. Everything below it may then keep
             // testing the raw line, as the `using:` branch does - see the note
             // there on why the two inputs have to agree.
-            for (const linePath of usingPathsOnLine(formatter, code)) {
+            for (const linePath of usingPathsOnLine(formatter, statements)) {
                 imports.push({
                     path: linePath,
                     startLine: i,
@@ -484,7 +525,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // never see that, because they all read rewritableImports, which
         // excludes a pinned entry; a reader of the unfiltered scan gets the
         // region reported once per path it carries.
-        if (/\busing\s*:\s*$/.test(code)) {
+        if (/\busing\s*:\s*$/.test(statements)) {
             // Every statement written before the pair. The `using:` contributes
             // no path of its own, since neither statement pattern matches it,
             // and a `using:` following something that is not a `using` never
@@ -495,7 +536,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // Counted with usingPathsOnLine because this branch holds first
             // refusal over the one below, so a line ending in `using:` is
             // counted here or nowhere.
-            for (const precedingPath of usingPathsOnLine(formatter, code)) {
+            for (const precedingPath of usingPathsOnLine(formatter, statements)) {
                 imports.push({
                     path: precedingPath,
                     startLine: i,
@@ -548,7 +589,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // agree on how many statements a line writes. Counting a second way
         // here would be the looser copy its doc warns against, and this caller
         // needs the count exact in both directions.
-        const pathsOnLine = usingPathsOnLine(formatter, code);
+        const pathsOnLine = usingPathsOnLine(formatter, statements);
         if (pathsOnLine.length > 1) {
             for (const linePath of pathsOnLine) {
                 imports.push({

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -392,7 +392,9 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   indented pair is not one of them - the path below it stays unrecorded, as
  *   it is for any `using:` the classification rejects.
  * - A path is only ever read from the line's statements, never from the text of
- *   a string or char literal it writes. See LineScan.codeOutsideLiterals.
+ *   a `"` string it writes. A `'` is not treated as opening literal text here,
+ *   because it also closes a path's quoted segment suffix; see
+ *   LineScan.codeOutsideLiterals for why that costs nothing.
  * - A collected import that itself opens a comment over the lines below it is
  *   flagged with `anchorsCommentBelow`. It is a real import and still counts
  *   as present, but no writer may rebuild or move its line, because where the

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -341,6 +341,10 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   same-directory folder-module import): module `using` is legal only at
  *   file level or module-definition body level, so a bare `using` at column 0
  *   can never be a legal local-scope using.
+ *   That classification reads the line from its head, so it rejects a line
+ *   whose `using` follows a definition. Such a line is not skipped: every
+ *   `using` it writes is recorded, pinned, because the path is imported and
+ *   writing it again would duplicate it.
  * - A collected import that itself opens a comment over the lines below it is
  *   flagged with `anchorsCommentBelow`. It is a real import and still counts
  *   as present, but no writer may rebuild or move its line, because where the
@@ -400,6 +404,32 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
 
         if (!ImportFormatter.isModuleImport(trimmed, nextLine, { atFileScope: true })) {
+            // The classification reads the line from its head, so a `using`
+            // written after a definition - `X := 1; using { /A }`, legal because
+            // `;` separates definitions in a scope exactly as a newline does -
+            // does not head its line and the line is rejected here. Its paths
+            // are still imported, and recording them is what stops a diagnostic
+            // asking for one writing a second copy above a line already making
+            // that import.
+            //
+            // All pinned, because the line writes a definition no rebuild from
+            // a path can reproduce. Their spans coincide, which no writer sees:
+            // writers read rewritableImports, which excludes a pinned entry.
+            //
+            // The gate itself is deliberately left refusing these lines rather
+            // than widened to admit them. Everything below it may then keep
+            // testing the raw line, as the `using:` branch does - see the note
+            // there on why the two inputs have to agree.
+            for (const linePath of usingPathsOnLine(formatter, code)) {
+                imports.push({
+                    path: linePath,
+                    startLine: i,
+                    endLine: i,
+                    anchorsCommentBelow: anchorsCommentBelow(i, i),
+                    rebuildLosesText: true,
+                    trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                });
+            }
             i += 1;
             continue;
         }
@@ -458,8 +488,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // Every statement written before the pair. The `using:` contributes
             // no path of its own, since neither statement pattern matches it,
             // and a `using:` following something that is not a `using` never
-            // reaches here - isModuleImport rejects the line above and it is
-            // skipped whole.
+            // reaches here - isModuleImport rejects the line above, which
+            // records the complete statements it writes but not the path its
+            // `using:` opens below.
             //
             // Counted with usingPathsOnLine because this branch holds first
             // refusal over the one below, so a line ending in `using:` is

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -802,6 +802,17 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
+    // The scan rejected the line for not opening with `using`, so the path read
+    // as absent and this wrote a second copy of an import the file already made.
+    it("counts a using written after a definition on its line as already present", async () => {
+        const input = ["X := 1; using { /Verse.org/Random }", "", "code()"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Verse.org/Random }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
     it("leaves a module-scoped using inside its module body during consolidation", async () => {
         (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
             get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -72,6 +72,14 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toContain("using { /A }");
     });
 
+    // Reading a path's quoted suffix as a char literal truncated it to the
+    // module named before the `'`, which the file does import - so organizing
+    // withheld that import as already made and deleted the line making it.
+    it("keeps an import a quoted path suffix on another line truncates to", () => {
+        const input = "using { /Verse.org/Random }\nX := 1; using. /Verse.org/Random'Loc'\ncode()";
+        expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toContain("using { /Verse.org/Random }");
+    });
+
     it("sorts alphabetically when enabled", () => {
         const input = "using { /Zebra }\nusing { /Apple }\ncode()";
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe("using { /Apple }\nusing { /Zebra }\n\ncode()");

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -56,6 +56,22 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe("using { /A }\n\ncode()");
     });
 
+    // A path read out of string text counted as a pinned import of that path,
+    // and a pinned path is withheld from the block on the grounds that the line
+    // holding it already makes the import. No line did, so organizing deleted
+    // the file's only real `using { /A }` and left it importing one path fewer.
+    it("keeps an import whose path a string literal elsewhere in the file names", () => {
+        const input = 'using { /A }\nusing { /B }\nHint := "using { /A }"\ncode()';
+        expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe('using { /A }\nusing { /B }\n\nHint := "using { /A }"\ncode()');
+    });
+
+    // The same loss reachable through a line that is itself an import, which is
+    // the shape that could hit it before a `using` after a definition counted.
+    it("keeps an import a literal on another import's line names", () => {
+        const input = 'using { /A }\nusing { /B }; Hint := "using { /A }"\ncode()';
+        expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toContain("using { /A }");
+    });
+
     it("sorts alphabetically when enabled", () => {
         const input = "using { /Zebra }\nusing { /Apple }\ncode()";
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe("using { /Apple }\nusing { /Zebra }\n\ncode()");

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -353,6 +353,51 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["X := 1; using:", "    Economy.Shop", "code()"])).toEqual([]);
     });
 
+    // The classification reads a line from its head, so this one was rejected
+    // and skipped whole. Nothing recorded that the file imports the path, and a
+    // diagnostic asking for it wrote a second copy above a line already making
+    // the import. `allUsingPaths` saw it throughout, so only deduplication was
+    // affected.
+    it("records a using written after a definition on its line, pinned", () => {
+        expect(scanModuleImports(["X := 1; using { /Verse.org/Random }", "code()"])).toEqual([
+            { path: "/Verse.org/Random", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("records a dotted using written after a definition on its line", () => {
+        expect(scanModuleImports(["X := 1; using. /Verse.org/Random", "code()"])).toEqual([
+            { path: "/Verse.org/Random", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("records every using written after a definition, in written order", () => {
+        expect(scanModuleImports(["X := 1; using { /X }; using { Economy.Shop }", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The definition sharing the line is what no rebuild from a path can
+    // reproduce, so the entry counts as present and nothing more. A writer
+    // handed it would rebuild the line as a bare import and delete `X := 1`.
+    it("offers no rewritable import for a using written after a definition", () => {
+        expect(rewritableImports(scanModuleImports(["X := 1; using { /Verse.org/Random }", "code()"]))).toEqual([]);
+    });
+
+    // Read from the line's code, so a path named in a comment is not an import.
+    // Searching the raw text records `/A` as present and the file never gets the
+    // import a diagnostic asked for.
+    it("records nothing for a using written in a comment after a definition", () => {
+        expect(scanModuleImports(["X := 1 # using { /A }", "code()"])).toEqual([]);
+    });
+
+    // Indented lines are skipped before the classification runs, and have to
+    // stay that way: a `using` in a module body is module-scoped, and counting
+    // it as present suppresses the file-level import the diagnostic asked for.
+    it("skips a using written after a definition inside a module body", () => {
+        expect(scanModuleImports(["MyModule := module:", "    X := 1; using { /A }", "code()"])).toEqual([]);
+    });
+
     // extractPathFromImport reads the statement at the head of what it is given
     // and reports nothing about the rest, so the line used to be recorded as
     // `/X` alone, spanning one line and rewritable. Organizing rebuilt it from

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -398,6 +398,32 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["MyModule := module:", "    X := 1; using { /A }", "code()"])).toEqual([]);
     });
 
+    // Literal text is data, not a statement. Recorded as an import it counts as
+    // present, which both withholds the path from a file that needs it and -
+    // since a pinned path is withheld from the rebuilt block - deletes the real
+    // `using` the author wrote elsewhere in the file.
+    it("records nothing for a using written inside a string literal", () => {
+        expect(scanModuleImports(['Hint := "using { /A }"', "code()"])).toEqual([]);
+    });
+
+    it("records nothing for a using written inside a char literal", () => {
+        expect(scanModuleImports(["Hint := 'using { /A }'", "code()"])).toEqual([]);
+    });
+
+    // The same rule on a line that is itself an import: the statement counts,
+    // the literal beside it does not.
+    it("records only the statement a line writes beside a literal naming a path", () => {
+        expect(scanModuleImports(['using { /A }; Hint := "using { /B }"', "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // An interpolation is code scope again, so a `using` written in one is a
+    // statement the line really does make and stays recorded.
+    it("records a using written inside a string interpolation", () => {
+        expect(scanModuleImports(['X := "a{using { /A }}b"', "code()"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" }]);
+    });
+
     // extractPathFromImport reads the statement at the head of what it is given
     // and reports nothing about the rest, so the line used to be recorded as
     // `/X` alone, spanning one line and rewritable. Organizing rebuilt it from

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -406,10 +406,6 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(['Hint := "using { /A }"', "code()"])).toEqual([]);
     });
 
-    it("records nothing for a using written inside a char literal", () => {
-        expect(scanModuleImports(["Hint := 'using { /A }'", "code()"])).toEqual([]);
-    });
-
     // The same rule on a line that is itself an import: the statement counts,
     // the literal beside it does not.
     it("records only the statement a line writes beside a literal naming a path", () => {
@@ -418,10 +414,21 @@ describe("scanModuleImports", () => {
         ]);
     });
 
-    // An interpolation is code scope again, so a `using` written in one is a
-    // statement the line really does make and stays recorded.
-    it("records a using written inside a string interpolation", () => {
-        expect(scanModuleImports(['X := "a{using { /A }}b"', "code()"])).toEqual([{ path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" }]);
+    // The masking must not reach a `'`. The lexer opens a char literal on one,
+    // but the same character closes a path's quoted segment suffix, and a
+    // masked suffix leaves `Economy.Shop` - a module that exists and is not the
+    // one the line imports. A writer asked for it reads the file as already
+    // importing it; organizing withholds the real import and deletes it.
+    it("records the whole quoted suffix of a path written beside another statement", () => {
+        expect(scanModuleImports(["using { /A }; using. Economy.Shop'Loc'", "code()"]).map((imp) => imp.path)).toEqual(["/A", "Economy.Shop'Loc'"]);
+    });
+
+    it("records the whole quoted suffix of a path written after a definition", () => {
+        expect(scanModuleImports(["X := 1; using. Economy.Shop'Loc'", "code()"]).map((imp) => imp.path)).toEqual(["Economy.Shop'Loc'"]);
+    });
+
+    it("records the whole quoted suffix of a braced path written after a definition", () => {
+        expect(scanModuleImports(["X := 1; using { Economy.Shop'Loc' }", "code()"]).map((imp) => imp.path)).toEqual(["Economy.Shop'Loc'"]);
     });
 
     // extractPathFromImport reads the statement at the head of what it is given


### PR DESCRIPTION
Closes #273

## What was wrong

`scanModuleImports` classifies a candidate line from its head, so `ImportFormatter.isModuleImport` rejects any line whose `using` follows a definition — legal Verse, since `;` separates definitions in a scope exactly as a newline does. The line was skipped whole, nothing recorded that the file imports the path, and a diagnostic asking for it wrote a second copy above a line already making that import.

Reproduced on `d2a1413`:

```
scanModuleImports(["X := 1; using { /Verse.org/Random }", "code()"]) -> []
allUsingPaths(["X := 1; using { /Verse.org/Random }", "code()"])     -> ["/Verse.org/Random"]
```

`allUsingPaths` saw it throughout, so removal safety was never affected and the line itself was never touched. The cost was the duplicate.

## The fix

Three commits.

**`49ee7de`** records every complete `using` statement such a line writes, pinned. Presence is judged from every scanned import including pinned ones, while the rebuilt block is built only from `rewritableImports`, so the path stops being written twice and no writer may move or rebuild the line. The classification gate is left refusing these lines rather than widened, so everything below it may keep testing the raw line, as the `using:` branch documents it must.

**`371775c`** closes a data-loss defect the first commit made common. The lexer kept literal text in the `code` it reports, so a `using` written as string data was offered as a statement the line makes. A path that counts as present is withheld from the rebuilt block, on the grounds that the line holding it already makes the import — so organizing a file whose string happened to name an imported path *deleted* the real `using`:

```
using { /A }                     using { /B }
using { /B }                ->
Hint := "using { /A }"           Hint := "using { /A }"
code()                           code()
```

Literal contents are now masked into `codeOutsideLiterals`, and every site whose paths count as imported reads that. `code` still answers what text a line holds, which is a question about the line rather than about the statements it writes.

That defect was reachable before this branch through a line that was itself an import — `using { /A }` + `using { /B }; Hint := "using { /A }"` loses `/A` on `d2a1413` too — so both shapes are covered and both are regression-tested. `allUsingPaths` deliberately keeps reading unmasked `code`, preserving the over-reporting its only consumer, `withholdIsSafe`, is documented to depend on.

**`6c54f73`** confines the mask to `"` strings. A `'` opens a char literal in the lexer, but the same character closes a path's quoted segment suffix, so masking it truncated `Economy.Shop'Loc'` to `Economy.Shop` — the exact misreading `DOTTED_STATEMENT`'s doc exists to prevent, since that is a different module that exists. Both harms returned through it, including deleting a real import. Nothing is given up by exempting `'`: a char literal holds one character, and a `using` does not fit in one.

Two tests written in the second commit were deleted rather than adjusted here. Neither pinned a shape Verse compiles — `'using { /A }'` is not a valid char literal, and a `using` is a definition rather than an expression, so it cannot appear in a string interpolation.

## Deliberately not covered

`X := 1; using:` opening an indented pair stays skipped whole, as it is today. Consuming it means reasoning about the pair's span, which is a separate change; the doc comment now says so rather than implying deduplication reaches it.

## Verification

```
$ npm run compile
> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm run format:check
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!

$ npm test
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 39 passed, 39 total
Tests:       797 passed, 797 total
Snapshots:   0 total
Time:        13.302 s
Ran all test suites.
```

Each new test was proven to detect its defect before the fix went in: 4 failures for the deduplication cases with the first commit's change removed, and every data-loss case above was reproduced directly against the commit that introduced it.

Both later commits answer a blocking finding from an independent reviewer given the diff with no knowledge of how it was written.
