### PR TITLE
refactor(imports): name the conversion result field and the convert-all method for their direction

### DIFF
--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -33,7 +33,7 @@ export interface CommandsDependencies {
  */
 interface PathConversionResult {
     originalImport: string;
-    fullPathImport: string;
+    convertedImport: string;
     moduleName: string;
     isAmbiguous: boolean;
     possiblePaths?: string[];
@@ -513,7 +513,7 @@ export class CommandsHandler {
                 return;
             }
 
-            vscode.window.setStatusBarMessage(`Using absolute path: ${result.fullPathImport}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
+            vscode.window.setStatusBarMessage(`Using absolute path: ${result.convertedImport}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
             this.finalizeConversion(documentUri);
         }
     }
@@ -522,7 +522,7 @@ export class CommandsHandler {
         const documentUri = document.uri.toString();
         this.prepareForConversion(documentUri);
 
-        const results = (await this.deps.importPathConverter.convertAllImportsInDocument(document)) as PathConversionResult[];
+        const results = (await this.deps.importPathConverter.convertAllImportsToFullPath(document)) as PathConversionResult[];
 
         if (results.length === 0) {
             vscode.window.showInformationMessage("No relative imports found to convert.");
@@ -575,7 +575,7 @@ export class CommandsHandler {
             return;
         }
 
-        vscode.window.setStatusBarMessage(`Using relative path: ${result.fullPathImport}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
+        vscode.window.setStatusBarMessage(`Using relative path: ${result.convertedImport}`, CommandsHandler.STATUS_MESSAGE_DURATION_MS);
         this.finalizeConversion(documentUri);
     }
 

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -172,7 +172,7 @@ const ABSOLUTE_PATH = `/mygame@fortnite.com/mygame/${RELATIVE_MODULE}`;
  */
 interface ConversionFixture {
     originalImport: string;
-    fullPathImport: string;
+    convertedImport: string;
     moduleName: string;
     isAmbiguous: boolean;
     possiblePaths?: string[];
@@ -181,7 +181,7 @@ interface ConversionFixture {
 function makeConversion(overrides: Partial<ConversionFixture> = {}): ConversionFixture {
     return {
         originalImport: `using { ${RELATIVE_MODULE} }`,
-        fullPathImport: `using { ${ABSOLUTE_PATH} }`,
+        convertedImport: `using { ${ABSOLUTE_PATH} }`,
         moduleName: RELATIVE_MODULE,
         isAmbiguous: false,
         ...overrides,
@@ -195,7 +195,7 @@ function makeConversionHandler(converterOverrides: Record<string, jest.Mock>): {
     const importPathConverter = {
         convertToFullPath: jest.fn().mockResolvedValue(null),
         convertFromFullPath: jest.fn().mockResolvedValue(null),
-        convertAllImportsInDocument: jest.fn().mockResolvedValue([]),
+        convertAllImportsToFullPath: jest.fn().mockResolvedValue([]),
         convertAllImportsFromFullPath: jest.fn().mockResolvedValue([]),
         applyConversion: jest.fn().mockResolvedValue(true),
         ...converterOverrides,
@@ -268,7 +268,7 @@ describe("CommandsHandler.convertToFullPath", () => {
 describe("CommandsHandler.convertToRelativePath", () => {
     it("warns and reports no path when the edit is refused", async () => {
         const { handler } = makeConversionHandler({
-            convertFromFullPath: jest.fn().mockResolvedValue(makeConversion({ fullPathImport: `using { ${RELATIVE_MODULE} }` })),
+            convertFromFullPath: jest.fn().mockResolvedValue(makeConversion({ convertedImport: `using { ${RELATIVE_MODULE} }` })),
             applyConversion: jest.fn().mockResolvedValue(false),
         });
 
@@ -283,7 +283,7 @@ describe("CommandsHandler.convertToRelativePath", () => {
 describe("CommandsHandler.convertAllToFullPath", () => {
     it("warns rather than reporting a count when every edit is refused", async () => {
         const { handler } = makeConversionHandler({
-            convertAllImportsInDocument: jest.fn().mockResolvedValue([makeConversion(), makeConversion()]),
+            convertAllImportsToFullPath: jest.fn().mockResolvedValue([makeConversion(), makeConversion()]),
             applyConversion: jest.fn().mockResolvedValue(false),
         });
 
@@ -297,7 +297,7 @@ describe("CommandsHandler.convertAllToFullPath", () => {
     it("counts a cancelled ambiguous pick as neither converted nor failed", async () => {
         (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
         const { handler } = makeConversionHandler({
-            convertAllImportsInDocument: jest.fn().mockResolvedValue([makeConversion({ isAmbiguous: true, possiblePaths: [ABSOLUTE_PATH] })]),
+            convertAllImportsToFullPath: jest.fn().mockResolvedValue([makeConversion({ isAmbiguous: true, possiblePaths: [ABSOLUTE_PATH] })]),
             applyConversion: jest.fn().mockResolvedValue(true),
         });
 
@@ -349,7 +349,7 @@ const CONVERSION_COMMANDS: ConversionCommandCase[] = [
         () => ({ convertFromFullPath: jest.fn().mockResolvedValue(makeConversion()) }),
         (handler, document) => handler.convertToRelativePath(document, `using { ${ABSOLUTE_PATH} }`, 4),
     ],
-    ["convertAllToFullPath", () => ({ convertAllImportsInDocument: jest.fn().mockResolvedValue([makeConversion()]) }), (handler, document) => handler.convertAllToFullPath(document)],
+    ["convertAllToFullPath", () => ({ convertAllImportsToFullPath: jest.fn().mockResolvedValue([makeConversion()]) }), (handler, document) => handler.convertAllToFullPath(document)],
     ["convertAllToRelativePath", () => ({ convertAllImportsFromFullPath: jest.fn().mockResolvedValue([makeConversion()]) }), (handler, document) => handler.convertAllToRelativePath(document)],
 ];
 

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -13,13 +13,12 @@ interface ImportConversionResult {
     /**
      * The statement to write in place of `originalImport`, whichever direction
      * the conversion runs: convertToFullPath puts the absolute form here and
-     * convertFromFullPath the relative one, so the name reads true on only one
-     * of the two paths.
+     * convertFromFullPath the relative one.
      *
      * Empty while `isAmbiguous`, where the statement cannot be built until the
      * user has picked from `possiblePaths`.
      */
-    fullPathImport: string;
+    convertedImport: string;
     moduleName: string;
     /** Whether the module resolved to more than one location, listed in `possiblePaths`. */
     isAmbiguous: boolean;
@@ -595,7 +594,7 @@ export class ImportPathConverter {
 
         return {
             originalImport: importStatement,
-            fullPathImport: relativeImport,
+            convertedImport: relativeImport,
             moduleName: modulePathSegments[modulePathSegments.length - 1],
             isAmbiguous: false,
             line,
@@ -681,11 +680,11 @@ export class ImportPathConverter {
             const fullPath = ImportPathConverter.buildFullVersePath(projectVersePath, location, modulePath);
             logger.debug("ImportPathConverter", `Constructed full path: ${fullPath}`);
 
-            const fullPathImport = usesCurlyBraces ? `using { ${fullPath} }` : `using. ${fullPath}`;
+            const convertedImport = usesCurlyBraces ? `using { ${fullPath} }` : `using. ${fullPath}`;
 
             return {
                 originalImport: importStatement,
-                fullPathImport,
+                convertedImport,
                 moduleName,
                 isAmbiguous: false,
                 line,
@@ -695,7 +694,7 @@ export class ImportPathConverter {
 
             return {
                 originalImport: importStatement,
-                fullPathImport: "",
+                convertedImport: "",
                 moduleName,
                 isAmbiguous: true,
                 possiblePaths,
@@ -709,7 +708,7 @@ export class ImportPathConverter {
      * lines run. Any of them may be ambiguous, so a caller applying the whole
      * set has a choice to put to the user for each one.
      */
-    async convertAllImportsInDocument(document: vscode.TextDocument): Promise<ImportConversionResult[]> {
+    async convertAllImportsToFullPath(document: vscode.TextDocument): Promise<ImportConversionResult[]> {
         const results: ImportConversionResult[] = [];
         const text = document.getText();
         const lines = text.split(LINE_SPLIT);
@@ -772,7 +771,7 @@ export class ImportPathConverter {
             return false;
         }
 
-        let finalImport = conversion.fullPathImport;
+        let finalImport = conversion.convertedImport;
         if (conversion.isAmbiguous && selectedPath) {
             const usesCurlyBraces = ImportPathConverter.usesBracedStyle(conversion.originalImport);
             finalImport = usesCurlyBraces ? `using { ${selectedPath} }` : `using. ${selectedPath}`;

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -141,7 +141,7 @@ describe("ImportPathConverter.applyConversion", () => {
     /** A resolved relative-to-absolute conversion of `using { Gadgets.Tools }`. */
     const conversion = (line?: number) => ({
         originalImport: "using { Gadgets.Tools }",
-        fullPathImport: "using { /mygame@fortnite.com/mygame/Gadgets/Tools }",
+        convertedImport: "using { /mygame@fortnite.com/mygame/Gadgets/Tools }",
         moduleName: "Tools",
         isAmbiguous: false,
         line,
@@ -259,7 +259,7 @@ describe("ImportPathConverter.applyConversion", () => {
         const document = fakeDocument([line, "", "code()"]);
         const ambiguous = {
             originalImport: line,
-            fullPathImport: "",
+            convertedImport: "",
             moduleName: "Tools",
             isAmbiguous: true,
             possiblePaths: ["/mygame@fortnite.com/mygame/Gadgets/Tools", "/mygame@fortnite.com/mygame/UI/Gadgets/Tools"],
@@ -378,7 +378,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
 
         const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # only the shop, not the vendor", undefined, 0);
 
-        expect(result?.fullPathImport).toBe("using. Economy.Shop");
+        expect(result?.convertedImport).toBe("using. Economy.Shop");
         expect(result?.moduleName).toBe("Shop");
     });
 
@@ -387,7 +387,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
 
         const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # only the shop", undefined, 0);
 
-        expect(result?.fullPathImport).toBe("using { Economy.Shop }");
+        expect(result?.convertedImport).toBe("using { Economy.Shop }");
     });
 
     it("keeps the dotted style when the trailing comment contains a brace", async () => {
@@ -398,7 +398,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
 
         const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # use {braces} here", undefined, 0);
 
-        expect(result?.fullPathImport).toBe("using. Economy.Shop");
+        expect(result?.convertedImport).toBe("using. Economy.Shop");
     });
 
     it("keeps the braced style when the trailing comment also contains a brace", async () => {
@@ -408,7 +408,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
 
         const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # see {Vendor}", undefined, 0);
 
-        expect(result?.fullPathImport).toBe("using { Economy.Shop }");
+        expect(result?.convertedImport).toBe("using { Economy.Shop }");
     });
 
     it("writes the comment once, and unaltered, when the conversion is applied", async () => {
@@ -443,7 +443,7 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
     async function relativeFormOf(fullPath: string, fileUri?: vscode.Uri): Promise<string | undefined> {
         const converter = converterWithProjectPath(projectVersePath);
         const result = await converter.convertFromFullPath(`using. ${fullPath}`, fileUri, 0);
-        return result?.fullPathImport;
+        return result?.convertedImport;
     }
 
     beforeEach(() => {
@@ -534,7 +534,7 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
         const converter = converterWithProjectPath(projectVersePath);
         const statement = `using { ${projectVersePath}/Systems/Economy/Shop } # only the shop`;
 
-        expect((await converter.convertFromFullPath(statement, fileAt("Systems/Economy"), 0))?.fullPathImport).toBe("using { Shop }");
+        expect((await converter.convertFromFullPath(statement, fileAt("Systems/Economy"), 0))?.convertedImport).toBe("using { Shop }");
     });
 
     // The round trip runs the real outward search over a folder tree, not a
@@ -570,7 +570,7 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
 
             const relative = await converter.convertFromFullPath(absolute, fileUri, 0);
 
-            expect((await converter.convertToFullPath(relative!.fullPathImport, fileUri, 0))?.fullPathImport).toBe(absolute);
+            expect((await converter.convertToFullPath(relative!.convertedImport, fileUri, 0))?.convertedImport).toBe(absolute);
         });
     });
 });
@@ -590,7 +590,7 @@ describe("ImportPathConverter.convertToFullPath", () => {
 
         const result = await converter.convertToFullPath("using. Shop # use {braces} here", vscode.Uri.file("C:/project/test.verse"), 0);
 
-        expect(result?.fullPathImport).toBe("using. /mygame@fortnite.com/mygame/Economy/Shop");
+        expect(result?.convertedImport).toBe("using. /mygame@fortnite.com/mygame/Economy/Shop");
     });
 
     it("keeps the braced style when the trailing comment also contains a brace", async () => {
@@ -598,7 +598,7 @@ describe("ImportPathConverter.convertToFullPath", () => {
 
         const result = await converter.convertToFullPath("using { Shop } # see {Vendor}", vscode.Uri.file("C:/project/test.verse"), 0);
 
-        expect(result?.fullPathImport).toBe("using { /mygame@fortnite.com/mygame/Economy/Shop }");
+        expect(result?.convertedImport).toBe("using { /mygame@fortnite.com/mygame/Economy/Shop }");
     });
 
     // A brace in comment prose costs the statement its style; a whole
@@ -609,7 +609,7 @@ describe("ImportPathConverter.convertToFullPath", () => {
 
         const result = await converter.convertToFullPath("using. Shop # was using { Inventory }", vscode.Uri.file("C:/project/test.verse"), 0);
 
-        expect(result?.fullPathImport).toBe("using. /mygame@fortnite.com/mygame/Economy/Shop");
+        expect(result?.convertedImport).toBe("using. /mygame@fortnite.com/mygame/Economy/Shop");
         expect(result?.moduleName).toBe("Shop");
     });
 });


### PR DESCRIPTION
Closes #257

Renames two names in `ImportPathConverter` that did not say what they were, with no behaviour change.

- `ImportConversionResult.fullPathImport` -> `convertedImport`. The field holds the statement to write in place of the original, whichever direction the conversion runs: `convertToFullPath` puts the absolute form there and `convertFromFullPath` the relative one, so the old name read true on only one of the two paths. The field doc lost the clause that apologised for that and kept the direction contract and the empty-while-ambiguous constraint.
- `convertAllImportsInDocument` -> `convertAllImportsToFullPath`, naming the direction its sibling `convertAllImportsFromFullPath` already names.

`CommandsHandler`'s hand-maintained structural copy of the result type, and the tests, are renamed in step. No command id, setting, user-visible string or document text changes, so there is no changelog fragment.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       961 passed, 961 total
Snapshots:   0 total
Time:        10.966 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh reviewer on opus: `PASS_WITH_SUGGESTIONS`, no Critical and no Important findings. It confirmed the rename is complete (no occurrence of either old name remains, and the unrelated `isFullPathImport` predicate was not caught), that the diff changes identifiers only, and that the two declarations of the result shape stay field-compatible.

Both suggestions are recorded rather than acted on, as out of this ticket's scope:

- The result shape is declared twice, in `ImportPathConverter` and again as `PathConversionResult` in `CommandsHandler`, reached by a cast. Exporting the original and deleting the copy would remove the cast with it. Worth its own ticket.
- `convertedImport` still reads as populated where an ambiguous conversion leaves it empty. The doc comment states that contract and `applyConversion` substitutes the picked path before use, and no candidate name improves on it.
