### PR TITLE
fix(imports): scan an indented using: pair across blank and comment lines

### DIFF
--- a/changelog.d/145.fixed.md
+++ b/changelog.d/145.fixed.md
@@ -1,0 +1,1 @@
+**Import scanning**: An indented `using:` import whose path sits below a blank line or a comment is now recognized, so the extension no longer adds a second copy of an import the file already has.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -129,10 +129,11 @@ function attachedCommentStart(importStartLine: number, classifications: LineClas
  * statements sharing its line owns its span alone.
  *
  * An indented `using:` pair reaches past the statement the same way, and has to
- * be asked separately: the pair's own scan entry spans both lines, but a line
- * may write a complete `using` and then open a pair, and that statement's entry
- * ends on the opener. Reading the opener alone leaves the path line free, and a
- * new import written there splits a pair that must stay adjacent.
+ * be asked separately: the pair's own scan entry already reaches its path line,
+ * but a line may write a complete `using` and then open a pair, and that
+ * statement's entry ends on the opener. Reading the opener alone leaves the
+ * path line free, and a new import written there leaves the `using:` with no
+ * body.
  *
  * The two rules alternate rather than run in turn, because either can extend a
  * span the other then extends again: a pair's path line may itself open a
@@ -596,29 +597,6 @@ export class ImportDocumentEditor {
             }
         }
         return runs;
-    }
-
-    /**
-     * The module import statements a document holds, deduplicated, with an
-     * indented pair (`using:` plus its path line) joined into one statement.
-     * Local-scope `using` is not among them.
-     */
-    extractExistingImports(document: vscode.TextDocument): string[] {
-        logger.debug("ImportDocumentEditor", "Extracting existing imports from document");
-        const lines = document.getText().split(LINE_SPLIT);
-        const imports = new Set<string>();
-
-        for (const imp of scanModuleImports(lines)) {
-            const statement = lines
-                .slice(imp.startLine, imp.endLine + 1)
-                .map((line) => line.trim())
-                .join(" ");
-            logger.trace("ImportDocumentEditor", `Found import: ${statement}`);
-            imports.add(statement);
-        }
-
-        logger.debug("ImportDocumentEditor", `Extracted ${imports.size} existing imports`);
-        return Array.from(imports);
     }
 
     /**

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -101,6 +101,13 @@ export class ImportFormatter {
      * @param nextLine The following line, which carries the content for the
      *   indented style. When it is not given and the line is `using:`, this
      *   conservatively returns `true`.
+     *
+     *   A `nextLine` that is given and carries no path must answer `false`,
+     *   blank and comment-only lines included. ImportScanner's loop gate reads
+     *   that answer to route a `using:` whose path sits further down onto its
+     *   pinned branch; answering `true` there makes the pair rewritable, and a
+     *   writer rebuilding that span from one path deletes the lines the author
+     *   wrote inside it.
      */
     static isModuleImport(line: string, nextLine?: string, options?: IsModuleImportOptions): boolean {
         const trimmed = line.trim();

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -29,10 +29,6 @@ export class ImportHandler {
         this.documentEditor = new ImportDocumentEditor(outputChannel, this.formatter);
     }
 
-    extractExistingImports(document: vscode.TextDocument): string[] {
-        return this.documentEditor.extractExistingImports(document);
-    }
-
     async extractImportSuggestions(errorMessage: string): Promise<ImportSuggestion[]> {
         return this.suggestionExtractor.extractImportSuggestions(errorMessage);
     }

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -14,7 +14,12 @@ export interface ScannedImport {
     /** The module path, e.g. "/Verse.org/Simulation" or "Gadgets.Tools". */
     path: string;
     startLine: number;
-    /** Last line of the statement: equal to startLine, or startLine + 1 for the indented pair. */
+    /**
+     * Last line of the statement: equal to startLine, or the line holding the
+     * path for the indented pair. That is the first line of code below the
+     * opener, which is not always the one directly below it - a blank line or
+     * a comment inside the pair does not end it. See indentedPairPathLine.
+     */
     endLine: number;
     /**
      * Whether the statement's own text opens a comment whose body is the lines
@@ -53,7 +58,7 @@ export interface ScannedImport {
     /**
      * The comment trailing the statement on its own line, or "" when it has
      * none. For the indented pair this is the comment on the path line, the
-     * only one of the two lines that can carry a path and therefore a comment
+     * only line of the span that can carry a path and therefore a comment
      * after it.
      *
      * Held here because a rebuild reconstructs the line from `path` and would
@@ -415,9 +420,13 @@ export function indentedPairPathLine(classifications: LineClassification[], open
  *   in it reads as an import: new imports get written into the comment, a
  *   needed import is judged already present, and organize hoists a
  *   deliberately disabled import back into force.
- * - The indented style (`using:` with the path on the following line) is
- *   consumed as one two-line entry so editing operations never orphan the
- *   path line or lose its path. A pair opened after a `using` statement and a
+ * - The indented style (`using:` with the path on a line below it) is consumed
+ *   as one entry spanning the opener and that path line, so editing operations
+ *   never orphan the path line or lose its path. The path is the first line of
+ *   code below the opener rather than the line directly below it, since
+ *   neither a blank line nor a comment ends an indented block; a pair holding
+ *   one is pinned, because a rebuild from its path would delete what sits
+ *   inside the span. A pair opened after a `using` statement and a
  *   `;` is consumed as well, but pinned rather than rewritable: its span says
  *   more than any one path can, so a writer rebuilding it deletes what it did
  *   not read. A pair opened after a definition is consumed and pinned too, by
@@ -485,8 +494,14 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         return depth > 0;
     };
 
-    // The path the indented pair opened on `opener` takes from the line below
-    // it, or "" when the line opens no pair.
+    // The path the indented pair opened on `opener` takes, with the line
+    // holding it, or null when the line opens no pair this scan admits.
+    //
+    // Which line that is comes from indentedPairPathLine: the first line of
+    // code below the opener, not the line directly below it, since neither a
+    // blank line nor a comment ends an indented block. One home for that rule
+    // as well, so the scan and the placement rules built on it cannot disagree
+    // about which lines a pair occupies.
     //
     // One home for the comment rule, because all three branches that reach a
     // pair need it and none of them can see it from where it is decided. A
@@ -503,7 +518,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     //
     // The opener always sits at column 0 outside any comment, since the loop
     // skips every other line before reaching a pair, so a comment continuing
-    // onto the path line was opened by the opener itself.
+    // onto the path line was opened by the opener itself or by a line inside
+    // the pair. Either way the path is comment text and the file does not
+    // import it.
     //
     // @param classifyContent whether content isModuleImport declines, such as
     //   the quoted segment suffix `Foo'Loc'`, disqualifies the pair. False for
@@ -511,7 +528,8 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     //   are recorded against the opener line alone, so the pair entry is the
     //   only one whose span reaches the path line, and declining it lets a new
     //   relative import be written between the opener and the path it opens -
-    //   two lines that must stay adjacent to compile. The comment rule above
+    //   a statement written there leaves the `using:` with no body. The
+    //   comment rule above
     //   costs nothing there, because pinnedSpanEnd rebuilds that reach from the
     //   comment structure itself; a content rule has nothing to rebuild it
     //   from. Over-recording the path is the cheaper error: the entry is
@@ -523,17 +541,19 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     //   strands the path line the same way and still classifies, as it always
     //   has. That is a standing gap rather than one this parameter closes, and
     //   narrowing it here would only move the hole.
-    const pairPathBelow = (opener: number, classifyContent: boolean): string => {
-        const pathLine = lines[opener + 1];
-        if (pathLine === undefined || !/^\s+\S/.test(pathLine) || classifications[opener + 1].continuesCommentAbove) {
-            return "";
+    const pairPathBelow = (opener: number, classifyContent: boolean): { path: string; pathLine: number } | null => {
+        const pathLine = indentedPairPathLine(classifications, opener);
+        if (pathLine === -1 || classifications[pathLine].continuesCommentAbove) {
+            return null;
         }
-        if (classifyContent && !ImportFormatter.isModuleImport("using:", pathLine, { atFileScope: true })) {
-            return "";
+        const text = lines[pathLine];
+        if (classifyContent && !ImportFormatter.isModuleImport("using:", text, { atFileScope: true })) {
+            return null;
         }
         // Empty where the line carries only a comment, which is no more a
         // usable pair than a missing line is.
-        return ImportFormatter.stripTrailingComment(pathLine);
+        const path = ImportFormatter.stripTrailingComment(text);
+        return path ? { path, pathLine } : null;
     };
 
     let i = 0;
@@ -604,20 +624,27 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // question, asked the same way by every branch that reaches a pair.
             //
             // Pinned like everything else the branch records, and for a second
-            // reason of its own: the span holds two lines, so a rebuild from
-            // one path deletes the other line whatever the head of the first
-            // one says.
-            const pairPath = /\busing\s*:\s*$/.test(statements) ? pairPathBelow(i, true) : "";
-            if (pairPath) {
+            // reason of its own: the span reaches from the opener to its path,
+            // so a rebuild from one path deletes every line between them
+            // whatever the head of the first one says.
+            //
+            // A plain `using:` whose path a blank or comment line separates
+            // from it lands here as well, and has to. The gate above reads the
+            // line directly below the opener, which for such a pair carries no
+            // path, so it refuses the line and the rewritable branch below is
+            // never reached - which is what stops a writer rebuilding a span
+            // over lines the author wrote inside it.
+            const pair = /\busing\s*:\s*$/.test(statements) ? pairPathBelow(i, true) : null;
+            if (pair) {
                 imports.push({
-                    path: pairPath,
+                    path: pair.path,
                     startLine: i,
-                    endLine: i + 1,
-                    anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                    endLine: pair.pathLine,
+                    anchorsCommentBelow: anchorsCommentBelow(i, pair.pathLine),
                     rebuildLosesText: true,
-                    trailingComment: ImportFormatter.extractTrailingComment(lines[i + 1]),
+                    trailingComment: ImportFormatter.extractTrailingComment(lines[pair.pathLine]),
                 });
-                i += 2;
+                i = pair.pathLine + 1;
                 continue;
             }
 
@@ -625,8 +652,14 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             continue;
         }
 
-        // Indented style: the path lives on the next line; consume both lines
-        // as a single entry.
+        // Indented style: the path lives on the line below; consume the pair as
+        // a single entry.
+        //
+        // Only a pair whose path sits directly below its opener reaches here,
+        // so this is the one branch whose entry is rewritable: the span holds
+        // the two lines a rebuild re-emits and nothing else. A pair with a
+        // blank or comment line inside it is refused by the gate above and
+        // recorded there instead, pinned.
         //
         // Neither half of what pairPathBelow refuses can arrive here: reaching
         // this branch needs the raw line to be `using:` and nothing else, which
@@ -635,17 +668,17 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // classifier. Asked anyway, so what a pair admits has one answer rather
         // than one this branch happens to agree with.
         if (/^using\s*:\s*$/.test(trimmed)) {
-            const pairPath = pairPathBelow(i, true);
-            if (pairPath) {
+            const pair = pairPathBelow(i, true);
+            if (pair) {
                 imports.push({
-                    path: pairPath,
+                    path: pair.path,
                     startLine: i,
-                    endLine: i + 1,
-                    anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                    endLine: pair.pathLine,
+                    anchorsCommentBelow: anchorsCommentBelow(i, pair.pathLine),
                     rebuildLosesText: false,
-                    trailingComment: ImportFormatter.extractTrailingComment(lines[i + 1]),
+                    trailingComment: ImportFormatter.extractTrailingComment(lines[pair.pathLine]),
                 });
-                i += 2;
+                i = pair.pathLine + 1;
                 continue;
             }
             // `using:` without indented content is not a usable import; leave it alone
@@ -715,8 +748,8 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             //
             // Content is the one question this branch answers differently, and
             // deliberately; see pairPathBelow's `classifyContent`.
-            const pairPath = pairPathBelow(i, false);
-            if (!pairPath) {
+            const pair = pairPathBelow(i, false);
+            if (!pair) {
                 // The `using:` opens nothing this scan admits, but the line
                 // still carries a statement this scanner cannot reproduce.
                 // Falling through to the single-statement branch would rebuild
@@ -726,14 +759,14 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             }
 
             imports.push({
-                path: pairPath,
+                path: pair.path,
                 startLine: i,
-                endLine: i + 1,
-                anchorsCommentBelow: anchorsCommentBelow(i, i + 1),
+                endLine: pair.pathLine,
+                anchorsCommentBelow: anchorsCommentBelow(i, pair.pathLine),
                 rebuildLosesText: true,
-                trailingComment: ImportFormatter.extractTrailingComment(lines[i + 1]),
+                trailingComment: ImportFormatter.extractTrailingComment(lines[pair.pathLine]),
             });
-            i += 2;
+            i = pair.pathLine + 1;
             continue;
         }
 
@@ -907,7 +940,8 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
  * - A `using:` opening an indented pair is recognised at the end of its line
  *   rather than as the whole of it, since a statement can precede it there too.
  *   The pair is the one shape counted once, because its path is read here from
- *   the line below. Neither rule scanModuleImports applies to a pair is applied
+ *   the first line of code below the opener, which is not always the line
+ *   directly below it. Neither rule scanModuleImports applies to a pair is applied
  *   here: over-reporting a path only makes the caller decline to tidy, so a
  *   path its opener comments out is offered rather than risk withholding one.
  *
@@ -931,21 +965,21 @@ export function allUsingPaths(lines: string[]): string[] {
         // extractPathFromImport reads neither pattern out of it - so the path
         // below it is read here instead.
         //
-        // Only the tail of the line has to match, because a statement can
-        // precede the `using:`. Requiring the whole line drops the path below
-        // such a pair, which the caller reads as permission to remove an
-        // import; matching the tail alone errs the safe way, since a line
-        // merely ending in `using:` contributes the text below it as a path and
-        // can only make the caller decline to tidy.
+        // Which line holds it is indentedPairPathLine's question, asked the
+        // same way the scan asks it: the first line of code below the opener,
+        // since neither a blank line nor a comment ends an indented block.
+        // Reading the line directly below instead drops the path of every pair
+        // written with one inside it, and a dropped path is what the caller
+        // reads as permission to remove an import.
         //
         // The indented half holds no `using` of its own, so the loop reaching
         // it adds no second copy of the path.
-        if (!/\busing\s*:\s*$/.test(trimmed)) {
+        const pathLine = indentedPairPathLine(classifications, i);
+        if (pathLine === -1) {
             continue;
         }
 
-        const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
-        const indentedPath = nextLine !== undefined && /^\s+\S/.test(nextLine) ? ImportFormatter.stripTrailingComment(nextLine) : "";
+        const indentedPath = ImportFormatter.stripTrailingComment(lines[pathLine]);
         if (indentedPath) {
             paths.push(indentedPath);
         }

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -528,11 +528,10 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     //   are recorded against the opener line alone, so the pair entry is the
     //   only one whose span reaches the path line, and declining it lets a new
     //   relative import be written between the opener and the path it opens -
-    //   a statement written there leaves the `using:` with no body. The
-    //   comment rule above
-    //   costs nothing there, because pinnedSpanEnd rebuilds that reach from the
-    //   comment structure itself; a content rule has nothing to rebuild it
-    //   from. Over-recording the path is the cheaper error: the entry is
+    //   a statement written there leaves the `using:` with no body. The comment
+    //   rule above costs nothing there, because pinnedSpanEnd rebuilds that
+    //   reach from the comment structure itself; a content rule has nothing to
+    //   rebuild it from. Over-recording the path is the cheaper error: the entry is
     //   pinned, so no writer rebuilds the line, and no diagnostic asks for a
     //   path of this shape.
     //
@@ -939,11 +938,17 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
  *   order, rather than the first.
  * - A `using:` opening an indented pair is recognised at the end of its line
  *   rather than as the whole of it, since a statement can precede it there too.
- *   The pair is the one shape counted once, because its path is read here from
- *   the first line of code below the opener, which is not always the line
- *   directly below it. Neither rule scanModuleImports applies to a pair is applied
- *   here: over-reporting a path only makes the caller decline to tidy, so a
- *   path its opener comments out is offered rather than risk withholding one.
+ *   The pair is the one shape counted once, because its path is read from the
+ *   line indentedPairPathLine names: the first line of code below the opener,
+ *   which is not always the line directly below it.
+ *
+ *   That helper carries the comment rule with it, so the pair is the one shape
+ *   this reports less of than the raw text would - a path the opener comments
+ *   out is not offered. Safe, for a reason the rest of the list cannot use:
+ *   comment text is not a `using`, so nothing resolves against it and removing
+ *   an import it appeared to provide strands nothing. Reading a pair any other
+ *   way here means a second opinion about what a pair is, which is the
+ *   disagreement sharing the helper exists to end.
  *
  * Positions are not reported; a caller that needs them wants scanModuleImports.
  */

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -191,6 +191,16 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, [], curlySorted)).toBeNull();
     });
 
+    // The end of the pinning rule, asserted where it can be seen: a pair whose
+    // path a comment separates from its opener is pinned, so the block is
+    // rebuilt above it and the comment inside it survives. Were such a pair
+    // ever rewritable, this rebuild would emit the path alone and the note
+    // would be gone.
+    it("keeps a comment written inside an indented pair", () => {
+        const input = ["using { /B }", "using:", "    # note", "    /A", "", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /B }", "", "using:", "    # note", "    /A", "", "code()"].join("\n"));
+    });
+
     // The `using:` opens nothing here, so there is no pair to read - but the
     // line is still not reproducible from the path before the `;`, and
     // rebuilding it deletes the `; using:` the author wrote.

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -876,6 +876,28 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
+    // The pair's path is the first line of code below the opener, so a blank
+    // line inside the pair does not end it. Scanned as the line directly below
+    // the opener the import was invisible, and the file ended up importing the
+    // same path twice.
+    it("recognizes an import an indented pair provides across a blank line", async () => {
+        const input = ["using:", "", "    /Verse.org/Simulation", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Verse.org/Simulation }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("recognizes an import an indented pair provides across a comment", async () => {
+        const input = ["using:", "    # the path below", "    /Verse.org/Simulation", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Verse.org/Simulation }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
     it("adds an import that exists only inside a block comment, above the comment", async () => {
         const input = ["<#", "using { /Fortnite.com/Devices }", "#>", "", "my_device := class(creative_device):", "    Button : button_device = button_device{}"].join("\n");
 

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -41,6 +41,18 @@ describe("ImportFormatter.isModuleImport", () => {
         expect(ImportFormatter.isModuleImport("using:", "    Features", { atFileScope: true })).toBe(true);
     });
 
+    // ImportScanner's loop gate reads this answer to route a `using:` whose
+    // path sits further down onto its pinned branch. Answering `true` for a
+    // line carrying no path makes such a pair rewritable, and a writer
+    // rebuilding that span from one path deletes what the author wrote between
+    // the opener and the path.
+    it("a using: over a line carrying no path is not a module import", () => {
+        expect(ImportFormatter.isModuleImport("using:", "", { atFileScope: true })).toBe(false);
+        expect(ImportFormatter.isModuleImport("using:", "    ", { atFileScope: true })).toBe(false);
+        expect(ImportFormatter.isModuleImport("using:", "    # the path below", { atFileScope: true })).toBe(false);
+        expect(ImportFormatter.isModuleImport("using:", "# a note of its own", { atFileScope: true })).toBe(false);
+    });
+
     // A bare identifier is the only dotted content the swallowed definition
     // changes the answer for: read to end of line the content was
     // `Features; MyVal := 5`, which is neither a path nor an identifier, so the

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -47,6 +47,14 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using:", "    # the path below", "    Features", "code()"])).toEqual(["Features"]);
     });
 
+    // The pair is the one shape this reports less of than the raw text would.
+    // Its path comes from indentedPairPathLine, which carries the comment rule,
+    // so a path the opener comments out is not offered - comment text is not a
+    // `using`, and nothing resolves against it.
+    it("does not read the path of a pair its opener comments out", () => {
+        expect(allUsingPaths(["using: <#>", "    /A", "code()"])).toEqual([]);
+    });
+
     it("ignores an import inside a block comment", () => {
         expect(allUsingPaths(["<#", "using { /Old }", "#>", "using { /A }", "code()"])).toEqual(["/A"]);
     });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -35,6 +35,18 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using:", "    /A", "code()"])).toEqual(["/A"]);
     });
 
+    // Neither a blank line nor a comment ends an indented block, so the path
+    // below one is still the pair's body. Missing it is the one error this must
+    // not make: the caller reads an empty answer as permission to remove an
+    // import, and a relative path left unreported is what makes that unsafe.
+    it("reads the path of a pair a blank line separates from its opener", () => {
+        expect(allUsingPaths(["using:", "", "    Features", "code()"])).toEqual(["Features"]);
+    });
+
+    it("reads the path of a pair a comment separates from its opener", () => {
+        expect(allUsingPaths(["using:", "    # the path below", "    Features", "code()"])).toEqual(["Features"]);
+    });
+
     it("ignores an import inside a block comment", () => {
         expect(allUsingPaths(["<#", "using { /Old }", "#>", "using { /A }", "code()"])).toEqual(["/A"]);
     });
@@ -300,6 +312,37 @@ describe("scanModuleImports", () => {
         expect(rewritableImports(scanModuleImports(["using:", "    Economy.Shop", "code()"]))).toEqual([
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
+    });
+
+    // The path is the first line of code below the opener, not the line
+    // directly below it: neither a blank line nor a comment ends an indented
+    // block. Read as `lines[opener + 1]` the pair was invisible, so the import
+    // counted as absent and a diagnostic asking for it wrote a second copy.
+    //
+    // Pinned, and the span reaches the path: a writer rebuilds a span from its
+    // path alone, so rewriting this one would delete the lines between.
+    it("consumes a pair holding a blank line, pinned", () => {
+        expect(scanModuleImports(["using:", "", "    /Verse.org/Random", "code()"])).toEqual([
+            { path: "/Verse.org/Random", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("consumes a pair holding a comment indented into it, pinned", () => {
+        expect(scanModuleImports(["using:", "    # the path below", "    /Verse.org/Simulation", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // A comment written back at column 0 leaves the block open just as an
+    // indented one does, so the pair reaches past it.
+    it("consumes a pair holding a comment written at column 0, pinned", () => {
+        expect(scanModuleImports(["using:", "# a note of its own", "    /A", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("offers no rewritable import for a pair holding a blank line", () => {
+        expect(rewritableImports(scanModuleImports(["using:", "", "    /A", "code()"]))).toEqual([]);
     });
 
     // The tail is tested against the line's code, not its raw text. A `$`


### PR DESCRIPTION
Closes #145

## What was wrong

`ImportScanner.indentedPairPathLine` already carried the correct rule for the indented `using:` style — the pair's path is the first line of **code** below the opener, because neither a blank line nor a comment ends an indented block. Only the placement layer used it (`ImportDocumentEditor.pinnedSpanEnd`). The scan layer still read the line directly below the opener, so the two disagreed about what a pair is.

A pair written with a blank or a comment line inside it was therefore invisible to the scan:

```verse
using:
    # the path below
    /Verse.org/Simulation
```

`scanModuleImports` returned `[]`. The path did not count as imported, so a diagnostic asking for it wrote a second copy of an import the file already had. The same miss in `allUsingPaths` fed `withholdIsSafe`, whose doc says plainly that a missed `using` is the one error it must not make, because an empty answer reads as permission to remove an import.

## What changed

- `pairPathBelow` returns `{ path, pathLine } | null` and takes the line from `indentedPairPathLine` rather than `lines[opener + 1]`. Both existing content rules are kept, applied to the located line.
- The three pair call sites take `endLine`, `anchorsCommentBelow`, `trailingComment` and the loop advance from that line.
- `allUsingPaths` goes through the same helper, so reader and scan cannot disagree about which lines a pair occupies.
- `extractExistingImports` and its `ImportHandler` re-export are deleted.

A **gapped** pair is always pinned, and needs no new rule to make it so: the loop gate classifies the indented style from the line directly below the opener, which for such a pair carries no path, so the gate refuses the line and it is recorded on the already-pinned branch. That is what stops a writer rebuilding the span over lines the author wrote. A pair whose path sits directly below its opener is unchanged — still `endLine === startLine + 1`, still rewritable. The routing was implicit; it is load-bearing here, so it is now commented as such.

## Why `extractExistingImports` was deleted rather than fixed

It had no caller in `src/` and no test. For a pair it emitted `using: /path`, and that is not merely unreadable by this repo's patterns — it is invalid Verse. `Block := Brace | DotSpace Space Def Space | (DotSpace | ':') Space Ind List Ded` (`VerseGrammar.h:2434`): the same-line-body alternative is the dotted form only, and `Ind()` opens with `ULANG_ASSERT(Ending())` (`VerseGrammar.h:1636-1641`). So a `:` clause body must begin on a following line, and teaching a reader that shape would have taught the repo a form the compiler rejects.

## Domain rules, with authority

Verified at the compiler source (`ue5-main`), not inferred from this codebase:

- **Neither a blank line nor a comment ends an indented block, at any indentation.** `VerseGrammar.h:1680-1684` consumes a whitespace-only line as `Gen.BlankLine` unconditionally; `VerseGrammar.h:1690-1755` runs a `Scan` lookahead for a less-indented whitespace-or-comment-only line, backtracking only on a non-whitespace/comment token — so a comment at column 0 leaves the block open.
- **A `using` clause holds exactly one expression.** `AnalyzeMacroCall_Using` rejects `Exprs().Num() != 1` (`SemanticAnalyzer.cpp:6377-6381`); `using` reaches it as an innate macro (`SemanticAnalyzer.cpp:17288`). So the first code line below the opener is the whole body.

## One behaviour change beyond the ticket, stated

Sharing `indentedPairPathLine` brings its comment rule with it, so `allUsingPaths` no longer reports the path of a pair its own opener comments out — `["using: <#>", "    /A", "code()"]` was `["/A"]`, is now `[]`. That is the one place the function reports less than the raw text would, and it is safe for a reason the rest of its "always over-report" list cannot use: comment text is not a `using`, so nothing resolves against it and removing an import it appeared to provide strands nothing. The doc said the opposite; it is corrected, and the new answer has a test.

## Tests

Ten added.

- `ImportScanner.test.ts` — gapped pair with a blank line, with an indented comment, with a column-0 comment; `rewritableImports` empty for a gapped pair; `allUsingPaths` across a blank line and across a comment; `allUsingPaths` declining a commented-out pair.
- `ImportDocumentEditor.test.ts` — at the entry point the issue names: `addImportsToDocument` makes no edit for a path a gapped pair already provides, across a blank line and across a comment. Plus the end-to-end assertion the rewritable/pinned split exists for — a comment written inside a pair survives `buildOrganizedContent`.
- `ImportFormatter.test.ts` — pins `isModuleImport("using:", <no path>) === false`, which is the answer the pair routing depends on.

Six fail against the unfixed code. Four are guards rather than defect detectors — they pass before and after, and exist so a future change cannot move the behaviour silently. Called out rather than counted as regression coverage.

## Review

A fresh reviewer probed the change over 27 executed cases: **PASS_WITH_SUGGESTIONS**, no Critical. It confirmed the pinning claim held under every input it could construct, and its data-loss sweep over a 42-document corpus found zero losses and zero non-idempotence. Both Important findings — the unpinned `isModuleImport` coupling and the stale `allUsingPaths` doc — are fixed in `fa38acb`.

One Suggestion is deliberately not taken: collapsing the three `imports.push` blocks behind a shared `pairEntry` helper. The per-shape branch structure is deliberate and `CLAUDE.md` calls its ordering load-bearing, so restructuring it is wider than this ticket.

## Verification

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       904 passed, 904 total
Snapshots:   0 total
Time:        9.44 s
Ran all test suites.
```

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No existing test regressed, including the 76 already covering the indented pair.
