### PR TITLE
fix(imports): decline a using: pair whose opener comments out its path

### DIFF
--- a/changelog.d/320.fixed.md
+++ b/changelog.d/320.fixed.md
@@ -1,0 +1,1 @@
+**Import scanner**: A `using:` pair whose opener comments out the path below it no longer counts that path as imported, so an import the file needs is written instead of declined.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -459,16 +459,22 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     //
     // @param classifyContent whether content isModuleImport declines, such as
     //   the quoted segment suffix `Foo'Loc'`, disqualifies the pair. False for
-    //   a pair opened after a complete `using`, and only there: the statements
-    //   before its `;` are recorded against the opener line alone, so the pair
-    //   entry is the only one whose span reaches the path line, and declining
-    //   it lets a new relative import be written between the opener and the
-    //   path it opens - two lines that must stay adjacent to compile. The
-    //   comment rule above costs nothing there, because pinnedSpanEnd rebuilds
-    //   that reach from the comment structure itself; a content rule has
-    //   nothing to rebuild it from. Over-recording the path is the cheaper
-    //   error: the entry is pinned, so no writer rebuilds the line, and no
-    //   diagnostic asks for a path of this shape.
+    //   a pair opened after a complete `using`: the statements before its `;`
+    //   are recorded against the opener line alone, so the pair entry is the
+    //   only one whose span reaches the path line, and declining it lets a new
+    //   relative import be written between the opener and the path it opens -
+    //   two lines that must stay adjacent to compile. The comment rule above
+    //   costs nothing there, because pinnedSpanEnd rebuilds that reach from the
+    //   comment structure itself; a content rule has nothing to rebuild it
+    //   from. Over-recording the path is the cheaper error: the entry is
+    //   pinned, so no writer rebuilds the line, and no diagnostic asks for a
+    //   path of this shape.
+    //
+    //   Not a property of that branch alone. A definition-headed line writing a
+    //   complete `using` before its pair, `X := 1; using { /A }; using:`,
+    //   strands the path line the same way and still classifies, as it always
+    //   has. That is a standing gap rather than one this parameter closes, and
+    //   narrowing it here would only move the hole.
     const pairPathBelow = (opener: number, classifyContent: boolean): string => {
         const pathLine = lines[opener + 1];
         if (pathLine === undefined || !/^\s+\S/.test(pathLine) || classifications[opener + 1].continuesCommentAbove) {
@@ -660,10 +666,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // every other branch gets.
             //
             // Content is the one question this branch answers differently, and
-            // deliberately: the entry recorded here is the only one whose span
-            // reaches the path line, so declining on content unpins that line
-            // rather than merely leaving a path uncounted. See pairPathBelow's
-            // `classifyContent`.
+            // deliberately; see pairPathBelow's `classifyContent`.
             const pairPath = pairPathBelow(i, false);
             if (!pairPath) {
                 // The `using:` opens nothing this scan admits, but the line

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -374,10 +374,12 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   more than any one path can, so a writer rebuilding it deletes what it did
  *   not read. A pair opened after a definition is consumed and pinned too, by
  *   the reject path below, since the path it opens is imported all the same.
- *   Which pairs are admitted is one rule for all three, pairPathBelow: the
- *   path line carries content the classification accepts, and does not
- *   continue a comment the opener's own line began - under one it is comment
- *   text, and counting it as imported withholds an import the file needs.
+ *   None of the three admits a pair whose path line continues a comment the
+ *   opener's own line began - under one it is comment text, and counting it
+ *   as imported withholds an import the file needs. They part company on
+ *   content: a pair opened after a `using` keeps a path the classification
+ *   declines, because its entry is the only one spanning the path line and
+ *   dropping it would let a writer split the pair. See pairPathBelow.
  * - Content classification (module import vs local-scope using) is delegated
  *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
  *   every candidate here already sits at column 0. So a bare identifier at
@@ -436,39 +438,48 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     };
 
     // The path the indented pair opened on `opener` takes from the line below
-    // it, or "" when the line opens no pair this scan admits.
+    // it, or "" when the line opens no pair.
     //
-    // One home for the rule, because three branches below reach a pair - one
-    // for a pair opening its own line, one for a pair opened after a complete
-    // `using`, one for a pair opened after anything else. Answered per branch,
-    // the same content counted as an import on one written shape and not on
-    // the others, which is the state that hid a path being counted from inside
-    // a comment.
+    // One home for the comment rule, because all three branches that reach a
+    // pair need it and none of them can see it from where it is decided. A
+    // path line continuing a comment the opener's own line began,
+    // `using: <#>` or an unclosed `<#`, is comment text, and the file does not
+    // import it - counting it as present declines the diagnostic asking for
+    // it, and the import is never written.
     //
-    // Two things disqualify a pair. The path line may continue a comment the
-    // opener's own line began, `using: <#>` or an unclosed `<#`, which makes
-    // that path comment text: counting it as present declines the diagnostic
-    // asking for it, and the file never gets the import it needs. That is the
-    // test, and not the wider "the path line is live code": a line may hold
-    // both, `using: <#` over `note #> /A`, where the comment ends mid-line and
-    // code follows it. Declining there costs a duplicate import on a shape
-    // nothing writes, where admitting the `<#>` case withholds a needed one.
-    //
-    // And the content may be one isModuleImport declines, `Foo'Loc'` - the
-    // same classifier, asked the same way, as the gate applies to a pair
-    // opening its own line.
+    // That is the test, and not the wider "the path line is live code": a line
+    // may hold both, `using: <#` over `note #> /A`, where the comment ends
+    // mid-line and code follows it. Declining there costs a duplicate import
+    // on a shape nothing writes, where admitting the `<#>` case withholds a
+    // needed one.
     //
     // The opener always sits at column 0 outside any comment, since the loop
     // skips every other line before reaching a pair, so a comment continuing
     // onto the path line was opened by the opener itself.
-    const pairPathBelow = (opener: number): string => {
+    //
+    // @param classifyContent whether content isModuleImport declines, such as
+    //   the quoted segment suffix `Foo'Loc'`, disqualifies the pair. False for
+    //   a pair opened after a complete `using`, and only there: the statements
+    //   before its `;` are recorded against the opener line alone, so the pair
+    //   entry is the only one whose span reaches the path line, and declining
+    //   it lets a new relative import be written between the opener and the
+    //   path it opens - two lines that must stay adjacent to compile. The
+    //   comment rule above costs nothing there, because pinnedSpanEnd rebuilds
+    //   that reach from the comment structure itself; a content rule has
+    //   nothing to rebuild it from. Over-recording the path is the cheaper
+    //   error: the entry is pinned, so no writer rebuilds the line, and no
+    //   diagnostic asks for a path of this shape.
+    const pairPathBelow = (opener: number, classifyContent: boolean): string => {
         const pathLine = lines[opener + 1];
         if (pathLine === undefined || !/^\s+\S/.test(pathLine) || classifications[opener + 1].continuesCommentAbove) {
             return "";
         }
-        // Non-empty wherever the classification accepts it: it reads this same
-        // stripped content, and declines it when there is none.
-        return ImportFormatter.isModuleImport("using:", pathLine, { atFileScope: true }) ? ImportFormatter.stripTrailingComment(pathLine) : "";
+        if (classifyContent && !ImportFormatter.isModuleImport("using:", pathLine, { atFileScope: true })) {
+            return "";
+        }
+        // Empty where the line carries only a comment, which is no more a
+        // usable pair than a missing line is.
+        return ImportFormatter.stripTrailingComment(pathLine);
     };
 
     let i = 0;
@@ -542,7 +553,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // reason of its own: the span holds two lines, so a rebuild from
             // one path deletes the other line whatever the head of the first
             // one says.
-            const pairPath = /\busing\s*:\s*$/.test(statements) ? pairPathBelow(i) : "";
+            const pairPath = /\busing\s*:\s*$/.test(statements) ? pairPathBelow(i, true) : "";
             if (pairPath) {
                 imports.push({
                     path: pairPath,
@@ -570,7 +581,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // classifier. Asked anyway, so what a pair admits has one answer rather
         // than one this branch happens to agree with.
         if (/^using\s*:\s*$/.test(trimmed)) {
-            const pairPath = pairPathBelow(i);
+            const pairPath = pairPathBelow(i, true);
             if (pairPath) {
                 imports.push({
                     path: pairPath,
@@ -645,9 +656,15 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // past the gate above, so the trivia that gate refuses a
             // definition-headed line for rides along - `using { /A }; using: <#>`
             // arrives here with its `<#>` intact, commenting out the path line
-            // below it. pairPathBelow is what declines it, on the same terms
+            // below it. pairPathBelow is what declines that, on the same terms
             // every other branch gets.
-            const pairPath = pairPathBelow(i);
+            //
+            // Content is the one question this branch answers differently, and
+            // deliberately: the entry recorded here is the only one whose span
+            // reaches the path line, so declining on content unpins that line
+            // rather than merely leaving a path uncounted. See pairPathBelow's
+            // `classifyContent`.
+            const pairPath = pairPathBelow(i, false);
             if (!pairPath) {
                 // The `using:` opens nothing this scan admits, but the line
                 // still carries a statement this scanner cannot reproduce.
@@ -839,7 +856,9 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
  * - A `using:` opening an indented pair is recognised at the end of its line
  *   rather than as the whole of it, since a statement can precede it there too.
  *   The pair is the one shape counted once, because its path is read here from
- *   the line below.
+ *   the line below. Neither rule scanModuleImports applies to a pair is applied
+ *   here: over-reporting a path only makes the caller decline to tidy, so a
+ *   path its opener comments out is offered rather than risk withholding one.
  *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -374,6 +374,10 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   more than any one path can, so a writer rebuilding it deletes what it did
  *   not read. A pair opened after a definition is consumed and pinned too, by
  *   the reject path below, since the path it opens is imported all the same.
+ *   Which pairs are admitted is one rule for all three, pairPathBelow: the
+ *   path line carries content the classification accepts, and does not
+ *   continue a comment the opener's own line began - under one it is comment
+ *   text, and counting it as imported withholds an import the file needs.
  * - Content classification (module import vs local-scope using) is delegated
  *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
  *   every candidate here already sits at column 0. So a bare identifier at
@@ -388,9 +392,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *   opens at the end of such a line is recorded with them, spanning both
  *   lines, on the same ground - the path below it is imported. That tail is
  *   read from the line's code, so a `using:` the classification refused only
- *   for the trivia after it opens a pair here as well; the path line must not
- *   continue a comment opened above it, or a `using: <#>` would count the
- *   comment text below it as an import.
+ *   for the trivia after it opens a pair here as well.
  * - A path is only ever read from the line's statements, never from the text of
  *   a `"` string it writes. A `'` is not treated as opening literal text here,
  *   because it also closes a path's quoted segment suffix; see
@@ -431,6 +433,42 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             depth = scan.depth;
         }
         return depth > 0;
+    };
+
+    // The path the indented pair opened on `opener` takes from the line below
+    // it, or "" when the line opens no pair this scan admits.
+    //
+    // One home for the rule, because three branches below reach a pair - one
+    // for a pair opening its own line, one for a pair opened after a complete
+    // `using`, one for a pair opened after anything else. Answered per branch,
+    // the same content counted as an import on one written shape and not on
+    // the others, which is the state that hid a path being counted from inside
+    // a comment.
+    //
+    // Two things disqualify a pair. The path line may continue a comment the
+    // opener's own line began, `using: <#>` or an unclosed `<#`, which makes
+    // that path comment text: counting it as present declines the diagnostic
+    // asking for it, and the file never gets the import it needs. That is the
+    // test, and not the wider "the path line is live code": a line may hold
+    // both, `using: <#` over `note #> /A`, where the comment ends mid-line and
+    // code follows it. Declining there costs a duplicate import on a shape
+    // nothing writes, where admitting the `<#>` case withholds a needed one.
+    //
+    // And the content may be one isModuleImport declines, `Foo'Loc'` - the
+    // same classifier, asked the same way, as the gate applies to a pair
+    // opening its own line.
+    //
+    // The opener always sits at column 0 outside any comment, since the loop
+    // skips every other line before reaching a pair, so a comment continuing
+    // onto the path line was opened by the opener itself.
+    const pairPathBelow = (opener: number): string => {
+        const pathLine = lines[opener + 1];
+        if (pathLine === undefined || !/^\s+\S/.test(pathLine) || classifications[opener + 1].continuesCommentAbove) {
+            return "";
+        }
+        // Non-empty wherever the classification accepts it: it reads this same
+        // stripped content, and declines it when there is none.
+        return ImportFormatter.isModuleImport("using:", pathLine, { atFileScope: true }) ? ImportFormatter.stripTrailingComment(pathLine) : "";
     };
 
     let i = 0;
@@ -497,46 +535,22 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // `using:` does not hide it. That admits more than a
             // definition-headed line: the head classification refuses
             // `using: # note` and `using: <#>` for their trivia alone, and
-            // both arrive here. What separates them is whether the path line
-            // continues a comment opened above it - under one the opener's own
-            // line began, the path is comment text, and counting it as
-            // imported withholds an import the file really needs.
-            //
-            // That is the test, and not the wider "the path line is live
-            // code": a line may hold both, `using: <#` over `note #> /A`,
-            // where the comment ends mid-line and code follows it. Declining
-            // there costs a duplicate import on a shape nothing writes, where
-            // admitting the `<#>` case withholds a needed one.
-            //
-            // Content is classified by handing isModuleImport the `using:`
-            // itself and the line below, so a pair is admitted on the same
-            // content rule the plain-pair branch gets from the gate above.
-            // Recording it unclassified would admit `using:` over `Foo'Loc'`,
-            // which that rule declines. Neither this check nor the comment one
-            // is applied by the branch for a pair opened after a `using`,
-            // which reaches its pair through that gate instead.
+            // both arrive here. What each of them opens is pairPathBelow's
+            // question, asked the same way by every branch that reaches a pair.
             //
             // Pinned like everything else the branch records, and for a second
             // reason of its own: the span holds two lines, so a rebuild from
             // one path deletes the other line whatever the head of the first
             // one says.
-            const pairOpener = /\busing\s*:\s*$/.exec(statements);
-            if (
-                pairOpener &&
-                nextLine !== undefined &&
-                /^\s+\S/.test(nextLine) &&
-                !classifications[i + 1].continuesCommentAbove &&
-                ImportFormatter.isModuleImport(pairOpener[0], nextLine, { atFileScope: true })
-            ) {
+            const pairPath = /\busing\s*:\s*$/.test(statements) ? pairPathBelow(i) : "";
+            if (pairPath) {
                 imports.push({
-                    // Non-empty: the classification reads this same stripped
-                    // content, and declines it when there is none.
-                    path: ImportFormatter.stripTrailingComment(nextLine),
+                    path: pairPath,
                     startLine: i,
                     endLine: i + 1,
                     anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
                     rebuildLosesText: true,
-                    trailingComment: ImportFormatter.extractTrailingComment(nextLine),
+                    trailingComment: ImportFormatter.extractTrailingComment(lines[i + 1]),
                 });
                 i += 2;
                 continue;
@@ -548,21 +562,26 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
 
         // Indented style: the path lives on the next line; consume both lines
         // as a single entry.
+        //
+        // Neither half of what pairPathBelow refuses can arrive here: reaching
+        // this branch needs the raw line to be `using:` and nothing else, which
+        // holds no marker to comment out the line below, and the gate above has
+        // already put that same line and the same one below it through the same
+        // classifier. Asked anyway, so what a pair admits has one answer rather
+        // than one this branch happens to agree with.
         if (/^using\s*:\s*$/.test(trimmed)) {
-            if (nextLine !== undefined && /^\s+\S/.test(nextLine)) {
-                const indentedPath = ImportFormatter.stripTrailingComment(nextLine);
-                if (indentedPath) {
-                    imports.push({
-                        path: indentedPath,
-                        startLine: i,
-                        endLine: i + 1,
-                        anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
-                        rebuildLosesText: false,
-                        trailingComment: ImportFormatter.extractTrailingComment(nextLine),
-                    });
-                    i += 2;
-                    continue;
-                }
+            const pairPath = pairPathBelow(i);
+            if (pairPath) {
+                imports.push({
+                    path: pairPath,
+                    startLine: i,
+                    endLine: i + 1,
+                    anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                    rebuildLosesText: false,
+                    trailingComment: ImportFormatter.extractTrailingComment(lines[i + 1]),
+                });
+                i += 2;
+                continue;
             }
             // `using:` without indented content is not a usable import; leave it alone
             i += 1;
@@ -622,23 +641,29 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 });
             }
 
-            const indentedPath = nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "";
-            if (!indentedPath) {
-                // The `using:` opens nothing usable, but the line still carries
-                // a statement this scanner cannot reproduce. Falling through to
-                // the single-statement branch would rebuild the line and delete
-                // the `; using:`.
+            // A complete `using` at the head of the line is what carries it
+            // past the gate above, so the trivia that gate refuses a
+            // definition-headed line for rides along - `using { /A }; using: <#>`
+            // arrives here with its `<#>` intact, commenting out the path line
+            // below it. pairPathBelow is what declines it, on the same terms
+            // every other branch gets.
+            const pairPath = pairPathBelow(i);
+            if (!pairPath) {
+                // The `using:` opens nothing this scan admits, but the line
+                // still carries a statement this scanner cannot reproduce.
+                // Falling through to the single-statement branch would rebuild
+                // the line and delete the `; using:`.
                 i += 1;
                 continue;
             }
 
             imports.push({
-                path: indentedPath,
+                path: pairPath,
                 startLine: i,
                 endLine: i + 1,
                 anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
                 rebuildLosesText: true,
-                trailingComment: ImportFormatter.extractTrailingComment(nextLine),
+                trailingComment: ImportFormatter.extractTrailingComment(lines[i + 1]),
             });
             i += 2;
             continue;

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -199,6 +199,17 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
     });
 
+    // A pair's two lines have to stay adjacent to compile, and the entry
+    // spanning both is the only thing holding a new import out from between
+    // them: the statement before the `;` is recorded against the opener line
+    // alone. So the pair is recorded even where its path is content the
+    // classification declines - the path counts for nothing, the span for
+    // everything. See ImportScanner's pairPathBelow.
+    it("writes a new relative import below a pair whose path the content rule declines", () => {
+        const input = ["using { /A }; using:", "    Foo'Loc'", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["using { /A }; using:", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
+    });
+
     // A line writing two complete statements read as its first path alone, so
     // organizing rebuilt it as `using { /X }` and Economy.Shop was simply gone.
     // The output was a well-formed import block, which is what made the loss

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -333,6 +333,37 @@ describe("scanModuleImports", () => {
         ]);
     });
 
+    // The opener's own marker makes the line below it comment text, so the path
+    // there is commented out and the file does not import it. Counting it as
+    // present declines the diagnostic asking for it, and the import is never
+    // written. Either marker, since their consequence is the same.
+    //
+    // The head classification refuses these lines for their trivia alone, so
+    // they reach the branch for a pair opened after a definition, which tests
+    // this. A complete `using` at the head of the line carries them past that
+    // gate and into this branch instead.
+    it("does not count a path the pair opener comments out", () => {
+        expect(scanModuleImports(["using { /A }; using: <#>", "    /Verse.org/Random", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<#>" },
+        ]);
+        expect(scanModuleImports(["using { /A }; using: <# note", "    /Verse.org/Random", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<# note" },
+        ]);
+    });
+
+    // The same content rule the other two readers of the pair shape apply: a
+    // quoted segment suffix is neither a path, nor dotted, nor a bare
+    // identifier, and both of them decline it. Recorded here alone, one written
+    // shape counted as an import while the same content in the other two did
+    // not.
+    it("applies the content rule to the path the pair opens", () => {
+        expect(scanModuleImports(["using { /A }; using:", "    Foo'Loc'", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+        expect(scanModuleImports(["using:", "    Foo'Loc'", "code()"])).toEqual([]);
+        expect(scanModuleImports(["X := 1; using:", "    Foo'Loc'", "code()"])).toEqual([]);
+    });
+
     // This branch has first refusal, so a line ending in `using:` never reaches
     // the one that counts what a line writes. Reading only the head recorded
     // `/X` and the indented path and left `/Y` out - not data loss, since the

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -351,14 +351,17 @@ describe("scanModuleImports", () => {
         ]);
     });
 
-    // The same content rule the other two readers of the pair shape apply: a
-    // quoted segment suffix is neither a path, nor dotted, nor a bare
-    // identifier, and both of them decline it. Recorded here alone, one written
-    // shape counted as an import while the same content in the other two did
-    // not.
-    it("applies the content rule to the path the pair opens", () => {
+    // Content is the one question this branch answers differently from the
+    // other two readers of the pair shape, and deliberately. The entry for the
+    // pair is the only one whose span reaches the path line - the statements
+    // before the `;` are recorded against the opener line alone - so declining
+    // a path the classification refuses unpins that line, and a new relative
+    // import is then written between the opener and the path it opens. The
+    // other two strand nothing by declining, and do.
+    it("keeps a content-declined path a pair opened after a using provides", () => {
         expect(scanModuleImports(["using { /A }; using:", "    Foo'Loc'", "code()"])).toEqual([
             { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Foo'Loc'", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
         expect(scanModuleImports(["using:", "    Foo'Loc'", "code()"])).toEqual([]);
         expect(scanModuleImports(["X := 1; using:", "    Foo'Loc'", "code()"])).toEqual([]);


### PR DESCRIPTION
Closes #320

## What

`scanModuleImports` reads the `using:` pair shape in three places, and the branch for a pair opened after a complete `using` statement diverged from the other two on two axes.

**The comment half (fixed).** A complete `using` at the head of the line carries it past the head classification, so the trivia that gate refuses a definition-headed line for rides along. `using { /A }; using: <#>` arrived at that branch with its marker intact, and the path line below it — which the marker comments out — was recorded as imported. A diagnostic asking for that path was then declined and the file never got the import it needs: the mirror of the defect #309 fixed for a pair opened after a definition.

**The content half (deliberately left, and now documented).** The same branch applies no content rule, so `Foo'Loc'` counts as an import there while the other two readers decline it.

## How

The comment rule moves into one closure, `pairPathBelow`, that all three readers share, so a path commented out by its own opener is declined wherever the pair is written. That is the ticket's first acceptance criterion.

The content rule stays opt-in, and the branch for a pair opened after a `using` opts out — the ticket's second acceptance criterion offers exactly this ("or each says in one line why it does not"). Applying it there is a regression, found by the review gate and confirmed by probe:

```
buildOrganizedContent(["using { /A }; using:", "    Foo'Loc'", "code()"], ["Gadgets.Tools"])
  -> "using { /A }; using:\nusing { Gadgets.Tools }\n    Foo'Loc'\ncode()"
```

The statements before the `;` are recorded against the opener line alone, so the pair's entry is the only one whose span reaches the path line. Declining the pair drops that entry, the floor falls to the opener, and a new **relative** import lands between the opener and the path it opens — two lines that must stay adjacent to compile. (An absolute path never raises the floor, which is why this only shows with a relative one.)

The comment rule costs nothing there, because `pinnedSpanEnd` rebuilds that reach from the comment structure itself. A content rule has nothing to rebuild it from. Over-recording the path is the cheaper error: the entry is pinned, so no writer rebuilds the line, and no diagnostic asks for a path of that shape.

`allUsingPaths` is a fourth reader and applies neither rule; its doc now says so, and why — it must fail towards reporting a path, since an empty answer reads as permission to remove an import.

## Tests

- `does not count a path the pair opener comments out` — both markers, `<#>` and an unclosed `<#`. Fails against the unfixed scanner, which returned the commented-out path.
- `keeps a content-declined path a pair opened after a using provides` — pins the deliberate divergence, and that the other two readers decline the same content.
- `writes a new relative import below a pair whose path the content rule declines` — pins the placement the divergence exists for.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       848 passed, 848 total
Snapshots:   0 total
Time:        7.077 s
Ran all test suites.
```

`npm run format:check`

```
Checking formatting...
All matched files use Prettier code style!
```

## Noted, not fixed

Filed as #325: a new import can be written between a `using:` opener and the path it opens, because a pinned entry's floor is computed from its own `endLine` plus comment continuation alone. Pre-existing on `main`, reproduced on an **admitted** pair and so untouched by this change:

```
buildOrganizedContent(["using { /A }; using:", "    Economy.Shop", "code()"], ["Features"])
  -> "using { /A }; using:\nusing { Features }\n    Economy.Shop\ncode()"
```

That same gap is why this PR leaves the after-a-`using` branch classifying nothing: the pair's entry is the only span holding a writer out of the pair, so dropping it on content would add a second way in.
