### PR TITLE
refactor(diagnostics): read the auto-import setting once per diagnostics event

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,7 +250,17 @@ export function activate(context: vscode.ExtensionContext) {
             // when the scope actually restricts something - this listener runs
             // on every compile pass, and the default path must not pay for a
             // feature it does not use.
-            const scope = vscode.workspace.getConfiguration("verseAutoImports").get<string>("general.autoImportScope", "allFiles");
+            //
+            // Every setting this listener reads is read here, for the same
+            // reason the visibility snapshot is taken here: the loop awaits, so
+            // a per-uri read answers for a different moment than the diagnostics
+            // it is deciding about. The debounce callback reads its own settings
+            // again when its timer fires, and that read is the authoritative
+            // one - hoisting it up here would be a different change, and a wrong
+            // one, since it is what makes a mid-loop toggle harmless.
+            const config = vscode.workspace.getConfiguration("verseAutoImports");
+            const scope = config.get<string>("general.autoImportScope", "allFiles");
+            const autoImportEnabled = config.get<boolean>("general.autoImport", true);
             const visibility = !DiagnosticsHandler.scopeRestrictsDocuments(scope)
                 ? { openUris: [] }
                 : {
@@ -280,14 +290,12 @@ export function activate(context: vscode.ExtensionContext) {
                 try {
                     const document = await vscode.workspace.openTextDocument(uri);
                     if (document.languageId === "verse") {
-                        const config = vscode.workspace.getConfiguration("verseAutoImports");
-                        // The snooze is in-memory state, not a setting, so it
-                        // is checked here rather than read back from config.
-                        // This is only the cheap early exit; the authoritative
-                        // check is in the debounce callback, which has to
-                        // re-check because a snooze can start after a timer
-                        // has already been scheduled.
-                        if (config.get<boolean>("general.autoImport", true) && !statusBarHandler.isSnoozeActive()) {
+                        // Asked per uri rather than hoisted with the settings
+                        // above, because a snooze starting mid-loop is meant to
+                        // take effect at once. This is still only the cheap
+                        // early exit: the authoritative check is in the debounce
+                        // callback, which fires later again.
+                        if (autoImportEnabled && !statusBarHandler.isSnoozeActive()) {
                             await diagnosticsHandler.handle(document);
                         }
                     }


### PR DESCRIPTION
Closes #46

The diagnostics listener read `general.autoImport` inside its per-uri loop, once per uri the compiler reported on. It is read once per event now, beside the `scope` and visibility snapshot already taken there for the same reason: the loop awaits `openTextDocument`, so a per-uri read answers for a later moment than the event it is deciding about.

The snooze check stays per uri. It is in-memory state rather than a setting, and one starting mid-loop is meant to take effect at once — hoisting it would have been a behaviour change, not a behaviour-preserving one.

## Why this is the whole of what is left

Five of the ticket's six items are already resolved. Audited against `origin/main` at `14b6055`:

| Item | State |
| --- | --- |
| 1 — pre-filter by extension before loading documents | Landed via #59. `DiagnosticsHandler.shouldProcessUri` gates before `openTextDocument`. |
| 2 — CodeLens recomputing two whole-file scans per import line | Landed via #182 (`537ef24`). One `scanConvertibleImports` per refresh, and both "for all" flags hoisted above the per-line loop. The dedup comment on the issue lists this as still open; it is stale. |
| 3 — index the digest by lowercased key | Dissolved by #304, per the maintainer's comment on the issue. |
| 4 — configuration reads hoisted out of per-uri loops | Half landed via #209, which hoisted `scope` and the visibility snapshot. **This PR is the other half.** |
| 5 — reset the precompiled-availability flag on cache clear | Dissolved by #304, per the maintainer's comment on the issue. |
| 6 — the two import-block filters sharing one predicate | Target gone. Filed as PLAUSIBLE and unreachable against `ImportDocumentEditor:43`, which the block-rebuild rewrites replaced; one path filter remains and it already drops empty strings. |

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
Test Suites: 40 passed, 40 total
Tests:       961 passed, 961 total
Snapshots:   0 total
Time:        5.98 s, estimated 9 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No new test: the change is in `src/extension.ts`, which needs the VS Code runtime and is not reachable from the jest suite. The ticket's Testing Decisions record the maintainer's call that no new suite is mandated for these items.

No changelog fragment: the ticket's Out of Scope excludes user-facing behaviour changes, and this is behaviour-preserving.

## Review

One round, fresh reviewer, `opus`. Verdict `PASS_WITH_SUGGESTIONS` — no Critical, no Important, four Suggestions. Two were applied before the commit: the hoist comment overclaimed ("every setting the loop reads is read here") in a way that invited a future editor to hoist the debounce callback's authoritative re-read too, and the snooze comment stated the same fact twice.

Two were reported and not acted on, both pre-existing and outside this ticket:

- Under a `true -> false` mid-loop toggle, a newly armed timer can still emit the "Multiple import options available" status-bar message, because `DiagnosticsHandler.ts:237` gates that on `hasMultiOptionSuggestions && multiOptionStrategy === "quickfix"` and not on the auto-import setting. No edit and no persistent state result. The same race is already reachable on `origin/main` once a timer is armed; this diff widens the window by the loop's duration only. If it ever matters the fix belongs in `DiagnosticsHandler`, not here.
- The listener's `config` shadows the activation-time `config`, which is a snapshot frozen at activation on purpose. The pattern is pre-existing and the hover provider shadows it the same way.
