### PR TITLE
fix(services): close a braced module body on its brace, not on indentation

### DIFF
--- a/changelog.d/330.fixed.md
+++ b/changelog.d/330.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: A module whose braced body sits at or left of its own indent now nests its members, so their import paths keep the enclosing module and an unimportable one no longer offers its contents as top-level candidates.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -115,8 +115,9 @@ export class ProjectPathScanner {
      * `sourceLine` is 1-based, so it is one more than the `vscode.Position` line
      * for the same declaration. `fullPath` carries the dotted chain of enclosing
      * modules, so it equals `name` only at file scope. Declarations nested in a
-     * class or struct body are not filtered out here; only indentation-scoped
-     * module nesting is tracked.
+     * class or struct body are not filtered out here; only module nesting is
+     * tracked, each module scoped by its braces or by its indentation according
+     * to how its body was opened.
      *
      * Comments and string literals are masked before the scan, so a
      * commented-out declaration is neither recorded nor pushed onto the module
@@ -133,6 +134,11 @@ export class ProjectPathScanner {
         const lines = maskCommentsAndStrings(content).split("\n");
 
         let currentModulePath = "";
+        // Brace depth across the file, counted on the masked lines so comments
+        // and string literals contribute none. Verse delimits a braced body by
+        // its braces alone, so this is the only thing that can close one: its
+        // members are free to sit at or left of the declaration's own indent.
+        let braceDepth = 0;
         // A skipped module is on the stack for its indent alone, so that what
         // it contains is dropped with it rather than losing the enclosing
         // segment from its path. Nothing is ever pushed above a skipped entry,
@@ -140,8 +146,10 @@ export class ProjectPathScanner {
         //
         // `awaitingBrace` is true only between a module declaration that ended
         // without opening a body and the next line considered, which is where
-        // its `{` may be.
-        const moduleStack: { name: string; indent: number; skipped: boolean; awaitingBrace: boolean }[] = [];
+        // its `{` may be. `closeDepth` is the brace depth just outside a braced
+        // body, and null while indentation is what closes the entry: the colon,
+        // dotted and `>` forms, and a braced one whose `{` is still to come.
+        const moduleStack: { name: string; indent: number; skipped: boolean; awaitingBrace: boolean; closeDepth: number | null }[] = [];
 
         // A declaration carries any number of stacked specifiers, of which at
         // most one is a visibility; the rest (<native>, <final>, ...) are noise
@@ -215,6 +223,20 @@ export class ProjectPathScanner {
                 continue;
             }
 
+            // Counted before the `using` skip below, and ahead of every other
+            // `continue` in this loop, so no line can leave the depth behind: a
+            // braced `using` clause spans lines, and skipping its opener while
+            // still counting its `}` would drive the depth below the point any
+            // enclosing module opened from.
+            const depthAtLineStart = braceDepth;
+            for (const character of line) {
+                if (character === "{") {
+                    braceDepth++;
+                } else if (character === "}") {
+                    braceDepth--;
+                }
+            }
+
             if (line.startsWith("using")) {
                 continue;
             }
@@ -235,12 +257,29 @@ export class ProjectPathScanner {
                 topBeforePop.awaitingBrace = false;
             }
 
-            // Indentation alone closes a module: a line at or left of the open
-            // module's own indent is outside it.
+            // How a body was opened decides what closes it. A braced body ends
+            // at the brace returning the depth to where it opened, so its entry
+            // is popped on the next line the scan considers - a closing brace
+            // declares nothing, so reading it a line late costs no path. An
+            // indented body ends at the first line back at or left of its
+            // declaration. The loop stops at the first entry still open, which
+            // is what keeps indentation from closing an outer module while a
+            // braced one nested inside it is still waiting for its `}`.
             if (!opensAwaitedBody) {
-                while (moduleStack.length > 0 && indent <= moduleStack[moduleStack.length - 1].indent) {
+                while (moduleStack.length > 0) {
+                    const openModule = moduleStack[moduleStack.length - 1];
+                    const closed = openModule.closeDepth !== null ? depthAtLineStart <= openModule.closeDepth : indent <= openModule.indent;
+                    if (!closed) {
+                        break;
+                    }
                     moduleStack.pop();
                 }
+            }
+
+            // After the pop loop: this brace opens the body, so it must not
+            // also be read as the depth that closes it.
+            if (opensAwaitedBody && topBeforePop) {
+                topBeforePop.closeDepth = depthAtLineStart;
             }
 
             // An import checks every path segment from the root, so anything
@@ -259,15 +298,22 @@ export class ProjectPathScanner {
                 const visibility = extractVisibility(specifiers);
                 const isPublic = visibility === "public";
                 const awaitingBrace = bodyTerminator === undefined;
+                // A `{` here opens the body on this line, and it opens from the
+                // depth the line started at: everything left of it belongs to
+                // the declaration, whose only braces are a `scoped{...}` list
+                // and so are balanced. The other terminators open a body
+                // indentation closes, and a body still awaiting its brace has
+                // no depth to measure until that brace is seen.
+                const closeDepth = bodyTerminator === "{" ? depthAtLineStart : null;
 
                 const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
 
                 if (shouldSkipDeclaration(visibility, true)) {
-                    moduleStack.push({ name: fullPath, indent, skipped: true, awaitingBrace });
+                    moduleStack.push({ name: fullPath, indent, skipped: true, awaitingBrace, closeDepth });
                     continue;
                 }
 
-                moduleStack.push({ name: fullPath, indent, skipped: false, awaitingBrace });
+                moduleStack.push({ name: fullPath, indent, skipped: false, awaitingBrace, closeDepth });
                 currentModulePath = fullPath;
 
                 nodes.push({

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -216,25 +216,34 @@ export class ProjectPathScanner {
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i].trim();
 
+            // Ahead of every `continue` below, so that no line can leave the
+            // depth behind: a braced `using` clause spans lines, and skipping
+            // its opener while still counting its `}` would drive the depth
+            // below the point any enclosing module opened from.
+            //
+            // A brace between single quotes is a char literal. Masking leaves
+            // single quotes alone, because one opens a char literal and an
+            // identifier's quoted suffix alike and it cannot tell them apart,
+            // but a suffix cannot hold a brace, so this much is unambiguous.
+            // Counting one would strand the depth for the rest of the file,
+            // where indentation used to recover it at the next dedent.
+            const depthAtLineStart = braceDepth;
+            for (let column = 0; column < line.length; column++) {
+                const character = line[column];
+                if (character !== "{" && character !== "}") {
+                    continue;
+                }
+                if (line[column - 1] === "'" && line[column + 1] === "'") {
+                    continue;
+                }
+                braceDepth += character === "{" ? 1 : -1;
+            }
+
             // A Verse comment is already blank here, so the empty test is what
             // skips one; `//` is not a Verse comment form and masking leaves it
             // alone.
             if (line === "" || line.startsWith("//")) {
                 continue;
-            }
-
-            // Counted before the `using` skip below, and ahead of every other
-            // `continue` in this loop, so no line can leave the depth behind: a
-            // braced `using` clause spans lines, and skipping its opener while
-            // still counting its `}` would drive the depth below the point any
-            // enclosing module opened from.
-            const depthAtLineStart = braceDepth;
-            for (const character of line) {
-                if (character === "{") {
-                    braceDepth++;
-                } else if (character === "}") {
-                    braceDepth--;
-                }
             }
 
             if (line.startsWith("using")) {
@@ -276,8 +285,8 @@ export class ProjectPathScanner {
                 }
             }
 
-            // After the pop loop: this brace opens the body, so it must not
-            // also be read as the depth that closes it.
+            // The depth the line started at, never the one its `{` just
+            // produced: a body closes back at the depth its brace opened from.
             if (opensAwaitedBody && topBeforePop) {
                 topBeforePop.closeDepth = depthAtLineStart;
             }

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -171,8 +171,8 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
     // top-level module of the same name.
     describe("braced module bodies", () => {
         it("nests the members of a same-line brace body written at the module's own indent", () => {
-            const source = "Systems<public> := module{\nB<public> := module:\n    X<public> := class {}\n}\n";
-            expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.B", "Systems.B.X"]);
+            const source = "Systems<public> := module{\nB<public> := module:\n    X<public> := class {}\n}\nLoose<public> := class {}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.B", "Systems.B.X", "Loose"]);
         });
 
         it("nests the members of a next-line brace body written at the module's own indent", () => {
@@ -201,6 +201,18 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
             // to the other shows up here as a lost or a surplus segment.
             const source = "A<public> := module{\nB<public> := module:\n    C<public> := module{\nD<public> := class {}\n    }\n    E<public> := class {}\n}\nF<public> := class {}\n";
             expect(declare(source).map((node) => node.fullPath)).toEqual(["A", "A.B", "A.B.C", "A.B.C.D", "A.B.E", "F"]);
+        });
+
+        it("keeps a brace written as a char literal out of the depth", () => {
+            // Masking cannot blank a char literal, because a single quote opens
+            // an identifier's quoted suffix too. A brace cannot appear in such
+            // a suffix, so one between quotes is always a literal, and counting
+            // it would hold the module open for the rest of the file.
+            const held = "Systems<public> := module{\nOpen<public>:char = '{'\nB<public> := class {}\n}\nLoose<public> := class {}\n";
+            expect(declare(held).map((node) => node.fullPath)).toEqual(["Systems", "Systems.Open", "Systems.B", "Loose"]);
+
+            const closed = "Systems<public> := module{\nShut<public>:char = '}'\nB<public> := class {}\n}\nLoose<public> := class {}\n";
+            expect(declare(closed).map((node) => node.fullPath)).toEqual(["Systems", "Systems.Shut", "Systems.B", "Loose"]);
         });
 
         it("keeps the brace of a using clause out of the depth that closes the module holding it", () => {

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -161,4 +161,54 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
     it("does not read a keyword that merely starts with module as a declaration", () => {
         expect(moduleNames("Inventory := modulex\n")).toEqual([]);
     });
+
+    // Verse delimits a braced body by its braces alone, so its members may sit
+    // at or left of the declaration's own indent - the Book of Verse writes it
+    // that way in a compile-validated example. Closing such a module on
+    // indentation lets its first member pop it, which promotes the whole body
+    // to file scope: paths one segment short under a kept parent, and under a
+    // skipped one a subtree the compiler rejects, offered beside any genuine
+    // top-level module of the same name.
+    describe("braced module bodies", () => {
+        it("nests the members of a same-line brace body written at the module's own indent", () => {
+            const source = "Systems<public> := module{\nB<public> := module:\n    X<public> := class {}\n}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.B", "Systems.B.X"]);
+        });
+
+        it("nests the members of a next-line brace body written at the module's own indent", () => {
+            const source = "Systems<public> := module\n{\nB<public> := module:\n    X<public> := class {}\n}\nLoose<public> := class {}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.B", "Systems.B.X", "Loose"]);
+        });
+
+        it("nests members written left of the declaration's own indent", () => {
+            const source = "Outer<public> := module:\n    Inner<public> := module{\nX<public> := class {}\n    }\n    Kept<public> := class {}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["Outer", "Outer.Inner", "Outer.Inner.X", "Outer.Kept"]);
+        });
+
+        it("drops the subtree of a skipped same-line brace module written at its own indent", () => {
+            const source = "Systems<scoped{ModuleA}> := module{\nB<public> := module:\n    X<public> := class {}\n}\nInventory<public> := module:\n    Item<public> := class {}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
+        });
+
+        it("drops the subtree of a skipped next-line brace module written at its own indent", () => {
+            const source = "Systems<scoped{ModuleA}> := module\n{\nB<public> := module:\n    X<public> := class {}\n}\nInventory<public> := module:\n    Item<public> := class {}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
+        });
+
+        it("closes each of a nested colon and brace module by its own rule", () => {
+            // Both directions at once: a braced body holding a colon module,
+            // that colon body holding a braced one. A rule leaking from either
+            // to the other shows up here as a lost or a surplus segment.
+            const source = "A<public> := module{\nB<public> := module:\n    C<public> := module{\nD<public> := class {}\n    }\n    E<public> := class {}\n}\nF<public> := class {}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["A", "A.B", "A.B.C", "A.B.C.D", "A.B.E", "F"]);
+        });
+
+        it("keeps the brace of a using clause out of the depth that closes the module holding it", () => {
+            // A braced `using` clause spans lines and is skipped a line at a
+            // time, so counting its `}` without its `{` would close the module
+            // around it one brace early.
+            const source = "Systems<public> := module{\nusing{\n    /Verse.org/Simulation\n}\nB<public> := class {}\n}\nLoose<public> := class {}\n";
+            expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.B", "Loose"]);
+        });
+    });
 });


### PR DESCRIPTION
Closes #330

The module stack closed every entry on indentation. Verse delimits a braced body by its braces alone, and lets its members sit at or left of the declaration's own indent — the Book of Verse writes it that way in a compile-validated example (`docs/16_modules.md:120-132`, `m := module{` holding `module1 := module:`, both at indent 0). The first such member popped the module enclosing it, so the whole body was promoted to file scope: paths one segment short under a kept parent, and under a skipped one a subtree the compiler rejects, offered beside any genuine top-level module of the same name.

#324 weighed brace-depth tracking and deferred it; #329 fixed the module's own opening brace closing it. This is the remaining half — the body's members closing it.

## The change

A `moduleStack` entry now carries `closeDepth`: the brace depth just outside a braced body, or `null` where indentation is what closes the entry (the colon, dotted and `>` forms, and a braced one whose `{` has not been seen yet). One pop loop applies whichever rule the entry was opened with, and stops at the first entry still open — which is what keeps indentation from closing an outer module while a braced one nested inside it is still waiting for its `}`.

Brace depth is counted on the masked lines, so comments and string literals contribute none, and it is counted ahead of the `using` skip: a braced `using` clause spans lines, and skipping its opener while still counting its `}` would close the module around it one brace early.

The grammar behind this is `Block := Brace | DotSpace Space Def Space | (DotSpace | ':') Space Ind List Ded` (`VerseGrammar.h:2346`) — the `Ind`/`Ded` pair appears only in the colon/dot alternative, so no indentation rule reaches a braced body.

## Char literals

`maskCommentsAndStrings` deliberately does not track the single quote, because a quote opens a char literal and an identifier's quoted suffix alike. Left alone, `X:char = '{'` would leak a brace into the depth counter — and unlike the old indentation rule, which recovered at the next dedent, a stranded depth never recovers, so one character would misplace every later declaration in the file. That is a regression this change would otherwise introduce, not carried-over debt, so it is fixed here rather than accepted: a brace between single quotes is skipped when counting. A quoted suffix cannot contain a brace (`Ident := ... "'" {!('<#'|'#>'|'\'|'{'|'}'|'"'|''') ...} "'"`, `VerseGrammar.h`), so a brace between quotes is unambiguously a literal and never a suffix.

One narrower hole is left, and it belongs to the masker rather than to this counter: a char literal holding a double quote (`Print('"')`) opens a string in the mask and blanks the rest of that line, taking any real brace on it. Making the masker track quotes means telling a char literal from a quoted suffix, which is the ambiguity it documents as the reason it does not.

## Tests

Eight new cases under `braced module bodies`, covering exactly what the ticket asked: members at and left of the declaration's own indent, in both the same-line and next-line brace forms, under `<public>` and under `<scoped{...}>`, with a grandchild and a sibling after the closing `}`; the mixed case in both directions (a colon module holding a braced one and the reverse) to show the two closing rules do not interfere; and a multi-line braced `using` clause inside a braced module.

Each was run against the unfixed scanner first — all seven of the original cases fail there, with the reported symptom (`Systems.B` recorded as `B`); the char-literal case fails with the guard removed (`Loose` recorded as `Systems.Loose`).

## Review

Reviewed in a fresh context at the `models.review` tier, over roughly sixty probes run against both this branch and its baseline. Verdict `PASS_WITH_SUGGESTIONS`, no `Critical`. The one `Important` was the char-literal regression above, which is fixed rather than accepted; two comments that named constraints the code does not actually impose were corrected, and the same-line `<public>` case gained the trailing sibling the ticket asks for, so it now asserts the module closes.

One finding is deliberately left alone as out of scope: `src/visibility/moduleDeclarations.ts` runs a second, independent scan that closes module nesting on indentation with the same rule this PR replaces, and returns `[["Systems"], ["B"]]` for the ticket's own snippet. This PR does not make it worse, and the ticket names only `ProjectPathScanner`. Worth its own issue, since a visibility edit driven by the wrong chain writes into the wrong module.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       900 passed, 900 total
Snapshots:   0 total
Time:        9.233 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
