### PR TITLE
fix(imports): keep a grouped relative import below the ones already written

### DIFF
--- a/changelog.d/314.fixed.md
+++ b/changelog.d/314.fixed.md
@@ -1,0 +1,1 @@
+**Auto import**: with import grouping set to digestFirst or localFirst, a newly added relative import is no longer written above a relative import the file already holds, and goes on its own line below instead.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -433,6 +433,39 @@ export class ImportDocumentEditor {
     }
 
     /**
+     * Whether a block sits far enough down the file for `path` to join it
+     * without crossing a relative import written below it.
+     *
+     * The grouped writer picks its block by group identity, which is a question
+     * about a block's content and not about its position, so the block it picks
+     * can have another below it: a mixed block counts as neither group and is
+     * skipped over rather than ruled out. A relative path resolves its first
+     * segment against what the `using` statements above it brought into scope
+     * (ImportFormatter.resolvesAgainstScopeAbove), so a relative import further
+     * down may be the one it needs, and joining a block above that import stops
+     * the file compiling. Grouping yields, since a grouped file that no longer
+     * compiles is the worse of the two.
+     *
+     * Only the relative imports below count, and an absolute one below is
+     * knowingly let through. A grouped file writes one group above the other by
+     * definition, so under localFirst every digest import sits below the local
+     * group: reading an absolute import as a possible provider would refuse
+     * that group to every relative path and leave the strategy with nothing to
+     * do. The residual is real, and is not the same judgement pinnedBounds
+     * makes - a relative path can still land above an absolute import in a
+     * later block that could be bringing its first segment into scope, where a
+     * pinned absolute import of the same shape would have pushed it below.
+     * A pinned line cannot be moved or grouped, so nothing chose that order;
+     * the grouping strategy is the user choosing this one.
+     */
+    private blockKeepsRelativeOrder(importBlocks: ImportBlock[], blockIndex: number, path: string): boolean {
+        if (!this.formatter.resolvesAgainstScopeAbove(path)) {
+            return true;
+        }
+        return !importBlocks.some((block, index) => index > blockIndex && block.imports.some((imp) => this.formatter.resolvesAgainstScopeAbove(imp.path)));
+    }
+
+    /**
      * Writes a run of import statements on their own lines at `line`.
      *
      * One home for the end-of-document case, which every caller has to handle
@@ -654,11 +687,14 @@ export class ImportDocumentEditor {
                     }
                 }
 
-                // A block can only take a new import where the pinned imports
-                // leave room for it. Rebuilding a block writes the new
-                // statement at that block's lines, so which block absorbs a
-                // path is a placement decision like any other, and a block
-                // sitting above a pinned provider cannot make one.
+                // A block can only take a new import where both the pinned
+                // imports and the movable ones below it leave room for it.
+                // Rebuilding a block writes the new statement at that block's
+                // lines, so which block absorbs a path is a placement decision
+                // like any other, and a block sitting above a provider cannot
+                // make one. The two bounds count different imports, though:
+                // see blockKeepsRelativeOrder for why an absolute import in a
+                // later block is let through where a pinned one is not.
                 //
                 // Partitioned in one pass rather than filtered twice, so taken
                 // and unhandled are complements by construction: two filters
@@ -668,7 +704,10 @@ export class ImportDocumentEditor {
                     const taken: string[] = [];
                     const unhandled: string[] = [];
                     for (const path of paths) {
-                        const canTake = blockIndex >= 0 && this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path));
+                        const canTake =
+                            blockIndex >= 0 &&
+                            this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path)) &&
+                            this.blockKeepsRelativeOrder(importBlocks, blockIndex, path);
                         (canTake ? taken : unhandled).push(path);
                     }
                     return { taken, unhandled };
@@ -685,8 +724,9 @@ export class ImportDocumentEditor {
                     this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], local.taken, preferDotSyntax, sortAlphabetically, eol);
                 }
 
-                // Imports no block took: one with no matching block, and one a
-                // pinned import keeps out of the block it would have matched.
+                // Imports no block took: one with no matching block, and one
+                // its matching block cannot hold - because a pinned import
+                // keeps it out, or because a relative import below it does.
                 const unhandledPaths = [...digest.unhandled, ...local.unhandled];
 
                 if (unhandledPaths.length > 0) {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1582,6 +1582,93 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         });
     });
 
+    // The grouped writer chooses its block by group identity, and a mixed block
+    // counts as neither group, so the pure block it settles on can have one
+    // below it holding a relative import the new import may be resolving
+    // through.
+    describe("grouped placement against a relative import written in a later block", () => {
+        it("digestFirst: keeps a new relative import out of the local group above a later relative import", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "digestFirst",
+            });
+            const input = ["using { Alpha }", "", "using { /Verse.org/Simulation }", "using { Beta.Gamma }", "", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Delta }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // The local group at line 0 would have taken it, above Beta.Gamma.
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(4);
+            expect(insert!.text).toBe("using { Delta }\n");
+        });
+
+        it("localFirst: keeps a new relative import out of the local group above a later relative import", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "localFirst",
+            });
+            const input = ["using { Alpha }", "", "using { /Verse.org/Simulation }", "using { Beta.Gamma }", "", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Delta }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(4);
+            expect(insert!.text).toBe("using { Delta }\n");
+        });
+
+        it("still merges a new relative import into its group when every block below holds only absolute imports", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "localFirst",
+            });
+            const input = ["using { Alpha }", "", "using { /Verse.org/Simulation }", "", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Delta }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // Nothing below can be providing for it, so the group still takes
+            // it rather than falling back to a standalone line.
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(0);
+            expect(replace!.text).toBe("using { Alpha }\nusing { Delta }\n");
+        });
+
+        it("still merges a new absolute import into the digest group above a later relative import", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "digestFirst",
+            });
+            const input = ["using { /Verse.org/Simulation }", "", "using { Alpha }", "using { Beta.Gamma }", "", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            // An absolute path needs nothing in scope above it, so a relative
+            // import below is not a provider it has to stay under.
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(0);
+            expect(replace!.text).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n");
+        });
+    });
+
     // The other reason an import stays on its line: another statement shares
     // the span, so rebuilding the line from the path alone would delete what
     // the author wrote beside it. It is out of every block for the same reason


### PR DESCRIPTION
Closes #314

The grouped placement path chose its target block by group identity alone — `digestBlockIndex` and `localBlockIndex` are the last *pure* block of each kind — and `splitForBlock` then asked only whether that block cleared the pinned bounds. A mixed block counts as neither group, so the block the writer settled on could sit above one holding a relative import, and a new relative import merged there landed above an import that may be bringing its first segment into scope.

`blockKeepsRelativeOrder` adds the missing question: for a path that resolves against the scope above it, no later block may hold a relative import. A path the check refuses joins the paths a pinned import already displaces and is written on its own line below the last block.

## The conflict the ticket asked to settle

> Worth deciding explicitly: grouping and written order genuinely conflict [...] so the fix may have to say which of the two yields.

**Written order wins; grouping yields.** It is the same answer the pinned path already gives — "keeps a new consumer out of the group above the anchored provider" — and it follows `hoistFloor`'s rule that a compiling file outranks a tidy one. Group identity still chooses *which* group a path joins, exactly as the acceptance allows; it no longer chooses a position.

## Scope, and one residual left in deliberately

Only relative imports below count. An absolute import below is let through, so a relative path can still land above an absolute one in a later block that could be its provider — where a *pinned* absolute import of the same shape would have pushed it below. That asymmetry is deliberate and documented at the predicate: a grouped file writes one group above the other by definition, so under `localFirst` every digest import sits below the local group, and counting an absolute import as a possible provider would refuse that group to every relative path and leave the strategy with nothing to do. A pinned line is an order nothing chose; a grouping strategy is one the user chose.

A second residual, pre-existing and unchanged: `placementLine` takes a ceiling exactly, so where a pinned dotted consumer raises one, a displaced path is written at that ceiling rather than below the last block, which can still be above an existing relative import. That is `couldResolveAgainst`'s documented override rather than anything this branch introduces.

## Verification

```
$ npm run compile
> tsc -p ./

$ npm test
Test Suites: 40 passed, 40 total
Tests:       849 passed, 849 total
Snapshots:   0 total
Time:        11.514 s

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

Four tests added. The two that pin the defect were proven to detect it — with the new conjunct removed from `splitForBlock` they fail, and the two that guard against over-refusal pass either way:

```
$ npx jest src/imports/__tests__/ImportDocumentEditor.test.ts -t "later block"    # fix removed
Tests:       2 failed, 182 skipped, 2 passed, 186 total
```

## Review

One round, fresh reviewer, verdict `PASS_WITH_SUGGESTIONS` — no Critical. Both Important findings are applied: the missing changelog fragment, and a wrong justification in the new doc comment, which claimed the rank sort produces the safe order anyway. It does not — the sort never runs across two blocks — so the comment now states the residual plainly instead of arguing it away. Two Suggestions were left: naming the ceiling exception in the predicate's doc, which `placementLine` already owns and documents, and passing `importBlocks.slice(blockIndex + 1)` in place of the list and index.
