### PR TITLE
fix(imports): bound the consolidated import block by the pinned lines above it

### DIFF
--- a/changelog.d/315.fixed.md
+++ b/changelog.d/315.fixed.md
@@ -1,0 +1,1 @@
+**Auto import**: with import locations not preserved, an existing import is no longer consolidated into the top block above a `using` pinned to its line that may bring its first segment into scope.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -353,6 +353,12 @@ export class ImportDocumentEditor {
      * since a block above every pinned line, and a path written directly below
      * this floor, both precede every pinned import further down.
      *
+     * A ceiling raised *above* the floor is the one it genuinely drops: the
+     * path lands below a pinned import that could have been the consumer it was
+     * added for, leaving that diagnostic unfixed. Deliberate - the alternative
+     * carries it above the pinned import bringing its own first segment into
+     * scope, and a compiling file outranks a fixed diagnostic.
+     *
      * Exempts the path from itself for the reason crossesPinnedProvider does.
      */
     private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string): number {
@@ -465,9 +471,11 @@ export class ImportDocumentEditor {
      * were written on, rather than let a rebuilt block at the top carry them
      * above it. Untidy, against a file that no longer compiles.
      *
-     * Keyed on the path, not the import, so a path written twice stays wherever
-     * either copy needs it: the block re-emits it once, and a copy left behind
-     * while the other is deleted would lose it from the line that needed it.
+     * Keyed on the path, not the import, because the block is built from sets
+     * of paths and can only decide per path. Whichever reader keys per import
+     * while the other keys per path deletes a line whose path the block then
+     * declines to re-emit. The cost is declining to hoist a copy written above
+     * every pinned import when another copy below one is grounded.
      *
      * Shared by the two writers that hoist into such a block, which is what
      * keeps them from holding two rules about what a pinned line stops.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -461,6 +461,48 @@ export class ImportDocumentEditor {
     }
 
     /**
+     * The paths among `movable` that a pinned import holds on the line they
+     * were written on, rather than let a rebuilt block at the top carry them
+     * above it. Untidy, against a file that no longer compiles.
+     *
+     * Keyed on the path, not the import, so a path written twice stays wherever
+     * either copy needs it: the block re-emits it once, and a copy left behind
+     * while the other is deleted would lose it from the line that needed it.
+     *
+     * Shared by the two writers that hoist into such a block, which is what
+     * keeps them from holding two rules about what a pinned line stops.
+     */
+    private groundedPaths(pinned: ScannedImport[], movable: ScannedImport[]): Set<string> {
+        return new Set(movable.filter((imp) => this.crossesPinnedProvider(pinned, imp)).map((imp) => imp.path));
+    }
+
+    /**
+     * The line ranges of a block that consolidating at the top may delete: the
+     * runs of imports it hoists, with the grounded ones left out.
+     *
+     * Deleting the block whole would take a grounded import's line with it while
+     * its path is deliberately not re-emitted at the top, losing the import
+     * rather than moving it. A block's imports are adjacent by construction, so
+     * a block with nothing grounded yields one run covering exactly the block.
+     */
+    private hoistedRuns(block: ImportBlock, grounded: Set<string>): Array<{ start: number; end: number }> {
+        const runs: Array<{ start: number; end: number }> = [];
+        for (const imp of block.imports) {
+            if (grounded.has(imp.path)) {
+                continue;
+            }
+
+            const last = runs[runs.length - 1];
+            if (last && imp.startLine === last.end + 1) {
+                last.end = imp.endLine;
+            } else {
+                runs.push({ start: imp.startLine, end: imp.endLine });
+            }
+        }
+        return runs;
+    }
+
+    /**
      * The module import statements a document holds, deduplicated, with an
      * indented pair (`using:` plus its path line) joined into one statement.
      * Local-scope `using` is not among them.
@@ -490,8 +532,8 @@ export class ImportDocumentEditor {
      *
      * Where they go is `behavior.preserveImportLocations`: with it on, each
      * path is merged into an existing block or written on its own line beside
-     * the imports it must sit relative to; with it off, every movable import in
-     * the file is consolidated at the top.
+     * the imports it must sit relative to; with it off, the movable imports are
+     * consolidated at the top, bar any a pinned line holds where it is.
      */
     async addImportsToDocument(document: vscode.TextDocument, importStatements: string[]): Promise<boolean> {
         logger.info("ImportDocumentEditor", `Adding ${importStatements.length} import statements to document`);
@@ -806,23 +848,49 @@ export class ImportDocumentEditor {
                 }
             }
         } else {
-            const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths]);
-            const allImportsArray = Array.from(allPaths);
+            // The block is written above every pinned line, so hoisting an
+            // import from below one carries it across. See groundedPaths.
+            const grounded = this.groundedPaths(pinned, rewritableImports(scannedImports));
 
-            const formattedImports = this.withTrailingComments(
-                this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping),
-                this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
-            );
+            // A new path has no line of its own to keep, so a pinned import
+            // that has to precede it names the line it is written below
+            // instead. The floor alone, as buildOrganizedContent asks of a path
+            // it adds and for its reason: this block goes above every pinned
+            // line, so a ceiling is already satisfied by it. See hoistFloor.
+            const blockPaths = new Set<string>(Array.from(relocatablePaths).filter((path) => !grounded.has(path)));
+            const newPathsByLine = new Map<number, string[]>();
+            for (const path of newImportPaths) {
+                const floor = this.hoistFloor(pinned, classifications, path);
+                if (floor === -1) {
+                    blockPaths.add(path);
+                    continue;
+                }
+                newPathsByLine.set(floor + 1, [...(newPathsByLine.get(floor + 1) ?? []), path]);
+            }
 
-            // No blank line after the block: ensureEmptyLinesAfterImports runs
-            // once the edit has been applied and puts the configured number
-            // there.
-            const importsText = formattedImports.join(eol) + eol;
-            edit.insert(document.uri, new vscode.Position(0, 0), importsText);
+            // Grounding can leave the block with nothing to write, and an empty
+            // block is a stray line ending at the top of the file.
+            if (blockPaths.size > 0) {
+                const formattedImports = this.withTrailingComments(
+                    this.formatter.groupAndFormatImports(Array.from(blockPaths), preferDotSyntax, sortAlphabetically, importGrouping),
+                    this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
+                );
+
+                // No blank line after the block: ensureEmptyLinesAfterImports
+                // runs once the edit has been applied and puts the configured
+                // number there.
+                const importsText = formattedImports.join(eol) + eol;
+                edit.insert(document.uri, new vscode.Position(0, 0), importsText);
+            }
+
+            for (const [line, paths] of [...newPathsByLine].sort(([a], [b]) => a - b)) {
+                this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, false);
+            }
 
             for (let i = importBlocks.length - 1; i >= 0; i--) {
-                const block = importBlocks[i];
-                edit.delete(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)));
+                for (const run of this.hoistedRuns(importBlocks[i], grounded).reverse()) {
+                    edit.delete(document.uri, new vscode.Range(new vscode.Position(run.start, 0), new vscode.Position(run.end + 1, 0)));
+                }
             }
         }
 
@@ -906,12 +974,11 @@ export class ImportDocumentEditor {
 
         // The block goes above every pinned line, so an import that hoisting
         // would carry above a pinned one it needs is left on the line it was
-        // written on. Untidy, and the alternative is a file that no longer
-        // compiles: a `using` resolves its own path top-down, so a path whose
+        // written on. A `using` resolves its own path top-down, so a path whose
         // first segment the pinned import brings into scope has to stay below
-        // it. See crossesPinnedProvider.
-        const groundedPaths = new Set(movableImports.filter((imp) => this.crossesPinnedProvider(pinned, imp)).map((imp) => imp.path));
-        const hoistableImports = movableImports.filter((imp) => !groundedPaths.has(imp.path));
+        // it. See groundedPaths.
+        const grounded = this.groundedPaths(pinned, movableImports);
+        const hoistableImports = movableImports.filter((imp) => !grounded.has(imp.path));
 
         // A path the file already imports is not written again, whichever
         // statement holds it - pinned, grounded, or hoisted into the block. The

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1652,6 +1652,156 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(insert!.text).toBe("using { Economy.Shop }\n");
         });
     });
+
+    // Consolidation writes its block above every pinned line, so it carried an
+    // import across the pinned one that may bring its first segment into scope -
+    // the hoist buildOrganizedContent already refuses. Verse resolves `using`
+    // top-down, so the file stopped compiling.
+    describe("consolidating past an import pinned to its line", () => {
+        const consolidating = {
+            "behavior.preserveImportLocations": false,
+            "behavior.importGrouping": "none",
+            "behavior.sortImportsAlphabetically": true,
+        };
+
+        it("leaves a consumer written below a pinned provider on its line", async () => {
+            mockConfig(consolidating);
+            const input = ["using { Features }; X := 1", "using { Economy.Shop }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations).toHaveLength(1);
+            expect(operations[0].kind).toBe("insert");
+            expect(operations[0].position).toEqual({ line: 0, character: 0 });
+            expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n");
+        });
+
+        it("still hoists a consumer written above the pinned line", async () => {
+            mockConfig(consolidating);
+            const input = ["using { Economy.Shop }", "using { Features }; MyVal := 5", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // Position is the question, not presence: hoisting this one lands
+            // it above the pinned line, which is where it already was.
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\nusing { Economy.Shop }\n");
+
+            const deletes = operations.filter((op) => op.kind === "delete");
+            expect(deletes).toHaveLength(1);
+            expect(deletes[0].range!.start.line).toBe(0);
+            expect(deletes[0].range!.end.line).toBe(1);
+        });
+
+        it("writes a new consumer below the pinned provider instead of into the block", async () => {
+            mockConfig(consolidating);
+            const input = ["using { Features }; MyVal := 5", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+
+            const inserts = operations.filter((op) => op.kind === "insert");
+            expect(inserts).toHaveLength(2);
+            expect(inserts[0].position).toEqual({ line: 0, character: 0 });
+            expect(inserts[0].text).toBe("using { /Verse.org/Simulation }\n");
+            expect(inserts[1].position!.line).toBe(1);
+            expect(inserts[1].text).toBe("using { Economy.Shop }\n");
+
+            // The hoisted import still leaves its line, or the file imports it
+            // twice.
+            const deletes = operations.filter((op) => op.kind === "delete");
+            expect(deletes).toHaveLength(1);
+            expect(deletes[0].range).toEqual({ start: { line: 1, character: 0 }, end: { line: 2, character: 0 } });
+        });
+
+        it("still consolidates a new provider the pinned consumer below it may need", async () => {
+            mockConfig(consolidating);
+            const input = ["using { /A }", "code()", "using { Economy.Shop }; X := 1"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // The block itself sits above the pinned consumer, so nothing is
+            // gained by writing the provider on a line of its own further down.
+            expect(operations).toHaveLength(2);
+            expect(operations[0].kind).toBe("insert");
+            expect(operations[0].position).toEqual({ line: 0, character: 0 });
+            expect(operations[0].text).toBe("using { /A }\nusing { Features }\n");
+            expect(operations[1].range).toEqual({ start: { line: 0, character: 0 }, end: { line: 1, character: 0 } });
+        });
+
+        it("keeps both copies of a path written on either side of the pinned line", async () => {
+            mockConfig(consolidating);
+            const input = ["using { Economy.Shop }", "using { Features }; X := 1", "using { Economy.Shop }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            // Grounding is keyed on the path: hoisting the copy above the
+            // pinned line while the block declines to re-emit the path would
+            // delete the one line that had to keep it.
+            const operations = appliedOperations(0);
+            expect(operations).toHaveLength(1);
+            expect(operations[0].kind).toBe("insert");
+            expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n");
+        });
+
+        it("splits the delete around a grounded import rather than taking its line with the block", async () => {
+            mockConfig(consolidating);
+            const input = ["using { Features }; MyVal := 5", "using { /A }", "using { Economy.Shop }", "using { /B }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert!.text).toBe("using { /A }\nusing { /B }\nusing { /Fortnite.com/Devices }\n");
+
+            // One block, two runs: deleting it whole would take the grounded
+            // line with it while nothing re-emits that path, losing the import.
+            const deletes = operations.filter((op) => op.kind === "delete").sort((a, b) => a.range!.start.line - b.range!.start.line);
+            expect(deletes).toHaveLength(2);
+            expect(deletes[0].range).toEqual({ start: { line: 1, character: 0 }, end: { line: 2, character: 0 } });
+            expect(deletes[1].range).toEqual({ start: { line: 3, character: 0 }, end: { line: 4, character: 0 } });
+        });
+
+        it("grounds against a provider pinned by the comment it anchors, past the comment body", async () => {
+            mockConfig(consolidating);
+            const input = ["using { Features } <#> why this is here", "    it brings Economy into scope", "using { Economy.Shop }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations).toHaveLength(1);
+            expect(operations[0].kind).toBe("insert");
+            expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n");
+        });
+
+        it("consolidates a file with nothing pinned exactly as before", async () => {
+            mockConfig(consolidating);
+            const input = ["using { /B }", "using { /A }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /C }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations).toHaveLength(2);
+            expect(operations[0].kind).toBe("insert");
+            expect(operations[0].position).toEqual({ line: 0, character: 0 });
+            expect(operations[0].text).toBe("using { /A }\nusing { /B }\nusing { /C }\n");
+            expect(operations[1].kind).toBe("delete");
+            expect(operations[1].range).toEqual({ start: { line: 0, character: 0 }, end: { line: 2, character: 0 } });
+        });
+    });
 });
 
 describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1737,6 +1737,24 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(operations[1].range).toEqual({ start: { line: 0, character: 0 }, end: { line: 1, character: 0 } });
         });
 
+        it("takes the floor over a pinned consumer sitting above it", async () => {
+            mockConfig(consolidating);
+            const input = ["using { Economy.Shop }; X := 1", "code()", "using { Features }; Y := 2", "more()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy }"]);
+
+            expect(success).toBe(true);
+            // The pinned consumer at line 0 could be what this import was added
+            // for, and it is left unfixed: the line above it is also above the
+            // pinned import that may bring this path's own first segment into
+            // scope. A compiling file outranks a fixed diagnostic.
+            const operations = appliedOperations(0);
+            expect(operations).toHaveLength(1);
+            expect(operations[0].kind).toBe("insert");
+            expect(operations[0].position!.line).toBe(3);
+            expect(operations[0].text).toBe("using { Economy }\n");
+        });
+
         it("keeps both copies of a path written on either side of the pinned line", async () => {
             mockConfig(consolidating);
             const input = ["using { Economy.Shop }", "using { Features }; X := 1", "using { Economy.Shop }", "code()"].join("\n");


### PR DESCRIPTION
Closes #315

With `behavior.preserveImportLocations` off, `addImportsToDocument` collected every rewritable import into one block at the top and deleted the blocks it came from, without asking what a pinned line stops. An import written below a pinned `using` was carried above it, and where that line brought the import's first segment into scope the file stopped compiling. Every other placement site in the file bounds itself against the pinned imports; this branch bounded itself against nothing.

## What changed

`src/imports/ImportDocumentEditor.ts`, the consolidation branch only:

- **An import a pinned line grounds keeps its line.** `crossesPinnedProvider` already answered this for the organize path; the grounded-path set is now one private helper (`groundedPaths`) that both writers call, so the two branches cannot drift apart on what a pinned line stops.
- **An added path is written below the floor a pinned import raises**, via `hoistFloor` — the same helper, and the same reasoning, `buildOrganizedContent` uses for a path it adds. A path with no floor still joins the block, so a file with nothing pinned produces the pre-change edit exactly.
- **Deletion follows the runs the block actually hoists** (`hoistedRuns`) rather than taking whole blocks. A grounded import between two hoisted ones would otherwise lose its line while its path is no longer re-emitted at the top — worse than the bug being fixed.

One documented trade-off, pinned by a test: where a pinned consumer sits above the pinned import that floors the added path, the floor wins and that consumer's diagnostic is left unfixed. Honouring the ceiling instead carries the import above the line bringing its own first segment into scope, and a compiling file outranks a fixed diagnostic. This is the answer `buildOrganizedContent` already gives on the same file.

## Tests

Nine cases under `consolidating past an import pinned to its line`, including both pin reasons (a shared span, and a `<#>` marker anchoring the line below it), the grounded-import-splits-the-delete case, a path written on either side of the pinned line, and two guards that unchanged behaviour stays unchanged. Four of them fail against the unfixed code; the rest are guards.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       827 passed, 827 total
Snapshots:   0 total
Time:        7.534 s
Ran all test suites.

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

Two rounds, both `PASS_WITH_SUGGESTIONS`, no Critical or Important finding outstanding. Round 1 moved added paths from the ceiling-aware `groupByPlacementLine` to `hoistFloor` (the ceiling is already satisfied by a block at line 0, so honouring it exiled a path from the block for no constraint reason), extracted the shared `groundedPaths` helper, and added the changelog fragment. Round 2 corrected the stated reason for keying that set on the path — the loss it described cannot happen; the real constraint is that the block is built from sets of paths — and pinned the dropped-ceiling case with a test.

Not done, and left as a follow-up if it ever bites: grouping added paths by the pinned line that floors them now has three spellings across `groupByPlacementLine`, this branch and `buildOrganizedContent`, differing in where the `+ 1` sits because one inserts into a document and the other splices into rebuilt text.
