### PR TITLE
fix(imports): require diagnostic evidence before a pinned import raises a ceiling

### DIFF
--- a/changelog.d/313.fixed.md
+++ b/changelog.d/313.fixed.md
@@ -1,0 +1,1 @@
+**Imports**: an auto-added import is no longer written above an existing dotted import that does not need it, where it could land above the import bringing its own first segment into scope.

--- a/changelog.d/313.fixed.md
+++ b/changelog.d/313.fixed.md
@@ -1,1 +1,1 @@
-**Imports**: an auto-added import is no longer written above an existing dotted import that does not need it, where it could land above the import bringing its own first segment into scope.
+**Import placement**: a newly added import is written above an import held on its line only when the compiler reported the problem there, so it no longer lands above the import bringing its first segment into scope.

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -105,11 +105,20 @@ export class CommandsHandler {
         await this.deps.moduleVisibilityWriter.makeModulePublic(request);
     }
 
-    async addSingleImport(document: vscode.TextDocument, importStatement: string): Promise<void> {
+    /**
+     * Adds one import statement to a document.
+     *
+     * @param diagnosticLine The 0-based line the diagnostic behind this import
+     *   was reported on, which decides whether a pinned import may be read as
+     *   the one that needs it. Optional because a caller that cannot name a
+     *   diagnostic must not imply it knows of one - placement then follows the
+     *   written order alone.
+     */
+    async addSingleImport(document: vscode.TextDocument, importStatement: string, diagnosticLine?: number): Promise<void> {
         // A false here means applyEdit was rejected - a stale document version
         // or a read-only file - and the document is unchanged. Reporting the
         // import as added would leave the only trace in the output channel.
-        const applied = await this.deps.importHandler.addImportsToDocument(document, [importStatement]);
+        const applied = await this.deps.importHandler.addImportsToDocument(document, [importStatement], diagnosticLine === undefined ? undefined : new Map([[importStatement, [diagnosticLine]]]));
 
         if (!applied) {
             logger.warn("CommandsHandler", `Failed to add import: ${importStatement}`);

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -157,6 +157,21 @@ export class DiagnosticsHandler {
                 const multiOptionStrategy = config.get<string>("behavior.multiOptionStrategy", "quickfix");
 
                 const autoImportSuggestions = new Set<string>();
+                // The line a diagnostic was reported on, kept beside the
+                // statement it asked for. Placement needs it to tell a pinned
+                // import that failed to resolve from one that merely looks as
+                // though it could (ImportDocumentEditor.couldResolveAgainst),
+                // and this loop is the last place it exists.
+                //
+                // Both go through one function so the set and the map cannot
+                // disagree about which statements were added: a statement in
+                // the set with no line placed as though no diagnostic asked for
+                // it, which is the reading this signal exists to correct.
+                const diagnosticLinesByStatement = new Map<string, number[]>();
+                const recordSuggestion = (statement: string, diagnostic: vscode.Diagnostic): void => {
+                    autoImportSuggestions.add(statement);
+                    diagnosticLinesByStatement.set(statement, [...(diagnosticLinesByStatement.get(statement) ?? []), diagnostic.range.start.line]);
+                };
                 let hasMultiOptionSuggestions = false;
 
                 for (const diagnostic of currentDiagnostics) {
@@ -173,7 +188,7 @@ export class DiagnosticsHandler {
                         if (multiOptionStrategy.startsWith("auto_")) {
                             const selectedSuggestion = this.selectBestSuggestion(suggestions, multiOptionStrategy);
                             if (selectedSuggestion && autoImportEnabled) {
-                                autoImportSuggestions.add(selectedSuggestion.importStatement);
+                                recordSuggestion(selectedSuggestion.importStatement, diagnostic);
                                 logger.debug("DiagnosticsHandler", `Auto-selected: ${selectedSuggestion.importStatement}`);
                             }
                         }
@@ -185,7 +200,7 @@ export class DiagnosticsHandler {
                     const suggestion = suggestions[0];
                     if (autoImportEnabled && suggestion.confidence === "high") {
                         logger.debug("DiagnosticsHandler", `Adding high-confidence import: ${suggestion.importStatement}`);
-                        autoImportSuggestions.add(suggestion.importStatement);
+                        recordSuggestion(suggestion.importStatement, diagnostic);
                     } else {
                         logger.debug("DiagnosticsHandler", `Low confidence or auto-import disabled - will use quick fix for: ${suggestion.importStatement}`);
                     }
@@ -209,7 +224,7 @@ export class DiagnosticsHandler {
                     // The edit is rejected when the document moved on between
                     // the read and the write, or when the file is read-only.
                     // Reporting the imports as applied hides that entirely.
-                    const applied = await this.importHandler.addImportsToDocument(document, Array.from(autoImportSuggestions));
+                    const applied = await this.importHandler.addImportsToDocument(document, Array.from(autoImportSuggestions), diagnosticLinesByStatement);
 
                     if (applied) {
                         vscode.window.setStatusBarMessage(`Auto-imported ${autoImportSuggestions.size} statements to ${displayName}`, 3000);

--- a/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
+++ b/src/diagnostics/__tests__/DiagnosticsHandler.test.ts
@@ -146,7 +146,7 @@ function makeDocument(fsPath = "C:\\Project\\Content\\device.verse"): vscode.Tex
 describe("DiagnosticsHandler auto-import suppression", () => {
     beforeEach(() => {
         jest.useFakeTimers();
-        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`." }]);
+        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`.", range: { start: { line: 7 } } }]);
     });
 
     afterEach(() => {
@@ -194,7 +194,7 @@ describe("DiagnosticsHandler debounce keying", () => {
 
     beforeEach(() => {
         jest.useFakeTimers();
-        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`." }]);
+        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`.", range: { start: { line: 7 } } }]);
     });
 
     afterEach(() => {
@@ -256,7 +256,7 @@ describe("DiagnosticsHandler debounce keying", () => {
 describe("DiagnosticsHandler auto-import failure reporting", () => {
     beforeEach(() => {
         jest.useFakeTimers();
-        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`." }]);
+        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`.", range: { start: { line: 7 } } }]);
     });
 
     afterEach(() => {
@@ -300,7 +300,7 @@ describe("DiagnosticsHandler auto-import failure reporting", () => {
 describe("DiagnosticsHandler teardown", () => {
     beforeEach(() => {
         jest.useFakeTimers();
-        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`." }]);
+        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`.", range: { start: { line: 7 } } }]);
     });
 
     afterEach(() => {

--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -88,10 +88,13 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
         action.kind = vscode.CodeActionKind.QuickFix.append("verse.import");
         action.diagnostics = [diagnostic];
 
+        // The diagnostic's line travels with the statement: placement reads it
+        // to tell a pinned import that failed to resolve, and so needs this
+        // import above it, from one that merely has the form of a consumer.
         action.command = {
             title: "Add Import",
             command: "verseAutoImports.addSingleImport",
-            arguments: [document, suggestion.importStatement],
+            arguments: [document, suggestion.importStatement, diagnostic.range.start.line],
         };
 
         return action;

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -312,12 +312,16 @@ export class ImportDocumentEditor {
      * This is the one place a newly added import is read as the provider rather
      * than the consumer, and it overrides the written order every other rule
      * here keeps. `diagnosticLines` is what licenses that override: a diagnostic
-     * reported inside this import's own statement is the compiler saying this
-     * import is the one that failed to resolve, so whatever is being added for
-     * it has to precede it. Form alone cannot say that. A pinned dotted import
-     * that already resolves is far commoner - the file compiled before the edit
-     * - and against one of those the new import is the consumer, which the
-     * written order keeps below it.
+     * reported on this import's own line is the compiler saying something there
+     * failed to resolve, so whatever is being added for it has to precede it.
+     * Form alone cannot say that. A pinned dotted import that already resolves
+     * is far commoner - the file compiled before the edit - and against one of
+     * those the new import is the consumer, which the written order keeps below
+     * it.
+     *
+     * A line, not a range, so an import pinned by a statement sharing its line
+     * still takes the override from a diagnostic about that other statement.
+     * Narrowing it needs a column, which ScannedImport does not carry.
      *
      * Still kept to a pinned dotted consumer and a new import that can supply a
      * first segment for it, because the override is only worth the risk that
@@ -642,9 +646,9 @@ export class ImportDocumentEditor {
                 logger.debug("ImportDocumentEditor", `New import needed: ${path}`);
                 newImportPaths.add(path);
 
-                const lines = diagnosticLinesByStatement?.get(imp);
-                if (lines?.length) {
-                    diagnosticLinesByPath.set(path, [...(diagnosticLinesByPath.get(path) ?? []), ...lines]);
+                const diagnosticLines = diagnosticLinesByStatement?.get(imp);
+                if (diagnosticLines?.length) {
+                    diagnosticLinesByPath.set(path, [...(diagnosticLinesByPath.get(path) ?? []), ...diagnosticLines]);
                 }
             }
         });

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -156,12 +156,12 @@ function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]
  *   (ImportFormatter.resolvesAgainstScopeAbove). Any of them can be bringing
  *   its first segment into scope, so it goes below all of them. An absolute
  *   path needs nothing above it and is unconstrained.
- * - `ceiling` - the first line of the highest pinned import that could be
- *   resolving against the new one (couldResolveAgainst). The new import goes
+ * - `ceiling` - the first line of the highest pinned import a diagnostic shows
+ *   is resolving against the new one (couldResolveAgainst). The new import goes
  *   directly above it, and that import raises no floor: see pinnedBounds.
  *
- * See couldResolveAgainst for why the override exists, and placementLine for
- * which bound wins where two pinned imports disagree.
+ * See couldResolveAgainst for what counts as that evidence, and placementLine
+ * for which bound wins where two pinned imports disagree.
  *
  * `-1` means unconstrained in that direction.
  */
@@ -169,6 +169,18 @@ interface PinnedBounds {
     floor: number;
     ceiling: number;
 }
+
+/**
+ * The lines of the diagnostics that asked for each newly added import, keyed on
+ * the import's path. Only couldResolveAgainst reads it.
+ */
+type DiagnosticLinesByPath = ReadonlyMap<string, readonly number[]>;
+
+/**
+ * For a caller that cannot name the diagnostic behind a path. It raises no
+ * ceiling, which is the ordering every other rule here keeps.
+ */
+const NO_DIAGNOSTIC_LINES: DiagnosticLinesByPath = new Map();
 
 /**
  * Managing a document's import block: adding the imports a diagnostic asked
@@ -293,25 +305,35 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * Whether an existing import of rank `existing` could be resolving against
-     * a newly added import of rank `rank`, which is what forces the new one
-     * above it rather than merely preferring it there.
+     * Whether `imp` is the pinned import a newly added import of rank `rank`
+     * was added for, which forces the new one above it rather than merely
+     * preferring it there.
      *
      * This is the one place a newly added import is read as the provider rather
-     * than the consumer, and it deliberately overrides the written order every
-     * other rule here keeps: the import is being added because a diagnostic
-     * asked for it, and a pinned dotted import whose first segment is missing
-     * is a diagnostic the extension cannot tell from any other. Placing the new
-     * import below it would decline to fix the one file this case exists for.
+     * than the consumer, and it overrides the written order every other rule
+     * here keeps. `diagnosticLines` is what licenses that override: a diagnostic
+     * reported inside this import's own statement is the compiler saying this
+     * import is the one that failed to resolve, so whatever is being added for
+     * it has to precede it. Form alone cannot say that. A pinned dotted import
+     * that already resolves is far commoner - the file compiled before the edit
+     * - and against one of those the new import is the consumer, which the
+     * written order keeps below it.
      *
-     * Kept to a pinned dotted consumer and a new import that can supply a first
-     * segment for it, because the override is only worth the risk that narrowly.
-     * The consequence of an upper bound here is refusing every block and writing
-     * a standalone line, so widening it fragments a file into import regions to
-     * satisfy nothing.
+     * Still kept to a pinned dotted consumer and a new import that can supply a
+     * first segment for it, because the override is only worth the risk that
+     * narrowly. The consequence of an upper bound here is refusing every block
+     * and writing a standalone line, so widening it fragments a file into
+     * import regions to satisfy nothing.
+     *
+     * @param diagnosticLines 0-based lines of the diagnostics that asked for the
+     *   new import. Empty where the caller knows of none, and empty raises no
+     *   ceiling.
      */
-    private couldResolveAgainst(existing: number, rank: number): boolean {
-        return existing === 2 && rank < 2;
+    private couldResolveAgainst(imp: ScannedImport, rank: number, diagnosticLines: readonly number[]): boolean {
+        if (this.formatter.importRank(imp.path) !== 2 || rank >= 2) {
+            return false;
+        }
+        return diagnosticLines.some((line) => line >= imp.startLine && line <= imp.endLine);
     }
 
     /**
@@ -353,6 +375,10 @@ export class ImportDocumentEditor {
      * since a block above every pinned line, and a path written directly below
      * this floor, both precede every pinned import further down.
      *
+     * The diagnostic evidence still has to reach it, because a pinned import
+     * that evidence shows is the consumer raises no floor either - carrying the
+     * new import past that one is the fix the diagnostic asked for.
+     *
      * A ceiling raised *above* the floor is the one it genuinely drops: the
      * path lands below a pinned import that could have been the consumer it was
      * added for, leaving that diagnostic unfixed. Deliberate - the alternative
@@ -361,11 +387,12 @@ export class ImportDocumentEditor {
      *
      * Exempts the path from itself for the reason crossesPinnedProvider does.
      */
-    private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string): number {
+    private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string, diagnosticLines: DiagnosticLinesByPath): number {
         return this.pinnedBounds(
             pinned.filter((imp) => imp.path !== path),
             classifications,
             path,
+            diagnosticLines,
         ).floor;
     }
 
@@ -373,9 +400,10 @@ export class ImportDocumentEditor {
      * Where the imports pinned to their line allow a new `path` to be written.
      * See PinnedBounds.
      */
-    private pinnedBounds(pinned: ScannedImport[], classifications: LineClassification[], path: string): PinnedBounds {
+    private pinnedBounds(pinned: ScannedImport[], classifications: LineClassification[], path: string, diagnosticLines: DiagnosticLinesByPath): PinnedBounds {
         const rank = this.formatter.importRank(path);
         const needsScopeAbove = this.formatter.resolvesAgainstScopeAbove(path);
+        const linesForPath = diagnosticLines.get(path) ?? [];
 
         let floor = -1;
         let ceiling = -1;
@@ -385,7 +413,7 @@ export class ImportDocumentEditor {
             // below the ceiling it raised, and blockIsWithin would then refuse
             // every block - including one lying entirely above the ceiling,
             // which satisfies the ceiling and the written order both.
-            if (this.couldResolveAgainst(this.formatter.importRank(imp.path), rank)) {
+            if (this.couldResolveAgainst(imp, rank, linesForPath)) {
                 ceiling = ceiling === -1 ? imp.startLine : Math.min(ceiling, imp.startLine);
                 continue;
             }
@@ -405,13 +433,13 @@ export class ImportDocumentEditor {
      * Both halves matter:
      *
      * - The ceiling wins over the floor. Only couldResolveAgainst raises one,
-     *   and it is that predicate's deliberate override: the new import is read
-     *   as the provider a pinned dotted import is missing, so it goes above it.
-     *   The floor is the opposite reading of the same file - a pinned import
-     *   further down could be what the new import resolves through - and the
-     *   two cannot both be honoured. Honouring the floor leaves the diagnostic
-     *   that asked for the import unfixed, which is the case the override
-     *   exists for.
+     *   and only where a diagnostic inside the pinned import's own statement
+     *   shows it is the one that failed to resolve: the new import is read as
+     *   the provider that import is missing, so it goes above it. The floor is
+     *   the opposite reading of the same file - a pinned import further down
+     *   could be what the new import resolves through - and the two cannot both
+     *   be honoured. Honouring the floor leaves the diagnostic that asked for
+     *   the import unfixed, which is the case the override exists for.
      * - Taken exactly, because the ceiling is the *lowest* legal line: the new
      *   import must precede that statement, so everything below the ceiling is
      *   ruled out and everything above it is merely further away. Landing
@@ -457,10 +485,10 @@ export class ImportDocumentEditor {
      * starting from the line the site would have used had no import been
      * pinned. Paths wanting the same line are written together.
      */
-    private groupByPlacementLine(paths: string[], desired: number, pinned: ScannedImport[], classifications: LineClassification[]): Map<number, string[]> {
+    private groupByPlacementLine(paths: string[], desired: number, pinned: ScannedImport[], classifications: LineClassification[], diagnosticLines: DiagnosticLinesByPath): Map<number, string[]> {
         const byLine = new Map<number, string[]>();
         for (const path of paths) {
-            const line = this.placementLine(desired, this.pinnedBounds(pinned, classifications, path));
+            const line = this.placementLine(desired, this.pinnedBounds(pinned, classifications, path, diagnosticLines));
             byLine.set(line, [...(byLine.get(line) ?? []), path]);
         }
         return new Map([...byLine].sort(([a], [b]) => a - b));
@@ -542,8 +570,14 @@ export class ImportDocumentEditor {
      * path is merged into an existing block or written on its own line beside
      * the imports it must sit relative to; with it off, the movable imports are
      * consolidated at the top, bar any a pinned line holds where it is.
+     *
+     * @param diagnosticLinesByStatement The 0-based lines of the diagnostics
+     *   that asked for each statement, keyed on the statement as it appears in
+     *   `importStatements`. A statement with no entry is placed by the written
+     *   order alone; only couldResolveAgainst reads these, to tell a pinned
+     *   import that failed to resolve from one that merely looks like it could.
      */
-    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[]): Promise<boolean> {
+    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: ReadonlyMap<string, readonly number[]>): Promise<boolean> {
         logger.info("ImportDocumentEditor", `Adding ${importStatements.length} import statements to document`);
 
         const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -597,11 +631,21 @@ export class ImportDocumentEditor {
         const relocatablePaths = new Set<string>(rewritableImports(scannedImports).map((imp) => imp.path));
 
         const newImportPaths = new Set<string>();
+        // Re-keyed from the statement the caller holds to the path every
+        // placement rule below works in, and concatenated where two statements
+        // share a path: a second diagnostic asking for the same import is
+        // further evidence, not a replacement for the first.
+        const diagnosticLinesByPath = new Map<string, number[]>();
         importStatements.forEach((imp) => {
             const path = this.formatter.extractPathFromImport(imp);
             if (path && !existingPaths.has(path)) {
                 logger.debug("ImportDocumentEditor", `New import needed: ${path}`);
                 newImportPaths.add(path);
+
+                const lines = diagnosticLinesByStatement?.get(imp);
+                if (lines?.length) {
+                    diagnosticLinesByPath.set(path, [...(diagnosticLinesByPath.get(path) ?? []), ...lines]);
+                }
             }
         });
 
@@ -668,7 +712,7 @@ export class ImportDocumentEditor {
                     const taken: string[] = [];
                     const unhandled: string[] = [];
                     for (const path of paths) {
-                        const canTake = blockIndex >= 0 && this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path));
+                        const canTake = blockIndex >= 0 && this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path, diagnosticLinesByPath));
                         (canTake ? taken : unhandled).push(path);
                     }
                     return { taken, unhandled };
@@ -691,7 +735,7 @@ export class ImportDocumentEditor {
 
                 if (unhandledPaths.length > 0) {
                     const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;
-                    for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, pinned, classifications)) {
+                    for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, pinned, classifications, diagnosticLinesByPath)) {
                         this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, importBlocks.length === 0);
                     }
                 }
@@ -706,7 +750,9 @@ export class ImportDocumentEditor {
                     // hasGrouping branch above), so every relocated path is
                     // already inside the block being rebuilt in place.
                     const displacedPaths =
-                        importBlocks.length > 0 ? Array.from(newImportPaths).filter((path) => !this.blockIsWithin(importBlocks[0], this.pinnedBounds(pinned, classifications, path))) : [];
+                        importBlocks.length > 0
+                            ? Array.from(newImportPaths).filter((path) => !this.blockIsWithin(importBlocks[0], this.pinnedBounds(pinned, classifications, path, diagnosticLinesByPath)))
+                            : [];
                     const displaced = new Set(displacedPaths);
 
                     const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths].filter((path) => !displaced.has(path)));
@@ -729,7 +775,7 @@ export class ImportDocumentEditor {
                             edit.delete(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)));
                         }
 
-                        for (const [line, paths] of this.groupByPlacementLine(displacedPaths, firstBlock.end + 1, pinned, classifications)) {
+                        for (const [line, paths] of this.groupByPlacementLine(displacedPaths, firstBlock.end + 1, pinned, classifications, diagnosticLinesByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, false);
                         }
                     } else {
@@ -746,7 +792,7 @@ export class ImportDocumentEditor {
                         // rewritable import opens or extends a block, so no
                         // block means none of them, which is also why the
                         // trailing comments here are always empty.
-                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, 0, pinned, classifications)) {
+                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, 0, pinned, classifications, diagnosticLinesByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, true);
                         }
                     }
@@ -776,7 +822,7 @@ export class ImportDocumentEditor {
                         const pathsByBlock = new Map<number, string[]>();
                         const unblockedPaths: string[] = [];
                         for (const path of newImportPathsArray) {
-                            const bounds = this.pinnedBounds(pinned, classifications, path);
+                            const bounds = this.pinnedBounds(pinned, classifications, path, diagnosticLinesByPath);
                             const eligible = importBlocks.map((block, index) => ({ block, index })).filter(({ block }) => this.blockIsWithin(block, bounds));
 
                             if (eligible.length === 0) {
@@ -822,7 +868,7 @@ export class ImportDocumentEditor {
                             this.createBlockReplacementEdit(edit, document, importBlocks[index], pathsByBlock.get(index)!, preferDotSyntax, true, eol);
                         }
 
-                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, 0, pinned, classifications)) {
+                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, 0, pinned, classifications, diagnosticLinesByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), eol, true);
                         }
                     } else {
@@ -849,7 +895,7 @@ export class ImportDocumentEditor {
                         const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;
                         const blankLineAfter = importBlocks.length === 0;
 
-                        for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, pinned, classifications)) {
+                        for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, pinned, classifications, diagnosticLinesByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, blankLineAfter);
                         }
                     }
@@ -868,7 +914,7 @@ export class ImportDocumentEditor {
             const blockPaths = new Set<string>(Array.from(relocatablePaths).filter((path) => !grounded.has(path)));
             const newPathsByLine = new Map<number, string[]>();
             for (const path of newImportPaths) {
-                const floor = this.hoistFloor(pinned, classifications, path);
+                const floor = this.hoistFloor(pinned, classifications, path, diagnosticLinesByPath);
                 if (floor === -1) {
                     blockPaths.add(path);
                     continue;
@@ -1055,7 +1101,10 @@ export class ImportDocumentEditor {
         const topExtraPaths: string[] = [];
         const groundedExtrasByLine = new Map<number, string[]>();
         for (const path of extraPaths) {
-            const floor = this.hoistFloor(pinned, classifications, path);
+            // No diagnostic reaches here: organizing is not a fix for one, so
+            // no pinned import can be shown to be the consumer and every one of
+            // them raises its floor.
+            const floor = this.hoistFloor(pinned, classifications, path, NO_DIAGNOSTIC_LINES);
             if (floor === -1) {
                 topExtraPaths.push(path);
                 continue;

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -295,8 +295,9 @@ export class ImportFormatter {
      *
      * Ranks 1 and 2 differ in form, not in ordering: either can bring the scope
      * the other resolves through, so neither belongs above the other. Which of
-     * the two a path is still decides one thing - whether a pinned import can
-     * be read as the consumer a newly added one was added for
+     * the two a path is still narrows one thing - whether a pinned import may
+     * be read as the consumer a newly added one was added for, which takes a
+     * diagnostic to establish and not the form alone
      * (ImportDocumentEditor.couldResolveAgainst). Everything else asks only
      * whether the rank is 0, through resolvesAgainstScopeAbove.
      */

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -37,8 +37,8 @@ export class ImportHandler {
         return this.suggestionExtractor.extractImportSuggestions(errorMessage);
     }
 
-    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[]): Promise<boolean> {
-        return this.documentEditor.addImportsToDocument(document, importStatements);
+    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: ReadonlyMap<string, readonly number[]>): Promise<boolean> {
+        return this.documentEditor.addImportsToDocument(document, importStatements, diagnosticLinesByStatement);
     }
 
     /**

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -27,7 +27,7 @@ describe("ImportCodeActionProvider quick fix titles", () => {
         const actions = await provider.provideCodeActions(
             { uri: { toString: () => "file:///Project/Content/Scripts/device.verse" } } as unknown as vscode.TextDocument,
             {} as unknown as vscode.Range,
-            { diagnostics: [{ message: "Unknown identifier `button_device`" }] } as unknown as vscode.CodeActionContext,
+            { diagnostics: [{ message: "Unknown identifier `button_device`", range: { start: { line: 7 } } }] } as unknown as vscode.CodeActionContext,
             {} as unknown as vscode.CancellationToken,
         );
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -434,6 +434,15 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             expect(editor.buildOrganizedContent(input, ["Economy.Other"], curlySorted)).toBe(["using { Features } <#> note", "    body", "using { Economy.Other }", "code()"].join("\n"));
         });
 
+        // A pinned dotted import is a possible provider like any other: it can
+        // bring the added path's first segment into scope. Organizing names no
+        // diagnostic, so nothing here can show it is the consumer instead, and
+        // the added path stays below it.
+        it("writes an added bare consumer below a pinned dotted import", () => {
+            const input = ["using { Economy.Shop } <#> note", "    body", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted)).toBe(["using { Economy.Shop } <#> note", "    body", "using { Features }", "code()"].join("\n"));
+        });
+
         // Only the paths the pinned import could provide are held back. An
         // absolute path needs nothing in scope, so the file is still organized
         // around what stays.
@@ -1692,6 +1701,27 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
         });
 
+        // The span is two lines and the compiler reports an unresolved path on
+        // the path line, so the bound is the pinned import's end and not its
+        // start. Narrowed to the start, this file takes no ceiling and the
+        // provider is written below the statement that needs it.
+        it("takes the ceiling from a diagnostic on the second line of a pinned indented pair", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Other }; using:", "    Economy.Shop", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 1));
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
         // A caller that names no diagnostic has to be read as evidence of
         // nothing, not as evidence for the override: the override is what
         // breaks a compiling file when it is wrong.
@@ -1798,6 +1828,29 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const deletes = operations.filter((op) => op.kind === "delete");
             expect(deletes).toHaveLength(1);
             expect(deletes[0].range).toEqual({ start: { line: 1, character: 0 }, end: { line: 2, character: 0 } });
+        });
+
+        // The same shape as the test below, with no diagnostic naming the
+        // pinned line. Nothing then shows the pinned dotted import is the
+        // consumer, and it may be what brings the new path's first segment into
+        // scope, so the new import is written below it rather than carried into
+        // the block that consolidates above it.
+        it("keeps a new import below the pinned dotted line when no diagnostic names it", async () => {
+            mockConfig(consolidating);
+            const input = ["using { /A }", "code()", "using { Economy.Shop }; X := 1", "more()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+
+            const top = operations.find((op) => op.kind === "insert" && op.position!.line === 0);
+            expect(top).toBeDefined();
+            expect(top!.text).toBe("using { /A }\n");
+
+            const below = operations.find((op) => op.kind === "insert" && op.text.includes("using { Features }"));
+            expect(below).toBeDefined();
+            expect(below!.position!.line).toBe(3);
         });
 
         it("still consolidates a new provider the pinned consumer below it may need", async () => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -756,6 +756,16 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
     let editor: ImportDocumentEditor;
     const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
 
+    /**
+     * The diagnostic-line argument addImportsToDocument takes, for one statement
+     * the compiler reported on one line.
+     *
+     * A pinned import is read as the consumer of a new import only where a
+     * diagnostic lands inside its own statement, so a call that omits this is
+     * exercising the no-evidence path and expects the written order to hold.
+     */
+    const reportedOn = (statement: string, line: number): ReadonlyMap<string, readonly number[]> => new Map([[statement, [line]]]);
+
     beforeEach(() => {
         const outputChannel = vscode.window.createOutputChannel("test");
         editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
@@ -1366,7 +1376,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             });
             const input = ["using { Economy.Shop } <#> note", "    body", "", "using { /Verse.org/Simulation }", "code()"].join("\n");
 
-            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
             const operations = appliedOperations(0);
@@ -1393,7 +1403,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             });
             const input = ["using { /Verse.org/Simulation }", "", "using { Economy.Shop } <#> note", "    body", "code()"].join("\n");
 
-            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
 
             expect(success).toBe(true);
             const operations = appliedOperations(0);
@@ -1434,7 +1444,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             });
             const input = ["using { Economy.Shop } <#> note", "    body", "using { /A } <#> note", "    body", "code()"].join("\n");
 
-            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
             const insert = appliedOperations(0).find((op) => op.kind === "insert");
@@ -1456,7 +1466,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             });
             const input = ["# Copyright 2026 MyGame", "", "using { Economy.Shop } <#> note", "    body", "using { /Verse.org/Simulation }", "code()"].join("\n");
 
-            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
 
             expect(success).toBe(true);
             const insert = appliedOperations(0).find((op) => op.kind === "insert");
@@ -1546,7 +1556,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             });
             const input = ["using { Economy.Shop } <#> note", "    body", "using { /Verse.org/Simulation }", "code()"].join("\n");
 
-            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
             const operations = appliedOperations(0);
@@ -1641,7 +1651,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             });
             const input = ["using { Economy.Shop }; MyVal := 5", "using { /Verse.org/Simulation }", "code()"].join("\n");
 
-            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
             const operations = appliedOperations(0);
@@ -1653,6 +1663,56 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(insert).toBeDefined();
             expect(insert!.position!.line).toBe(0);
             expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // The same file and the same new import as the test above, differing
+        // only in where the compiler reported the problem - which is the whole
+        // rule. A pinned dotted import that already resolves is the common case,
+        // since the file compiled before this edit, and there it may be what
+        // brings the new import's own first segment into scope. Reading it as
+        // the consumer on the strength of its path form puts the new import
+        // above the provider it needs.
+        it("writes a new import below a pinned dotted import when the diagnostic points elsewhere", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Economy.Shop }; MyVal := 5", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(1);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+        });
+
+        // A caller that names no diagnostic has to be read as evidence of
+        // nothing, not as evidence for the override: the override is what
+        // breaks a compiling file when it is wrong.
+        it("writes a new import below a pinned dotted import when no diagnostic is named", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Economy.Shop }; MyVal := 5", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(1);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
         });
 
         it("sort OFF: appends below the pinned provider rather than after the last block", async () => {
@@ -1744,7 +1804,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             mockConfig(consolidating);
             const input = ["using { /A }", "code()", "using { Economy.Shop }; X := 1"].join("\n");
 
-            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
 
             expect(success).toBe(true);
             const operations = appliedOperations(0);


### PR DESCRIPTION
Closes #313

`ImportDocumentEditor.couldResolveAgainst` decided on path form alone — `existing === 2 && rank < 2` — so any pinned dotted import raised a placement ceiling and `placementLine` took it exactly, writing the newly added import directly above that line. That reading is right only where the pinned import is itself broken. Where it already resolves — the common case, since the file compiled before the edit — the pinned import may be what brings the new import's first segment into scope, and writing the new one above it is the #271 inversion reintroduced on the pinned path.

## Approach

Option 1 from the ticket. The diagnostic's line is reachable at the placement seam, so it is threaded there rather than dropping the ceiling wholesale:

- `addImportsToDocument` takes an optional `diagnosticLinesByStatement`, re-keyed internally onto paths.
- `couldResolveAgainst` now takes the pinned import itself and raises a ceiling only where a diagnostic lands within `startLine..endLine`. **No evidence raises no ceiling**, so any caller that cannot name a diagnostic gets the written order.
- The two entry points that held the diagnostic and discarded it now pass it: the auto-import loop in `DiagnosticsHandler`, and the quick fix via `ImportCodeActionProvider` → `CommandsHandler.addSingleImport` (third argument optional — the command is registered in `package.json`).

Option 2 was rejected because it would regress the case the override exists for, which `ImportDocumentEditor.test.ts` already covered.

## One thing beyond the plan

The evidence also had to reach `hoistFloor`. `couldResolveAgainst` suppresses the **floor** as well, via the `continue` in `pinnedBounds`, and `hoistFloor` reads that floor from the consolidate and organize paths. Leaving it out would have made consolidation refuse to carry a provider past a pinned consumer even when a diagnostic proved it was needed.

The visible consequence is that Optimize Imports and consolidation now keep an added relative path below a pinned dotted import instead of hoisting it above — the same inversion this ticket is about, on those paths. Both directions are covered by new tests; flag it if you would rather that half were split out.

## Known limit

The evidence is a line, not a range. An import pinned by a statement sharing its line still takes the override from a diagnostic about that other statement, because `ScannedImport` carries no column. Documented at the predicate; say the word and I will file it.

## Tests

Five added, each verified to fail against the unfixed predicate before being kept:

- placement below a pinned dotted import when the diagnostic points elsewhere, and when none is named at all
- the ceiling taken from the second line of a pinned indented `using:` pair — the only test that fails if the bound narrows to `startLine`
- the organize path (`buildOrganizedContent`) and the consolidate path with no diagnostic

Six existing tests that pinned the old form-only behaviour now supply a diagnostic line inside the pinned span and keep their original expectations, so the "keep it where it is right" half stays covered.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

Test Suites: 40 passed, 40 total
Tests:       850 passed, 850 total
Snapshots:   0 total
Time:        6.871 s

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"
Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, Opus, fresh context: `PASS_WITH_SUGGESTIONS` — no Critical. The Important finding (the `hoistFloor` behaviour change had no test) and three suggestions (shadowed local, doc overstating what a line proves, changelog wording) are applied in `adcd1db`. It independently confirmed the key-agreement, command-argument and `endLine`-bound questions.
