### PR TITLE
fix(services): drop a skipped module's subtree with its parent

### DIFF
--- a/changelog.d/316.fixed.md
+++ b/changelog.d/316.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: The declarations nested inside a module that cannot be imported are no longer offered as import candidates under a shortened path that does not compile.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -133,7 +133,11 @@ export class ProjectPathScanner {
         const lines = maskCommentsAndStrings(content).split("\n");
 
         let currentModulePath = "";
-        const moduleStack: { name: string; indent: number }[] = [];
+        // A skipped module is on the stack for its indent alone, so that what
+        // it contains is dropped with it rather than losing the enclosing
+        // segment from its path. Nothing is ever pushed above a skipped entry,
+        // because every declaration under one is skipped before it can be.
+        const moduleStack: { name: string; indent: number; skipped: boolean }[] = [];
 
         // A declaration carries any number of stacked specifiers, of which at
         // most one is a visibility; the rest (<native>, <final>, ...) are noise
@@ -213,6 +217,15 @@ export class ProjectPathScanner {
             while (moduleStack.length > 0 && indent <= moduleStack[moduleStack.length - 1].indent) {
                 moduleStack.pop();
             }
+
+            // An import checks every path segment from the root, so anything
+            // still inside a skipped module is as unreachable as the module
+            // and is dropped with it. The pop loop above has already closed
+            // the module for a line that left it.
+            if (moduleStack.length > 0 && moduleStack[moduleStack.length - 1].skipped) {
+                continue;
+            }
+
             currentModulePath = moduleStack.length > 0 ? moduleStack[moduleStack.length - 1].name : "";
 
             const moduleMatch = line.match(modulePattern);
@@ -221,12 +234,14 @@ export class ProjectPathScanner {
                 const visibility = extractVisibility(specifiers);
                 const isPublic = visibility === "public";
 
+                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
+
                 if (shouldSkipDeclaration(visibility, true)) {
+                    moduleStack.push({ name: fullPath, indent, skipped: true });
                     continue;
                 }
 
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-                moduleStack.push({ name: fullPath, indent });
+                moduleStack.push({ name: fullPath, indent, skipped: false });
                 currentModulePath = fullPath;
 
                 nodes.push({

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -116,6 +116,14 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
         expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
     });
 
+    it("resumes the enclosing module after a skipped one nested in it closes", () => {
+        // The skipped entry is popped back to a kept parent rather than to an
+        // empty stack, so a wrong pop bound shows up here as a missing `Outer.`
+        // prefix instead of as a dropped declaration.
+        const source = "Outer<public> := module:\n    Hidden<private> := module:\n        Deep<public> := class {}\n    Kept<public> := class {}\n";
+        expect(declare(source).map((node) => node.fullPath)).toEqual(["Outer", "Outer.Kept"]);
+    });
+
     it("keeps a skipped module's subtree, nested, when includePrivate lifts the skip", () => {
         const source = "Systems<private> := module:\n    Inner<public> := module:\n        Deep<public> := class {}\n";
         expect(declareAll(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.Inner", "Systems.Inner.Deep"]);

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -17,6 +17,8 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
 
     const declare = (source: string): ProjectPathNode[] => scanner.extractDeclarations(source, "Content/Inventory.verse");
 
+    const declareAll = (source: string): ProjectPathNode[] => scanner.extractDeclarations(source, "Content/Inventory.verse", { includePrivate: true });
+
     const moduleNames = (source: string): string[] =>
         declare(source)
             .filter((node) => node.type === "module")
@@ -95,19 +97,28 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
         expect(moduleNames("Systems<scoped_X> := module {}\n")).toEqual(["Systems"]);
     });
 
-    it("promotes a skipped module's descendants to file scope", () => {
-        // Pins the limit rather than endorsing it: a skipped module never
-        // reaches the module stack, so what it contains loses the enclosing
-        // segment from its path instead of being dropped alongside its parent.
+    it("drops a skipped module's descendants along with it", () => {
         // Every segment from the root has to be accessible for an import to
-        // compile, so the subtree is as unreachable as the parent. Long
-        // predates the specifiers this scan newly reads - <private> reads the
-        // same way.
-        const scoped = declare("Systems<scoped{ModuleA}> := module:\n    Inner<public> := module:\n");
-        expect(scoped.map((node) => node.fullPath)).toEqual(["Inner"]);
+        // compile, so what a skipped module contains is exactly as unreachable
+        // as the module itself. Recording the subtree without its enclosing
+        // segment would offer a path that does not exist, and would collide
+        // with a genuine top-level module of the same name.
+        expect(declare("Systems<scoped{ModuleA}> := module:\n    Inner<public> := module:\n")).toEqual([]);
+        expect(declare("Systems<private> := module:\n    Inner<public> := module:\n")).toEqual([]);
+    });
 
-        const priv = declare("Systems<private> := module:\n    Inner<public> := module:\n");
-        expect(priv.map((node) => node.fullPath)).toEqual(["Inner"]);
+    it("drops a skipped module's grandchildren too", () => {
+        expect(declare("Systems<private> := module:\n    Inner<public> := module:\n        Deep<public> := class {}\n")).toEqual([]);
+    });
+
+    it("records a sibling declared after a skipped module closes", () => {
+        const source = "Systems<private> := module:\n    Inner<public> := module:\n\nInventory<public> := module:\n    Item<public> := class {}\n";
+        expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
+    });
+
+    it("keeps a skipped module's subtree, nested, when includePrivate lifts the skip", () => {
+        const source = "Systems<private> := module:\n    Inner<public> := module:\n        Deep<public> := class {}\n";
+        expect(declareAll(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.Inner", "Systems.Inner.Deep"]);
     });
 
     it("does not read a keyword that merely starts with module as a declaration", () => {


### PR DESCRIPTION
Closes #316

`extractDeclarations` skipped a module it judged unimportable but `continue`d before the module reached `moduleStack`. The stack supplies the enclosing segment of every `fullPath` below it, so the subtree did not go away with its parent — it was promoted to file scope, producing a path the compiler rejects and a spurious second candidate for any genuine top-level module of the same name.

A skipped module now reaches the stack marked `skipped`, holding its indent, and every declaration under one is dropped with it. Grandchildren need no separate handling: they are deeper than the skipped entry, so it is still open when they are read. `includePrivate` lifts this along with the two checks it already lifted, so a caller asking for everything gains the subtree nested rather than losing it.

## Behaviour change

For `Systems<private or scoped{...}> := module:` containing `Inner<public> := module:` containing `X`:

| | Before | After |
| --- | --- | --- |
| Recorded | `Inner`, `Inner.X` | nothing |
| `includePrivate: true` | `Systems`, `Systems.Inner`, `Systems.Inner.X` | unchanged |

## Tests

`promotes a skipped module's descendants to file scope` inverted to `drops a skipped module's descendants along with it`. Added: a grandchild two levels down, a sibling declared after the skipped module closes, the `includePrivate: true` path, and a skipped module nested inside a kept one — the case where the pop unwinds back to a kept parent, so a wrong pop bound surfaces as a missing prefix rather than a dropped node.

The first three fail against the unfixed scanner, each returning the promoted `Inner` / `Inner.Deep` paths. The `includePrivate` case passes before and after by design: it guards the lift rather than detecting the defect.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       849 passed, 849 total
Snapshots:   0 total
Time:        12.629 s
Ran all test suites.
```

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh context, verdict `PASS_WITH_SUGGESTIONS` — no Critical findings. The reviewer compiled the scanner and ran inputs through it rather than reading alone, confirming: the "nothing is pushed above a skipped entry" invariant holds, so the top-of-stack test is equivalent to scanning the stack; no stale `currentModulePath` leaks past the gate; a `#` comment at column 0 inside a skipped module does not close it; tab-indented bodies drop; consecutive skipped siblings do not swallow the following kept module.

Two findings noted and deliberately not taken here, both pre-existing and outside this ticket:

- **The next-line brace form still promotes its subtree.** `Systems<private> := module` with `{` on the following line leaks `Inner` and `Deep` to file scope. The bare `{` sits at the declaration's own indent, so the existing pop rule closes the skipped entry before the body is read. That rule is already pinned for a public parent by `leaves the members of a next-line brace module unnested`, and the prescribed mechanism in #316 is implemented to the letter. Worth its own ticket against the pop rule.
- **`currentModulePath = fullPath` is a dead store** — line 229 recomputes it from the stack top before any read. Pre-existing; removing it is a refactor this ticket did not ask for.
