### PR TITLE
fix(imports): count a using: pair opened after a definition as present

### DIFF
--- a/changelog.d/309.fixed.md
+++ b/changelog.d/309.fixed.md
@@ -1,0 +1,1 @@
+**Import scanning**: An indented `using:` pair opened after another statement on the same line now counts as already imported, so a suggested import is no longer added a second time.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -386,8 +386,11 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   complete `using` statement it writes is recorded, pinned, because the path
  *   is imported and writing it again would duplicate it. The pair a `using:`
  *   opens at the end of such a line is recorded with them, spanning both
- *   lines, on the same ground - the path below it is imported, and the
- *   classification would have admitted it had the `using:` headed the line.
+ *   lines, on the same ground - the path below it is imported. That tail is
+ *   read from the line's code, so a `using:` the classification refused only
+ *   for the trivia after it opens a pair here as well; the path line must
+ *   itself read as live code, or a `using: <#>` would count the comment text
+ *   below it as an import.
  * - A path is only ever read from the line's statements, never from the text of
  *   a `"` string it writes. A `'` is not treated as opening literal text here,
  *   because it also closes a path's quoted segment suffix; see
@@ -490,18 +493,32 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // no path of its own - and the path is on a line the scan skips,
             // which is what left it uncounted.
             //
-            // Classified by handing isModuleImport the `using:` itself and the
-            // line below, so this admits exactly the pairs it would admit had
-            // the `using:` headed its line. Recording the pair unclassified
-            // widens the plain pair too: content the classification declines,
-            // `using:` over `Foo'Loc'`, arrives here by that same rejection.
+            // The tail is read from the line's code, so trivia after the
+            // `using:` does not hide it. That admits more than a
+            // definition-headed line: the head classification refuses
+            // `using: # note` and `using: <#>` for their trivia alone, and
+            // both arrive here. The path line has to read as live code to
+            // separate them - under a comment its own opener line began, the
+            // path is comment text, and counting it as imported withholds an
+            // import the file really needs.
+            //
+            // Content is classified by handing isModuleImport the `using:`
+            // itself and the line below, so a pair is admitted on the same
+            // content rule the branch below applies. Recording it unclassified
+            // would admit `using:` over `Foo'Loc'`, which that rule declines.
             //
             // Pinned like everything else the branch records, and for a second
             // reason of its own: the span holds two lines, so a rebuild from
             // one path deletes the other line whatever the head of the first
             // one says.
             const pairOpener = /\busing\s*:\s*$/.exec(statements);
-            if (pairOpener && nextLine !== undefined && /^\s+\S/.test(nextLine) && ImportFormatter.isModuleImport(pairOpener[0], nextLine, { atFileScope: true })) {
+            if (
+                pairOpener &&
+                nextLine !== undefined &&
+                /^\s+\S/.test(nextLine) &&
+                !classifications[i + 1].continuesCommentAbove &&
+                ImportFormatter.isModuleImport(pairOpener[0], nextLine, { atFileScope: true })
+            ) {
                 imports.push({
                     // Non-empty: the classification reads this same stripped
                     // content, and declines it when there is none.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -372,8 +372,8 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   path line or lose its path. A pair opened after a `using` statement and a
  *   `;` is consumed as well, but pinned rather than rewritable: its span says
  *   more than any one path can, so a writer rebuilding it deletes what it did
- *   not read. A `using:` following anything that is not itself a `using` is
- *   not an import line at all and is skipped whole.
+ *   not read. A pair opened after a definition is consumed and pinned too, by
+ *   the reject path below, since the path it opens is imported all the same.
  * - Content classification (module import vs local-scope using) is delegated
  *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
  *   every candidate here already sits at column 0. So a bare identifier at
@@ -384,9 +384,10 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   That classification reads the line from its head, so it rejects a line
  *   whose `using` follows a definition. Such a line is not skipped: every
  *   complete `using` statement it writes is recorded, pinned, because the path
- *   is imported and writing it again would duplicate it. A `using:` opening an
- *   indented pair is not one of them - the path below it stays unrecorded, as
- *   it is for any `using:` the classification rejects.
+ *   is imported and writing it again would duplicate it. The pair a `using:`
+ *   opens at the end of such a line is recorded with them, spanning both
+ *   lines, on the same ground - the path below it is imported, and the
+ *   classification would have admitted it had the `using:` headed the line.
  * - A path is only ever read from the line's statements, never from the text of
  *   a `"` string it writes. A `'` is not treated as opening literal text here,
  *   because it also closes a path's quoted segment suffix; see
@@ -483,6 +484,38 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
                 });
             }
+
+            // The pair such a line opens, `X := 1; using:` over an indented
+            // path. The loop above records nothing for it - a `using:` writes
+            // no path of its own - and the path is on a line the scan skips,
+            // which is what left it uncounted.
+            //
+            // Classified by handing isModuleImport the `using:` itself and the
+            // line below, so this admits exactly the pairs it would admit had
+            // the `using:` headed its line. Recording the pair unclassified
+            // widens the plain pair too: content the classification declines,
+            // `using:` over `Foo'Loc'`, arrives here by that same rejection.
+            //
+            // Pinned like everything else the branch records, and for a second
+            // reason of its own: the span holds two lines, so a rebuild from
+            // one path deletes the other line whatever the head of the first
+            // one says.
+            const pairOpener = /\busing\s*:\s*$/.exec(statements);
+            if (pairOpener && nextLine !== undefined && /^\s+\S/.test(nextLine) && ImportFormatter.isModuleImport(pairOpener[0], nextLine, { atFileScope: true })) {
+                imports.push({
+                    // Non-empty: the classification reads this same stripped
+                    // content, and declines it when there is none.
+                    path: ImportFormatter.stripTrailingComment(nextLine),
+                    startLine: i,
+                    endLine: i + 1,
+                    anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                    rebuildLosesText: true,
+                    trailingComment: ImportFormatter.extractTrailingComment(nextLine),
+                });
+                i += 2;
+                continue;
+            }
+
             i += 1;
             continue;
         }

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -388,9 +388,9 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   opens at the end of such a line is recorded with them, spanning both
  *   lines, on the same ground - the path below it is imported. That tail is
  *   read from the line's code, so a `using:` the classification refused only
- *   for the trivia after it opens a pair here as well; the path line must
- *   itself read as live code, or a `using: <#>` would count the comment text
- *   below it as an import.
+ *   for the trivia after it opens a pair here as well; the path line must not
+ *   continue a comment opened above it, or a `using: <#>` would count the
+ *   comment text below it as an import.
  * - A path is only ever read from the line's statements, never from the text of
  *   a `"` string it writes. A `'` is not treated as opening literal text here,
  *   because it also closes a path's quoted segment suffix; see
@@ -497,15 +497,24 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // `using:` does not hide it. That admits more than a
             // definition-headed line: the head classification refuses
             // `using: # note` and `using: <#>` for their trivia alone, and
-            // both arrive here. The path line has to read as live code to
-            // separate them - under a comment its own opener line began, the
-            // path is comment text, and counting it as imported withholds an
-            // import the file really needs.
+            // both arrive here. What separates them is whether the path line
+            // continues a comment opened above it - under one the opener's own
+            // line began, the path is comment text, and counting it as
+            // imported withholds an import the file really needs.
+            //
+            // That is the test, and not the wider "the path line is live
+            // code": a line may hold both, `using: <#` over `note #> /A`,
+            // where the comment ends mid-line and code follows it. Declining
+            // there costs a duplicate import on a shape nothing writes, where
+            // admitting the `<#>` case withholds a needed one.
             //
             // Content is classified by handing isModuleImport the `using:`
             // itself and the line below, so a pair is admitted on the same
-            // content rule the branch below applies. Recording it unclassified
-            // would admit `using:` over `Foo'Loc'`, which that rule declines.
+            // content rule the plain-pair branch gets from the gate above.
+            // Recording it unclassified would admit `using:` over `Foo'Loc'`,
+            // which that rule declines. Neither this check nor the comment one
+            // is applied by the branch for a pair opened after a `using`,
+            // which reaches its pair through that gate instead.
             //
             // Pinned like everything else the branch records, and for a second
             // reason of its own: the span holds two lines, so a rebuild from

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -847,6 +847,17 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
+    // The same rejection, reaching the path through the pair the line opens
+    // rather than through a complete statement on it.
+    it("counts the path below a using: opened after a definition as already present", async () => {
+        const input = ["X := 1; using:", "    /Verse.org/Random", "", "code()"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Verse.org/Random }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
     it("leaves a module-scoped using inside its module body during consolidation", async () => {
         (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
             get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -174,6 +174,15 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Economy.Shop"], curlySorted)).toBeNull();
     });
 
+    // Counting the pair after a definition as present is what makes this
+    // reachable: the movable copy is withheld rather than re-emitted, since the
+    // pinned pair below it already imports that path. The same answer the pair
+    // opened after a `using` gives for the same file.
+    it("withholds a movable duplicate of a path a pair after a definition provides", () => {
+        const input = ["using { /Verse.org/Random }", "X := 1; using:", "    /Verse.org/Random", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["X := 1; using:", "    /Verse.org/Random", "code()"].join("\n"));
+    });
+
     // A comment after the `using:` defeats a `$` anchored on the raw line, which
     // put the line straight back on the mangling path: rebuilt as
     // `using { /X } # note`, with Economy.Shop stranded below it.

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -406,6 +406,25 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["using:", "    Foo'Loc'", "code()"])).toEqual([]);
     });
 
+    // The opener's own line begins the comment its path sits in, so the path is
+    // comment text. Counting it as imported is the mirror of the gap this
+    // closes: the extension declines to add an import the file does not make.
+    it("records nothing for a pair whose opener line comments out the path below it", () => {
+        expect(scanModuleImports(["using: <#>", "    /Verse.org/Random", "code()"])).toEqual([]);
+        expect(scanModuleImports(["using: <# note", "    /Verse.org/Random", "#>", "code()"])).toEqual([]);
+        expect(scanModuleImports(["X := 1; using: <#>", "    /Verse.org/Random", "code()"])).toEqual([]);
+    });
+
+    // A line comment ends with its line, so this path is live code and really
+    // is imported. Pinned because a rebuild from the path drops the comment on
+    // the opener line, which trailingComment reads from the path line and so
+    // cannot put back.
+    it("records the path below a plain pair whose opener carries a line comment", () => {
+        expect(scanModuleImports(["using: # note", "    /Verse.org/Random", "code()"])).toEqual([
+            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
     // The classification reads a line from its head, so this one was rejected
     // and skipped whole. Nothing recorded that the file imports the path, and a
     // diagnostic asking for it wrote a second copy above a line already making

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -425,6 +425,25 @@ describe("scanModuleImports", () => {
         ]);
     });
 
+    // The boundary of the check above: a block comment the opener line also
+    // closes leaves the path below it live, so the pair counts. Narrowing the
+    // check to "the opener line holds no `<#`" would pass every other test here
+    // and drop this one.
+    it("records the path below a pair whose opener closes the comment it opens", () => {
+        expect(scanModuleImports(["using: <# note #>", "    /Verse.org/Random", "code()"])).toEqual([
+            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // anchorsCommentBelow is asked of the whole span, so a marker on the path
+    // line counts even though the opener line holds none. The pair is pinned
+    // either way; what this pins is that the flag is read rather than assumed.
+    it("flags a pair after a definition whose path line opens a comment", () => {
+        expect(scanModuleImports(["X := 1; using:", "    /Verse.org/Random <#>", "        body", "code()"])).toEqual([
+            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<#>" },
+        ]);
+    });
+
     // The classification reads a line from its head, so this one was rejected
     // and skipped whole. Nothing recorded that the file imports the path, and a
     // diagnostic asking for it wrote a second copy above a line already making

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -346,11 +346,64 @@ describe("scanModuleImports", () => {
         ]);
     });
 
-    // A `using:` following something that is not a `using` writes no import
-    // this scanner may touch: isModuleImport rejects the line, so it is skipped
-    // whole and left exactly as written.
-    it("skips a using: opened after a statement that is not a using", () => {
-        expect(scanModuleImports(["X := 1; using:", "    Economy.Shop", "code()"])).toEqual([]);
+    // The classification rejects the line, and the reject path recorded only
+    // the complete statements it writes - a `using:` is not one of them, and
+    // the path it opens is on a line the scan skips. So nothing counted the
+    // path as present and a diagnostic asking for it wrote a second copy of an
+    // import the file already makes. `allUsingPaths` saw it throughout, so the
+    // line itself was never at risk.
+    it("records the path below a using: opened after a definition, pinned", () => {
+        expect(scanModuleImports(["X := 1; using:", "    Economy.Shop", "code()"])).toEqual([
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // Two lines the scanner cannot reproduce from one path, so the acceptance
+    // criterion is that both stay exactly as written.
+    it("offers no rewritable import for a pair opened after a definition", () => {
+        expect(rewritableImports(scanModuleImports(["X := 1; using:", "    Economy.Shop", "code()"]))).toEqual([]);
+    });
+
+    it("records every statement written before a pair opened after a definition", () => {
+        expect(scanModuleImports(["X := 1; using { /A }; using:", "    Economy.Shop", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // Read from the line's code, as the branch for a pair opened after a
+    // `using` is: a comment after the opener defeats a `$` anchored on the raw
+    // line, and the path line keeps its own comment for a writer to put back.
+    it("records a pair opened after a definition when a comment trails the opener", () => {
+        expect(scanModuleImports(["X := 1; using: # note", "    Economy.Shop # why", "code()"])).toEqual([
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "# why" },
+        ]);
+    });
+
+    // The mirror error: this line ends in `using:` inside a comment, and
+    // reading that as an opener records the comment text below it as a path.
+    it("does not read a using: written in a comment after a definition as opening a pair", () => {
+        expect(scanModuleImports(["X := 1 <# note about using:", "    still comment", "#>", "code()"])).toEqual([]);
+    });
+
+    it("records nothing when a using: after a definition opens no indented path", () => {
+        expect(scanModuleImports(["X := 1; using:", "code()"])).toEqual([]);
+        expect(scanModuleImports(["X := 1; using:", "    # just a note", "code()"])).toEqual([]);
+    });
+
+    // Indented lines are skipped before the classification runs. A `using` in a
+    // module body is module-scoped, and counting it as present suppresses the
+    // file-level import the diagnostic asked for.
+    it("skips a pair opened after a definition inside a module body", () => {
+        expect(scanModuleImports(["MyModule := module:", "    X := 1; using:", "        Economy.Shop", "code()"])).toEqual([]);
+    });
+
+    // Content the classification declines reaches the reject path by the same
+    // rejection as a definition-headed line. Recording the pair without
+    // classifying it would admit this one too, which is a plain pair changing
+    // shape rather than the gap this closes.
+    it("leaves a plain pair whose content the classification declines skipped", () => {
+        expect(scanModuleImports(["using:", "    Foo'Loc'", "code()"])).toEqual([]);
     });
 
     // The classification reads a line from its head, so this one was rejected


### PR DESCRIPTION
Closes #309

## What changed

`scanModuleImports` recorded nothing for a `using:` pair opened after a non-using definition, `X := 1; using:` over an indented path. The classification reads a line from its head, so the line is rejected, and the reject path recorded only the complete `using` statements the line writes — a `using:` carries none of its own, and the path below it is on a line the scan skips. Nothing counted that path as present, so a diagnostic asking for it wrote a second copy of an import the file already makes.

The reject path now records the pair as well, spanning both lines and pinned, so neither line is ever rebuilt or moved. `allUsingPaths` already saw the path, so removal safety was never affected and the line was never at risk.

Two rules decide what the new branch admits:

- **Content** is classified by handing `isModuleImport` the matched `using:` and the line below it, so a pair is admitted on the same content rule the branch for a pair after a `using` applies. Recording it unclassified would have widened the plain pair too — content the classification declines, `using:` over `Foo'Loc'`, reaches the reject path by the same rejection.
- **The path line must read as live code.** The tail is matched against the line's code, so it is found whatever trivia follows the `using:` — which admits `using: # note` and `using: <#>` as well as a definition-headed line. Under `<#>` the path is comment text, and counting it as imported would withhold an import the file genuinely needs, the mirror of the gap being closed. A line comment ends with its line, so `using: # note` over a path does count, pinned because a rebuild drops the opener's comment.

## Acceptance criteria

| Criterion | Where |
|---|---|
| The path below such a pair counts as present for deduplication | `records the path below a using: opened after a definition, pinned`; `counts the path below a using: opened after a definition as already present` |
| Both lines stay exactly as written | `offers no rewritable import for a pair opened after a definition` |

## Verse semantics

The shape is legal Verse, confirmed against the compiler grammar rather than inferred: `Block := Brace | DotSpace Space Def Space | (DotSpace | ':') Space Ind List Ded`, and `Ind := Ending push; set Nest=false; set BlockInd=LineInd` sets the block body's indent reference to the whole line's leading whitespace, whatever text preceded the `:`. With `;` separating scope elements, `X := 1; using:` over an indented path parses as two elements of the file-scope list.

## Not in scope

The branch for a pair opened after a `using` statement answers two of these questions differently: it counts the comment text below a `using { /A }; using: <#>` as a path, and it applies no content rule to the pair, so it records a `Foo'Loc'` this branch declines. Both divergences reproduce identically on `main`, byte for byte, and are untouched here. They belong in their own issue rather than in this diff.

## Review

Two rounds, fresh context each, against the smell baseline and both acceptance criteria.

- **Round 1** — PASS_WITH_SUGGESTIONS, 1 Important, 3 Suggestions. The Important was a real regression this diff introduced: matching the `using:` tail against the line's code admits openers the head check rejected for trailing trivia alone, so `using: <#>` counted its commented-out path as imported. Fixed by requiring the path line not to continue a comment opened above it. Two suggestions taken as tests; one declined as scope widening.
- **Round 2** — PASS_WITH_SUGGESTIONS, 1 Important, 5 Suggestions. The Important was comment accuracy, not behaviour: the branch comment said "the path line has to read as live code", which is a wider predicate than the guard applies, and implementing it literally would have admitted `using: <#` over `note #> /A` with the suite still green. Reworded to name the actual check, with the two boundary cases pinned by tests. The remaining suggestions were the out-of-scope divergences above and one informational note on an unterminated-literal shape that `LineScan.codeOutsideLiterals` already documents as accepted.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       831 passed, 831 total
Snapshots:   0 total
Time:        8.585 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Each new regression test was proved to detect the defect: with the fix removed, the four tests asserting the new behaviour fail and the guard tests still pass.
