### PR TITLE
fix(services): read a visibility specifier whose entry runs past its keyword

### DIFF
--- a/changelog.d/305.fixed.md
+++ b/changelog.d/305.fixed.md
@@ -1,1 +1,1 @@
-**Project scan**: a module declared `scoped{...}`, `epic_internal` or with padding inside its specifier brackets is no longer offered as an import candidate it cannot be imported from.
+**Project scan**: a module declared `scoped{...}` or `epic_internal`, or one with padding inside its specifier brackets, is no longer offered as an import candidate that would not compile.

--- a/changelog.d/305.fixed.md
+++ b/changelog.d/305.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: a module declared `scoped{...}`, `epic_internal` or with padding inside its specifier brackets is no longer offered as an import candidate it cannot be imported from.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -135,14 +135,18 @@ export class ProjectPathScanner {
         let currentModulePath = "";
         const moduleStack: { name: string; indent: number }[] = [];
 
-        const visibilitySpecifiers = "public|protected|private|internal|scoped";
-
         // A declaration carries any number of stacked specifiers, of which at
         // most one is a visibility; the rest (<native>, <final>, ...) are noise
-        // to this scan.
+        // to this scan. The `\b[^>]*` tail lets an entry run past its keyword,
+        // which `scoped`'s module list needs; a visibility this fails to read is
+        // indistinguishable from none at all. A named scope alias is an ordinary
+        // identifier, so no keyword list reaches it and it still reads as none.
+        // Holds parity with moduleDeclarations' VISIBILITY_SPECIFIER.
+        const visibilitySpecifier = /<\s*(public|protected|private|internal|epic_internal|scoped)\b[^>]*>/;
+
         const extractVisibility = (specifiers: string | undefined): string | undefined => {
             if (!specifiers) return undefined;
-            const match = specifiers.match(new RegExp(`<(${visibilitySpecifiers})>`));
+            const match = specifiers.match(visibilitySpecifier);
             return match ? match[1] : undefined;
         };
 

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -69,6 +69,46 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
         expect(moduleNames("Hidden<private> := module {}\n")).toEqual([]);
     });
 
+    it("skips a module whose visibility entry runs past its keyword", () => {
+        expect(moduleNames("Systems<scoped{ModuleA, ModuleB}> := module {}\n")).toEqual([]);
+        expect(moduleNames("Systems<epic_internal> := module {}\n")).toEqual([]);
+        expect(moduleNames("Systems<final><scoped{ModuleA}> := module {}\n")).toEqual([]);
+    });
+
+    it("reads a visibility padded inside its brackets", () => {
+        const [declared] = declare("Inventory<  public  > := module {}\n");
+        expect(declared).toMatchObject({ name: "Inventory", type: "module", isPublic: true });
+    });
+
+    it("does not read a following specifier as the visibility entry's tail", () => {
+        const [declared] = declare("Inventory<public><native> := module {}\n");
+        expect(declared).toMatchObject({ name: "Inventory", type: "module", isPublic: true });
+    });
+
+    it("keeps a module carrying a named scope alias, which reads as no specifier", () => {
+        // Pins the limit rather than endorsing it: `SharedScope := scoped{A, B}`
+        // makes the specifier an ordinary identifier, indistinguishable from
+        // <final> or any other non-visibility attribute without resolving the
+        // alias, so the module is still offered as an import candidate that
+        // does not compile.
+        expect(moduleNames("Systems<SharedScope> := module {}\n")).toEqual(["Systems"]);
+        expect(moduleNames("Systems<scoped_X> := module {}\n")).toEqual(["Systems"]);
+    });
+
+    it("promotes a skipped module's descendants to file scope", () => {
+        // Pins the limit rather than endorsing it: a skipped module never
+        // reaches the module stack, so what it contains loses the enclosing
+        // segment from its path instead of being dropped alongside its parent.
+        // Every segment from the root has to be accessible for an import to
+        // compile, so the subtree is as unreachable as the parent. Long
+        // predates the specifiers below - <private> reads the same way.
+        const scoped = declare("Systems<scoped{ModuleA}> := module:\n    Inner<public> := module:\n");
+        expect(scoped.map((node) => node.fullPath)).toEqual(["Inner"]);
+
+        const priv = declare("Systems<private> := module:\n    Inner<public> := module:\n");
+        expect(priv.map((node) => node.fullPath)).toEqual(["Inner"]);
+    });
+
     it("does not read a keyword that merely starts with module as a declaration", () => {
         expect(moduleNames("Inventory := modulex\n")).toEqual([]);
     });

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -101,7 +101,8 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
         // segment from its path instead of being dropped alongside its parent.
         // Every segment from the root has to be accessible for an import to
         // compile, so the subtree is as unreachable as the parent. Long
-        // predates the specifiers below - <private> reads the same way.
+        // predates the specifiers this scan newly reads - <private> reads the
+        // same way.
         const scoped = declare("Systems<scoped{ModuleA}> := module:\n    Inner<public> := module:\n");
         expect(scoped.map((node) => node.fullPath)).toEqual(["Inner"]);
 


### PR DESCRIPTION
Closes #305

## What changed

`ProjectPathScanner.extractDeclarations` read a declaration's visibility with a pattern that required `>` to follow the keyword directly, so three legal specifier shapes read as no specifier at all. An unread specifier is indistinguishable from an absent one, which the scan treats as `internal`, so a module that cannot be imported from outside was kept and offered as an import candidate that does not compile.

The pattern now takes the tail form `moduleDeclarations`' `VISIBILITY_SPECIFIER` already uses:

```
<\s*(public|protected|private|internal|epic_internal|scoped)\b[^>]*>
```

| Shape | Before | After |
| --- | --- | --- |
| `Systems<scoped{ModuleA, ModuleB}> := module:` | kept | skipped |
| `Systems<epic_internal> := module:` | kept | skipped |
| `Inventory<  public  > := module:` | read as bare | read as public |
| `Systems<final><scoped{ModuleA}> := module:` | kept | skipped |

The `\b` is load-bearing in both directions: it lets `scoped`'s module list run past the keyword, and it stops `<scoped_X>` and `<publicish>` being misread as visibilities they are not.

## What this deliberately does not change

**Named scope aliases.** `Systems<SharedScope> := module:`, where `SharedScope := scoped{A, B}`, still reads as no specifier. The alias is an ordinary identifier, so no keyword list can reach it, and #305 says this "needs a decision rather than a wider alternation" and is "worth deciding alongside #293". Deciding it here would pre-empt that issue, so it is pinned as a known limit instead.

**Descendants of a skipped module.** A skipped module never reaches `moduleStack`, so what it contains is promoted to file scope rather than dropped alongside it. This predates #305 and is reachable today through `<private>`, which behaves identically; this change routes `scoped` and `epic_internal` into the same path. Filed as #316 and pinned here rather than folded into this diff.

| Parent specifier | Nodes recorded |
| --- | --- |
| `<public>` | `Systems`, `Systems.Inner`, `Systems.Inner.X` |
| `<private>` (unchanged by this PR) | `Inner`, `Inner.X` |
| `<scoped{ModuleA}>` (after this PR) | `Inner`, `Inner.X` |

## Tests

Five tests added to `ProjectPathScanner.test.ts`. Two of them detect the defect: reverting the regex to its old form fails exactly those two, the first receiving all three module names rather than none. The other three guard against over-reach (`<public><native>` must not have its tail swallowed across the entry boundary) and pin the two limits above.

## Verification

```
$ npm run compile
> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test
Test Suites: 40 passed, 40 total
Tests:       823 passed, 823 total
Snapshots:   0 total
Time:        8.775 s
Ran all test suites.

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

## Review

Two rounds, opus, fresh context. Round 1 raised the descendant promotion and a missing changelog fragment; the first was reproduced independently, confirmed pre-existing, and split out as #316 on the maintainer's call, and the second was added. Round 2 returned PASS_WITH_SUGGESTIONS with two wording findings, both applied, and withdrew its round-1 FAIL as one notch too harsh given it had listed no Critical finding.
