### PR TITLE
fix(imports): mask comments and strings before the module declaration scan

### DIFF
--- a/changelog.d/306.fixed.md
+++ b/changelog.d/306.fixed.md
@@ -1,0 +1,1 @@
+**Import path conversion**: The fallback scan no longer treats a commented-out or string-quoted module declaration as a live one, so a conversion stops resolving to that file or asking which of two locations was meant.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -256,6 +256,11 @@ const workspace = {
      * a path under no folder, which is what production code reads as a file
      * outside the project - so a test wanting a folder must register it in
      * workspaceFolders rather than rely on a fallback.
+     *
+     * The first containing folder wins, where real VS Code returns the
+     * innermost, and a URI equal to a folder root answers undefined rather than
+     * that folder. A test covering the multi-root UEFN workspace, or nested
+     * folders, needs more than this.
      */
     getWorkspaceFolder: jest.fn().mockImplementation((target: { fsPath: string }) => {
         const normalized = target.fsPath.replace(/\\/g, "/");

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -251,6 +251,16 @@ const workspace = {
     // undefined - which is how the environment snapshot tells the two apart.
     workspaceFile: undefined as { fsPath: string } | undefined,
     findFiles: jest.fn().mockResolvedValue([]),
+    /**
+     * The workspace folder a URI sits in, matched on path prefix. Undefined for
+     * a path under no folder, which is what production code reads as a file
+     * outside the project - so a test wanting a folder must register it in
+     * workspaceFolders rather than rely on a fallback.
+     */
+    getWorkspaceFolder: jest.fn().mockImplementation((target: { fsPath: string }) => {
+        const normalized = target.fsPath.replace(/\\/g, "/");
+        return workspace.workspaceFolders?.find((folder) => normalized.startsWith(`${folder.uri.fsPath.replace(/\\/g, "/").replace(/\/+$/, "")}/`));
+    }),
     // Rejecting is the "no such file" answer, which is what production code
     // reads a missing file as. A resolving default would make an absent
     // definitions file look like an empty existing one.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { logger } from "../utils";
+import { maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathCache } from "../services";
 import { ImportFormatter } from "./ImportFormatter";
@@ -107,12 +108,12 @@ export class ImportPathConverter {
      * entry is accepted - a `scoped{A, B}` list included, whose specifier does
      * not end at its keyword.
      *
-     * A specifier body must exclude `<` and newlines. Callers test unmasked
-     * whole-file content, so a body free to span lines lets a comparison
-     * operator or a `<` in a comment run on to the `>` of a LATER
-     * declaration's specifier, reporting a file that declares no such module.
-     * MODULE_DECLARATION affords the wider `[^>]` because it masks comments
-     * and strings first; this does not, so the two cannot be synchronized.
+     * A specifier body must exclude `<` and newlines. A body free to span lines
+     * lets a `<` that opens nothing - a comparison operator, say - run on to
+     * the `>` of a LATER declaration's specifier, reporting a file that
+     * declares no such module. The narrowing holds whether or not the text is
+     * masked first, and nothing binds a caller of this builder to mask, so it
+     * cannot be widened to MODULE_DECLARATION's `[^>]`.
      *
      * Non-global on purpose: the pattern is reused with `.test()` across many
      * files, and a global flag would carry `lastIndex` between calls and skip
@@ -332,7 +333,13 @@ export class ImportPathConverter {
                 () => null,
             );
 
-            if (!content || !modulePattern.test(content)) continue;
+            // Only a live declaration attests to a location. Matched against
+            // raw text, a commented-out declaration or one quoted in a string
+            // puts its directory into `locations`, which either makes the
+            // conversion ambiguous or writes a path to the wrong file. The two
+            // sibling scanners, moduleDeclarations and ProjectPathScanner, mask
+            // for the same reason.
+            if (!content || !modulePattern.test(maskCommentsAndStrings(content))) continue;
 
             logger.debug("ImportPathConverter", `Found module definition in: ${file.fsPath}`);
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(file);

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -64,10 +64,10 @@ describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
     });
 
     it("does not let a stray < reach the specifier of a later declaration", () => {
-        // The whole file is tested unmasked, so a `<` that opens nothing - a
-        // comparison, or one written in a comment - sits between the name and
-        // the next declaration's specifier. A specifier body that could span
-        // that far would report this file as declaring Inventory.
+        // A `<` that opens nothing - a comparison, say - sits between the name
+        // and the next declaration's specifier. A specifier body free to span
+        // that far would report this file as declaring Inventory, and masking
+        // the text first does not take a live comparison away.
         const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
 
         expect(re.test("if (Inventory < MaxSlots):\n\nHelpers<public> := module:")).toBe(false);

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -447,3 +447,59 @@ describe("ImportPathConverter.convertToFullPath", () => {
         expect(result?.moduleName).toBe("Shop");
     });
 });
+
+describe("ImportPathConverter.findModuleLocations explicit declaration scan", () => {
+    const workspaceRoot = "C:/Project";
+    const declaringFile = `${workspaceRoot}/Content/Systems/Inventory.verse`;
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    /**
+     * The locations the scan finds for "Inventory" in a project whose one
+     * `.verse` file holds `source`. No current file is passed, so the folder
+     * search is skipped and the declaration scan is the only phase that runs.
+     */
+    async function locationsFor(source: string): Promise<string[]> {
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([vscode.Uri.file(declaringFile)]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from(source, "utf8"));
+
+        const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
+        return converter.findModuleLocations("Inventory");
+    }
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("reports the directory of a live declaration", async () => {
+        expect(await locationsFor("Inventory := module:\n    Count<public>:int = 0\n")).toEqual(["/Systems"]);
+    });
+
+    // A location the module does not live in is worse than none: it either
+    // makes a single, correct conversion ambiguous, or resolves to the wrong
+    // file and writes that path into the user's source.
+    it("ignores a declaration commented out with a line comment", async () => {
+        expect(await locationsFor("# Inventory := module:            # renamed, kept for reference\n")).toEqual([]);
+    });
+
+    it("ignores a declaration inside a block comment", async () => {
+        expect(await locationsFor("<# Inventory := module:\n   dropped in the 1.4 pass #>\n")).toEqual([]);
+    });
+
+    it("ignores a declaration inside an indented comment marker", async () => {
+        expect(await locationsFor("<#>\n    Inventory := module:\n        Count<public>:int = 0\n")).toEqual([]);
+    });
+
+    it("ignores declaration text quoted in a string literal", async () => {
+        expect(await locationsFor('Doc := "Inventory := module:"\n')).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #306

## What

`searchExplicitModuleDefinitions` matched its module-declaration regex against each candidate file's raw text, so a declaration inside a `#` comment, a `<# ... #>` block, a `<#>` marker body, or a string literal reported that file's directory as a place the module lives. The conversion then either raised a quick-pick where the answer had been single and correct, or resolved to the wrong location and wrote that absolute path into the user's source.

## How

`maskCommentsAndStrings(content)` before the `.test()`. Masking is space-for-character and keeps newlines, and nothing downstream of the test reads the content — the loop uses only `file.fsPath` from there on — so the masked copy stays local to the check. This is the third of the three declaration scanners to mask; `moduleDeclarations` and `ProjectPathScanner` (#292) already did, and this call site was the one never brought along.

Two comments were corrected rather than left to age, both invalidated by the change:

- `buildModuleDefinitionRegex`'s doc justified its `[^<>\n]` specifier body with "callers test unmasked whole-file content ... MODULE_DECLARATION affords the wider `[^>]` because it masks first; this does not". Its sole caller now masks. The narrowing is still right — a `<` that opens nothing can be live code, a comparison, which no masking removes — so the doc now states that reason instead.
- The regression test for that narrowing carried the same premise in its prose.

## Coverage

`ImportPathConverter.findModuleLocations` with a faked single-folder workspace: one `.verse` file, `findFiles` and `fs.readFile` stubbed, no current file passed so the folder search is skipped and the declaration scan is the only phase that runs.

- a live declaration still yields `/Systems` (the over-masking guard)
- the `#` line comment, the `<# ... #>` block, the `<#>` marker body and the string-literal forms each yield no location

All four negative assertions were proven to fail against the pre-fix file — reverted it to HEAD, ran the file, saw 4 failures and the positive control passing, then restored.

`getWorkspaceFolder` was absent from the vscode mock and production calls it, so it was added: prefix match against `workspaceFolders`, `undefined` for a path under none. Its doc names where it diverges from the real API (first containing folder rather than innermost; a URI equal to a folder root answers `undefined`). No existing suite both sets `workspaceFolders` and drives the converter, so nothing else changes behaviour.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       815 passed, 815 total
Snapshots:   0 total
Time:        11.712 s, estimated 18 s
Ran all test suites.

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh reviewer, opus. `PASS_WITH_SUGGESTIONS` — 0 Critical, 1 Important, 3 Suggestions. The Important (no changelog fragment) and two Suggestions (the stale test comment, the undocumented mock divergences) are taken above. One declined: extracting the shared path-normalization shape out of the mock's `getWorkspaceFolder` and `asRelativePath`, which would buy indirection in a test double for two call sites.
