### PR TITLE
fix(imports): keep relative imports in written order, whichever form they take

### DIFF
--- a/changelog.d/271.fixed.md
+++ b/changelog.d/271.fixed.md
@@ -1,0 +1,1 @@
+**Import sorting**: Sorting and adding imports now keep every relative `using` in its written order, since a dotted import can bring into scope the module a later bare import names.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -147,18 +147,21 @@ function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]
  * bound placement the same way, for the same reason: the line stays put, so
  * whichever of the two put it there changes nothing about what may cross it.
  *
- * Both bounds read the ranks selectTargetBlockIndex compares, so pinned and
- * blocked imports cannot disagree about what precedes what:
+ * Both bounds ask what selectTargetBlockIndex asks, so pinned and blocked
+ * imports cannot disagree about what precedes what:
  *
- * - `floor` - the last line owned by the lowest pinned import that belongs
- *   above the new one (belongsAbove). The new import goes below it.
+ * - `floor` - the last line owned by the lowest pinned import, where the new
+ *   path resolves against what is in scope above it
+ *   (ImportFormatter.resolvesAgainstScopeAbove). Any of them can be bringing
+ *   its first segment into scope, so it goes below all of them. An absolute
+ *   path needs nothing above it and is unconstrained.
  * - `ceiling` - the first line of the highest pinned import that could be
  *   resolving against the new one (couldResolveAgainst). The new import goes
  *   directly above it.
  *
- * The two predicates are deliberately not mirror images: see
- * couldResolveAgainst for why an upper bound here has to be a scope
- * requirement rather than the ordering preference belongsBelow also captures.
+ * The two are deliberately not mirror images: the floor is what every rule
+ * here keeps, and the ceiling is the one documented override of it. See
+ * couldResolveAgainst, and placementLine for which wins.
  *
  * `-1` means unconstrained in that direction.
  */
@@ -263,68 +266,30 @@ export class ImportDocumentEditor {
 
     /**
      * Chooses which existing import block a new path must be merged into so the
-     * rank ordering holds across the whole file rather than only inside one
-     * block.
+     * ordering holds across the whole file rather than only inside one block.
      *
-     * createBlockReplacementEdit rank-sorts the block it rewrites, so it orders
-     * a provider above its consumer only while both sit in that same block. Any
-     * blank line between imports starts a second block, so always merging into
+     * createBlockReplacementEdit sorts the block it rewrites, so it keeps a new
+     * import below a provider only while both sit in that same block. Any blank
+     * line between imports starts a second block, so always merging into
      * `importBlocks[0]` could place a new `using { Economy.Shop }` above the
      * `using { Features }` that brings `Economy` into scope - the breakage the
-     * rank sort exists to prevent.
+     * sort exists to prevent.
      *
-     * Two bounds decide the block, read from the same ranks sortImportsByRank
-     * compares:
-     * - the last block holding an import that belongs above the new one: a
-     *   lower rank, or another bare reference, whose relative order is semantic
-     *   and which the sort likewise keeps ahead of a newly added one.
-     * - the first block holding an import the new one belongs above: a higher
-     *   rank. This is what keeps a bare provider above the dotted consumer it
-     *   was added for, even when that consumer is in an earlier block.
+     * The form of the new path decides it, the same question
+     * sortImportsByRank asks (ImportFormatter.resolvesAgainstScopeAbove):
+     * - a relative path goes in the last block, since every import already in
+     *   the file may be the one bringing its first segment into scope and the
+     *   sort will keep it below them there.
+     * - an absolute path goes in the first, since it needs nothing in scope and
+     *   no import has to precede it.
      *
-     * The lower bound wins where both apply, keeping the new import as high in
-     * the file as is safe, and the upper bound caps it where the two disagree.
-     * With no lower bound the first block is used, which is also where an
-     * absolute path belongs: it needs nothing in scope, so no import has to
-     * precede it.
+     * @param importBlocks The blocks the new path may go in, in document order.
+     *   Never empty - the caller drops a path with no eligible block before
+     *   asking. A block is never empty either, so holding an import is not a
+     *   condition to check.
      */
     private selectTargetBlockIndex(importBlocks: ImportBlock[], path: string): number {
-        const rank = this.formatter.importRank(path);
-
-        let lowerBound = -1;
-        let upperBound = -1;
-        importBlocks.forEach((block, index) => {
-            const ranks = block.imports.map((imp) => this.formatter.importRank(imp.path));
-            if (ranks.some((existing) => this.belongsAbove(existing, rank))) {
-                lowerBound = index;
-            }
-            if (upperBound === -1 && ranks.some((existing) => this.belongsBelow(existing, rank))) {
-                upperBound = index;
-            }
-        });
-
-        if (lowerBound === -1) {
-            return 0;
-        }
-        return upperBound !== -1 && upperBound < lowerBound ? upperBound : lowerBound;
-    }
-
-    /**
-     * Whether an existing import of rank `existing` belongs above a newly added
-     * import of rank `rank`.
-     *
-     * A lower rank always precedes a higher one, and two bare references keep
-     * their written order because it is semantic - a nested child must follow
-     * the parent providing it, and a newly added one has no claim to go first.
-     * See ImportFormatter.sortImportsByRank.
-     */
-    private belongsAbove(existing: number, rank: number): boolean {
-        return existing < rank || (existing === rank && rank === 1);
-    }
-
-    /** Whether an existing import of rank `existing` belongs below a newly added one of rank `rank`. */
-    private belongsBelow(existing: number, rank: number): boolean {
-        return existing > rank;
+        return this.formatter.resolvesAgainstScopeAbove(path) ? importBlocks.length - 1 : 0;
     }
 
     /**
@@ -332,19 +297,18 @@ export class ImportDocumentEditor {
      * a newly added import of rank `rank`, which is what forces the new one
      * above it rather than merely preferring it there.
      *
-     * Only a dotted path needs something in scope above it - its first segment.
-     * An absolute path needs nothing at all. A bare reference can need another
-     * bare one, a nested child its parent, but a newly added import has no
-     * claim to be that parent: belongsAbove already keeps a new bare import
-     * below the existing ones, so raising an upper bound from a bare import
-     * would only contradict the lower bound it raises anyway.
+     * This is the one place a newly added import is read as the provider rather
+     * than the consumer, and it deliberately overrides the written order every
+     * other rule here keeps: the import is being added because a diagnostic
+     * asked for it, and a pinned dotted import whose first segment is missing
+     * is a diagnostic the extension cannot tell from any other. Placing the new
+     * import below it would decline to fix the one file this case exists for.
      *
-     * Narrower than belongsBelow on purpose. Preference is the right strength
-     * in selectTargetBlockIndex, where the consequence of an upper bound is
-     * merging into an earlier block - always a legal place for the import.
-     * Here the consequence is refusing every block and writing a standalone
-     * line, so applying a preference at that strength fragments a file into
-     * import regions to satisfy nothing.
+     * Kept to a pinned dotted consumer and a new import that can supply a first
+     * segment for it, because the override is only worth the risk that narrowly.
+     * The consequence of an upper bound here is refusing every block and writing
+     * a standalone line, so widening it fragments a file into import regions to
+     * satisfy nothing.
      */
     private couldResolveAgainst(existing: number, rank: number): boolean {
         return existing === 2 && rank < 2;
@@ -356,19 +320,25 @@ export class ImportDocumentEditor {
      *
      * Position is the whole question, not the presence of such an import. The
      * block is written above every pinned line, so an import already above
-     * every pinned one that must precede it lands in the same relation to them
-     * afterwards and can be sorted freely; one written below such a line would
-     * cross it, and a `using` that crosses the import bringing its first
-     * segment into scope stops resolving. Holding back an import that was never
-     * at risk would leave a file the sort could have repaired unrepaired.
+     * every pinned one lands in the same relation to them afterwards and can be
+     * sorted freely; one written below a pinned line would cross it, and a
+     * `using` that crosses the import bringing its first segment into scope
+     * stops resolving. Holding back an import that was never at risk would
+     * leave a file the sort could have repaired unrepaired.
+     *
+     * Every pinned import above counts, whatever its form: any of them can be
+     * the one bringing that first segment into scope
+     * (ImportFormatter.resolvesAgainstScopeAbove).
      *
      * A pinned import never constrains its own path: nothing needs itself in
      * scope, and the duplicate of a pinned path the withhold rules deliberately
      * keep would be stranded in the body rather than organized.
      */
     private crossesPinnedProvider(pinned: ScannedImport[], imp: ScannedImport): boolean {
-        const rank = this.formatter.importRank(imp.path);
-        return pinned.some((other) => other.path !== imp.path && other.startLine < imp.startLine && this.belongsAbove(this.formatter.importRank(other.path), rank));
+        if (!this.formatter.resolvesAgainstScopeAbove(imp.path)) {
+            return false;
+        }
+        return pinned.some((other) => other.path !== imp.path && other.startLine < imp.startLine);
     }
 
     /**
@@ -377,12 +347,11 @@ export class ImportDocumentEditor {
      * import that must precede it both rules the block out and names the line
      * the path is written below instead.
      *
-     * The floor is pinnedBounds', from the same belongsAbove, so a rebuilt
-     * block and a singly added import read one rule rather than two. Only the
-     * floor: the ceiling pinnedBounds returns with it answers a question this
-     * caller has already answered, since a block above every pinned line, and a
-     * path written directly below this floor, both precede every pinned import
-     * further down.
+     * The floor is pinnedBounds', so a rebuilt block and a singly added import
+     * read one rule rather than two. Only the floor: the ceiling pinnedBounds
+     * returns with it answers a question this caller has already answered,
+     * since a block above every pinned line, and a path written directly below
+     * this floor, both precede every pinned import further down.
      *
      * Exempts the path from itself for the reason crossesPinnedProvider does.
      */
@@ -400,15 +369,15 @@ export class ImportDocumentEditor {
      */
     private pinnedBounds(pinned: ScannedImport[], classifications: LineClassification[], path: string): PinnedBounds {
         const rank = this.formatter.importRank(path);
+        const needsScopeAbove = this.formatter.resolvesAgainstScopeAbove(path);
 
         let floor = -1;
         let ceiling = -1;
         for (const imp of pinned) {
-            const existing = this.formatter.importRank(imp.path);
-            if (this.belongsAbove(existing, rank)) {
+            if (needsScopeAbove) {
                 floor = Math.max(floor, pinnedSpanEnd(imp, classifications));
             }
-            if (this.couldResolveAgainst(existing, rank)) {
+            if (this.couldResolveAgainst(this.formatter.importRank(imp.path), rank)) {
                 ceiling = ceiling === -1 ? imp.startLine : Math.min(ceiling, imp.startLine);
             }
         }
@@ -424,16 +393,13 @@ export class ImportDocumentEditor {
      * Both halves matter:
      *
      * - The ceiling wins over the floor. Only couldResolveAgainst raises one,
-     *   so a ceiling is always a scope requirement - a pinned dotted import
-     *   whose first segment this new import is being added to provide. A floor
-     *   disagreeing with it is usually the rank-0-before-rank-1 preference,
-     *   raised by a pinned absolute path that brings nothing into scope, and
-     *   honouring a preference over a requirement writes the provider below its
-     *   consumer: the defect this whole path exists to prevent. The one
-     *   disagreement that is not a preference - a pinned bare parent below a
-     *   pinned dotted consumer - is a file where the consumer already sits
-     *   above the chain it resolves through, so no line satisfies both and
-     *   neither choice makes it compile.
+     *   and it is that predicate's deliberate override: the new import is read
+     *   as the provider a pinned dotted import is missing, so it goes above it.
+     *   The floor is the opposite reading of the same file - a pinned import
+     *   further down could be what the new import resolves through - and the
+     *   two cannot both be honoured. Honouring the floor leaves the diagnostic
+     *   that asked for the import unfixed, which is the case the override
+     *   exists for.
      * - Taken exactly, because the ceiling is the *lowest* legal line: the new
      *   import must precede that statement, so everything below the ceiling is
      *   ruled out and everything above it is merely further away. Landing
@@ -733,19 +699,18 @@ export class ImportDocumentEditor {
 
                     if (sortAlphabetically && importBlocks.length > 0) {
                         // Merge each new import into an existing block in place
-                        // so the combined block is rank-ordered (bare module
-                        // providers before the dotted consumers that depend on
-                        // them). Appending the new imports after the block
-                        // instead could place a provider such as
-                        // `using { Features }` below a consumer such as
-                        // `using { Economy.Shop }`, which breaks Verse's
-                        // top-down using resolution.
+                        // so the combined block is sorted as one, with the
+                        // absolute paths at the top and every relative import
+                        // in its written order. Appending the new imports after
+                        // the block instead would leave them below imports the
+                        // sort had already placed, in a second region the sort
+                        // never sees together.
                         //
                         // Which block each import joins is a whole-file
-                        // decision, not always the first one: rank-sorting one
-                        // block orders the new import against that block alone,
-                        // which leaves a consumer in another block free to sit
-                        // above its provider (see selectTargetBlockIndex).
+                        // decision, not always the first one: sorting one block
+                        // orders the new import against that block alone, which
+                        // leaves it free to sit above a provider in another
+                        // block (see selectTargetBlockIndex).
                         //
                         // Only a block inside the space the pinned imports
                         // leave is eligible, and the selector chooses among
@@ -962,9 +927,10 @@ export class ImportDocumentEditor {
         // Withholding it is only safe when no `using` in the file could resolve
         // against it. File scope governs what code can see, but a `using`
         // resolves its own path top-down: a path that is not absolute needs its
-        // first segment already in scope above it, which is why sorting ranks
-        // them (see ImportFormatter.sortImportsByRank). The anchored line ends
-        // up below the rebuilt block, so withholding the copy above it can
+        // first segment already in scope above it, which is why the sort leaves
+        // those in written order (see ImportFormatter.sortImportsByRank). The
+        // anchored line ends up below the rebuilt block, so withholding the
+        // copy above it can
         // strand such a path - in the block, or further down the body where
         // scanModuleImports does not even look, as in a module-definition body.
         //
@@ -974,7 +940,7 @@ export class ImportDocumentEditor {
         // copy being removed. A `using` that is not absolute blocks it whichever
         // meaning it carries - judging that needs the enclosing construct, and
         // guessing wrong is what deletes a provider. So the question asked is
-        // just the rank.
+        // just the path's form.
         //
         // extraPaths joins the question because those paths are written into the
         // block too. They keep their own unconditional filter above: suppressing
@@ -985,7 +951,7 @@ export class ImportDocumentEditor {
         // `using` anywhere, a local-scope one included. That is the safe
         // direction: the duplicate left behind is legal Verse, and a stranded
         // provider is a file that stops compiling.
-        const withholdIsSafe = [...allUsingPaths(lines), ...extraPaths].every((path) => this.formatter.importRank(path) === 0);
+        const withholdIsSafe = [...allUsingPaths(lines), ...extraPaths].every((path) => !this.formatter.resolvesAgainstScopeAbove(path));
         const blockImports = withholdIsSafe ? hoistableImports.filter((imp) => !pinnedPaths.has(imp.path)) : hoistableImports;
 
         const paths = blockImports.map((imp) => imp.path);

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -147,8 +147,9 @@ function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]
  * bound placement the same way, for the same reason: the line stays put, so
  * whichever of the two put it there changes nothing about what may cross it.
  *
- * Both bounds ask what selectTargetBlockIndex asks, so pinned and blocked
- * imports cannot disagree about what precedes what:
+ * The floor asks what selectTargetBlockIndex asks, so pinned and blocked
+ * imports cannot disagree about what precedes what. The ceiling is the one
+ * documented override of it, and no pinned import raises both:
  *
  * - `floor` - the last line owned by the lowest pinned import, where the new
  *   path resolves against what is in scope above it
@@ -157,11 +158,10 @@ function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]
  *   path needs nothing above it and is unconstrained.
  * - `ceiling` - the first line of the highest pinned import that could be
  *   resolving against the new one (couldResolveAgainst). The new import goes
- *   directly above it.
+ *   directly above it, and that import raises no floor: see pinnedBounds.
  *
- * The two are deliberately not mirror images: the floor is what every rule
- * here keeps, and the ceiling is the one documented override of it. See
- * couldResolveAgainst, and placementLine for which wins.
+ * See couldResolveAgainst for why the override exists, and placementLine for
+ * which bound wins where two pinned imports disagree.
  *
  * `-1` means unconstrained in that direction.
  */
@@ -374,11 +374,17 @@ export class ImportDocumentEditor {
         let floor = -1;
         let ceiling = -1;
         for (const imp of pinned) {
-            if (needsScopeAbove) {
-                floor = Math.max(floor, pinnedSpanEnd(imp, classifications));
-            }
+            // One pinned import raises one bound. Reading it as the consumer
+            // and as a possible provider at once would put the floor at or
+            // below the ceiling it raised, and blockIsWithin would then refuse
+            // every block - including one lying entirely above the ceiling,
+            // which satisfies the ceiling and the written order both.
             if (this.couldResolveAgainst(this.formatter.importRank(imp.path), rank)) {
                 ceiling = ceiling === -1 ? imp.startLine : Math.min(ceiling, imp.startLine);
+                continue;
+            }
+            if (needsScopeAbove) {
+                floor = Math.max(floor, pinnedSpanEnd(imp, classifications));
             }
         }
 
@@ -929,10 +935,10 @@ export class ImportDocumentEditor {
         // resolves its own path top-down: a path that is not absolute needs its
         // first segment already in scope above it, which is why the sort leaves
         // those in written order (see ImportFormatter.sortImportsByRank). The
-        // anchored line ends up below the rebuilt block, so withholding the
-        // copy above it can
-        // strand such a path - in the block, or further down the body where
-        // scanModuleImports does not even look, as in a module-definition body.
+        // anchored line ends up below the rebuilt block, so withholding the copy
+        // above it can strand such a path - in the block, or further down the
+        // body where scanModuleImports does not even look, as in a
+        // module-definition body.
         //
         // So this asks the whole file, every `using` at every indentation, and
         // withholds only where all of them are absolute. An absolute path needs

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -289,15 +289,14 @@ export class ImportFormatter {
     }
 
     /**
-     * The ordering rank of an import path: 0 for an absolute path, 1 for a bare
-     * module reference, 2 for anything else (a dotted reference such as
-     * `Economy.Shop`). A lower rank belongs above a higher one, because a
-     * `using` can only see identifiers brought into scope above it. See
-     * sortImportsByRank for what each rank means and why.
+     * The form of an import path: 0 for an absolute path, 1 for a bare module
+     * reference, 2 for anything else (a dotted reference such as
+     * `Economy.Shop`).
      *
-     * Placement reads the same ranks the sort compares, so a new import can be
-     * ranked against the whole file rather than only against the block it is
-     * merged into.
+     * Only rank 0 decides a position, and resolvesAgainstScopeAbove is the
+     * question that reads it. Ranks 1 and 2 differ in form, not in placement:
+     * either can bring the scope the other resolves through, so neither belongs
+     * above the other.
      */
     importRank(path: string): number {
         if (path.startsWith("/")) {
@@ -310,41 +309,47 @@ export class ImportFormatter {
     }
 
     /**
-     * A new array of the paths ordered by rank, and alphabetically within ranks
-     * 0 and 2. The input is not modified.
+     * Whether `path` resolves its first segment against what the `using`
+     * statements above it brought into scope, which makes every import written
+     * above it a possible provider for it.
      *
-     * Rank ordering rather than plain alphabetical order, because Verse
-     * resolves `using` statements top-down: a statement sees only identifiers
-     * brought into scope above it. A dotted import's first segment is in scope
-     * only if a bare module reference already provided it, so
-     * `using { Economy.Shop }` needs the `Economy` that `using { Features }`
-     * brings - and alphabetical order puts `Economy.Shop` first (E < F) and
-     * breaks compilation, though both imports are individually valid.
+     * True of every relative path, dotted and bare alike. Either can provide
+     * for the other: `using { Features }` brings the `Economy` that
+     * `using { Economy.Shop }` needs, and `using { GameSystems.Inventory }`
+     * brings the `Weapons` that a later bare `using { Weapons }` needs. Only an
+     * absolute path resolves from the global registry and needs nothing above
+     * it.
+     */
+    resolvesAgainstScopeAbove(path: string): boolean {
+        return this.importRank(path) !== 0;
+    }
+
+    /**
+     * A new array with the absolute paths hoisted to the front and
+     * alphabetized, and every relative path left in input order. The input is
+     * not modified.
      *
-     * - Rank 0, absolute paths (leading `/`): self-contained, alphabetized.
-     * - Rank 1, bare identifiers (no `/`, no `.`): kept in input order, never
-     *   alphabetized, since the order between bare module imports is semantic
-     *   - a nested child must follow the parent that provides it.
-     * - Rank 2, everything else (dotted references such as `Economy.Shop`):
-     *   alphabetized.
+     * Not plain alphabetical order, because Verse resolves `using` statements
+     * top-down and importing a scope exposes that scope's member modules to the
+     * statements below it. Which of two relative imports provides for the other
+     * can go either way, and their written order is the only evidence of which
+     * way round it is here - so relative imports keep it, and a file that
+     * compiles still compiles after being organized.
      *
-     * A lower rank always precedes a higher one, so a provider precedes
-     * anything that might depend on it. The sort is stable, which is what keeps
-     * rank 1 in input order once its comparator returns 0.
+     * Absolute paths are free to sort: one needs nothing in scope, and hoisting
+     * it takes scope away from nothing below it.
+     *
+     * The sort is stable, which is what keeps the relative paths in input order
+     * once their comparator returns 0.
      */
     sortImportsByRank(paths: string[]): string[] {
-        const rankOf = (path: string): number => this.importRank(path);
-
         return [...paths].sort((a, b) => {
-            const rankDifference = rankOf(a) - rankOf(b);
-            if (rankDifference !== 0) {
-                return rankDifference;
+            const aIsRelative = this.resolvesAgainstScopeAbove(a);
+            const bIsRelative = this.resolvesAgainstScopeAbove(b);
+            if (aIsRelative !== bIsRelative) {
+                return aIsRelative ? 1 : -1;
             }
-            if (rankOf(a) === 1) {
-                // Bare identifiers keep their input order; relative order is semantic.
-                return 0;
-            }
-            return a.localeCompare(b);
+            return aIsRelative ? 0 : a.localeCompare(b);
         });
     }
 

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -293,10 +293,12 @@ export class ImportFormatter {
      * reference, 2 for anything else (a dotted reference such as
      * `Economy.Shop`).
      *
-     * Only rank 0 decides a position, and resolvesAgainstScopeAbove is the
-     * question that reads it. Ranks 1 and 2 differ in form, not in placement:
-     * either can bring the scope the other resolves through, so neither belongs
-     * above the other.
+     * Ranks 1 and 2 differ in form, not in ordering: either can bring the scope
+     * the other resolves through, so neither belongs above the other. Which of
+     * the two a path is still decides one thing - whether a pinned import can
+     * be read as the consumer a newly added one was added for
+     * (ImportDocumentEditor.couldResolveAgainst). Everything else asks only
+     * whether the rank is 0, through resolvesAgainstScopeAbove.
      */
     importRank(path: string): number {
         if (path.startsWith("/")) {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -440,8 +440,8 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         // back on the presence of a pinned import rather than on crossing it,
         // this file would go untidied.
         it("still sorts the imports written above the pinned line", () => {
-            const input = ["using { /Zebra }", "using { /Apple }", "using { /A }; X := 1", "code()"].join("\n");
-            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /Apple }", "using { /Zebra }", "", "using { /A }; X := 1", "code()"].join("\n"));
+            const input = ["using { Features }", "using { /Zebra }", "using { /A }; X := 1", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /Zebra }", "using { Features }", "", "using { /A }; X := 1", "code()"].join("\n"));
         });
 
         // A stale diagnostic naming a path the buffer already imports is the
@@ -672,6 +672,14 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
     it("keeps every relative import in input order, dotted and bare alike, never alphabetized", () => {
         const input = ["using { Economy.Shop }", "using { Zeta }", "using { Alpha }", "code()"].join("\n");
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Economy.Shop }", "using { Zeta }", "using { Alpha }", "", "code()"].join("\n"));
+    });
+
+    // An added path has no written position of its own, and every import the
+    // file already holds may be bringing its first segment into scope, so it
+    // goes below all of them rather than wherever a name would put it.
+    it("writes an additional relative path below the relative imports the file already holds", () => {
+        const input = ["using { Economy.Shop }", "using { Zeta }", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Features"], curlySorted)).toBe(["using { Economy.Shop }", "using { Zeta }", "using { Features }", "", "code()"].join("\n"));
     });
 
     it("leaves a module-scoped using inside its module body", () => {
@@ -1350,6 +1358,31 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(insert).toBeDefined();
             expect(insert!.position!.line).toBe(0);
             expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // The anchored consumer names the line the new import must stay above,
+        // so it cannot also be read as an import the new one has to stay below.
+        // Counted as both, its two bounds cross and every block is refused -
+        // including this one, which lies wholly above the anchored line and
+        // satisfies the bound that is real.
+        it("merges into a block lying entirely above the anchored consumer rather than writing a standalone line", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { /Verse.org/Simulation }", "", "using { Economy.Shop } <#> note", "    body", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(0);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
         });
 
         it("sort OFF: appends below the anchored provider rather than after the last block", async () => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -437,11 +437,11 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
 
         // Hoisting only carries an import across the pinned lines above it, so
         // one already written above them all is sorted as it always was. Held
-        // back on the presence of a pinned provider rather than on crossing it,
-        // this file would keep an order that does not compile.
+        // back on the presence of a pinned import rather than on crossing it,
+        // this file would go untidied.
         it("still sorts the imports written above the pinned line", () => {
-            const input = ["using { Economy.Shop }", "using { Features }", "using { /A }; X := 1", "code()"].join("\n");
-            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "using { Economy.Shop }", "", "using { /A }; X := 1", "code()"].join("\n"));
+            const input = ["using { /Zebra }", "using { /Apple }", "using { /A }; X := 1", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /Apple }", "using { /Zebra }", "", "using { /A }; X := 1", "code()"].join("\n"));
         });
 
         // A stale diagnostic naming a path the buffer already imports is the
@@ -459,9 +459,11 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             );
         });
 
-        it("sorts a provider above its consumer as before when no import is pinned", () => {
+        // The control for the cases above: written order survives because the
+        // sort keeps it, not because a pinned line held anything back.
+        it("keeps a dotted import above the bare one below it when no import is pinned", () => {
             const input = ["using { Economy.Other }", "using { Features }", "code()"].join("\n");
-            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Features }", "using { Economy.Other }", "", "code()"].join("\n"));
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Economy.Other }", "using { Features }", "", "code()"].join("\n"));
         });
     });
 
@@ -667,9 +669,9 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["", "   "], curlyNoSort)).toBe("using { /A }\n\ncode()");
     });
 
-    it("orders bare folder imports in input order before dotted references, never alphabetized", () => {
+    it("keeps every relative import in input order, dotted and bare alike, never alphabetized", () => {
         const input = ["using { Economy.Shop }", "using { Zeta }", "using { Alpha }", "code()"].join("\n");
-        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Zeta }", "using { Alpha }", "using { Economy.Shop }", "", "code()"].join("\n"));
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Economy.Shop }", "using { Zeta }", "using { Alpha }", "", "code()"].join("\n"));
     });
 
     it("leaves a module-scoped using inside its module body", () => {
@@ -973,7 +975,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(insertsAtTop).toHaveLength(0);
     });
 
-    it("preserve + digestFirst: a new bare local import is ordered before an existing dotted local import in its block (rank sort, not alphabetical)", async () => {
+    it("preserve + digestFirst: a new bare local import lands after the dotted local import already in its block", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,
             "behavior.importGrouping": "digestFirst",
@@ -988,10 +990,10 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
 
         const replace = operations.find((op) => op.kind === "replace");
         expect(replace).toBeDefined();
-        expect(replace!.text).toBe("using { Features }\nusing { Economy.Shop }\n");
+        expect(replace!.text).toBe("using { Economy.Shop }\nusing { Features }\n");
     });
 
-    it("preserve + grouping none + sort on (default config): merges a new bare provider into the existing block in rank order", async () => {
+    it("preserve + grouping none + sort on (default config): merges a new bare import into the existing block, below the import already there", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,
             "behavior.importGrouping": "none",
@@ -1007,7 +1009,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const replace = operations.find((op) => op.kind === "replace");
         expect(replace).toBeDefined();
         expect(replace!.range!.start.line).toBe(0);
-        expect(replace!.text).toBe("using { Features }\nusing { Economy.Shop }\n");
+        expect(replace!.text).toBe("using { Economy.Shop }\nusing { Features }\n");
 
         // The new import is not appended after the block.
         const insertsAfterBlock = operations.filter((op) => op.kind === "insert" && op.position!.line === 1);
@@ -1056,7 +1058,10 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(replaces[0].text).toBe("using { Features }\nusing { Economy.Shop }\n");
     });
 
-    it("preserve + grouping none + sort on: a new bare provider joins the earlier block holding the dotted consumer it provides for", async () => {
+    // The dotted import in the earlier block can be what brings the new import's
+    // own name into scope, so the new one has no claim to be written above it.
+    // Joining the earlier block would put it there.
+    it("preserve + grouping none + sort on: a new bare import joins the last block, not the earlier one holding a dotted import", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,
             "behavior.importGrouping": "none",
@@ -1069,8 +1074,8 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(success).toBe(true);
         const replaces = appliedOperations(0).filter((op) => op.kind === "replace");
         expect(replaces).toHaveLength(1);
-        expect(replaces[0].range!.start.line).toBe(0);
-        expect(replaces[0].text).toBe("using { Features }\nusing { Economy.Shop }\n");
+        expect(replaces[0].range!.start.line).toBe(2);
+        expect(replaces[0].text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
     });
 
     it("preserve + grouping none + sort on: a new absolute import still joins the first block", async () => {
@@ -1188,7 +1193,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
 
         expect(success).toBe(true);
         const replace = appliedOperations(0).find((op) => op.kind === "replace");
-        expect(replace!.text).toBe("using { Features }\r\nusing { Economy.Shop }\r\n");
+        expect(replace!.text).toBe("using { Economy.Shop }\r\nusing { Features }\r\n");
     });
 
     it("writes CRLF endings into a CRLF document when inserting a new block at the top", async () => {

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -234,20 +234,28 @@ describe("ImportFormatter.sortImportsByRank", () => {
         formatter = new ImportFormatter();
     });
 
-    it("orders absolute paths before bare identifiers before dotted references", () => {
-        expect(formatter.sortImportsByRank(["Economy.Shop", "/Verse.org/Simulation", "Features"])).toEqual(["/Verse.org/Simulation", "Features", "Economy.Shop"]);
+    it("orders absolute paths before relative ones, which keep their written order", () => {
+        expect(formatter.sortImportsByRank(["Economy.Shop", "/Verse.org/Simulation", "Features"])).toEqual(["/Verse.org/Simulation", "Economy.Shop", "Features"]);
     });
 
     it("keeps bare identifiers in their original input order", () => {
-        expect(formatter.sortImportsByRank(["Zeta", "Economy.Shop", "Alpha"])).toEqual(["Zeta", "Alpha", "Economy.Shop"]);
+        expect(formatter.sortImportsByRank(["Zeta", "Economy.Shop", "Alpha"])).toEqual(["Zeta", "Economy.Shop", "Alpha"]);
     });
 
     it("alphabetizes absolute paths among themselves", () => {
         expect(formatter.sortImportsByRank(["/Verse.org/Simulation", "/Fortnite.com/Devices"])).toEqual(["/Fortnite.com/Devices", "/Verse.org/Simulation"]);
     });
 
-    it("alphabetizes dotted references among themselves", () => {
-        expect(formatter.sortImportsByRank(["Systems.Economy", "Features.Economy"])).toEqual(["Features.Economy", "Systems.Economy"]);
+    it("keeps dotted references in their written order rather than alphabetizing them", () => {
+        expect(formatter.sortImportsByRank(["Systems.Economy", "Features.Economy"])).toEqual(["Systems.Economy", "Features.Economy"]);
+    });
+
+    // A dotted import brings the module it names into scope, so a bare import
+    // written below it can be resolving through it - `Weapons` nested inside
+    // the `Inventory` that `GameSystems.Inventory` imports. Sinking the dotted
+    // one below the bare one turns a compiling file into one that does not.
+    it("keeps a dotted import above the bare import written below it", () => {
+        expect(formatter.sortImportsByRank(["GameSystems.Inventory", "Weapons"])).toEqual(["GameSystems.Inventory", "Weapons"]);
     });
 });
 
@@ -258,14 +266,14 @@ describe("ImportFormatter.groupAndFormatImports", () => {
         formatter = new ImportFormatter();
     });
 
-    it("digestFirst with sorting: local group orders the bare import before the dotted import that depends on it", () => {
+    it("digestFirst with sorting: local group keeps its imports in written order", () => {
         const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Economy.Shop", "Features"], false, true, "digestFirst");
-        expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Features }", "using { Economy.Shop }"]);
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Economy.Shop }", "using { Features }"]);
     });
 
-    it("grouping none with sorting: absolute paths first (alpha), then bare (input order), then dotted (alpha)", () => {
+    it("grouping none with sorting: absolute paths first (alpha), then every relative one in input order", () => {
         const result = formatter.groupAndFormatImports(["Systems.Economy", "/Verse.org/Simulation", "Zeta", "/Fortnite.com/Devices", "Alpha", "Features.Economy"], false, true, "none");
-        expect(result).toEqual(["using { /Fortnite.com/Devices }", "using { /Verse.org/Simulation }", "using { Zeta }", "using { Alpha }", "using { Features.Economy }", "using { Systems.Economy }"]);
+        expect(result).toEqual(["using { /Fortnite.com/Devices }", "using { /Verse.org/Simulation }", "using { Systems.Economy }", "using { Zeta }", "using { Alpha }", "using { Features.Economy }"]);
     });
 
     it("grouping none without sorting: leaves the original order untouched", () => {
@@ -280,7 +288,7 @@ describe("ImportFormatter.groupAndFormatImports", () => {
 
     it("localFirst with sorting: local group precedes the digest group", () => {
         const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Economy.Shop", "Features"], false, true, "localFirst");
-        expect(result).toEqual(["using { Features }", "using { Economy.Shop }", "", "using { /Verse.org/Simulation }"]);
+        expect(result).toEqual(["using { Economy.Shop }", "using { Features }", "", "using { /Verse.org/Simulation }"]);
     });
 
     // An out-of-enum value reaches here from a hand-edited settings.json, a case
@@ -295,6 +303,6 @@ describe("ImportFormatter.groupAndFormatImports", () => {
 
     it("an unrecognised grouping value still honours sorting", () => {
         const result = formatter.groupAndFormatImports(["Economy.Shop", "/Verse.org/Simulation", "Features"], false, true, "typo");
-        expect(result).toEqual(["using { /Verse.org/Simulation }", "using { Features }", "using { Economy.Shop }"]);
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "using { Economy.Shop }", "using { Features }"]);
     });
 });


### PR DESCRIPTION
Closes #271

A `using` of any scope exposes that scope's public member modules to the statements below it, so a dotted import can bring into scope the module a later bare import names — `using { GameSystems.Inventory }` then `using { Weapons }`. The rank model read that relationship one way only, so `sortImportsByRank` sank a dotted provider below its bare consumer and block selection wrote a newly added import above relative imports already written above it.

## The rule now

Only an absolute path resolves from the global registry and needs nothing above it. Every relative path, dotted and bare alike, resolves its first segment against what a `using` above it brought into scope, so either can provide for the other and written order is the only evidence of which way round it is.

- Absolute paths still hoist to the top and alphabetize among themselves.
- Every relative import keeps its written order.
- A newly added relative import goes last, below everything the file already holds.

`ImportFormatter.resolvesAgainstScopeAbove` is the single name for that question. `belongsAbove` and `belongsBelow` are gone: with the model corrected the first collapses to it and the second is unreachable, since it only fires for a newly added absolute path and `selectTargetBlockIndex` returns block 0 for those before the upper bound is read.

`importRank` keeps its three values — `couldResolveAgainst` still reads the bare-vs-dotted distinction — but only rank 0 decides an ordering now.

## Left unchanged, deliberately

`ImportDocumentEditor.couldResolveAgainst`. It is pinned-only and encodes an intentional override: the import being added is read as the provider a pinned dotted import is missing, which is the one case where writing it above an existing import is right. Against the corrected model that is now an explicit override rather than a consequence of the rank order, and its doc says so. Agreed with the maintainer before implementing; filed separately rather than decided here.

The second commit fixes a regression the first introduced against that override: a pinned import raising the ceiling also raised the floor, so `blockIsWithin` refused every block — including one lying wholly above the ceiling, which satisfies both the ceiling and the written order. One pinned import now raises one bound.

## Verification

```
$ npm run compile
> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test
Test Suites: 40 passed, 40 total
Tests:       813 passed, 813 total
Snapshots:   0 total
Time:        8.207 s, estimated 9 s
Ran all test suites.

$ npm run format:check
> prettier --check "**/*.ts"
Checking formatting...
All matched files use Prettier code style!
```

Both new regression tests were checked against the unfixed source. `sortImportsByRank(["GameSystems.Inventory", "Weapons"])` and the block-selection case fail on `origin/main`; the ceiling case fails on this branch's first commit.

## Review

One round, fresh context, `PASS_WITH_SUGGESTIONS` — 0 Critical, 4 Important, 5 Suggestion. The four Important findings are addressed in the second commit, except one left out of scope and noted below: the ceiling/floor regression, a false sentence in the `importRank` doc, a self-contradicting `PinnedBounds` doc, and a test whose fixture no longer exercised the case it was named for.

Two findings are outside this ticket and want issues of their own:

- With `importGrouping` set to `digestFirst` or `localFirst`, the grouping branch picks a target block by digest/local purity and never asks which imports are already written where, so a new relative import can still land above an existing relative one. Behaviour is identical on `main`; the corrected model is what turns it into a wrong answer.
- With `preserveImportLocations` off, the consolidation branch hoists every rewritable import to the top with no pinned-import bound at all. Pre-existing and unchanged here.
