### PR TITLE
fix(services): keep a module open across its own next-line brace

### DIFF
--- a/changelog.d/324.fixed.md
+++ b/changelog.d/324.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: A module whose body opens with a brace on the next line now nests its members, so their import paths carry the enclosing module and an unimportable one no longer offers its contents as top-level candidates.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -137,7 +137,11 @@ export class ProjectPathScanner {
         // it contains is dropped with it rather than losing the enclosing
         // segment from its path. Nothing is ever pushed above a skipped entry,
         // because every declaration under one is skipped before it can be.
-        const moduleStack: { name: string; indent: number; skipped: boolean }[] = [];
+        //
+        // `awaitingBrace` is true only between a module declaration that ended
+        // without opening a body and the next line considered, which is where
+        // its `{` may be.
+        const moduleStack: { name: string; indent: number; skipped: boolean; awaitingBrace: boolean }[] = [];
 
         // A declaration carries any number of stacked specifiers, of which at
         // most one is a visibility; the rest (<native>, <final>, ...) are noise
@@ -184,8 +188,10 @@ export class ProjectPathScanner {
         // how a next-line brace reaches a scan that sees one line at a time.
         // `>` holds parity with the two other spellings of this grammar,
         // ImportPathConverter.buildModuleDefinitionRegex and
-        // moduleDeclarations' MODULE_DECLARATION.
-        const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*(?:[:>{.]|$)/;
+        // moduleDeclarations' MODULE_DECLARATION. [3] captures which of them
+        // ended the keyword, and is undefined for the line end alone; the
+        // module stack needs that to know a body is still to open.
+        const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*(?:([:>{.])|$)/;
         const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\s*(?:<[^>]+>)*\s*[\(:]?/;
         const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\s*(?:<[^>]+>)*\s*[\(:]?/;
         const interfacePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*interface\s*(?:<[^>]+>)*\s*[\(:]?/;
@@ -212,10 +218,24 @@ export class ProjectPathScanner {
 
             const indent = indentOf(sourceLines[i], 0);
 
+            // A module whose body opens on a later line puts its `{` at the
+            // declaration's own indent, where the rule below would read it as a
+            // line that left the module and close it before its members are
+            // read. That brace opens the body, so it closes nothing. Verse lets
+            // blank lines and comments sit between the two, and those never
+            // reach here, so the wait ends at the next line this scan considers.
+            const openModule = moduleStack[moduleStack.length - 1];
+            const opensAwaitedBody = openModule?.awaitingBrace === true && line.startsWith("{");
+            if (openModule) {
+                openModule.awaitingBrace = false;
+            }
+
             // Indentation alone closes a module: a line at or left of the open
             // module's own indent is outside it.
-            while (moduleStack.length > 0 && indent <= moduleStack[moduleStack.length - 1].indent) {
-                moduleStack.pop();
+            if (!opensAwaitedBody) {
+                while (moduleStack.length > 0 && indent <= moduleStack[moduleStack.length - 1].indent) {
+                    moduleStack.pop();
+                }
             }
 
             // An import checks every path segment from the root, so anything
@@ -230,18 +250,19 @@ export class ProjectPathScanner {
 
             const moduleMatch = line.match(modulePattern);
             if (moduleMatch) {
-                const [, name, specifiers] = moduleMatch;
+                const [, name, specifiers, bodyTerminator] = moduleMatch;
                 const visibility = extractVisibility(specifiers);
                 const isPublic = visibility === "public";
+                const awaitingBrace = bodyTerminator === undefined;
 
                 const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
 
                 if (shouldSkipDeclaration(visibility, true)) {
-                    moduleStack.push({ name: fullPath, indent, skipped: true });
+                    moduleStack.push({ name: fullPath, indent, skipped: true, awaitingBrace });
                     continue;
                 }
 
-                moduleStack.push({ name: fullPath, indent, skipped: false });
+                moduleStack.push({ name: fullPath, indent, skipped: false, awaitingBrace });
                 currentModulePath = fullPath;
 
                 nodes.push({

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -224,10 +224,12 @@ export class ProjectPathScanner {
             // read. That brace opens the body, so it closes nothing. Verse lets
             // blank lines and comments sit between the two, and those never
             // reach here, so the wait ends at the next line this scan considers.
-            const openModule = moduleStack[moduleStack.length - 1];
-            const opensAwaitedBody = openModule?.awaitingBrace === true && line.startsWith("{");
-            if (openModule) {
-                openModule.awaitingBrace = false;
+            // Read before the pop loop, so it may name a module that loop then
+            // closes; nothing below it may treat this as the open module.
+            const topBeforePop = moduleStack[moduleStack.length - 1];
+            const opensAwaitedBody = topBeforePop?.awaitingBrace === true && line.startsWith("{");
+            if (topBeforePop) {
+                topBeforePop.awaitingBrace = false;
             }
 
             // Indentation alone closes a module: a line at or left of the open

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -53,15 +53,30 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
         ]);
     });
 
-    it("leaves the members of a next-line brace module unnested", () => {
-        // Pins the limit rather than endorsing it: indentation alone closes a
-        // module, and the bare brace sits at the declaration's own indent, so
-        // it pops the module before the body is read.
+    it("nests the members of a next-line brace module", () => {
         const nested = declare("Inventory := module\n{\n    Item := class {}\n}\n");
         expect(nested.map((node) => [node.type, node.fullPath])).toEqual([
             ["module", "Inventory"],
-            ["class", "Item"],
+            ["class", "Inventory.Item"],
         ]);
+    });
+
+    it("closes a next-line brace module at its closing brace", () => {
+        const source = "Inventory := module\n{\n    Item := class {}\n}\nLoose := class {}\n";
+        expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item", "Loose"]);
+    });
+
+    it("still waits for the brace across the blank lines and comments Verse allows before it", () => {
+        const source = "Inventory := module\n\n# opening below\n{\n    Item := class {}\n}\n";
+        expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
+    });
+
+    it("closes a module whose declaration line opened no body and no brace followed", () => {
+        // Not valid Verse, so this pins degradation rather than a shape a user
+        // can compile: the wait lasts one line, so a module missing its body
+        // cannot swallow the rest of the file.
+        const source = "Inventory := module\nLoose := class {}\n";
+        expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Loose"]);
     });
 
     it("keeps reading the visibility specifier attached to the name", () => {
@@ -109,6 +124,20 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
 
     it("drops a skipped module's grandchildren too", () => {
         expect(declare("Systems<private> := module:\n    Inner<public> := module:\n        Deep<public> := class {}\n")).toEqual([]);
+    });
+
+    it("drops the subtree of a skipped module whose body opens on the next line", () => {
+        // The brace form reaches the skip through a different route than the
+        // colon form: the module has to survive its own opening brace before
+        // the skip can hold its subtree at all.
+        const source =
+            "Systems<scoped{ModuleA}> := module\n{\n    Inner<public> := module\n    {\n        Deep<public> := class {}\n    }\n}\nInventory<public> := module:\n    Item<public> := class {}\n";
+        expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
+    });
+
+    it("nests a kept module's subtree through a next-line brace body", () => {
+        const source = "Systems<public> := module\n{\n    Inner<public> := module\n    {\n        Deep<public> := class {}\n    }\n}\nLoose<public> := class {}\n";
+        expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.Inner", "Systems.Inner.Deep", "Loose"]);
     });
 
     it("records a sibling declared after a skipped module closes", () => {


### PR DESCRIPTION
Closes #324

## What was wrong

`ProjectPathScanner.extractDeclarations` closed a module on indentation alone. A module written in the next-line brace form puts its opening `{` at the declaration's own indent, so that brace read as a line that had left the module and popped it before any member was scanned.

For a kept parent the members lost their enclosing segment, so recorded paths were merely shorter than they should be — the limit the test `leaves the members of a next-line brace module unnested` pinned. For a parent the scan judges unimportable it was the failure #316 fixed, reached by another route: #316 holds a skipped module's subtree by keeping the module on the stack, which only works while the module is still open, and here it was closed a line early. The subtree was promoted to file scope again, offering paths the compiler rejects plus a spurious second candidate for any genuine top-level module of the same name.

## The change

The ticket weighed two shapes. This takes the first, the deferred pop, rather than full brace-depth tracking: a module declaration whose line ends without opening a body now waits one considered line for its brace, and that brace no longer reaches the pop rule. Blank lines and comments never reach the pop rule either, so the wait tolerates the ones Verse permits between the declaration and its brace.

Both fix shapes invert the pinned test, as the ticket noted, so it is renamed and its expectation corrected rather than worked around.

## One correction to the ticket's coverage list

The ticket asked for a next-line brace module under each of `<private>`, `<scoped{...}>` and `<public>`. `<private>` on a module is not legal Verse — `assert_semantic_error(3594){ M<private> := module {} }` in the Book of Verse `Tests/Modules/Module.versetest:36`, "Access levels protected and private are only allowed inside classes." A module can never sit inside a class, so that is unconditional. `<scoped{...}>` on a module is legal, so it carries the unimportable-parent case and the `<private>` case is dropped.

The next-line brace form itself is confirmed legal: the Book of Verse carries it as a compile-validated versetest at `docs/16_modules.md:128-131`, labelled "Bracket syntax (also supported)".

## Coverage

Six tests, five of which fail against the unfixed scanner:

- `nests the members of a next-line brace module` — the inverted pin
- `closes a next-line brace module at its closing brace` — a sibling after `}` is not swallowed
- `still waits for the brace across the blank lines and comments Verse allows before it`
- `drops the subtree of a skipped module whose body opens on the next line` — `<scoped{...}>` parent, grandchild, sibling after `}`
- `nests a kept module's subtree through a next-line brace body` — `<public>` parent, grandchild, sibling
- `closes a module whose declaration line opened no body and no brace followed` — passes both ways by design; it guards against the wait over-holding a module, so it is a guard rather than a regression test for this defect

Each of the five was confirmed to fail with the fix reverted and the tests left in place.

## Known limitation, left alone

A braced body written at or left of the module's own indent still pops early. Verse permits it — the Book of Verse's own example has `m := module{` at indent 0 with its body at indent 0 — but this is pre-existing and shared with the same-line brace form, so it is outside this ticket. Fixing it is the brace-depth tracking the ticket weighed as the larger second shape.

## Review

One round, verdict `PASS_WITH_SUGGESTIONS` — no Critical, no Important. The reviewer reproduced the build, the suite and the revert-and-rerun, and probed the shapes the fix could plausibly break: a trailing `#` comment on the declaration line, a `<# ... #>` block spanning the gap, the `<#>` indented marker, tabs, a stray `using` between declaration and brace, nested next-line braces, and a module as the last line of a file. All nest correctly.

It also settled a property the change rests on but did not state: a line that triggers the wait can never itself record a node, because every declaration pattern is anchored `^(\w+)` or `^\([^)]+\)\.` and none can match a leading `{`. So suppressing the pop loop on that line cannot mis-attribute anything, and only the top of stack can ever be awaiting a brace.

Both suggestions were addressed: the pop-loop snapshot is renamed and commented for when it is read (second commit), and the residual limitation is documented above rather than fixed here.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       866 passed, 866 total
Snapshots:   0 total
Time:        42.084 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
