### PR TITLE
refactor(imports): read the converter's dotted path through the shared pattern

### DIFF
--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -45,6 +45,7 @@ const CONTENT_FOLDER = "Content";
 export class ImportPathConverter {
     private readonly projectPathHandler: ProjectPathHandler;
     private projectPathCache: ProjectPathCache | null = null;
+    private readonly formatter = new ImportFormatter();
 
     constructor(
         private readonly outputChannel: vscode.OutputChannel,
@@ -126,20 +127,19 @@ export class ImportPathConverter {
 
     /**
      * The path a `using` statement names, with any trailing comment removed,
-     * or "" when the statement is in neither style.
+     * or "" when the statement names nothing.
      *
-     * Anchored on the trimmed statement, and dotted before braced, to match
-     * ImportFormatter. Unanchored, the braced pattern is free to match inside
-     * the trailing comment of a dotted statement and win the path - which
-     * misclassifies the import through isFullPathImport and isBuiltinModule as
-     * well as converting the wrong module.
+     * Read through ImportFormatter rather than from a copy of its patterns, so
+     * the converter cannot disagree with the rest of the extension about how
+     * much of a line the statement occupies. A copy that ends the dotted form
+     * at end of line instead converts whatever a line writes after its
+     * statement along with the path.
+     *
+     * "" where the formatter answers null, because isFullPathImport and
+     * isBuiltinModule test the result as a string.
      */
     private extractPathFromImport(importStatement: string): string {
-        const trimmed = importStatement.trim();
-        const dotMatch = trimmed.match(/^using\.\s*(.+)/);
-        const curlyMatch = dotMatch ? null : trimmed.match(/^using\s*\{\s*([^}]+)\s*\}/);
-        const captured = dotMatch ? dotMatch[1] : curlyMatch ? curlyMatch[1] : "";
-        return ImportFormatter.stripTrailingComment(captured);
+        return this.formatter.extractPathFromImport(importStatement) ?? "";
     }
 
     /**
@@ -475,11 +475,9 @@ export class ImportPathConverter {
         }
 
         // Read through extractPathFromImport rather than a second copy of its
-        // regexes, so the trailing-comment strip cannot be left out of the
-        // copy. The dotted capture runs to end of line, so `using. /A/B # note`
-        // yields the path `/A/B # note` without it - and applyConversion
-        // restores the comment itself, so a comment left in the path is written
-        // twice.
+        // patterns, so the trailing-comment strip cannot be left out of the
+        // copy: applyConversion restores the comment itself, so one left in the
+        // path is written twice.
         const fullPath = this.extractPathFromImport(importStatement);
 
         if (!fullPath || !fullPath.startsWith("/")) {

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -343,6 +343,24 @@ describe("ImportPathConverter import classification", () => {
         expect(converter.isBuiltinModule(statement)).toBe(false);
         expect(converter.extractModuleFromImport(statement)?.moduleName).toBe("Shop");
     });
+
+    // No caller reaches these readers with a line carrying anything after its
+    // statement: scanConvertibleImports feeds them, and it excludes such a line
+    // because a rebuild cannot reproduce its span. That filter is written for
+    // that reason rather than to keep the path readers honest, so the two are
+    // pinned apart - widening what the converter is fed must not silently start
+    // converting the leftover.
+    it("reads a dotted path as far as the statement ends, not to end of line", () => {
+        const converter = converterWithProjectPath("/mygame@fortnite.com/mygame");
+
+        expect(converter.extractModuleFromImport("using. Gadgets.Tools; MyVal := 5")).toEqual({ fullPath: "Gadgets/Tools", moduleName: "Tools" });
+    });
+
+    it("names the module of a dotted absolute path without the statement written after it", () => {
+        const converter = converterWithProjectPath("/mygame@fortnite.com/mygame");
+
+        expect(converter.extractModuleName("using. /mygame@fortnite.com/mygame/Gadgets/Tools; MyVal := 5")).toBe("Tools");
+    });
 });
 
 describe("ImportPathConverter.convertFromFullPath", () => {
@@ -353,9 +371,9 @@ describe("ImportPathConverter.convertFromFullPath", () => {
     });
 
     it("leaves the comment trailing a dotted import out of the converted path", async () => {
-        // The dotted capture runs to end of line, so reading the path without
-        // stripping the comment first builds the comment into the relative
-        // import - where applyConversion, which restores it, writes it twice.
+        // Reading the path without stripping the comment first builds the
+        // comment into the relative import - where applyConversion, which
+        // restores it, writes it twice.
         const converter = converterWithProjectPath(projectVersePath);
 
         const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # only the shop, not the vendor", 0);


### PR DESCRIPTION
Closes #264

`ImportPathConverter.extractPathFromImport` held a third copy of the dotted `using.` pattern, `/^using\.\s*(.+)/`, greedy to end of line, where `matchImport` (#244) and `isModuleImport` (#247) both read the terminated `DOTTED_STATEMENT`. It was safe only because `scanConvertibleImports` feeds it single-line rewritable imports, so leftover text never reached it - an invariant held two modules away and stated next to neither pattern.

The converter now delegates to `ImportFormatter.extractPathFromImport`, deleting the copy rather than replacing it. `DOTTED_STATEMENT` is now the single home for the dotted pattern in `src/`.

## What changed

- `ImportPathConverter` gains a private `ImportFormatter` field - the same way `ImportScanner` and `ImportHandler` already obtain one - and its private `extractPathFromImport` delegates to the formatter's public reader.
- The converter keeps its own `""` contract, translating the formatter's `null`, because `isFullPathImport` and `isBuiltinModule` call string methods on the result.
- Two comments the change made false are rewritten to their durable half.

## No change to what converts today

The two readers diverge only where the old capture ran past the statement. Every other case - a trailing `#` comment, an inline `<# #>`, a quoted segment suffix, the braced forms - strips to the identical path.

The two edge divergences are unreachable. A zero-length dotted capture can only arise on a string starting `using.`, which `^using\s*\{` never matches, so the old fall-through to the braced pattern produced the same `""`. And `using.{Foo}` is refused upstream by `isModuleImport`, which reads the same pattern.

No changelog fragment: nothing user-visible changes.

## Tests

Two regression tests in `src/imports/__tests__/ImportPathConverter.test.ts`, each verified to fail against the unfixed code:

- `extractModuleFromImport("using. Gadgets.Tools; MyVal := 5")` is `{ fullPath: "Gadgets/Tools", moduleName: "Tools" }` - was `{ fullPath: "Gadgets/Tools/MyVal", moduleName: "MyVal" }`.
- `extractModuleName("using. /mygame@fortnite.com/mygame/Gadgets/Tools; MyVal := 5")` is `"Tools"` - was `"Tools; MyVal := 5"`.

They pin the converter against an input `scanConvertibleImports` excludes today, so widening its feed fails loudly rather than converting the leftover.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       863 passed, 863 total
Snapshots:   0 total
Time:        13.643 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh reviewer with its own context, verdict `PASS` with no findings.
