### PR TITLE
fix(imports): keep a new import out of the using: pair a pinned line opens

### DIFF
--- a/changelog.d/325.fixed.md
+++ b/changelog.d/325.fixed.md
@@ -1,1 +1,1 @@
-**Import placement**: a new import is no longer written between an indented `using:` and the path it opens when the opener line also writes a complete statement.
+**Import placement**: a new import is no longer written between an indented `using:` and the path it opens, which left the file unable to compile.

--- a/changelog.d/325.fixed.md
+++ b/changelog.d/325.fixed.md
@@ -1,0 +1,1 @@
+**Import placement**: a new import is no longer written between an indented `using:` and the path it opens when the opener line also writes a complete statement.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
 import { ImportFormatter } from "./ImportFormatter";
-import { allUsingPaths, classifyLines, LINE_SPLIT, LineClassification, pinnedImports, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
+import { allUsingPaths, classifyLines, LINE_SPLIT, LineClassification, opensIndentedPair, pinnedImports, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
 
 /**
  * A run of import statements on consecutive lines. Any gap starts a new block,
@@ -127,13 +127,30 @@ function attachedCommentStart(importStartLine: number, classifications: LineClas
  * line whose comment was opened above it, under either marker. So the span ends
  * at the last line still carrying it, and an import pinned only by the
  * statements sharing its line owns its span alone.
+ *
+ * An indented `using:` pair reaches past the statement the same way, and has to
+ * be asked separately: the pair's own scan entry spans both lines, but a line
+ * may write a complete `using` and then open a pair, and that statement's entry
+ * ends on the opener. Reading the opener alone leaves the line below it free,
+ * and a new import written there splits a pair that must stay adjacent.
+ *
+ * The two rules alternate rather than run in turn, because either can extend a
+ * span the other then extends again: a pair's path line may itself open a
+ * comment over the lines below it.
  */
 function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]): number {
     let end = imp.endLine;
-    while (end + 1 < classifications.length && classifications[end + 1].continuesCommentAbove) {
-        end++;
+    for (;;) {
+        if (end + 1 < classifications.length && classifications[end + 1].continuesCommentAbove) {
+            end++;
+            continue;
+        }
+        if (opensIndentedPair(classifications, end)) {
+            end++;
+            continue;
+        }
+        return end;
     }
-    return end;
 }
 
 /**

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -137,17 +137,22 @@ function attachedCommentStart(importStartLine: number, classifications: LineClas
  * The two rules alternate rather than run in turn, because either can extend a
  * span the other then extends again: a pair's path line may itself open a
  * comment over the lines below it.
+ *
+ * The pair rule goes first, and that order is load-bearing. Each hop re-anchors
+ * on the new end, and only the opener line carries the `using:` - so where the
+ * opener also opens a comment, letting the comment rule run first steps the
+ * anchor past the opener and the pair is never found at all.
  */
 function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]): number {
     let end = imp.endLine;
     for (;;) {
-        if (end + 1 < classifications.length && classifications[end + 1].continuesCommentAbove) {
-            end++;
-            continue;
-        }
         const pathLine = indentedPairPathLine(classifications, end);
         if (pathLine > end) {
             end = pathLine;
+            continue;
+        }
+        if (end + 1 < classifications.length && classifications[end + 1].continuesCommentAbove) {
+            end++;
             continue;
         }
         return end;

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
 import { ImportFormatter } from "./ImportFormatter";
-import { allUsingPaths, classifyLines, LINE_SPLIT, LineClassification, opensIndentedPair, pinnedImports, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
+import { allUsingPaths, classifyLines, indentedPairPathLine, LINE_SPLIT, LineClassification, pinnedImports, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
 
 /**
  * A run of import statements on consecutive lines. Any gap starts a new block,
@@ -131,8 +131,8 @@ function attachedCommentStart(importStartLine: number, classifications: LineClas
  * An indented `using:` pair reaches past the statement the same way, and has to
  * be asked separately: the pair's own scan entry spans both lines, but a line
  * may write a complete `using` and then open a pair, and that statement's entry
- * ends on the opener. Reading the opener alone leaves the line below it free,
- * and a new import written there splits a pair that must stay adjacent.
+ * ends on the opener. Reading the opener alone leaves the path line free, and a
+ * new import written there splits a pair that must stay adjacent.
  *
  * The two rules alternate rather than run in turn, because either can extend a
  * span the other then extends again: a pair's path line may itself open a
@@ -145,8 +145,9 @@ function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]
             end++;
             continue;
         }
-        if (opensIndentedPair(classifications, end)) {
-            end++;
+        const pathLine = indentedPairPathLine(classifications, end);
+        if (pathLine > end) {
+            end = pathLine;
             continue;
         }
         return end;

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -355,6 +355,31 @@ export function classifyLines(lines: string[]): LineClassification[] {
 }
 
 /**
+ * Whether the line at `opener` ends in a `using:` that opens an indented pair
+ * over the line below it.
+ *
+ * The two lines have to stay adjacent to compile, so nothing may be written
+ * between them: the `using:` would be left with no indented body, and the path
+ * below it stranded as a bare indented expression.
+ *
+ * Asked of the classifications rather than the raw text, for the reason the
+ * scan's own tail tests are: a `using:` in a comment is trivia, and one a
+ * comment follows on the same line is still an opener.
+ *
+ * Says nothing about what the path line holds, deliberately. Whether the scan
+ * admits that path decides what counts as imported; it does not decide who owns
+ * the line, and a pair whose path the classification declines owns the line
+ * below it exactly as one it admits does.
+ */
+export function opensIndentedPair(classifications: LineClassification[], opener: number): boolean {
+    const below = classifications[opener + 1];
+    if (below === undefined || below.kind !== "code" || !/^\s/.test(below.codeWithoutComments)) {
+        return false;
+    }
+    return /\busing\s*:\s*$/.test(classifications[opener].codeOutsideLiterals.trim());
+}
+
+/**
  * Scans document lines for module imports. This is the single scanner behind
  * every import-editing operation so they all agree on what counts as an
  * import:

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -355,12 +355,20 @@ export function classifyLines(lines: string[]): LineClassification[] {
 }
 
 /**
- * Whether the line at `opener` ends in a `using:` that opens an indented pair
- * over the line below it.
+ * The line holding the path that the `using:` ending line `opener` opens, or
+ * `-1` where that line opens no pair.
  *
- * The two lines have to stay adjacent to compile, so nothing may be written
- * between them: the `using:` would be left with no indented body, and the path
- * below it stranded as a bare indented expression.
+ * Nothing may be written between the two: the `using:` would be left with no
+ * indented body, and the path below it stranded as a bare indented expression.
+ * So this is the last line such an opener owns, and a caller placing a new
+ * statement has to clear it rather than the opener.
+ *
+ * The path is the next non-blank indented line rather than the line directly
+ * below, because the compiler reads the body that way: blank lines between the
+ * two do not end the pair, and neither does a comment line indented into it.
+ * A line at column 0 does end it, and so does one carrying a comment opened
+ * above it - there the pair is comment text, which is the comment rule's to
+ * span and not this one's.
  *
  * Asked of the classifications rather than the raw text, for the reason the
  * scan's own tail tests are: a `using:` in a comment is trivia, and one a
@@ -368,15 +376,30 @@ export function classifyLines(lines: string[]): LineClassification[] {
  *
  * Says nothing about what the path line holds, deliberately. Whether the scan
  * admits that path decides what counts as imported; it does not decide who owns
- * the line, and a pair whose path the classification declines owns the line
- * below it exactly as one it admits does.
+ * the line, and a pair whose path the classification declines owns its line
+ * exactly as one it admits does.
  */
-export function opensIndentedPair(classifications: LineClassification[], opener: number): boolean {
-    const below = classifications[opener + 1];
-    if (below === undefined || below.kind !== "code" || !/^\s/.test(below.codeWithoutComments)) {
-        return false;
+export function indentedPairPathLine(classifications: LineClassification[], opener: number): number {
+    if (!/\busing\s*:\s*$/.test(classifications[opener].codeOutsideLiterals.trim())) {
+        return -1;
     }
-    return /\busing\s*:\s*$/.test(classifications[opener].codeOutsideLiterals.trim());
+
+    for (let line = opener + 1; line < classifications.length; line++) {
+        const classification = classifications[line];
+        if (classification.kind === "blank") {
+            continue;
+        }
+        // Read from the code rather than the raw line, so the indent of a
+        // comment line is its own and not the `#`'s.
+        if (classification.continuesCommentAbove || !/^\s/.test(classification.codeWithoutComments)) {
+            return -1;
+        }
+        if (classification.kind === "code") {
+            return line;
+        }
+    }
+
+    return -1;
 }
 
 /**

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -392,8 +392,10 @@ export function indentedPairPathLine(classifications: LineClassification[], open
         if (classification.kind !== "code") {
             continue;
         }
-        // Read from the code rather than the raw line, so a `#` sitting at
-        // column 0 does not make an indented statement look like one.
+        // Indentation read from the code, so a line closing a block comment
+        // ahead of its statement reads as indented. Harmless in both
+        // directions: were that statement really at column 0, the opener
+        // opened nothing and the file did not compile to begin with.
         return /^\s/.test(classification.codeWithoutComments) ? line : -1;
     }
 

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -363,12 +363,12 @@ export function classifyLines(lines: string[]): LineClassification[] {
  * So this is the last line such an opener owns, and a caller placing a new
  * statement has to clear it rather than the opener.
  *
- * The path is the next non-blank indented line rather than the line directly
- * below, because the compiler reads the body that way: blank lines between the
- * two do not end the pair, and neither does a comment line indented into it.
- * A line at column 0 does end it, and so does one carrying a comment opened
- * above it - there the pair is comment text, which is the comment rule's to
- * span and not this one's.
+ * The path is the first line of code below the opener rather than the line
+ * directly below it, because that is the body the compiler reads. Neither a
+ * blank line nor a comment ends an indented block, at any indentation - a
+ * comment written back at column 0 leaves the block open, and so does a block
+ * comment opened inside it. Only code ends it, and code at column 0 ends it
+ * without ever having been the body, so there the opener opens nothing.
  *
  * Asked of the classifications rather than the raw text, for the reason the
  * scan's own tail tests are: a `using:` in a comment is trivia, and one a
@@ -378,25 +378,23 @@ export function classifyLines(lines: string[]): LineClassification[] {
  * admits that path decides what counts as imported; it does not decide who owns
  * the line, and a pair whose path the classification declines owns its line
  * exactly as one it admits does.
+ *
+ * `-1` for a line that opens no pair, an opener the file ends on, and an
+ * `opener` past the end of the file.
  */
 export function indentedPairPathLine(classifications: LineClassification[], opener: number): number {
-    if (!/\busing\s*:\s*$/.test(classifications[opener].codeOutsideLiterals.trim())) {
+    if (classifications[opener] === undefined || !/\busing\s*:\s*$/.test(classifications[opener].codeOutsideLiterals.trim())) {
         return -1;
     }
 
     for (let line = opener + 1; line < classifications.length; line++) {
         const classification = classifications[line];
-        if (classification.kind === "blank") {
+        if (classification.kind !== "code") {
             continue;
         }
-        // Read from the code rather than the raw line, so the indent of a
-        // comment line is its own and not the `#`'s.
-        if (classification.continuesCommentAbove || !/^\s/.test(classification.codeWithoutComments)) {
-            return -1;
-        }
-        if (classification.kind === "code") {
-            return line;
-        }
+        // Read from the code rather than the raw line, so a `#` sitting at
+        // column 0 does not make an indented statement look like one.
+        return /^\s/.test(classification.codeWithoutComments) ? line : -1;
     }
 
     return -1;

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -220,11 +220,19 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using:", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
     });
 
-    // The compiler takes the pair's path from the next non-blank indented line,
-    // so a blank line between the two is inside the pair and not a gap after it.
+    // The compiler takes the pair's path from the first line of code below the
+    // opener, so a blank line between the two is inside the pair and not a gap
+    // after it.
     it("writes a new relative import below a pair holding a blank line", () => {
         const input = ["X := 1; using { /A }; using:", "", "    Foo'Loc'", "code()"].join("\n");
         expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using:", "", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
+    });
+
+    // A comment does not end an indented block at any indentation, so one
+    // written back at column 0 is inside the pair rather than after it.
+    it("writes a new relative import below a pair holding a comment at column 0", () => {
+        const input = ["X := 1; using { /A }; using:", "# note", "    Foo'Loc'", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using:", "# note", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
     });
 
     // Both halves of the span reach here: the pair carries it to the path line,

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -235,6 +235,19 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using:", "# note", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
     });
 
+    // The opener opens a comment as well as a pair, so the rule that spans
+    // comments would carry the span past the only line carrying the `using:`.
+    // Asked in the other order the pair is never found and the import splits it.
+    it("writes a new relative import below a pair whose opener also opens a comment", () => {
+        const input = ["using { /A }; using: <#", "note #>", "    /B", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["using { /A }; using: <#", "note #>", "    /B", "using { Gadgets.Tools }", "code()"].join("\n"));
+    });
+
+    it("writes a new relative import below a pair whose opener opens a comment over several lines", () => {
+        const input = ["X := 1; using { /A }; using: <#", "note", "#>", "    /B", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using: <#", "note", "#>", "    /B", "using { Gadgets.Tools }", "code()"].join("\n"));
+    });
+
     // Both halves of the span reach here: the pair carries it to the path line,
     // and the comment that line opens carries it to the end of the comment.
     it("writes a new relative import below a comment the pair's path line opens", () => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -210,6 +210,16 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["using { /A }; using:", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
     });
 
+    // Where the opener line is definition-headed the pair is declined on
+    // content, so no entry spans the path line at all and the span above cannot
+    // be what holds the import out. The statement before the `;` is pinned to
+    // the opener line alone, and a floor taken from its own end leaves the path
+    // line free.
+    it("writes a new relative import below a pair a definition-headed line opens", () => {
+        const input = ["X := 1; using { /A }; using:", "    Foo'Loc'", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using:", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
+    });
+
     // A line writing two complete statements read as its first path alone, so
     // organizing rebuilt it as `using { /X }` and Economy.Shop was simply gone.
     // The output was a well-formed import block, which is what made the loss
@@ -1817,6 +1827,28 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const insert = appliedOperations(0).find((op) => op.kind === "insert");
             expect(insert).toBeDefined();
             expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // The floor reaches past the pinned statement, because the `using:` at
+        // the end of its line owns the line below it and no entry of its own
+        // spans that line - the pair is declined on content. Taken from the
+        // statement's own end, the floor leaves the path line free and the
+        // import is written between the opener and the path it opens.
+        it("writes a new import below the pair a pinned definition-headed line opens", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["X := 1; using { /A }; using:", "    Foo'Loc'", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(2);
             expect(insert!.text).toBe("using { Features }\n\n");
         });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -220,6 +220,22 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using:", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
     });
 
+    // The compiler takes the pair's path from the next non-blank indented line,
+    // so a blank line between the two is inside the pair and not a gap after it.
+    it("writes a new relative import below a pair holding a blank line", () => {
+        const input = ["X := 1; using { /A }; using:", "", "    Foo'Loc'", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["X := 1; using { /A }; using:", "", "    Foo'Loc'", "using { Gadgets.Tools }", "code()"].join("\n"));
+    });
+
+    // Both halves of the span reach here: the pair carries it to the path line,
+    // and the comment that line opens carries it to the end of the comment.
+    it("writes a new relative import below a comment the pair's path line opens", () => {
+        const input = ["X := 1; using { /A }; using:", "    Foo'Loc' <#", "note", "#>", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(
+            ["X := 1; using { /A }; using:", "    Foo'Loc' <#", "note", "#>", "using { Gadgets.Tools }", "code()"].join("\n"),
+        );
+    });
+
     // A line writing two complete statements read as its first path alone, so
     // organizing rebuilt it as `using { /X }` and Economy.Shop was simply gone.
     // The output was a well-formed import block, which is what made the loss

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1,4 +1,4 @@
-import { allUsingPaths, classifyLines, opensIndentedPair, rewritableImports, scanConvertibleImports, scanModuleImports } from "../ImportScanner";
+import { allUsingPaths, classifyLines, indentedPairPathLine, rewritableImports, scanConvertibleImports, scanModuleImports } from "../ImportScanner";
 
 describe("allUsingPaths", () => {
     it("collects a file-scope import the same way scanModuleImports does", () => {
@@ -1028,49 +1028,65 @@ describe("classifyLines", () => {
     });
 });
 
-describe("opensIndentedPair", () => {
-    const opens = (lines: string[], opener = 0) => opensIndentedPair(classifyLines(lines), opener);
+describe("indentedPairPathLine", () => {
+    const pathLine = (lines: string[], opener = 0) => indentedPairPathLine(classifyLines(lines), opener);
 
     it("reads a using: ending a line that also writes statements as an opener", () => {
-        expect(opens(["X := 1; using { /A }; using:", "    /B"])).toBe(true);
+        expect(pathLine(["X := 1; using { /A }; using:", "    /B"])).toBe(1);
     });
 
     it("reads a whole-line using: as one", () => {
-        expect(opens(["using:", "    /B"])).toBe(true);
+        expect(pathLine(["using:", "    /B"])).toBe(1);
     });
 
     // The path counts for nothing here; the ownership of the line is the whole
     // question, and it is the shape no scan entry spans.
-    it("owns the line below whatever the path written on it holds", () => {
-        expect(opens(["X := 1; using { /A }; using:", "    Foo'Loc'"])).toBe(true);
+    it("owns the path line whatever the path written on it holds", () => {
+        expect(pathLine(["X := 1; using { /A }; using:", "    Foo'Loc'"])).toBe(1);
     });
 
     // A comment after the opener defeats a `$` anchored on the raw line.
     it("looks past a comment trailing the using:", () => {
-        expect(opens(["using: # note", "    /B"])).toBe(true);
+        expect(pathLine(["using: # note", "    /B"])).toBe(1);
+    });
+
+    // The compiler reads the body as the next non-blank indented line, so these
+    // lines are inside the pair and a statement written on one splits it.
+    it("looks past blank lines between the opener and its path", () => {
+        expect(pathLine(["using { /A }; using:", "", "", "    /B"])).toBe(3);
+    });
+
+    it("looks past a comment line indented into the pair", () => {
+        expect(pathLine(["using { /A }; using:", "    # note", "    /B"])).toBe(2);
     });
 
     it("does not read a using: written inside a comment as an opener", () => {
-        expect(opens(["# see using:", "    /B"])).toBe(false);
+        expect(pathLine(["# see using:", "    /B"])).toBe(-1);
     });
 
     it("does not read a line that opens no pair as an opener", () => {
-        expect(opens(["using { /A }", "    /B"])).toBe(false);
+        expect(pathLine(["using { /A }", "    /B"])).toBe(-1);
     });
 
-    it("declines a line below that is comment text the opener began", () => {
-        expect(opens(["using: <#", "    still a comment"])).toBe(false);
+    // Comment text is the comment rule's to span, and it reaches these lines
+    // from the marker that opened them.
+    it("declines a path line carrying a comment the opener began", () => {
+        expect(pathLine(["using: <#", "    still a comment"])).toBe(-1);
     });
 
-    it("declines a line below carrying no code of its own", () => {
-        expect(opens(["using:", "    # just a note"])).toBe(false);
+    it("declines where the first line that is not blank sits at column 0", () => {
+        expect(pathLine(["using:", "", "code()"])).toBe(-1);
     });
 
-    it("declines a line below written at column 0", () => {
-        expect(opens(["using:", "code()"])).toBe(false);
+    it("declines where a comment at column 0 follows the opener", () => {
+        expect(pathLine(["using:", "# a note of its own", "    /B"])).toBe(-1);
     });
 
     it("declines an opener on the last line of the file", () => {
-        expect(opens(["using:"])).toBe(false);
+        expect(pathLine(["using:"])).toBe(-1);
+    });
+
+    it("declines an opener followed only by blank lines", () => {
+        expect(pathLine(["using:", "", ""])).toBe(-1);
     });
 });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1050,14 +1050,24 @@ describe("indentedPairPathLine", () => {
         expect(pathLine(["using: # note", "    /B"])).toBe(1);
     });
 
-    // The compiler reads the body as the next non-blank indented line, so these
-    // lines are inside the pair and a statement written on one splits it.
+    // Neither a blank line nor a comment ends an indented block, at any
+    // indentation, so all of these lines are inside the pair and a statement
+    // written on one splits it. Epic's own compile-validated cases are in the
+    // book's Tests/Bugs/SOL-3662-LineCommentEndsIndentedBlock.versetest.
     it("looks past blank lines between the opener and its path", () => {
         expect(pathLine(["using { /A }; using:", "", "", "    /B"])).toBe(3);
     });
 
     it("looks past a comment line indented into the pair", () => {
         expect(pathLine(["using { /A }; using:", "    # note", "    /B"])).toBe(2);
+    });
+
+    it("looks past a comment written back at column 0", () => {
+        expect(pathLine(["using { /A }; using:", "# a note of its own", "    /B"])).toBe(2);
+    });
+
+    it("looks past a block comment opened inside the pair", () => {
+        expect(pathLine(["using { /A }; using: <#", "note #>", "    /B"])).toBe(2);
     });
 
     it("does not read a using: written inside a comment as an opener", () => {
@@ -1068,18 +1078,14 @@ describe("indentedPairPathLine", () => {
         expect(pathLine(["using { /A }", "    /B"])).toBe(-1);
     });
 
-    // Comment text is the comment rule's to span, and it reaches these lines
-    // from the marker that opened them.
-    it("declines a path line carrying a comment the opener began", () => {
-        expect(pathLine(["using: <#", "    still a comment"])).toBe(-1);
+    // The marker comments out everything indented past it, so the pair opens no
+    // code at all and there is no path line to own.
+    it("declines where a <#> marker on the opener comments the body out", () => {
+        expect(pathLine(["using { /A }; using: <#>", "    a comment body", "    /B"])).toBe(-1);
     });
 
-    it("declines where the first line that is not blank sits at column 0", () => {
+    it("declines where the first line of code sits at column 0", () => {
         expect(pathLine(["using:", "", "code()"])).toBe(-1);
-    });
-
-    it("declines where a comment at column 0 follows the opener", () => {
-        expect(pathLine(["using:", "# a note of its own", "    /B"])).toBe(-1);
     });
 
     it("declines an opener on the last line of the file", () => {

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1052,8 +1052,7 @@ describe("indentedPairPathLine", () => {
 
     // Neither a blank line nor a comment ends an indented block, at any
     // indentation, so all of these lines are inside the pair and a statement
-    // written on one splits it. Epic's own compile-validated cases are in the
-    // book's Tests/Bugs/SOL-3662-LineCommentEndsIndentedBlock.versetest.
+    // written on one splits it.
     it("looks past blank lines between the opener and its path", () => {
         expect(pathLine(["using { /A }; using:", "", "", "    /B"])).toBe(3);
     });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1,4 +1,4 @@
-import { allUsingPaths, classifyLines, rewritableImports, scanConvertibleImports, scanModuleImports } from "../ImportScanner";
+import { allUsingPaths, classifyLines, opensIndentedPair, rewritableImports, scanConvertibleImports, scanModuleImports } from "../ImportScanner";
 
 describe("allUsingPaths", () => {
     it("collects a file-scope import the same way scanModuleImports does", () => {
@@ -1025,5 +1025,52 @@ describe("classifyLines", () => {
         // The body affects `kind` only: what the import scanner sees through
         // insideBlockComment has to stay exactly what it saw before.
         expect(classifyLines(["<#> Notes", "    opens <#", "code()", "#>", "code()"]).map((classification) => classification.insideBlockComment)).toEqual([false, false, true, true, false]);
+    });
+});
+
+describe("opensIndentedPair", () => {
+    const opens = (lines: string[], opener = 0) => opensIndentedPair(classifyLines(lines), opener);
+
+    it("reads a using: ending a line that also writes statements as an opener", () => {
+        expect(opens(["X := 1; using { /A }; using:", "    /B"])).toBe(true);
+    });
+
+    it("reads a whole-line using: as one", () => {
+        expect(opens(["using:", "    /B"])).toBe(true);
+    });
+
+    // The path counts for nothing here; the ownership of the line is the whole
+    // question, and it is the shape no scan entry spans.
+    it("owns the line below whatever the path written on it holds", () => {
+        expect(opens(["X := 1; using { /A }; using:", "    Foo'Loc'"])).toBe(true);
+    });
+
+    // A comment after the opener defeats a `$` anchored on the raw line.
+    it("looks past a comment trailing the using:", () => {
+        expect(opens(["using: # note", "    /B"])).toBe(true);
+    });
+
+    it("does not read a using: written inside a comment as an opener", () => {
+        expect(opens(["# see using:", "    /B"])).toBe(false);
+    });
+
+    it("does not read a line that opens no pair as an opener", () => {
+        expect(opens(["using { /A }", "    /B"])).toBe(false);
+    });
+
+    it("declines a line below that is comment text the opener began", () => {
+        expect(opens(["using: <#", "    still a comment"])).toBe(false);
+    });
+
+    it("declines a line below carrying no code of its own", () => {
+        expect(opens(["using:", "    # just a note"])).toBe(false);
+    });
+
+    it("declines a line below written at column 0", () => {
+        expect(opens(["using:", "code()"])).toBe(false);
+    });
+
+    it("declines an opener on the last line of the file", () => {
+        expect(opens(["using:"])).toBe(false);
     });
 });


### PR DESCRIPTION
Closes #325

A pinned import's span was its own statement plus any comment it opened, so an entry recorded against a line ending in `using:` stopped at the opener while the opener owns the indented body below it. The floor taken from that span left the body line free, and a new relative import was written between the two: the `using:` lost its body and the path was stranded as a bare indented expression.

## What changed

`indentedPairPathLine` in `ImportScanner.ts` answers where an opener's body is — the first line of **code** below it, or `-1` when the line opens no pair. `pinnedSpanEnd` in `ImportDocumentEditor.ts` alternates that with the existing comment rule, pair rule first.

The body is the first line of code, not the line directly below, because that is what the compiler reads: neither a blank line nor a comment ends an indented block, at any indentation. That rule is settled against the compiler source in a comment on #325, along with why `using:` reaches its body exactly as `class:` does and why the walk cannot stop short on a file that compiles.

The pair rule runs before the comment rule, and that order is load-bearing: each hop re-anchors on the new end and only the opener line carries the `using:`, so spanning the comment first steps the anchor past an opener that also opened a comment.

## Findings from triage worth recording

- **The issue's first shape no longer reproduces.** #326 closed it incidentally — with no diagnostic evidence the pair entry now contributes a floor rather than being consumed as a ceiling. Only the definition-headed shape survived on `main`.
- **`addImportsToDocument` was affected too**, contrary to the issue's note that its ceiling wins. It took the same floor and inserted inside the pair.
- **Shapes where the opener line pins nothing are safe** (`X := 1; using:`, `using: # note`): the scan records nothing, so the import goes to the top of the file, above the pair.
- **Absolute paths were never at risk** — they raise no floor, so they land at the top.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./

Test Suites: 40 passed, 40 total
Tests:       882 passed, 882 total
Snapshots:   0 total

Checking formatting...
All matched files use Prettier code style!
```

Each regression test was proved to detect its defect by disabling the code it covers and watching it fail: the five placement tests fail without the pair rule, and the two ordering tests fail with the two rules swapped back.

## Review

Four rounds. The first three returned `FAIL` with one Critical each, every one confirmed against the code before it was acted on:

1. A blank line inside the pair defeated the fix — the walk only looked at `opener + 1`.
2. A comment at column 0 inside the body ended the walk, which the compiler contradicts.
3. The comment rule ran first and consumed openers that also opened a comment, so the pair was never found. The unit test for that shape passed while the file still split, which is why its regression tests are at the placement level.

The third fix was one round beyond the two the process normally allows; it was applied because the finding was an ordering mistake rather than the approach being wrong, and the maintainer then called for a fourth review on a stronger model with a clean context.

That round returned **`PASS_WITH_SUGGESTIONS`**. It settled the language rule at the compiler source rather than the versetests, confirmed all three prior Criticals genuinely closed — re-probing the third through `addImportsToDocument`, which had only been pinned through `buildOrganizedContent` — and ran twenty scratch probes across both entry points, every config permutation, CRLF, tabs, stacked and nested pairs, a diagnostic-driven ceiling, and reverse-failure checks for over-extension in files that were already correct. Its one suggestion, a source citation that belonged on the issue rather than in a test comment, is applied.

## Deliberately not done

- `indentedPairPathLine` and the scanner's `pairPathBelow` now answer "where is this pair's body" by different rules — the scanner is still `lines[opener + 1]`, so it records no pair entry for a blank- or comment-separated pair and a diagnostic asking for that path would write a duplicate. Only the placement side matches the compiler.
- The pair-opener tail test `/\busing\s*:\s*$/` is copied at four sites.
- The same failure exists for any indented-block opener sharing a line with a pinned import, not just `using:` — `using { /A }; M := module:` over `    X := 1` takes an import between the two.

All three want their own issue; none is filed, pending your say.
