### PR TITLE
refactor(imports): name the two fields their comments only existed to explain

### DIFF
--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -69,24 +69,19 @@ interface LineScan {
     /** Whether the line carries any text outside a comment. */
     hasCode: boolean;
     /**
-     * The line with its comments removed. A statement is not required to open
-     * its line - one can follow a `;`, or the `#>` that closes a block comment
-     * - so a reader has to search the whole line, and searching the raw line
-     * reads a `using` written in trivia as the line's own statement.
-     *
      * Nothing is put in a removed comment's place, so text on either side of
      * one joins. That is what the field is for: a comment splicing a token
-     * apart, `us<##>ing { /A }`, rejoins into a `using` the search can find,
-     * and a missed `using` is the one error its callers cannot survive. Putting
-     * a space there instead loses that, and buys only
+     * apart, `us<##>ing { /A }`, rejoins into a `using` a search of the whole
+     * line can find, and a missed `using` is the one error its callers cannot
+     * survive. Putting a space there instead loses that, and buys only
      * `X := 1<# note #>using { /A }` - a shape two statements with nothing
      * between them do not compile as anyway.
      */
-    code: string;
+    codeWithoutComments: string;
     /**
-     * `code` with the contents of every `"` string replaced by spaces, so a
-     * `using` written as string text is not offered as a statement the line
-     * makes.
+     * `codeWithoutComments` with the contents of every `"` string replaced by
+     * spaces, so a `using` written as string text is not offered as a statement
+     * the line makes.
      *
      * Read this wherever a path is going to count as imported. The text of a
      * string is data, not a statement, and recording a path from it both
@@ -102,14 +97,15 @@ interface LineScan {
      * `using` cannot fit in one.
      *
      * Spaces rather than nothing, so the text on either side of a string does
-     * not join into a token neither side wrote. `code` removes comments without
-     * replacement on purpose, for the opposite reason; the two differ because a
-     * comment can splice a token apart and a string cannot.
+     * not join into a token neither side wrote. `codeWithoutComments` removes
+     * comments without replacement on purpose, for the opposite reason; the two
+     * differ because a comment can splice a token apart and a string cannot.
      *
-     * Equal to `code` on a line that ended inside an open literal or
-     * interpolation, which the second lexing pass reads with literal tracking
-     * off. Nothing there can be classified, so nothing is masked, and a `using`
-     * written in an unterminated string on such a line still counts as present.
+     * Equal to `codeWithoutComments` on a line that ended inside an open
+     * literal or interpolation, which the second lexing pass reads with literal
+     * tracking off. Nothing there can be classified, so nothing is masked, and
+     * a `using` written in an unterminated string on such a line still counts
+     * as present.
      */
     codeOutsideLiterals: string;
     /**
@@ -172,7 +168,7 @@ type LexFrame =
 function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan | null {
     let nesting = depth;
     let hasCode = false;
-    let code = "";
+    let codeWithoutComments = "";
     let codeOutsideLiterals = "";
     let i = 0;
     // What is open at this point, innermost last, and empty at code scope. A
@@ -198,7 +194,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
         }
 
         if (line.startsWith("<#>", i)) {
-            return { depth: nesting, hasCode, code, codeOutsideLiterals, opensIndentedComment: true };
+            return { depth: nesting, hasCode, codeWithoutComments, codeOutsideLiterals, opensIndentedComment: true };
         }
 
         const innermost = trackLiterals ? open[open.length - 1] : undefined;
@@ -209,7 +205,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
         // pass ends at the first `#` on the line, which may sit further back
         // inside string text this pass has already read as content.
         if (line[i] === "#" && innermost?.kind !== "literal") {
-            return { depth: nesting, hasCode, code, codeOutsideLiterals, opensIndentedComment: false };
+            return { depth: nesting, hasCode, codeWithoutComments, codeOutsideLiterals, opensIndentedComment: false };
         }
 
         if (line.startsWith("<#", i)) {
@@ -224,7 +220,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
             // as code. `\{` is the same rule, and is what keeps an escaped brace
             // from opening an interpolation.
             if (line[i] === "\\") {
-                code += line.slice(i, i + 2);
+                codeWithoutComments += line.slice(i, i + 2);
                 codeOutsideLiterals += innermost.quote === '"' ? "  " : line.slice(i, i + 2);
                 i += 2;
                 continue;
@@ -256,7 +252,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
         if (!/\s/.test(line[i])) {
             hasCode = true;
         }
-        code += line[i];
+        codeWithoutComments += line[i];
         // Only a `"` string. A `'` opens a char literal here, but the same
         // character ends a path's quoted segment suffix, `Economy.Shop'Loc'`,
         // and masking that truncates the path to `Economy.Shop` - a different
@@ -266,7 +262,7 @@ function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan 
         i += 1;
     }
 
-    return open.length === 0 ? { depth: nesting, hasCode, code, codeOutsideLiterals, opensIndentedComment: false } : null;
+    return open.length === 0 ? { depth: nesting, hasCode, codeWithoutComments, codeOutsideLiterals, opensIndentedComment: false } : null;
 }
 
 function indentWidth(line: string): number {
@@ -294,14 +290,14 @@ export interface LineClassification {
      */
     continuesCommentAbove: boolean;
     /**
-     * The line with its comments removed. Search the raw line instead and a
-     * `using` written in its trivia reads as the line's own statement.
+     * Search the raw line instead and a `using` written in its trivia reads as
+     * the line's own statement.
      */
-    code: string;
+    codeWithoutComments: string;
     /**
-     * `code` with every literal's contents masked. Read this, not `code`,
-     * wherever a path found on the line is going to count as imported; see
-     * LineScan.codeOutsideLiterals.
+     * `codeWithoutComments` with every literal's contents masked. Read this, not
+     * `codeWithoutComments`, wherever a path found on the line is going to count
+     * as imported; see LineScan.codeOutsideLiterals.
      */
     codeOutsideLiterals: string;
 }
@@ -345,7 +341,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
             kind,
             insideBlockComment,
             continuesCommentAbove: insideBlockComment || insideIndentedComment,
-            code: scan.code,
+            codeWithoutComments: scan.codeWithoutComments,
             codeOutsideLiterals: scan.codeOutsideLiterals,
         };
 
@@ -450,12 +446,13 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         }
 
         const trimmed = line.trim();
-        const code = classifications[i].code.trim();
-        // Every path recorded below is read from this rather than from `code`,
-        // because every one of them counts as imported. See
-        // LineScan.codeOutsideLiterals for what a path read out of string text
-        // costs. `code` still answers what text the line holds, which is a
-        // question about the whole line and not about its statements.
+        const codeWithoutComments = classifications[i].codeWithoutComments.trim();
+        // Every path recorded below is read from this rather than from
+        // `codeWithoutComments`, because every one of them counts as imported.
+        // See LineScan.codeOutsideLiterals for what a path read out of string
+        // text costs. `codeWithoutComments` still answers what text the line
+        // holds, which is a question about the whole line and not about its
+        // statements.
         const statements = classifications[i].codeOutsideLiterals.trim();
         const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
 
@@ -642,7 +639,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 startLine: i,
                 endLine: i,
                 anchorsCommentBelow: anchorsCommentBelow(i, i),
-                rebuildLosesText: formatter.textAfterImport(code) !== "",
+                rebuildLosesText: formatter.textAfterImport(codeWithoutComments) !== "",
                 trailingComment: ImportFormatter.extractTrailingComment(trimmed),
             });
         }
@@ -750,9 +747,9 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
  *   count while one sharing a line with comment trivia still does.
  * - The statement need not open its line - it can follow a `;`, the `#>` that
  *   closes a block comment, or closed inline trivia - so the whole line is
- *   searched. The line searched is the classifier's `code` rather than the raw
- *   text, or a `using { X }` written in a comment stands in for the line's own
- *   statement.
+ *   searched. The line searched is the classifier's `codeWithoutComments`
+ *   rather than the raw text, or a `using { X }` written in a comment stands in
+ *   for the line's own statement.
  * - A line contributes every `using` usingPathsOnLine finds on it, in written
  *   order, rather than the first.
  * - A `using:` opening an indented pair is recognised at the end of its line
@@ -768,12 +765,12 @@ export function allUsingPaths(lines: string[]): string[] {
     const paths: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
-        const { kind, code } = classifications[i];
+        const { kind, codeWithoutComments } = classifications[i];
         if (kind === "comment") {
             continue;
         }
 
-        const trimmed = code.trim();
+        const trimmed = codeWithoutComments.trim();
         paths.push(...usingPathsOnLine(formatter, trimmed));
 
         // A `using:` opening an indented pair carries no path of its own -

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -107,17 +107,16 @@ export class ImportSuggestionExtractor {
     }
 
     /**
-     * Splits a fully qualified name into the module path to import and the
-     * class name within it, or null when the name is not a dotted identifier
-     * chain or carries no module part at all.
-     *
      * The split normally falls before the last segment. An intermediate segment
      * that names a known asset class moves it earlier, since everything from
      * that class onward addresses members rather than modules.
      *
+     * Null when the name is not a dotted identifier chain, or carries no module
+     * part at all.
+     *
      * @param fullName e.g. "MyGame.UI.UI_Widget.ClassName"
      */
-    private findCorrectModulePath(fullName: string): { modulePath: string; className: string } | null {
+    private splitModulePathAndClass(fullName: string): { modulePath: string; className: string } | null {
         // "Did you mean" captures raw sentence text, so trailing punctuation
         // ("Economy.Shop.") or prose ("to use Bar.Baz instead?") reaches this
         // point, and splitting those produces a plausible-looking but wrong
@@ -176,7 +175,7 @@ export class ImportSuggestionExtractor {
             }
             // A fully qualified name, "Module.ClassName" or
             // "Module.AssetClass.Member".
-            const result = this.findCorrectModulePath(option);
+            const result = this.splitModulePathAndClass(option);
             if (result && result.modulePath) {
                 candidates.push({ path: result.modulePath, description: `${result.className} from ${result.modulePath}` });
             } else {
@@ -271,7 +270,7 @@ export class ImportSuggestionExtractor {
             return null;
         }
         const fullName = didYouMeanMatch[1].trim();
-        const result = this.findCorrectModulePath(fullName);
+        const result = this.splitModulePathAndClass(fullName);
         if (result && result.modulePath) {
             return { path: result.modulePath, description: `Inferred import for ${fullName}` };
         }

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -850,24 +850,24 @@ describe("classifyLines", () => {
     });
 
     it("keeps a # inside a string literal in the line's code", () => {
-        expect(classifyLines(['X := "a#b"; using { /A }'])[0].code).toBe('X := "a#b"; using { /A }');
+        expect(classifyLines(['X := "a#b"; using { /A }'])[0].codeWithoutComments).toBe('X := "a#b"; using { /A }');
     });
 
     it("keeps a # inside a char literal in the line's code", () => {
-        expect(classifyLines(["C := '#'; using { /A }"])[0].code).toBe("C := '#'; using { /A }");
+        expect(classifyLines(["C := '#'; using { /A }"])[0].codeWithoutComments).toBe("C := '#'; using { /A }");
     });
 
     // A block comment opened inside a string does not end the string:
     // "a<#c#>#b" is the string "a#b", so the `#` after the `#>` is content too.
     it("keeps a string open across a block comment written inside it", () => {
-        expect(classifyLines(['X := "a<#c#>#b"; using { /A }'])[0].code).toBe('X := "a#b"; using { /A }');
+        expect(classifyLines(['X := "a<#c#>#b"; using { /A }'])[0].codeWithoutComments).toBe('X := "a#b"; using { /A }');
     });
 
     // The quote opening a string inside an interpolation does not close the
     // string around it, so the `#` between them is still content and the code
     // keeps everything the line writes after the literal.
     it("keeps a # inside a string nested in an interpolation in the line's code", () => {
-        expect(classifyLines(['X := "a{F("#")}b"; using { /A }'])[0].code).toBe('X := "a{F("#")}b"; using { /A }');
+        expect(classifyLines(['X := "a{F("#")}b"; using { /A }'])[0].codeWithoutComments).toBe('X := "a{F("#")}b"; using { /A }');
     });
 
     it("marks only the lines a block comment was opened above", () => {


### PR DESCRIPTION
Closes #248

Two renames in `src/imports`, each removing the reason its comment existed.

- `LineScan.code` and `LineClassification.code` become `codeWithoutComments`. The lexer's accumulator, the `scanModuleImports` local, the `allUsingPaths` destructure and every prose citation of the old name move with them. Each field's doc drops the sentence that only said what the field holds: `LineScan.codeWithoutComments` now states the no-replacement constraint alone, and `LineClassification.codeWithoutComments` the consequence of searching the raw line instead.
- `findCorrectModulePath` becomes `splitModulePathAndClass`, its doc shortened to the asset-class rule plus the null contract the return type does not carry.

Pure renames: no logic, control flow or output changed, and nothing user-visible moves, so no changelog fragment.

One note on the ticket body: it says `ImportDocumentEditor` reads `code` off `classifyLines`. That is stale — it imports `LineClassification` as a type only and touches neither field, so no edit was needed there.

## Verification

```
$ npm run compile
> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       810 passed, 810 total
Snapshots:   0 total
Time:        20.455 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh reviewer, verdict `PASS_WITH_SUGGESTIONS`. No Critical or Important findings. Two suggestions, both outside the ticket's scope and left alone:

- `usingPathsOnLine`'s parameter is still named `code`, and its two callers pass different maskings.
- The dropped first paragraph of `LineScan.codeWithoutComments` carried the fact that a statement need not open its line; it is still stated at the two call sites that depend on it.
