### PR TITLE
fix(imports): read a braced using across the lines it spans

### DIFF
--- a/changelog.d/274.fixed.md
+++ b/changelog.d/274.fixed.md
@@ -1,0 +1,1 @@
+**Import scanner**: A braced `using` written across several lines now counts as an import the file already makes, so a second copy of it is no longer added.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -502,7 +502,14 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     } else {
         between.push(braceCode.slice(braceCode.indexOf("{") + 1));
         for (let line = braceLine + 1; line < endLine; line++) {
-            between.push(classifications[line].codeOutsideLiterals);
+            // Only code, because a `<#>` written on the opener makes the lines
+            // indented past it comment text, and the masking these lines carry
+            // knows nothing of a comment opened above them. Counting such a
+            // path as imported withholds the import the file actually needs,
+            // which is the direction pairPathBelow refuses the same shape in.
+            if (classifications[line].kind === "code") {
+                between.push(classifications[line].codeOutsideLiterals);
+            }
         }
         between.push(classifications[endLine].codeOutsideLiterals.slice(0, closeAt));
     }
@@ -801,7 +808,14 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                         trailingComment: ImportFormatter.extractTrailingComment(trimmed),
                     });
                 }
-                i = braced.endLine + 1;
+                // Resumed *on* the closing line, not past it. A `;` separates
+                // statements exactly as a newline does, so `}; using { /B }`
+                // writes an import after the clause closes, and stepping over
+                // that line loses it - which is this branch's own failure,
+                // a path that does not count as present and is then written
+                // a second time. Only the lines between the braces are
+                // consumed here; the closing line is read like any other.
+                i = braced.endLine;
                 continue;
             }
 
@@ -1134,12 +1148,14 @@ export function allUsingPaths(lines: string[]): string[] {
         // holds no `using`. A path this reader misses is what the caller reads
         // as permission to remove an import.
         //
-        // The span is stepped over, so no line of it is read a second time.
+        // No line of the span is stepped over. The lines between the braces
+        // write paths and no `using` of their own, so the loop reaching them
+        // adds no second copy, and the closing line may write a statement after
+        // its `}` that skipping the line would lose - a dropped path being the
+        // one error this must not make.
         const braced = bracedUsingSpan(classifications, i);
         if (braced) {
             paths.push(...braced.paths);
-            i = braced.endLine;
-            continue;
         }
 
         // A `using:` opening an indented pair carries no path of its own -

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -491,7 +491,12 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
         }
     }
 
-    if (endLine === -1 || endLine === opener) {
+    // A `}` that is itself comment text closes nothing, so there is no clause
+    // here rather than a clause whose last line is trivia. The masking these
+    // lines carry removes a comment written on the line; it knows nothing of an
+    // indented comment opened above it, which is what can leave the whole
+    // closing line inert while still spelling a brace.
+    if (endLine === -1 || endLine === opener || classifications[endLine].kind !== "code") {
         return null;
     }
 

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -360,6 +360,22 @@ export function classifyLines(lines: string[]): LineClassification[] {
 }
 
 /**
+ * The first line of code below `from`, or `-1` where there is none.
+ *
+ * Blank and comment lines are passed over, because neither ends what a
+ * statement above them opened: an indented block runs through both, and so does
+ * the whitespace a braced clause may open across.
+ */
+function firstCodeLineBelow(classifications: LineClassification[], from: number): number {
+    for (let line = from + 1; line < classifications.length; line++) {
+        if (classifications[line].kind === "code") {
+            return line;
+        }
+    }
+    return -1;
+}
+
+/**
  * The line holding the path that the `using:` ending line `opener` opens, or
  * `-1` where that line opens no pair.
  *
@@ -392,19 +408,122 @@ export function indentedPairPathLine(classifications: LineClassification[], open
         return -1;
     }
 
-    for (let line = opener + 1; line < classifications.length; line++) {
-        const classification = classifications[line];
-        if (classification.kind !== "code") {
-            continue;
-        }
+    const pathLine = firstCodeLineBelow(classifications, opener);
+    if (pathLine !== -1) {
         // Indentation read from the code, so a line closing a block comment
         // ahead of its statement reads as indented. Harmless in both
         // directions: were that statement really at column 0, the opener
         // opened nothing and the file did not compile to begin with.
-        return /^\s/.test(classification.codeWithoutComments) ? line : -1;
+        return /^\s/.test(classifications[pathLine].codeWithoutComments) ? pathLine : -1;
     }
 
     return -1;
+}
+
+/**
+ * The lines a braced `using` opened on `opener` occupies, with every path
+ * written between its braces, or null where the line opens no such span.
+ *
+ * The braced style is the one import shape whose statement can outlive its
+ * line. A macro's braced clause opens across whitespace and line breaks alike,
+ * so the `{` may sit below the `using` and the `}` below the path, and inside
+ * the braces a line ending separates elements exactly as `;` does. The
+ * single-line patterns in ImportFormatter read only the shape that opens and
+ * closes on one line, which is why every caller that has to see a span asks
+ * this instead of asking them.
+ *
+ * Read from the classifications rather than the raw text, so a brace written in
+ * a comment or inside a string literal closes nothing.
+ *
+ * Indentation is the caller's question, not this one's: scanModuleImports asks
+ * only about column 0, allUsingPaths about every line.
+ *
+ * Null for the single-line form, whose whole span is the opener - the statement
+ * patterns already read it, and offering it here would have a caller count it
+ * twice - and null for an unclosed `{`, which no file that compiles writes.
+ *
+ * @returns the closing brace's line, with the paths the braces hold. More than
+ *   one path where the file does not compile: a `using` clause takes a single
+ *   path, and a buffer being edited need not compile yet.
+ */
+function bracedUsingSpan(classifications: LineClassification[], opener: number): { paths: string[]; endLine: number } | null {
+    const openerCode = classifications[opener].codeOutsideLiterals.trim();
+
+    // Where the braces begin. On the opener's own line for `using {`, and on
+    // the first line of code below it for a `using` whose brace is written
+    // there - a line break before the `{` is whitespace to the parser, so both
+    // spell the same clause.
+    let braceLine: number;
+    if (/^using\s*\{/.test(openerCode)) {
+        braceLine = opener;
+    } else if (/^using$/.test(openerCode)) {
+        const below = firstCodeLineBelow(classifications, opener);
+        if (below === -1 || !classifications[below].codeOutsideLiterals.trim().startsWith("{")) {
+            return null;
+        }
+        braceLine = below;
+    } else {
+        return null;
+    }
+
+    // The `}` that returns the depth to where the clause opened, with the
+    // column it sits at, so the content is cut at that brace rather than at the
+    // last one on its line.
+    let depth = 0;
+    let endLine = -1;
+    let closeAt = -1;
+    for (let line = braceLine; line < classifications.length && endLine === -1; line++) {
+        const code = classifications[line].codeOutsideLiterals;
+        for (let column = 0; column < code.length; column++) {
+            if (code[column] === "{") {
+                depth++;
+                continue;
+            }
+            if (code[column] !== "}") {
+                continue;
+            }
+            depth--;
+            if (depth <= 0) {
+                endLine = line;
+                closeAt = column;
+                break;
+            }
+        }
+    }
+
+    if (endLine === -1 || endLine === opener) {
+        return null;
+    }
+
+    const braceCode = classifications[braceLine].codeOutsideLiterals;
+    const between: string[] = [];
+    if (braceLine === endLine) {
+        between.push(braceCode.slice(braceCode.indexOf("{") + 1, closeAt));
+    } else {
+        between.push(braceCode.slice(braceCode.indexOf("{") + 1));
+        for (let line = braceLine + 1; line < endLine; line++) {
+            between.push(classifications[line].codeOutsideLiterals);
+        }
+        between.push(classifications[endLine].codeOutsideLiterals.slice(0, closeAt));
+    }
+
+    // A line ending and a `;` separate elements alike, and the text arrives
+    // here one line to an entry, so splitting on `;` leaves one element each.
+    //
+    // Content is classified the way pairPathBelow classifies the line under a
+    // `using:`, by handing isModuleImport a `using:` and the content as its
+    // next line. The two shapes ask the same question - is this bare text a
+    // module path - and asking it a second way here is the looser copy that
+    // ends with the reader and the writer disagreeing.
+    const paths: string[] = [];
+    for (const element of between.flatMap((text) => text.split(";"))) {
+        const content = element.trim();
+        if (content && ImportFormatter.isModuleImport("using:", content, { atFileScope: true })) {
+            paths.push(content);
+        }
+    }
+
+    return { paths, endLine };
 }
 
 /**
@@ -437,6 +556,14 @@ export function indentedPairPathLine(classifications: LineClassification[], open
  *   content: a pair opened after a `using` keeps a path the classification
  *   declines, because its entry is the only one spanning the path line and
  *   dropping it would let a writer split the pair. See pairPathBelow.
+ * - The braced style whose `}` closes on a later line is consumed as one entry
+ *   spanning the opener and that brace, pinned, since the span holds lines no
+ *   rebuild from a path reproduces. Both spellings of it are read, the `{` on
+ *   the `using`'s own line and the `{` on the line below, because a line break
+ *   before the brace is whitespace to the parser. Without this the span is
+ *   invisible whole: the opener fails a classification that needs the closing
+ *   brace on one line, and the path between the braces is indented, which the
+ *   rule above skips. See bracedUsingSpan.
  * - Content classification (module import vs local-scope using) is delegated
  *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
  *   every candidate here already sits at column 0. So a bare identifier at
@@ -644,6 +771,37 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     trailingComment: ImportFormatter.extractTrailingComment(lines[pair.pathLine]),
                 });
                 i = pair.pathLine + 1;
+                continue;
+            }
+
+            // The braced clause this line opens, `using{` over an indented path
+            // over its own `}`. The classification refuses the opener - the
+            // single-line pattern needs the closing brace on the line it reads -
+            // and the path between the braces is indented, so the scan skips
+            // that too. The whole span goes uncounted, and a writer then adds a
+            // second copy of a path the file already imports.
+            //
+            // Pinned, like everything else this branch records. The span holds
+            // lines no rebuild from one path reproduces: the braces may sit
+            // around a comment or a blank line the author wrote, and collapsing
+            // the span onto a single line is a rewrite nothing asked for.
+            // Counting the path is what the duplicate needed.
+            const braced = bracedUsingSpan(classifications, i);
+            if (braced) {
+                for (const bracedPath of braced.paths) {
+                    imports.push({
+                        path: bracedPath,
+                        startLine: i,
+                        endLine: braced.endLine,
+                        anchorsCommentBelow: anchorsCommentBelow(i, braced.endLine),
+                        rebuildLosesText: true,
+                        // The opener's own comment. Nothing re-emits a pinned
+                        // entry, and the path sits on a line inside the braces
+                        // rather than after the statement.
+                        trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                    });
+                }
+                i = braced.endLine + 1;
                 continue;
             }
 
@@ -936,6 +1094,9 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
  *   for the line's own statement.
  * - A line contributes every `using` usingPathsOnLine finds on it, in written
  *   order, rather than the first.
+ * - A braced clause whose `}` closes on a later line contributes the paths
+ *   between its braces. No line of that span writes a `using` statement holding
+ *   them, so nothing else here would offer them. See bracedUsingSpan.
  * - A `using:` opening an indented pair is recognised at the end of its line
  *   rather than as the whole of it, since a statement can precede it there too.
  *   The pair is the one shape counted once, because its path is read from the
@@ -965,6 +1126,21 @@ export function allUsingPaths(lines: string[]): string[] {
 
         const trimmed = codeWithoutComments.trim();
         paths.push(...usingPathsOnLine(formatter, trimmed));
+
+        // A braced clause whose `}` closes on a later line writes its path
+        // between the braces rather than as a statement of its own, so
+        // usingPathsOnLine finds nothing on any line of the span - not on the
+        // opener, which holds no path, and not on the path's own line, which
+        // holds no `using`. A path this reader misses is what the caller reads
+        // as permission to remove an import.
+        //
+        // The span is stepped over, so no line of it is read a second time.
+        const braced = bracedUsingSpan(classifications, i);
+        if (braced) {
+            paths.push(...braced.paths);
+            i = braced.endLine;
+            continue;
+        }
 
         // A `using:` opening an indented pair carries no path of its own -
         // extractPathFromImport reads neither pattern out of it - so the path

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -908,6 +908,27 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
+    // The reported symptom. The braced classification needs the closing brace on
+    // the line it reads, so the scan saw no import here at all: the path counted
+    // as absent and the file ended up importing the same module twice.
+    it("recognizes an import a braced clause provides across lines", async () => {
+        const input = ["using{", "    /Verse.org/Simulation", "}", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Verse.org/Simulation }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("recognizes an import a braced clause opening on the line below provides", async () => {
+        const input = ["using", "{", "    /Verse.org/Simulation", "}", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Verse.org/Simulation }"]);
+
+        expect(success).toBe(true);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
     it("adds an import that exists only inside a block comment, above the comment", async () => {
         const input = ["<#", "using { /Fortnite.com/Devices }", "#>", "", "my_device := class(creative_device):", "    Button : button_device = button_device{}"].join("\n");
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -19,6 +19,13 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using", "{", "    /A", "}", "code()"])).toEqual(["/A"]);
     });
 
+    // The closing line is read like any other, so an import written after the
+    // `}` is still offered. A path this reader drops is what the caller reads as
+    // permission to remove an import.
+    it("collects an import written after the closing brace of a braced clause", () => {
+        expect(allUsingPaths(["using{", "    /A", "}; using { /B }", "code()"])).toEqual(["/A", "/B"]);
+    });
+
     it("collects a multi-line braced path indented inside a module body, which scanModuleImports skips", () => {
         const lines = ["using { /A }", "MyModule := module:", "    using{", "        Economy.Shop", "    }", "code()"];
         expect(allUsingPaths(lines)).toEqual(["/A", "Economy.Shop"]);
@@ -341,6 +348,25 @@ describe("scanModuleImports", () => {
             { path: "/A", startLine: 0, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
             { path: "/B", startLine: 0, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
+    });
+
+    // The clause is consumed to its `}` and no further. A `;` separates
+    // statements exactly as a newline does, so the closing line can write an
+    // import after the brace, and stepping over that line loses it - the same
+    // uncounted path, one line further down.
+    it("records an import written after the closing brace of a braced span", () => {
+        expect(scanModuleImports(["using{", "    /A", "}; using { /B }", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/B", startLine: 2, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The `<#>` makes every line indented past it comment text, so the path
+    // below is not imported at all. Counting it as present declines the
+    // diagnostic asking for it, and the import the file needs is never written -
+    // the failure direction the indented pair refuses this same shape in.
+    it("counts no path from a braced span a marker on its opener comments out", () => {
+        expect(scanModuleImports(["using{ <#>", "    /Verse.org/Simulation", "}", "code()"])).toEqual([]);
     });
 
     it("records nothing for a braced using the file never closes", () => {

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -7,6 +7,24 @@ describe("allUsingPaths", () => {
 
     // The whole reason this exists: scanModuleImports skips indented lines, so
     // an import in a module body is invisible to it.
+    // No line of the span writes a `using` statement holding this path: the
+    // opener carries no path and the path's own line carries no `using`. Missing
+    // it is the one error this reader must not make, since the caller reads an
+    // empty answer as permission to remove an import.
+    it("collects a path from a braced clause whose brace closes on a later line", () => {
+        expect(allUsingPaths(["using{", "    /A", "}", "code()"])).toEqual(["/A"]);
+    });
+
+    it("collects a path from a braced clause whose brace opens on the line below", () => {
+        expect(allUsingPaths(["using", "{", "    /A", "}", "code()"])).toEqual(["/A"]);
+    });
+
+    it("collects a multi-line braced path indented inside a module body, which scanModuleImports skips", () => {
+        const lines = ["using { /A }", "MyModule := module:", "    using{", "        Economy.Shop", "    }", "code()"];
+        expect(allUsingPaths(lines)).toEqual(["/A", "Economy.Shop"]);
+        expect(scanModuleImports(lines).map((imp) => imp.path)).toEqual(["/A"]);
+    });
+
     it("collects a dotted import indented inside a module body, which scanModuleImports skips", () => {
         const lines = ["using { /A }", "MyModule := module:", "    using { Economy.Shop }", "code()"];
         expect(allUsingPaths(lines)).toEqual(["/A", "Economy.Shop"]);
@@ -265,6 +283,80 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["using. /Verse.org/Simulation"])).toEqual([
             { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
+    });
+
+    // The braced classification needs the closing brace on the line it reads, so
+    // this opener was no import at all and the path between the braces was
+    // skipped as an indented line. The scan returned nothing, the path counted
+    // as absent, and a diagnostic asking for it wrote a second copy of an import
+    // the file was already making.
+    it("consumes a braced import whose brace closes on a later line, pinned", () => {
+        expect(scanModuleImports(["using{", "    /Verse.org/Simulation", "}", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // A line break before the `{` is whitespace to the parser, so this is the
+    // same clause written another way and has to be read as one.
+    it("consumes a braced import whose brace opens on the line below the using", () => {
+        expect(scanModuleImports(["using", "{", "    /Verse.org/Simulation", "}", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("consumes a braced import holding its path on the opening line and closing below", () => {
+        expect(scanModuleImports(["using { /Verse.org/Simulation", "}", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("reads a bare folder-module path out of a multi-line braced span", () => {
+        expect(scanModuleImports(["using{", "    Features", "}", "code()"])).toEqual([
+            { path: "Features", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // A line ending separates elements inside the braces exactly as `;` does,
+    // and the whitespace around one is skipped, so neither a blank line nor a
+    // comment ends the clause or hides the path under it.
+    it("reads the path of a braced span written around a blank line and a comment", () => {
+        expect(scanModuleImports(["using{", "", "    # the path below", "    Economy.Shop", "}", "code()"])).toEqual([
+            { path: "Economy.Shop", startLine: 0, endLine: 4, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The span is pinned, so the path counts as present - which is what stops a
+    // second copy being written - while no writer rebuilds the lines. Rebuilding
+    // them from the path alone would collapse the span onto one line and delete
+    // whatever else the author wrote between the braces.
+    it("offers no rewritable import for a multi-line braced span", () => {
+        expect(rewritableImports(scanModuleImports(["using{", "    /Verse.org/Simulation", "}", "code()"]))).toEqual([]);
+    });
+
+    // A `using` clause takes a single path, so this file does not compile. It is
+    // still a buffer someone is editing, and both paths are recorded for the
+    // reason every pinned entry is: neither may be written a second time.
+    it("records every path of a braced span that writes more than one", () => {
+        expect(scanModuleImports(["using{", "    /A", "    /B", "}", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/B", startLine: 0, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    it("records nothing for a braced using the file never closes", () => {
+        expect(scanModuleImports(["using{", "    /Verse.org/Simulation", "code()"])).toEqual([]);
+    });
+
+    it("leaves a multi-line braced using commented out by a block comment uncounted", () => {
+        expect(scanModuleImports(["<#", "using{", "    /Old", "}", "#>", "using { /Verse.org/Simulation }", "code()"])).toEqual([
+            { path: "/Verse.org/Simulation", startLine: 5, endLine: 5, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+    });
+
+    // Module-scoped, like every other indented `using`: it belongs to the body
+    // it sits in, not to the file-level block a writer rebuilds.
+    it("leaves a multi-line braced using indented inside a module body uncollected", () => {
+        expect(scanModuleImports(["MyModule := module:", "    using{", "        /A", "    }", "code()"])).toEqual([]);
     });
 
     // The classification read the dotted content to end of line, so this one

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -369,6 +369,12 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["using{ <#>", "    /Verse.org/Simulation", "}", "code()"])).toEqual([]);
     });
 
+    // The brace that would close the clause is comment text under the marker on
+    // the opener, so it closes nothing and the path beside it is not imported.
+    it("counts no path from a braced span whose closing brace is commented out", () => {
+        expect(scanModuleImports(["using { <#>", "    /Verse.org/Simulation }", "}", "code()"])).toEqual([]);
+    });
+
     it("records nothing for a braced using the file never closes", () => {
         expect(scanModuleImports(["using{", "    /Verse.org/Simulation", "code()"])).toEqual([]);
     });


### PR DESCRIPTION
Closes #274

## What was wrong

A macro's braced clause opens across line breaks, so a `using` may write its `{` below the keyword and its `}` below the path. `ImportFormatter`'s braced pattern reads a single line and needs the closing brace on it, so this classified as no import at all:

```verse
using{
    /Verse.org/Native
}
```

`scanModuleImports` gates its loop on that classifier, so the opener fell into the reject branch and the path between the braces was skipped as an indented line. The scan returned `[]`, the path never counted as present, and `addImportsToDocument` wrote a second `using { /Verse.org/Native }` for a module the file already imported. Nothing was corrupted — no writer touches lines it cannot see.

## What changed

`bracedUsingSpan` in `src/imports/ImportScanner.ts` reads the span a braced `using` occupies and the paths between its braces. Both spellings the parser accepts are covered: the `{` on the `using`'s own line, and the `{` on the line below. Two call sites use it:

- **`scanModuleImports`** records one entry per path, spanning the opener to the closing brace, **pinned** (`rebuildLosesText: true`). Presence and dedup are fixed; no writer rebuilds or moves the lines, because the span may hold comments and blank lines a rebuild from the path alone would delete. `pinnedSpanEnd` needed no change — it starts from `endLine`, so the placement floor already lands on the closing brace.
- **`allUsingPaths`** reads the same span, closing the matching blind spot behind the `withholdIsSafe` check, where a missed path is what a caller reads as permission to remove an import.

`isModuleImport` is deliberately **not** widened: a one-line classifier cannot see an arbitrary span, and its own comment records that the gate stays refusing so the branches beneath it may keep testing the raw line. `firstCodeLineBelow` is extracted so this and `indentedPairPathLine` share one copy of "the first line of code below", rather than growing a second.

## Grammar this relies on

Verified against the compiler source rather than inferred from this codebase:

- `Brace := Scan '{' List '}' Space` with `Scan := Space {Line}` (`VerseGrammar.h:2345`, `:1759`) — the `{` may sit below the `using`, the `}` below the path.
- `Separator := (';'|Ending) Scan` (`VerseGrammar.h:4060`) — inside the braces a line ending separates elements exactly as `;` does, and the whitespace around one is skipped.
- `using` clause must contain a single path (`SemanticAnalyzer.cpp:6378-6381`) — so a span writing two does not compile. Both are still recorded, pinned, because the extension reads live buffers that need not compile yet.
- The shape is what the compiler's own auto-qualification printer emits (`book-of-verse Tests/AutoQualification.versetest:230`).

## Verification

```
$ npm run compile
> tsc -p ./
(no output)

$ npm test
Test Suites: 40 passed, 40 total
Tests:       931 passed, 931 total
Snapshots:   0 total

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

Every new test was proven to detect the defect by restoring `ImportScanner.ts` from `HEAD` and re-running: 11 of the first batch failed without the fix. The ones that pass either way assert unchanged behaviour — an unclosed brace, a span inside a block comment, a span indented in a module body, and that nothing became rewritable.

## Review

Two rounds, fresh context, ending **PASS** with no Critical findings. The reviewer probed rather than only read: CRLF, tabs, block and indented comments, braces inside string literals and quoted path suffixes, nested and stray braces, spans back to back, and placement with relative *and* absolute paths.

Round 1 found two regressions against `main` by differential probing, both fixed in `5312054`:

- **A statement written after the closing brace was swallowed.** `}; using { /B }` is legal — `;` separates statements exactly as a newline does — and stepping over that line lost `/B`, which was then written a second time. That is this ticket's own bug one line further down. The branch now resumes *on* the closing line, so it is read like any other.
- **A path an indented-comment marker had commented out counted as imported**, which declines the diagnostic asking for it and leaves the import unwritten. Span content now comes from code lines alone.

Round 2 confirmed both closed, found no new regressions across 53 differential inputs, and proved the resume change terminates — structurally over every span in a 4-line corpus, and by fuzzing 170,808 documents over an adversarial token alphabet. `fb55f9c` then closed the last case it surfaced: a `}` that is itself comment text closes nothing, so a span reaching one is no clause at all.

Two known limitations are left open deliberately, both needing already-invalid Verse to reach and both recording only pinned entries that no writer rebuilds: interior text that is not a path is recorded verbatim, and the depth scan is unbounded, as `ProjectPathScanner`'s is.
