### PR TITLE
fix(visibility): read a named access level as the specifier it is

### DIFF
--- a/changelog.d/293.fixed.md
+++ b/changelog.d/293.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: The quick fix now reports a module declared with a named access level instead of stacking a second specifier beside it, which the compiler rejects.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -145,7 +145,10 @@ export class ProjectPathScanner {
         // which `scoped`'s module list needs; a visibility this fails to read is
         // indistinguishable from none at all. A named scope alias is an ordinary
         // identifier, so no keyword list reaches it and it still reads as none.
-        // Holds parity with moduleDeclarations' VISIBILITY_SPECIFIER.
+        // Keyword parity with moduleDeclarations' VISIBILITY_KEYWORD, whose
+        // NAMED_ACCESS_LEVEL branch is deliberately not mirrored: reading a bare
+        // identifier as an access level costs this scan a dropped candidate,
+        // where there it prevents an edit that would not compile.
         const visibilitySpecifier = /<\s*(public|protected|private|internal|epic_internal|scoped)\b[^>]*>/;
 
         const extractVisibility = (specifiers: string | undefined): string | undefined => {

--- a/src/visibility/__tests__/moduleDeclarations.test.ts
+++ b/src/visibility/__tests__/moduleDeclarations.test.ts
@@ -53,6 +53,28 @@ describe("findExplicitModuleDeclarations", () => {
         expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<epic_internal>");
     });
 
+    it("reads a named access level, which no keyword list can reach", () => {
+        const content = "Tools<SharedScope> := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(declaration.visibility?.keyword).toBe("SharedScope");
+        expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<SharedScope>");
+    });
+
+    it("prefers a keyword entry to a bare identifier stacked beside it", () => {
+        const content = "Tools<final><public> := module {}\n";
+        const [declaration] = findExplicitModuleDeclarations(content);
+
+        expect(declaration.visibility?.keyword).toBe("public");
+        expect(content.slice(declaration.visibility!.start, declaration.visibility!.end)).toBe("<public>");
+    });
+
+    it("leaves an entry carrying arguments alone, since a named access level is written bare", () => {
+        const [declaration] = findExplicitModuleDeclarations("Tools<available{MinUploadedAtFNVersion := 3000}> := module {}\n");
+
+        expect(declaration.visibility).toBeUndefined();
+    });
+
     it("points the insertion point at the end of the name when there is no specifier", () => {
         const content = "Tools := module {}\n";
         const [declaration] = findExplicitModuleDeclarations(content);

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -51,6 +51,15 @@ describe("resolveVisibility", () => {
         expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: { start: 5, end: 15 }, text: "<public>" }]);
     });
 
+    it("reports a named access level rather than stacking a specifier beside it", () => {
+        const found = declarationsIn("file://a", "Gadgets", "Tools<SharedScope> := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.edits).toEqual([]);
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets/Tools", keyword: "SharedScope", reason: "widen" }]);
+    });
+
     it("does nothing for a module already declared public", () => {
         const found = declarationsIn("file://a", "Gadgets", "Tools<public> := module {}\n");
 

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -22,16 +22,29 @@ import { indentOf, maskCommentsAndStrings } from "../utils/verseText";
  */
 const MODULE_DECLARATION = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)((?:\s*<[^>]+>)*)\s*:=\s*module\s*[:>{.]/g;
 
+/** One entry of a stacked specifier block, spelled as MODULE_DECLARATION's group 2 spells it. */
+const SPECIFIER_ENTRY = /<[^>]+>/g;
+
 /**
- * The visibility entry inside a stacked specifier block. Group 1 is the keyword
- * alone; the span covers the whole entry, `scoped`'s module list included.
+ * A visibility entry named by a keyword. Group 1 is the keyword alone; the match
+ * covers the whole entry, `scoped`'s module list included.
  *
- * A specifier the alternation does not name reads as no specifier at all, and a
- * caller then stacks its own beside the real one - two access specifiers on one
- * definition, which is error 3543. That is why `epic_internal` is here despite
- * being unreachable in user Content.
+ * `epic_internal` is here despite being unreachable in user Content, because an
+ * entry no branch below recognizes reads as no specifier at all.
  */
-const VISIBILITY_SPECIFIER = /<\s*(public|protected|private|internal|epic_internal|scoped)\b[^>]*>/;
+const VISIBILITY_KEYWORD = /^<\s*(public|protected|private|internal|epic_internal|scoped)\b[^>]*>$/;
+
+/**
+ * A bare `<Identifier>`, which is how a named access level - `Name := scoped{...}`
+ * - is written. The compiler resolves the identifier and treats it as an access
+ * specifier, so one has to be read as a visibility here too even though no
+ * keyword list can reach a user-chosen name.
+ *
+ * Deliberately only the bare form: an entry carrying arguments or a qualifier
+ * cannot be a named access level, and matching it would refuse on ordinary
+ * attributes for nothing.
+ */
+const NAMED_ACCESS_LEVEL = /^<\s*([A-Za-z_][A-Za-z0-9_]*)\s*>$/;
 
 /** A half-open character span in the source text. */
 export interface SourceSpan {
@@ -57,7 +70,12 @@ export interface ModuleDeclaration {
     /** Where a specifier is inserted when the declaration carries none. */
     insertionPoint: number;
 
-    /** The visibility specifier's span and keyword, absent when the declaration carries none. */
+    /**
+     * The access specifier's span, and its keyword as written, absent when the
+     * declaration carries none. A named access level puts a user-chosen
+     * identifier here, so this is not always one of the visibility keywords -
+     * see findAccessLevel for why it is read as one.
+     */
     visibility?: SourceSpan & { keyword: string };
 }
 
@@ -108,13 +126,13 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
 
         // The specifier block starts exactly at the name's end, so an offset
         // inside it is an offset from there.
-        const visibility = specifierBlock.match(VISIBILITY_SPECIFIER);
-        if (visibility && visibility.index !== undefined) {
-            const start = nameEnd + visibility.index;
+        const accessLevel = findAccessLevel(specifierBlock);
+        if (accessLevel) {
+            const start = nameEnd + accessLevel.index;
             declaration.visibility = {
                 start,
-                end: start + visibility[0].length,
-                keyword: visibility[1],
+                end: start + accessLevel.length,
+                keyword: accessLevel.keyword,
             };
         }
 
@@ -122,6 +140,40 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
     }
 
     return declarations;
+}
+
+/**
+ * The entry in a stacked specifier block that carries the declaration's access
+ * level, its offset inside the block, and its keyword as written.
+ *
+ * A keyword entry wins wherever both kinds appear, so a block stacking a real
+ * visibility onto an unknown attribute still reads as that visibility.
+ *
+ * An entry that is only a bare identifier is reported rather than passed over,
+ * because passing one over is indistinguishable from no specifier at all and a
+ * caller then stacks its own beside it - two access levels on one definition,
+ * which is error 3543. Callers refuse on every keyword but `public` and
+ * `internal`, so an ordinary attribute caught here costs a refusal the user can
+ * act on, never a broken edit.
+ */
+function findAccessLevel(specifierBlock: string): { index: number; length: number; keyword: string } | undefined {
+    let named: { index: number; length: number; keyword: string } | undefined;
+
+    for (const entry of specifierBlock.matchAll(SPECIFIER_ENTRY)) {
+        const keyword = entry[0].match(VISIBILITY_KEYWORD);
+        if (keyword) {
+            return { index: entry.index, length: entry[0].length, keyword: keyword[1] };
+        }
+
+        if (!named) {
+            const identifier = entry[0].match(NAMED_ACCESS_LEVEL);
+            if (identifier) {
+                named = { index: entry.index, length: entry[0].length, keyword: identifier[1] };
+            }
+        }
+    }
+
+    return named;
 }
 
 /** Offset of the first character of every line, so a line number is a binary search. */


### PR DESCRIPTION
Closes #293

## What changed

A module declaration whose access specifier is a named access level — `SharedScope := scoped{ModuleA, ModuleB}`, written `Systems<SharedScope> := module:` — matched no keyword in `moduleDeclarations`' visibility regex, so it reported `visibility: undefined`. That is indistinguishable from a declaration carrying no specifier at all, so `resolveVisibility` treated the module as non-blocking and the inaccessible-module quick fix inserted `<public>` at the declaration's `insertionPoint`:

```
Systems<public><SharedScope> := module:
```

Two access levels on one definition, which the compiler rejects as error 3543.

A bare `<Identifier>` entry now reads as an access level carrying that identifier as its keyword. That routes it into the refusal path already there for anything that is not `public` or `internal`, so the quick fix reports rather than writes:

> making 'X' reachable would mean widening Systems, declared SharedScope. Make the change by hand if that is intended.

| Specifier on the declaration | Before | After |
| --- | --- | --- |
| `Systems<SharedScope>` | `<public>` stacked beside it — error 3543 | reported as a conflict, nothing written |
| `Systems<final><public>` | read as public | read as public |
| `Systems<available{...}>` | read as bare | read as bare |
| `Systems<scoped{A, B}>` | reported as a conflict | reported as a conflict |

Two rules keep the widening from over-reaching. A keyword entry wins wherever both kinds appear, which is what preserves the existing `<internal><final>` behaviour. And only the bare form is matched — an entry carrying arguments or a qualifier cannot be a named access level, so `<available{...}>` is left alone.

This mirrors what the compiler does: `SemanticAnalyzer.cpp`'s `SeparateAccessAttributes` resolves an otherwise-unresolved identifier attribute and classifies it as an access specifier, and `GetAccessLevelFromAttributes` counts it alongside the keywords, which is what makes `<public>` beside it a conflict rather than a duplicate.

## The design decision

The issue left three options open and #305 deferred the choice here. The maintainer chose the first: treat an unrecognized single-identifier specifier as an unknown visibility and refuse, reporting it.

The accepted cost is that a module declaration carrying only an unknown non-visibility attribute now refuses where it previously inserted. That fails closed — a refusal names what to do by hand, where the old path wrote source that does not compile — and it matches how `<scoped{...}>` is already handled.

## What this deliberately does not change

**`ProjectPathScanner`.** It keeps its own keyword-only regex, so a named access level still reads as no specifier there. Its failure mode is different in kind: a dropped or kept import candidate, not an edit that will not compile. That side is tracked by #305 and #316. Only its parity comment is touched here, because this branch renamed the constant it named.

## Tests

Four added. Two detect the defect — reverting `src/visibility/moduleDeclarations.ts` alone and re-running fails exactly those two:

- `moduleDeclarations`: "reads a named access level, which no keyword list can reach"
- `visibilityResolution`: "reports a named access level rather than stacking a specifier beside it"

Two guard the over-reach, and pass either way by design:

- "prefers a keyword entry to a bare identifier stacked beside it"
- "leaves an entry carrying arguments alone, since a named access level is written bare"

## Verification

```
$ npm run compile

> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test

Test Suites: 40 passed, 40 total
Tests:       865 passed, 865 total
Snapshots:   0 total
Time:        25.224 s
Ran all test suites.

$ npm run format:check

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, opus, fresh context: `PASS_WITH_SUGGESTIONS`, no Critical.

The Important finding was a stale cross-reference this branch's rename left in `ProjectPathScanner`'s comment — verified independently and fixed in `1df885a`.

Two Suggestions are left unfixed and recorded here instead. Where a block stacks two bare identifiers and no keyword, the first wins, so `T<final><SharedScope>` reports `final` in the refusal text rather than the alias that actually blocks; the refusal is still correct and fail-closed, only less precise in its naming. And the `{ index; length; keyword }` shape is spelled out four times in `findAccessLevel` and could be one named type.

## Note

The first commit on this branch carries a malformed subject (`@ fix(visibility): ...`), from a shell quoting error. The branch is squash-merged, so the PR title is what lands on `main`; it was left rather than force-pushed.
