### PR TITLE
fix(visibility): close a braced module body on its brace, not on indentation

### DIFF
--- a/changelog.d/333.fixed.md
+++ b/changelog.d/333.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: Making a module public now finds a declaration nested in a braced module whose body sits at or left of its own indent, editing that declaration instead of writing a second part beside it.

--- a/src/visibility/__tests__/moduleDeclarations.test.ts
+++ b/src/visibility/__tests__/moduleDeclarations.test.ts
@@ -109,11 +109,37 @@ describe("findExplicitModuleDeclarations", () => {
     });
 
     it("nests the same way when the brace opens the body on the next line", () => {
-        const content = "Systems := module\n{\nB := module:\n    X:int = 1\n}\nLater := module {}\n";
+        const content = "Systems := module\n{\nB := module:\n    X := module {}\n}\nLater := module {}\n";
 
         const declarations = findExplicitModuleDeclarations(content);
 
-        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Systems"], ["Systems", "B"], ["Later"]]);
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Systems"], ["Systems", "B"], ["Systems", "B", "X"], ["Later"]]);
+    });
+
+    it("returns a sibling to the enclosing module when the braced body it follows was written left of its declaration", () => {
+        const content = "Outer := module:\n    Inner := module{\nMember := module:\n    Q:int = 1\n    }\n    Kept := module {}\n";
+
+        const declarations = findExplicitModuleDeclarations(content);
+
+        // `Member` reads as open on indentation alone at `Kept`, so closing only
+        // from the top would leave it shielding `Inner`, whose `}` has passed.
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Outer"], ["Outer", "Inner"], ["Outer", "Inner", "Member"], ["Outer", "Kept"]]);
+    });
+
+    it("returns the sibling the same way when the brace opened the body on the next line", () => {
+        const content = "Outer := module:\n    Inner := module\n    {\nMember := module:\n    Q:int = 1\n    }\n    Kept := module {}\n";
+
+        const declarations = findExplicitModuleDeclarations(content);
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Outer"], ["Outer", "Inner"], ["Outer", "Inner", "Member"], ["Outer", "Kept"]]);
+    });
+
+    it("closes one braced body of several without closing those still open around it", () => {
+        const content = "Systems := module{\nB := module:\n    C := module{\nD := module:\n        Z:int = 1\n    }\n    E := module {}\n}\nSibling := module {}\n";
+
+        const declarations = findExplicitModuleDeclarations(content);
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Systems"], ["Systems", "B"], ["Systems", "B", "C"], ["Systems", "B", "C", "D"], ["Systems", "B", "E"], ["Sibling"]]);
     });
 
     it("keeps the chain of braces opened on one line", () => {

--- a/src/visibility/__tests__/moduleDeclarations.test.ts
+++ b/src/visibility/__tests__/moduleDeclarations.test.ts
@@ -100,6 +100,46 @@ describe("findExplicitModuleDeclarations", () => {
         expect(declarations.map((declaration) => declaration.chain)).toEqual([["Outer"], ["Outer", "Inner"], ["Outer", "Other"]]);
     });
 
+    it("nests a braced module's members where they sit at or left of its own indent", () => {
+        const content = "Systems<scoped{ModuleA}> := module{\nB<public> := module:\n    X<public> := module {}\n}\nLater := module {}\n";
+
+        const declarations = findExplicitModuleDeclarations(content);
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Systems"], ["Systems", "B"], ["Systems", "B", "X"], ["Later"]]);
+    });
+
+    it("nests the same way when the brace opens the body on the next line", () => {
+        const content = "Systems := module\n{\nB := module:\n    X:int = 1\n}\nLater := module {}\n";
+
+        const declarations = findExplicitModuleDeclarations(content);
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Systems"], ["Systems", "B"], ["Later"]]);
+    });
+
+    it("keeps the chain of braces opened on one line", () => {
+        const declarations = findExplicitModuleDeclarations("M := module{ N := module{\n}}\n");
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["M"], ["M", "N"]]);
+    });
+
+    it("holds a braced module open through a colon module written at its indent", () => {
+        const content = "Outer := module:\n    Inner := module{\n    Leaf := module:\n        Y:int = 1\n    }\nSibling := module:\n";
+
+        const declarations = findExplicitModuleDeclarations(content);
+
+        expect(declarations.map((declaration) => declaration.chain)).toEqual([["Outer"], ["Outer", "Inner"], ["Outer", "Inner", "Leaf"], ["Sibling"]]);
+    });
+
+    it("leaves a single-quoted brace out of the depth that closes a module", () => {
+        // A quoted suffix cannot hold a brace, so one between quotes delimits
+        // nothing; counting it would strand the depth for the rest of the file.
+        const held = "Systems := module{\nOpen:char = '{'\nB := module:\n    X:int = 1\n}\nLater := module {}\n";
+        expect(findExplicitModuleDeclarations(held).map((declaration) => declaration.chain)).toEqual([["Systems"], ["Systems", "B"], ["Later"]]);
+
+        const closed = "Systems := module{\nShut:char = '}'\nB := module:\n    X:int = 1\n}\nLater := module {}\n";
+        expect(findExplicitModuleDeclarations(closed).map((declaration) => declaration.chain)).toEqual([["Systems"], ["Systems", "B"], ["Later"]]);
+    });
+
     it("skips a declaration inside a line comment", () => {
         expect(findExplicitModuleDeclarations("# Ghost := module {}\nReal := module {}\n").map((declaration) => declaration.name)).toEqual(["Real"]);
     });

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -35,6 +35,17 @@ describe("resolveVisibility", () => {
         expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Tools", span: { start: 5, end: 5 }, text: "<public>" }]);
     });
 
+    it("edits a declaration nested in a braced module whose members sit at its own indent", () => {
+        const found = declarationsIn("file://a", "Gadgets", "Systems := module{\nTools := module:\n    X:int = 1\n}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Systems", false], ["Tools", true]), found);
+
+        // A chain here would be a second part of a module that is already
+        // declared, written under a path this declaration does not carry.
+        expect(resolved.chain).toEqual([]);
+        expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Systems/Tools", span: { start: 24, end: 24 }, text: "<public>" }]);
+    });
+
     it("rewrites every part of a module, since later parts must repeat the specifier", () => {
         const found = [...declarationsIn("file://a", "Gadgets", "Tools := module {}\n"), ...declarationsIn("file://b", "Gadgets", "Tools := module:\n    X:int = 1\n")];
 

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -46,6 +46,20 @@ describe("resolveVisibility", () => {
         expect(resolved.edits).toEqual([{ file: "file://a", path: "Gadgets/Systems/Tools", span: { start: 24, end: 24 }, text: "<public>" }]);
     });
 
+    it("rewrites the real declaration of a module following a braced body written left of its declaration", () => {
+        const content = "Outer := module:\n    Inner := module{\nMember := module:\n    Q:int = 1\n    }\n    Kept<internal> := module {}\n";
+        const found = declarationsIn("file://a", "Gadgets", content);
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Outer", false], ["Kept", true]), found);
+
+        expect(resolved.chain).toEqual([]);
+        expect(resolved.edits).toHaveLength(1);
+        expect(resolved.edits[0]).toMatchObject({ file: "file://a", path: "Gadgets/Outer/Kept", text: "<public>" });
+        // The specifier that is really there is rewritten. A second part
+        // declaring a different one is ErrSemantic_MismatchedPartialAttributes.
+        expect(content.slice(resolved.edits[0].span.start, resolved.edits[0].span.end)).toBe("<internal>");
+    });
+
     it("rewrites every part of a module, since later parts must repeat the specifier", () => {
         const found = [...declarationsIn("file://a", "Gadgets", "Tools := module {}\n"), ...declarationsIn("file://b", "Gadgets", "Tools := module:\n    X:int = 1\n")];
 

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -103,7 +103,9 @@ interface OpenModule {
  * left of the declaration's own indent; both brace placements open such a body,
  * the one on the declaration's line and the one on the next. A colon body, and
  * the dotted form, end instead at the first later line back at or left of the
- * declaration.
+ * declaration. A closing brace takes every module inside its body along,
+ * whatever their own indentation would say, so the two are resolved in that
+ * order.
  *
  * Text inside comments and string literals is masked before matching, so a
  * commented-out declaration is not reported and a `#` inside a string does not
@@ -133,10 +135,19 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
 
         const line = lineOf(lineStarts, nameStart);
         const indent = indentOf(content, lineStarts[line - 1]);
-        // Stops at the first entry still open, which is what keeps indentation
-        // from closing an outer module while a braced one nested inside it is
-        // still waiting for its `}`.
-        while (open.length > 0 && closesBefore(open[open.length - 1], braceDepth, indent, line)) {
+
+        // Closed braced bodies go first, outermost in, because one takes every
+        // module inside it along. A colon module written left of the brace's own
+        // declaration reads as open on indentation alone, and closing only from
+        // the top would let it shield the closed brace beneath it.
+        const closedBrace = outermostClosedBrace(open, braceDepth);
+        if (closedBrace !== -1) {
+            open.length = closedBrace;
+        }
+
+        // What is left closes innermost out, and stops at a braced body still
+        // waiting for its `}`.
+        while (open.length > 0 && closedByIndent(open[open.length - 1], indent, line)) {
             open.pop();
         }
 
@@ -209,21 +220,28 @@ function findAccessLevel(specifierBlock: string): { index: number; length: numbe
 }
 
 /**
- * Whether an open module ends before a declaration at this depth, indent and
- * line.
+ * Index of the outermost open module whose braced body has already closed, and
+ * so of the first entry the stack no longer holds; -1 while none has closed.
  *
- * A braced body ends at the brace returning the depth to where it opened, and
- * no indentation closes one - that is what lets its members sit at or left of
- * the declaration. An indented body ends at the first later line back at or
- * left of its declaration; a declaration on the parent's own line is inside it,
- * which is what the dotted chain means.
+ * Only a braced body can be found closed from below like this. Its depth test
+ * holds anywhere in the file, whereas an indent compared across a brace
+ * boundary means nothing - a module inside the braces may be written left of
+ * the declaration that opened them.
  */
-function closesBefore(open: OpenModule, braceDepth: number, indent: number, line: number): boolean {
-    if (open.closeDepth !== null) {
-        return braceDepth <= open.closeDepth;
-    }
+function outermostClosedBrace(open: readonly OpenModule[], braceDepth: number): number {
+    return open.findIndex((entry) => entry.closeDepth !== null && braceDepth <= entry.closeDepth);
+}
 
-    return open.line !== line && indent <= open.indent;
+/**
+ * Whether an open module that indentation delimits ends before a declaration at
+ * this indent and line. A declaration on the parent's own line is inside it,
+ * which is what the dotted chain means.
+ *
+ * False for a braced body, whose end no indentation can announce. That is what
+ * stops the pop loop at one, leaving the modules below it open.
+ */
+function closedByIndent(open: OpenModule, indent: number, line: number): boolean {
+    return open.closeDepth === null && open.line !== line && indent <= open.indent;
 }
 
 /**

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -80,15 +80,30 @@ export interface ModuleDeclaration {
 }
 
 /**
+ * An enclosing module the scan is still inside, and what will close it.
+ *
+ * `closeDepth` is the brace depth just outside a braced body, and null when
+ * indentation closes the entry instead - the colon, dotted and `>` forms.
+ * `line` is held because a declaration sharing its parent's line is inside it,
+ * which is what the dotted chain means.
+ */
+interface OpenModule {
+    chain: string[];
+    indent: number;
+    line: number;
+    closeDepth: number | null;
+}
+
+/**
  * Every explicit module declaration in the text, in source order.
  *
- * Nesting is read two ways, because the three declaration styles do not agree
- * on how a body opens. A declaration on the same line as the one before it is
- * nested in it, which is what the dotted and same-line brace chains mean;
- * otherwise indentation decides, as it does for the colon style and for a
- * brace opened on the following line. A one-line `module {}` followed by a
- * MORE indented sibling is therefore read as nesting - invalid Verse anyway,
- * and the alternative is tracking brace depth as well.
+ * Nesting is read from how each body was opened, because the declaration
+ * styles do not agree on what closes one. A braced body ends at the brace
+ * returning the depth to where it opened, so its members are free to sit at or
+ * left of the declaration's own indent; both brace placements open such a body,
+ * the one on the declaration's line and the one on the next. A colon body, and
+ * the dotted form, end instead at the first later line back at or left of the
+ * declaration.
  *
  * Text inside comments and string literals is masked before matching, so a
  * commented-out declaration is not reported and a `#` inside a string does not
@@ -101,20 +116,37 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
     const searchable = maskCommentsAndStrings(content);
     const pattern = new RegExp(MODULE_DECLARATION.source, "g");
     const lineStarts = buildLineStarts(content);
-    const open: { chain: string[]; indent: number; line: number }[] = [];
+    const open: OpenModule[] = [];
+
+    // Brace depth at the declaration being read. Counted forward over the gap
+    // between one match and the next, so every brace in the file is seen once
+    // and a closing brace is never missed for sitting between declarations.
+    let braceDepth = 0;
+    let counted = 0;
 
     let match: RegExpExecArray | null;
     while ((match = pattern.exec(searchable)) !== null) {
         const [, name, specifierBlock] = match;
         const nameStart = match.index;
+        braceDepth = countBraces(searchable, counted, nameStart, braceDepth);
+        counted = nameStart;
+
         const line = lineOf(lineStarts, nameStart);
         const indent = indentOf(content, lineStarts[line - 1]);
-        while (open.length > 0 && open[open.length - 1].line !== line && indent <= open[open.length - 1].indent) {
+        // Stops at the first entry still open, which is what keeps indentation
+        // from closing an outer module while a braced one nested inside it is
+        // still waiting for its `}`.
+        while (open.length > 0 && closesBefore(open[open.length - 1], braceDepth, indent, line)) {
             open.pop();
         }
 
         const chain = open.length > 0 ? [...open[open.length - 1].chain, name] : [name];
-        open.push({ chain, indent, line });
+        // The terminator is the match's last character. A `{` opens the body
+        // from the depth measured here, never the one it produces: the
+        // declaration's own braces are a `scoped{...}` list and so balance out,
+        // and they are counted on the way to the next match rather than now.
+        const closeDepth = match[0].endsWith("{") ? braceDepth : null;
+        open.push({ chain, indent, line, closeDepth });
 
         const nameEnd = nameStart + name.length;
         const declaration: ModuleDeclaration = {
@@ -174,6 +206,52 @@ function findAccessLevel(specifierBlock: string): { index: number; length: numbe
     }
 
     return named;
+}
+
+/**
+ * Whether an open module ends before a declaration at this depth, indent and
+ * line.
+ *
+ * A braced body ends at the brace returning the depth to where it opened, and
+ * no indentation closes one - that is what lets its members sit at or left of
+ * the declaration. An indented body ends at the first later line back at or
+ * left of its declaration; a declaration on the parent's own line is inside it,
+ * which is what the dotted chain means.
+ */
+function closesBefore(open: OpenModule, braceDepth: number, indent: number, line: number): boolean {
+    if (open.closeDepth !== null) {
+        return braceDepth <= open.closeDepth;
+    }
+
+    return open.line !== line && indent <= open.indent;
+}
+
+/**
+ * The brace depth after the half-open range, starting from the depth before it.
+ * Counted on masked text, so a brace in a comment or a string contributes none.
+ */
+function countBraces(searchable: string, start: number, end: number, depth: number): number {
+    let braceDepth = depth;
+
+    for (let i = start; i < end; i++) {
+        const character = searchable[i];
+        if (character !== "{" && character !== "}") {
+            continue;
+        }
+
+        // A single-quoted brace delimits nothing. Masking leaves single quotes
+        // alone because one opens a char literal and an identifier's quoted
+        // suffix alike, but neither reading makes this brace a body's, and
+        // counting one would strand the depth for the rest of the file with
+        // nothing left to recover it.
+        if (searchable[i - 1] === "'" && searchable[i + 1] === "'") {
+            continue;
+        }
+
+        braceDepth += character === "{" ? 1 : -1;
+    }
+
+    return braceDepth;
 }
 
 /** Offset of the first character of every line, so a line number is a binary search. */

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -227,6 +227,12 @@ function findAccessLevel(specifierBlock: string): { index: number; length: numbe
  * holds anywhere in the file, whereas an indent compared across a brace
  * boundary means nothing - a module inside the braces may be written left of
  * the declaration that opened them.
+ *
+ * The lowest such index is the cut rather than merely one of them, because a
+ * braced entry records the depth it opens from and every braced entry left on
+ * the stack sits below the current depth: their close depths increase upwards,
+ * so nothing below the index found here has closed too. Cutting the stack
+ * before the next entry is pushed is what keeps that true.
  */
 function outermostClosedBrace(open: readonly OpenModule[], braceDepth: number): number {
     return open.findIndex((entry) => entry.closeDepth !== null && braceDepth <= entry.closeDepth);


### PR DESCRIPTION
Closes #333

`findExplicitModuleDeclarations` closed an open module purely on indentation, so a braced body whose members sit at or left of the declaration's own indent popped its parent early and returned a chain short by a segment. The chain names the module the visibility writer edits against, so a short one sends a `<public>` marking to the wrong part, or writes a second part where one already exists — and where the real module carries a different specifier, that second part is `ErrSemantic_MismatchedPartialAttributes` (error 3623).

This is the shape #332 landed in `ProjectPathScanner`, which read the same file the other way until now.

## What changed

Each open module records how its body was opened and is closed accordingly:

- **A braced body** ends at the brace returning the depth to where it opened. Both placements open one — the brace on the declaration's line and the brace on the next.
- **A colon body, and the dotted form**, end at the first later line back at or left of the declaration, as before.
- **A closing brace takes every module inside its body along**, whatever their own indentation would say. Closed braced bodies are resolved first, outermost in; what remains closes innermost out and stops at a brace still awaiting its `}`.

That last rule is the one the first attempt got wrong, and the review gate caught it. Closing only from the top of the stack let an indentation-closed module shield a braced one beneath it: a colon module written *left of* the brace's own declaration — the very shape this fix exists to support — reads as still open at any declaration indented past it, so the pop stopped there and never reached the brace whose `}` had passed. A sibling after that `}` came back several segments too long.

Only a braced entry can be closed from below this way. Its depth test holds anywhere in the file, whereas an indent compared across a brace boundary means nothing.

Depth is counted on the masked text, so a brace in a comment or a string contributes none, and a single-quoted brace is left out of it — whether `'{'` is a char literal or part of an identifier's quoted suffix, neither delimits a body, and counting one strands the depth for the rest of the file with nothing to recover it.

### Domain rules this relies on

- **A braced module body is delimited by its braces alone**, and its members may sit at or left of the declaration's indent, in either brace placement. Book of Verse `docs/16_modules.md:120-132`, a compile-validated `versetest` block where `m := module{` encloses `module1 := module:` and `module2 := module` / `{` at indent 0.
- **A mismatched specifier on a second partial part is error 3623.** `VerseCompiler/Public/uLang/Diagnostics/Glitch.h:228` — "Attributes of partial module definition differ from attributes of related other partial definition."

## Files

- `src/visibility/moduleDeclarations.ts` — the closing rule, split into `outermostClosedBrace` (phase one, by depth) and `closedByIndent` (phase two, which returns false for a braced entry and so stops the pop at one), plus `countBraces`. The doc comment that named brace-depth tracking as the declined alternative is rewritten.
- `src/visibility/__tests__/moduleDeclarations.test.ts` — the ticket's coverage: members at and left of the declaration's own indent in both brace placements, with a grandchild and a sibling after the closing `}`; one braced body of several closing without closing those still open around it; the same-line chain `M := module{ N := module{` held unchanged; a colon module containing a braced one and the reverse; and the single-quoted brace in both directions.
- `src/visibility/__tests__/visibilityResolution.test.ts` — two tests at the consumer, where a short chain is user-visible: the resolved path carries the full chain, and a real `Kept<internal>` is rewritten in place rather than getting a second `<public>` part beside it.
- `changelog.d/333.fixed.md`

Each new test was run against the unfixed source and observed to fail before being kept.

## Verification

```
$ npm run compile

> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test

> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       922 passed, 922 total
Snapshots:   0 total
Time:        6.61 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

Two rounds, fresh context, opus.

- **Round 1 — FAIL.** One Critical: the shielding defect above, with the consumer harm demonstrated through `resolveVisibility`. Two Important: coverage missing exactly the failing shapes (members *left of* the indent, and the sibling after `}` at the enclosing body's indent), and `countBraces` duplicating the counter #332 landed in `ProjectPathScanner`. One Suggestion.
- **Round 2 — PASS_WITH_SUGGESTIONS.** 77 probes, including all 44 from round 1 re-run: every previously-passing shape returns an identical chain, and only the four broken shapes changed, each to the correct answer. Probed the two hazards the two-phase pop introduces — negative brace depth meeting `braceDepth <= closeDepth` at index 0, and truncation discarding an entry it should keep — across nine and fourteen shapes respectively, all correct. The Suggestion (write down why the *lowest* closed index is the right cut) is applied in `27762ee`.

**One Important is deliberately left unfixed here.** The two scans now disagree in the other direction: this one is correct and `ProjectPathScanner` carries the shielding bug alone, where it means an import path a segment too long and, under a skipped parent, a subtree offered as top-level candidates. Porting the rule to the scanner and extracting `countBraces` into `src/utils/verseText.ts` so the two cannot drift again is a behaviour fix in a second module, which does not belong in this diff. It wants its own issue.
