### PR TITLE
feat(imports): convert to relative paths the way the compiler does

### DIFF
--- a/changelog.d/277.changed.md
+++ b/changelog.d/277.changed.md
@@ -1,0 +1,1 @@
+**Convert to relative path**: shortens an import against the module the file sits in, matching the spelling the Verse compiler suggests, instead of always against the project root.

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -562,7 +562,7 @@ export class CommandsHandler {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);
 
-        const result = (await this.deps.importPathConverter.convertFromFullPath(importStatement, lineNumber)) as PathConversionResult | null;
+        const result = (await this.deps.importPathConverter.convertFromFullPath(importStatement, document.uri, lineNumber)) as PathConversionResult | null;
 
         if (!result) {
             vscode.window.showInformationMessage("Import cannot be converted to relative path.");

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -371,6 +371,19 @@ describe("CommandsHandler per-document conversion keying", () => {
         expect(codeLensProvider.forceRefreshAfterConversion).toHaveBeenCalledWith(document.uri.toString());
     });
 
+    // The converter places the importing scope from this uri, so it decides
+    // which module the path is shortened against. A stale or substituted
+    // document changes the spelling written, and nothing else would show it.
+    it("hands the acting document's uri to convertFromFullPath", async () => {
+        const convertFromFullPath = jest.fn().mockResolvedValue(makeConversion());
+        const { handler } = makeConversionHandler({ convertFromFullPath });
+        const document = makeDocument(WEAPONS_UTILS);
+
+        await handler.convertToRelativePath(document, `using { ${ABSOLUTE_PATH} }`, 4);
+
+        expect(convertFromFullPath).toHaveBeenCalledWith(`using { ${ABSOLUTE_PATH} }`, document.uri, 4);
+    });
+
     it.each(CONVERSION_COMMANDS)("%s forwards a distinct uri for each of two same-named documents", async (_name, converterOverrides, run) => {
         const { handler, codeLensProvider } = makeConversionHandler(converterOverrides());
         const weapons = makeDocument(WEAPONS_UTILS);

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -578,8 +578,10 @@ export class ImportPathConverter {
         // construction Epic uses, which shortens the definition's parent and
         // appends the definition's own name. The project root is the one target
         // this does not hold for: what encloses it is the registry rather than
-        // a scope the file sits in.
-        const relativeImportPath = shortened || (fullPath.startsWith(`${projectVersePath}/`) ? fullPath.substring(fullPath.lastIndexOf("/") + 1) : "");
+        // a scope the file sits in. That test shortens against the root rather
+        // than comparing prefixes, so both halves fold case the same way.
+        const belowProjectRoot = ImportPathConverter.relativizeAgainst(fullPath, projectVersePath);
+        const relativeImportPath = shortened || (belowProjectRoot ? fullPath.substring(fullPath.lastIndexOf("/") + 1) : "");
 
         if (!relativeImportPath) {
             logger.debug("ImportPathConverter", "Could not extract relative path from full path");

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -450,20 +450,87 @@ export class ImportPathConverter {
     }
 
     /**
+     * The dotted reference naming `fullPath` from a scope at `basePath`: the
+     * segments left after the longest prefix the two paths share, joined with
+     * ".". Empty when nothing is left, which is a path naming the base itself.
+     *
+     * Segments are compared whole and folded ASCII-only, which is Epic's rule
+     * for this one conversion rather than a claim that Verse resolves paths
+     * case-insensitively - it does not.
+     *
+     * Comparing whole segments is a deliberate divergence. Epic walks
+     * characters and, when one path runs out inside the other's segment, ends
+     * the common part mid-label: `/proj/Economy/Shop` against a scope at
+     * `/proj/Econ` yields `omy.Shop` there.
+     */
+    private static relativizeAgainst(fullPath: string, basePath: string): string {
+        const foldAscii = (segment: string): string => segment.replace(/[a-z]/g, (character) => character.toUpperCase());
+        const fullSegments = fullPath.split("/").filter((segment) => segment);
+        const baseSegments = basePath.split("/").filter((segment) => segment);
+
+        let common = 0;
+        while (common < fullSegments.length && common < baseSegments.length && foldAscii(fullSegments[common]) === foldAscii(baseSegments[common])) {
+            common++;
+        }
+
+        return fullSegments.slice(common).join(".");
+    }
+
+    /**
+     * The absolute Verse path of the folder module a file sits in, or null when
+     * the file is not under a Content root this project addresses.
+     *
+     * The directory is the whole of the evidence, a folder being an implicit
+     * module. Only the folder chain is read, so a `using` written inside a
+     * nested `module { }` block in the file is placed at the file's own scope
+     * rather than the block's - a longer reference than the compiler would
+     * name, and one that still resolves, since resolution walks the parent
+     * chain outward.
+     */
+    private enclosingModulePath(documentUri: vscode.Uri, projectVersePath: string): string | null {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri);
+        if (!workspaceFolder) return null;
+
+        const relativeFilePath = path.relative(workspaceFolder.uri.fsPath, documentUri.fsPath).replace(/\\/g, "/");
+        let fileDir = path.dirname(relativeFilePath).replace(/\\/g, "/");
+
+        // Every path below is reasoned about with a leading Content/, so a
+        // workspace opened at Content itself has that segment put back on -
+        // the same correction searchImplicitModules makes.
+        if (path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER) {
+            fileDir = fileDir === "" || fileDir === "." ? CONTENT_FOLDER : `${CONTENT_FOLDER}/${fileDir}`;
+        }
+
+        if (fileDir === CONTENT_FOLDER) return projectVersePath;
+        if (!fileDir.startsWith(`${CONTENT_FOLDER}/`)) return null;
+
+        return `${projectVersePath}/${fileDir.substring(CONTENT_FOLDER.length + 1)}`;
+    }
+
+    /**
      * The relative form of an absolute import, in the style the author wrote,
      * or null when there is none to give: a built-in module, an import that
      * was never absolute, a workspace with no `.uefnproject` to take the
      * project path from, or a path that shortens to nothing.
      *
-     * Never ambiguous, because one project path shortens one import exactly one
-     * way. The other direction has a whole workspace of candidate locations to
+     * Shortened against the module the importing file sits in, which is the
+     * dialect the compiler speaks: its own suggestions arrive spelled that way
+     * and are written as imports, so a second dialect here would put one module
+     * in a file under two spellings, and the presence check compares spellings.
+     *
+     * Never ambiguous, because one scope shortens one import exactly one way.
+     * The other direction has a whole workspace of candidate locations to
      * choose between.
      *
      * A path belonging to another project is not refused, only left whole: with
-     * no project prefix to strip, every segment survives into the dotted form,
-     * which this project cannot resolve.
+     * no prefix in common, every segment survives into the dotted form, which
+     * this project cannot resolve.
+     *
+     * @param documentUri The file the import is written in. Without it the
+     *   project root stands in as the scope, which is what shortens an import
+     *   when the file cannot be placed under Content.
      */
-    async convertFromFullPath(importStatement: string, line?: number): Promise<ImportConversionResult | null> {
+    async convertFromFullPath(importStatement: string, documentUri?: vscode.Uri, line?: number): Promise<ImportConversionResult | null> {
         if (this.isBuiltinModule(importStatement)) {
             logger.debug("ImportPathConverter", "Cannot convert built-in module to relative path");
             return null;
@@ -489,16 +556,9 @@ export class ImportPathConverter {
             return null;
         }
 
-        let relativePath = fullPath;
-
-        if (fullPath.startsWith(projectVersePath + "/")) {
-            relativePath = fullPath.substring(projectVersePath.length + 1);
-        } else if (fullPath === projectVersePath) {
-            relativePath = "";
-        }
-
-        const modulePathSegments = relativePath.split("/").filter((s) => s);
-        const relativeImportPath = modulePathSegments.join(".");
+        const scopePath = (documentUri && this.enclosingModulePath(documentUri, projectVersePath)) || projectVersePath;
+        const relativeImportPath = ImportPathConverter.relativizeAgainst(fullPath, scopePath);
+        const modulePathSegments = relativeImportPath.split(".").filter((segment) => segment);
 
         if (!relativeImportPath) {
             logger.debug("ImportPathConverter", "Could not extract relative path from full path");
@@ -529,7 +589,7 @@ export class ImportPathConverter {
 
         for (const { statement, line } of scanConvertibleImports(lines)) {
             if (this.isFullPathImport(statement) && !this.isBuiltinModule(statement)) {
-                const result = await this.convertFromFullPath(statement, line);
+                const result = await this.convertFromFullPath(statement, document.uri, line);
                 if (result) {
                     results.push(result);
                 }

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -274,6 +274,18 @@ export class ImportPathConverter {
             return logicalPath;
         };
 
+        // The file's own directory first, and nearest of all: a folder beside
+        // the file is a member of the file's own module, which is what a bare
+        // reference names from here - and what convertFromFullPath writes when
+        // it shortens such a path. Without this the two directions stop being
+        // inverses, and the shortest spelling is the one that cannot be read
+        // back.
+        const ownTestPath = `${currentFileDir}/${modulePath}`;
+        if (await this.folderExists(workspaceFolder, getFsCheckPath(ownTestPath))) {
+            const relativePath = currentFileDir === CONTENT_FOLDER ? "" : "/" + currentFileDir.substring(CONTENT_FOLDER.length + 1);
+            if (!locations.includes(relativePath)) locations.push(relativePath);
+        }
+
         if (dirSegments.length > 1) {
             const parentPath = dirSegments.slice(0, dirSegments.length - 1).join("/");
             const siblingTestPath = `${parentPath}/${modulePath}`;
@@ -522,9 +534,10 @@ export class ImportPathConverter {
      * The other direction has a whole workspace of candidate locations to
      * choose between.
      *
-     * A path belonging to another project is not refused, only left whole: with
-     * no prefix in common, every segment survives into the dotted form, which
-     * this project cannot resolve.
+     * A path outside this project is not refused, only shortened by whatever
+     * prefix it does share: another project under the same account keeps its
+     * own project segment, a different account keeps every segment. Neither
+     * resolves here.
      *
      * @param documentUri The file the import is written in. Without it the
      *   project root stands in as the scope, which is what shortens an import
@@ -557,13 +570,23 @@ export class ImportPathConverter {
         }
 
         const scopePath = (documentUri && this.enclosingModulePath(documentUri, projectVersePath)) || projectVersePath;
-        const relativeImportPath = ImportPathConverter.relativizeAgainst(fullPath, scopePath);
-        const modulePathSegments = relativeImportPath.split(".").filter((segment) => segment);
+        const shortened = ImportPathConverter.relativizeAgainst(fullPath, scopePath);
+
+        // Nothing left over means the target is the importing file's own module
+        // or an ancestor of it. The module still has a name, and whatever
+        // encloses it encloses the file too, so the bare name reaches it - the
+        // construction Epic uses, which shortens the definition's parent and
+        // appends the definition's own name. The project root is the one target
+        // this does not hold for: what encloses it is the registry rather than
+        // a scope the file sits in.
+        const relativeImportPath = shortened || (fullPath.startsWith(`${projectVersePath}/`) ? fullPath.substring(fullPath.lastIndexOf("/") + 1) : "");
 
         if (!relativeImportPath) {
             logger.debug("ImportPathConverter", "Could not extract relative path from full path");
             return null;
         }
+
+        const modulePathSegments = relativeImportPath.split(".");
 
         const usesCurlyBraces = ImportPathConverter.usesBracedStyle(importStatement);
         const relativeImport = usesCurlyBraces ? `using { ${relativeImportPath} }` : `using. ${relativeImportPath}`;
@@ -571,7 +594,7 @@ export class ImportPathConverter {
         return {
             originalImport: importStatement,
             fullPathImport: relativeImport,
-            moduleName: modulePathSegments[modulePathSegments.length - 1] || relativeImportPath,
+            moduleName: modulePathSegments[modulePathSegments.length - 1],
             isAmbiguous: false,
             line,
         };

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -486,6 +486,13 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
         expect(await relativeFormOf(`${projectVersePath}/Systems/Economy`, fileAt("Systems/Economy"))).toBe("using. Economy");
     });
 
+    it("names an ancestor whose project prefix differs from the project's only in case", async () => {
+        // The ancestor branch has its own test for "is this inside the
+        // project", and a case-sensitive one there would refuse exactly the
+        // paths the case-insensitive shortening above it accepts.
+        expect(await relativeFormOf("/MYGAME@FORTNITE.COM/MYGAME/Systems", fileAt("Systems/Economy"))).toBe("using. Systems");
+    });
+
     it("offers no conversion for the project root itself", async () => {
         // The one target with nothing nameable above it: what encloses the
         // project root is the registry, not a scope the file sits in.
@@ -554,6 +561,8 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
             ["a module inside the file's own module", "Systems/Economy/Shop"],
             ["a module beside the file's own module", "Systems/Inventory"],
             ["a module on an unrelated branch", "UI/HUD/Textures"],
+            ["the file's own module", "Systems/Economy"],
+            ["an ancestor of the file's own module", "Systems"],
         ])("restores the absolute path of %s", async (_name, modulePath) => {
             const converter = converterWithProjectPath(projectVersePath);
             const fileUri = fileAt("Systems/Economy");

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -376,7 +376,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         // restores it, writes it twice.
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # only the shop, not the vendor", 0);
+        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # only the shop, not the vendor", undefined, 0);
 
         expect(result?.fullPathImport).toBe("using. Economy.Shop");
         expect(result?.moduleName).toBe("Shop");
@@ -385,7 +385,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
     it("leaves the comment trailing a braced import out of the converted path", async () => {
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # only the shop", 0);
+        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # only the shop", undefined, 0);
 
         expect(result?.fullPathImport).toBe("using { Economy.Shop }");
     });
@@ -396,7 +396,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         // author asking for braced syntax.
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # use {braces} here", 0);
+        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # use {braces} here", undefined, 0);
 
         expect(result?.fullPathImport).toBe("using. Economy.Shop");
     });
@@ -406,7 +406,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         // a braced import its braces, whatever the comment happens to hold.
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # see {Vendor}", 0);
+        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # see {Vendor}", undefined, 0);
 
         expect(result?.fullPathImport).toBe("using { Economy.Shop }");
     });
@@ -420,10 +420,112 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         const document = fakeDocument([line, "", "code()"]);
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath(line, 0);
+        const result = await converter.convertFromFullPath(line, undefined, 0);
         expect(await converter.applyConversion(document, result!)).toBe(true);
 
         expect(replacedOperation().text).toBe("using. Economy.Shop # see Economy/Vendor");
+    });
+});
+
+describe("ImportPathConverter.convertFromFullPath scope-relative shortening", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    /** A file in a module under the project's Content root, which is what places the importing scope. */
+    const fileAt = (contentRelativeDir: string): vscode.Uri => vscode.Uri.file(`${workspaceRoot}/Content/${contentRelativeDir}/Feature.verse`);
+
+    /** The statement the converter writes for an absolute path, as seen from `fileUri`. */
+    async function relativeFormOf(fullPath: string, fileUri?: vscode.Uri): Promise<string | undefined> {
+        const converter = converterWithProjectPath(projectVersePath);
+        const result = await converter.convertFromFullPath(`using. ${fullPath}`, fileUri, 0);
+        return result?.fullPathImport;
+    }
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+    });
+
+    it("names a module in the importing file's own module by its bare name", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, fileAt("Systems/Economy"))).toBe("using. Shop");
+    });
+
+    it("drops only the segments the importing file's module shares", async () => {
+        // Inventory sits beside the file's module rather than in it, so the
+        // reference resolves through Systems - the nearest scope both share.
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Inventory`, fileAt("Systems/Economy"))).toBe("using. Inventory");
+    });
+
+    it("keeps every segment below the project when the two branches part at the root", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/UI/HUD/Textures`, fileAt("Systems/Economy"))).toBe("using. UI.HUD.Textures");
+    });
+
+    it("converts a path whose project prefix differs from the project's only in case", async () => {
+        // The prefix test used to be case-sensitive, and a mismatch did not
+        // fall back - it skipped the strip, leaving the account segment in the
+        // dotted form.
+        expect(await relativeFormOf("/MYGAME@FORTNITE.COM/MYGAME/Systems/Economy/Shop", fileAt("Systems/Economy"))).toBe("using. Shop");
+    });
+
+    it("ends the shared part at a segment boundary, never inside a segment", async () => {
+        // Epic's own converter walks characters and ends the common part
+        // mid-label when one path runs out inside the other's segment, which
+        // would make this `omy.Shop`.
+        expect(await relativeFormOf(`${projectVersePath}/Economy/Shop`, fileAt("Econ"))).toBe("using. Economy.Shop");
+    });
+
+    it("offers no conversion for a path naming the importing file's own module", async () => {
+        const converter = converterWithProjectPath(projectVersePath);
+
+        expect(await converter.convertFromFullPath(`using. ${projectVersePath}/Systems/Economy`, fileAt("Systems/Economy"), 0)).toBeNull();
+    });
+
+    it("places a file the same way when the workspace is opened at Content itself", async () => {
+        setWorkspaceFolders([{ uri: { fsPath: `${workspaceRoot}/Content` }, name: "Content", index: 0 }]);
+
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Content/Systems/Economy/Feature.verse`))).toBe("using. Shop");
+    });
+
+    // The three fallbacks below are the pre-existing root-relative behaviour,
+    // which is what a file with no module of its own to shorten against gets.
+    it("shortens against the project root for a file at the Content root", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Content/Feature.verse`))).toBe("using. Systems.Economy.Shop");
+    });
+
+    it("shortens against the project root for a file outside Content", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Plugins/Feature.verse`))).toBe("using. Systems.Economy.Shop");
+    });
+
+    it("shortens against the project root when no workspace folder holds the file", async () => {
+        setWorkspaceFolders(undefined);
+
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, fileAt("Systems/Economy"))).toBe("using. Systems.Economy.Shop");
+    });
+
+    // The reverse direction searches outward from the importing file, so it
+    // resolves the shortened spellings this one writes. Pinning the location
+    // stands in for that search and leaves the arithmetic on both sides.
+    it.each([
+        ["Systems/Economy/Shop", "Systems/Economy", "/Systems/Economy"],
+        ["UI/HUD/Textures", "Systems/Economy", ""],
+        ["Systems/Inventory", "Systems/Economy", "/Systems"],
+    ])("round-trips %s back to the path it came from", async (modulePath, fileDir, location) => {
+        const converter = converterWithProjectPath(projectVersePath);
+        const fileUri = fileAt(fileDir);
+        const absolute = `using. ${projectVersePath}/${modulePath}`;
+
+        const relative = await converter.convertFromFullPath(absolute, fileUri, 0);
+        converter.findModuleLocations = async () => [location];
+
+        expect((await converter.convertToFullPath(relative!.fullPathImport, fileUri, 0))?.fullPathImport).toBe(absolute);
     });
 });
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -482,10 +482,16 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
         expect(await relativeFormOf(`${projectVersePath}/Economy/Shop`, fileAt("Econ"))).toBe("using. Economy.Shop");
     });
 
-    it("offers no conversion for a path naming the importing file's own module", async () => {
+    it("names the importing file's own module by its own name", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy`, fileAt("Systems/Economy"))).toBe("using. Economy");
+    });
+
+    it("offers no conversion for the project root itself", async () => {
+        // The one target with nothing nameable above it: what encloses the
+        // project root is the registry, not a scope the file sits in.
         const converter = converterWithProjectPath(projectVersePath);
 
-        expect(await converter.convertFromFullPath(`using. ${projectVersePath}/Systems/Economy`, fileAt("Systems/Economy"), 0)).toBeNull();
+        expect(await converter.convertFromFullPath(`using. ${projectVersePath}`, fileAt("Systems/Economy"), 0)).toBeNull();
     });
 
     it("places a file the same way when the workspace is opened at Content itself", async () => {
@@ -510,22 +516,53 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
         expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, fileAt("Systems/Economy"))).toBe("using. Systems.Economy.Shop");
     });
 
-    // The reverse direction searches outward from the importing file, so it
-    // resolves the shortened spellings this one writes. Pinning the location
-    // stands in for that search and leaves the arithmetic on both sides.
-    it.each([
-        ["Systems/Economy/Shop", "Systems/Economy", "/Systems/Economy"],
-        ["UI/HUD/Textures", "Systems/Economy", ""],
-        ["Systems/Inventory", "Systems/Economy", "/Systems"],
-    ])("round-trips %s back to the path it came from", async (modulePath, fileDir, location) => {
+    it("names an ancestor of the importing file's module by its own name", async () => {
+        // Nothing is left after the shared part, but the module still has a
+        // name, and what encloses it encloses the file too. Returning no
+        // conversion here instead took away one the lens used to offer.
+        expect(await relativeFormOf(`${projectVersePath}/Systems`, fileAt("Systems/Economy"))).toBe("using. Systems");
+    });
+
+    it("keeps the braced style and the trailing comment while shortening", async () => {
         const converter = converterWithProjectPath(projectVersePath);
-        const fileUri = fileAt(fileDir);
-        const absolute = `using. ${projectVersePath}/${modulePath}`;
+        const statement = `using { ${projectVersePath}/Systems/Economy/Shop } # only the shop`;
 
-        const relative = await converter.convertFromFullPath(absolute, fileUri, 0);
-        converter.findModuleLocations = async () => [location];
+        expect((await converter.convertFromFullPath(statement, fileAt("Systems/Economy"), 0))?.fullPathImport).toBe("using { Shop }");
+    });
 
-        expect((await converter.convertToFullPath(relative!.fullPathImport, fileUri, 0))?.fullPathImport).toBe(absolute);
+    // The round trip runs the real outward search over a folder tree, not a
+    // pinned location: a stub answers with the location the assertion already
+    // assumes, so it recomposes the path from its own input and cannot see the
+    // reverse direction failing to place a spelling this one writes.
+    describe("round trip through the real module search", () => {
+        /** Every folder the project holds, as Content-relative paths. */
+        const folders = ["Systems", "Systems/Economy", "Systems/Economy/Shop", "Systems/Inventory", "UI", "UI/HUD", "UI/HUD/Textures"];
+
+        beforeEach(() => {
+            (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+                const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${workspaceRoot}/Content/`, "");
+                if (!folders.includes(contentRelative)) throw new Error("ENOENT");
+                return { type: vscode.FileType.Directory };
+            });
+        });
+
+        afterEach(() => {
+            (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        });
+
+        it.each([
+            ["a module inside the file's own module", "Systems/Economy/Shop"],
+            ["a module beside the file's own module", "Systems/Inventory"],
+            ["a module on an unrelated branch", "UI/HUD/Textures"],
+        ])("restores the absolute path of %s", async (_name, modulePath) => {
+            const converter = converterWithProjectPath(projectVersePath);
+            const fileUri = fileAt("Systems/Economy");
+            const absolute = `using. ${projectVersePath}/${modulePath}`;
+
+            const relative = await converter.convertFromFullPath(absolute, fileUri, 0);
+
+            expect((await converter.convertToFullPath(relative!.fullPathImport, fileUri, 0))?.fullPathImport).toBe(absolute);
+        });
     });
 });
 


### PR DESCRIPTION
Closes #277

The conversion lens and the compiler spoke different dialects of "relative". `convertFromFullPath` stripped only the project-root prefix, case-sensitively, so a module was always spelled from the project root — `Systems.Economy.Shop` — wherever the importing file sat. The compiler shortens against the current scope instead, and its suggestions arrive spelled that way and are written into files: `ImportSuggestionExtractor.inferFromDidYouMean` turns a `Did you mean Economy.Shop.Vendor` into the import path `Economy.Shop`. Presence and dedup compare path strings, so one module under two spellings passed the existence check twice.

## What changed

Conversion now shortens against the module the importing file sits in, derived from the file's Content-relative directory. The rule follows Epic's `ConvertFullVersePathToRelativeDotSyntax`: longest common prefix, compared ASCII-case-insensitively, remainder dot-joined. Two deliberate divergences from Epic, both asked for by the ticket:

- **Whole segments only.** Epic walks characters and can end the shared part mid-label, turning `/proj/Economy/Shop` seen from `/proj/Econ` into `omy.Shop`.
- **No style setting.** Two dialects is the disease.

Where the enclosing module cannot be derived — a file at the Content root, outside `Content/`, or with no workspace folder — the project root stands in, which is the previous behaviour, now case-insensitive too. The `startsWith` it replaces did not fall back on a case mismatch; it skipped the strip entirely and left the account segment in the dotted form.

Where the shared part consumes the whole target — the file's own module, or an ancestor of it — the module's own name is used. That is Epic's construction rather than a patch on top of it: `CreateGlitchForMissingUsing` relativizes the definition's *enclosing* scope and appends the definition's name, which is the same function composed the other way round. The project root is the one target it does not hold for, and still converts to nothing: what encloses it is the registry, not a scope the file sits in.

The reverse direction needed a fix to stay the inverse of this one. `searchImplicitModules` tested siblings, ancestors and the Content root, but never the importing file's **own** directory — so the bare name this change now writes for a module inside the file's own module could not be read back at all: "Use absolute path" returned null and showed "Could not find module". It tests the file's own directory first now, nearest of all.

That also fixes a pre-existing wrong answer. With `Shop` under both `Systems/Economy/` and `Systems/`, the old search returned a single confident `/proj/Systems/Shop` for a file in `Systems/Economy` — the wrong one, since Verse binds the nearer module. It now returns both, nearest first, so the quick pick's default is what the compiler would bind.

## Why the shortened spelling resolves

Name resolution walks the scope's parent chain to the root (`SemanticScope.cpp:522-532`, "Traverse scope's parent chain to the root scope"), so a name defined in any enclosing module is reachable without a `using`. That is what makes the remainder after the shared prefix valid from the importing file, and it is the rule the whole change rests on.

## Trade-off, as accepted on the ticket

Root-relative spellings survive file moves; scope-relative ones are anchored to the importing file's module. A moved file surfaces that as a compile error with a fresh suggestion, whereas the two-spellings dedup failure is silent. Existing root-relative imports in user files stay valid, so there is no migration — only different lens output going forward.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
Test Suites: 40 passed, 40 total
Tests:       932 passed, 932 total
Snapshots:   0 total
Time:        7.157 s
```

`npm run format:check`

```
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Every new assertion was checked against the unfixed code rather than assumed to bite. Disabling the scope lookup fails 6; removing the ASCII fold fails exactly the case-mismatch test; replacing the segment loop with Epic's character walk fails exactly the boundary test; disabling the own-directory lookup fails exactly the own-module round trip; restoring the case-sensitive guard on the ancestor branch fails exactly the ancestor case test.

The round trip drives the real outward module search over a folder tree instead of pinning `findModuleLocations` to a literal. The pinned version recomposed the path from an answer the test itself supplied, which is precisely why it did not catch the reverse-direction defect above; it now covers all five reachable shapes, including the two the own-module and ancestor spellings introduce.

## Noted, not done here

`searchImplicitModules` and `enclosingModulePath` now express the same "location from a Content-relative directory" rule in four places. Left alone deliberately — #45 is named on the ticket as the owner of the shared path/scope arithmetic, and restructuring that search further is scope this ticket did not ask for.
