### PR TITLE
fix(services): leave a closed braced body the modules inside it shield

### DIFF
--- a/changelog.d/336.fixed.md
+++ b/changelog.d/336.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: A module written inside a braced module body no longer holds that body open past its closing brace, so imports are no longer offered at paths one or more segments too long.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -534,10 +534,11 @@ export class ProjectPathScanner {
  * the declaration that opened them.
  *
  * The lowest such index is the cut rather than merely one of them, because a
- * braced entry records the depth it opens from and every braced entry left on
- * the stack sits below the current depth: their close depths increase upwards,
- * so nothing below the index found here has closed too. Cutting the stack
- * before the next entry is pushed is what keeps that true.
+ * braced entry records the depth it opens from: close depths never decrease
+ * going up the stack, so nothing below the index found here has closed too.
+ * Two entries may record the same depth - the line opening an awaited body
+ * assigns one after this has already run - which the lowest index still
+ * answers, both of them being closed together.
  */
 function outermostClosedBrace(open: readonly OpenModule[], braceDepth: number): number {
     return open.findIndex((entry) => entry.closeDepth !== null && braceDepth <= entry.closeDepth);

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -1,11 +1,38 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
-import { indentOf, maskCommentsAndStrings } from "../utils/verseText";
+import { countBraces, indentOf, maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 
 /** Number of .verse files parsed concurrently during a full scan. */
 const SCAN_CONCURRENCY = 8;
+
+/**
+ * A module whose body the scan is inside, held while its declarations are read
+ * so each can be given the path it sits at.
+ *
+ * A skipped module is on the stack for its indent alone, so that what it
+ * contains is dropped with it rather than losing the enclosing segment from its
+ * path. Nothing is ever pushed above a skipped entry, because every declaration
+ * under one is skipped before it can be.
+ */
+interface OpenModule {
+    /** Dotted path of the module itself, enclosing segments included. */
+    name: string;
+    indent: number;
+    skipped: boolean;
+    /**
+     * True only between a module declaration that ended without opening a body
+     * and the next line considered, which is where its `{` may be.
+     */
+    awaitingBrace: boolean;
+    /**
+     * Brace depth just outside a braced body, and null while indentation is
+     * what closes the entry: the colon, dotted and `>` forms, and a braced one
+     * whose `{` is still to come.
+     */
+    closeDepth: number | null;
+}
 
 /**
  * Reads the project's .verse files into a flat list of the module, class,
@@ -139,17 +166,7 @@ export class ProjectPathScanner {
         // its braces alone, so this is the only thing that can close one: its
         // members are free to sit at or left of the declaration's own indent.
         let braceDepth = 0;
-        // A skipped module is on the stack for its indent alone, so that what
-        // it contains is dropped with it rather than losing the enclosing
-        // segment from its path. Nothing is ever pushed above a skipped entry,
-        // because every declaration under one is skipped before it can be.
-        //
-        // `awaitingBrace` is true only between a module declaration that ended
-        // without opening a body and the next line considered, which is where
-        // its `{` may be. `closeDepth` is the brace depth just outside a braced
-        // body, and null while indentation is what closes the entry: the colon,
-        // dotted and `>` forms, and a braced one whose `{` is still to come.
-        const moduleStack: { name: string; indent: number; skipped: boolean; awaitingBrace: boolean; closeDepth: number | null }[] = [];
+        const moduleStack: OpenModule[] = [];
 
         // A declaration carries any number of stacked specifiers, of which at
         // most one is a visibility; the rest (<native>, <final>, ...) are noise
@@ -220,24 +237,8 @@ export class ProjectPathScanner {
             // depth behind: a braced `using` clause spans lines, and skipping
             // its opener while still counting its `}` would drive the depth
             // below the point any enclosing module opened from.
-            //
-            // A brace between single quotes is a char literal. Masking leaves
-            // single quotes alone, because one opens a char literal and an
-            // identifier's quoted suffix alike and it cannot tell them apart,
-            // but a suffix cannot hold a brace, so this much is unambiguous.
-            // Counting one would strand the depth for the rest of the file,
-            // where indentation used to recover it at the next dedent.
             const depthAtLineStart = braceDepth;
-            for (let column = 0; column < line.length; column++) {
-                const character = line[column];
-                if (character !== "{" && character !== "}") {
-                    continue;
-                }
-                if (line[column - 1] === "'" && line[column + 1] === "'") {
-                    continue;
-                }
-                braceDepth += character === "{" ? 1 : -1;
-            }
+            braceDepth = countBraces(line, 0, line.length, braceDepth);
 
             // A Verse comment is already blank here, so the empty test is what
             // skips one; `//` is not a Verse comment form and masking leaves it
@@ -271,16 +272,21 @@ export class ProjectPathScanner {
             // is popped on the next line the scan considers - a closing brace
             // declares nothing, so reading it a line late costs no path. An
             // indented body ends at the first line back at or left of its
-            // declaration. The loop stops at the first entry still open, which
-            // is what keeps indentation from closing an outer module while a
-            // braced one nested inside it is still waiting for its `}`.
+            // declaration.
             if (!opensAwaitedBody) {
-                while (moduleStack.length > 0) {
-                    const openModule = moduleStack[moduleStack.length - 1];
-                    const closed = openModule.closeDepth !== null ? depthAtLineStart <= openModule.closeDepth : indent <= openModule.indent;
-                    if (!closed) {
-                        break;
-                    }
+                // Closed braced bodies go first, outermost in, because one
+                // takes every module inside it along. A colon module written
+                // left of the brace's own declaration reads as open on
+                // indentation alone, and closing only from the top would let it
+                // shield the closed brace beneath it.
+                const closedBrace = outermostClosedBrace(moduleStack, depthAtLineStart);
+                if (closedBrace !== -1) {
+                    moduleStack.length = closedBrace;
+                }
+
+                // What is left closes innermost out, and stops at a braced body
+                // still waiting for its `}`.
+                while (moduleStack.length > 0 && closedByIndent(moduleStack[moduleStack.length - 1], indent)) {
                     moduleStack.pop();
                 }
             }
@@ -516,4 +522,34 @@ export class ProjectPathScanner {
 
         return nodes;
     }
+}
+
+/**
+ * Index of the outermost open module whose braced body has already closed, and
+ * so of the first entry the stack no longer holds; -1 while none has closed.
+ *
+ * Only a braced body can be found closed from below like this. Its depth test
+ * holds anywhere in the file, whereas an indent compared across a brace
+ * boundary means nothing - a module inside the braces may be written left of
+ * the declaration that opened them.
+ *
+ * The lowest such index is the cut rather than merely one of them, because a
+ * braced entry records the depth it opens from and every braced entry left on
+ * the stack sits below the current depth: their close depths increase upwards,
+ * so nothing below the index found here has closed too. Cutting the stack
+ * before the next entry is pushed is what keeps that true.
+ */
+function outermostClosedBrace(open: readonly OpenModule[], braceDepth: number): number {
+    return open.findIndex((entry) => entry.closeDepth !== null && braceDepth <= entry.closeDepth);
+}
+
+/**
+ * Whether an open module that indentation delimits ends before a declaration at
+ * this indent.
+ *
+ * False for a braced body, whose end no indentation can announce. That is what
+ * stops the pop loop at one, leaving the modules below it open.
+ */
+function closedByIndent(open: OpenModule, indent: number): boolean {
+    return open.closeDepth === null && indent <= open.indent;
 }

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -262,6 +262,14 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
                 expect(declare(source).map((node) => node.fullPath)).toEqual(["A", "A.B", "A.B.C", "A.B.C.D", "A.B.C.D.Q", "A.B.E", "Z"]);
             });
 
+            it("takes two colon levels along when the braced body holding them closes", () => {
+                // The other direction of the same cut: everything the closed
+                // body contained goes with it in one truncation, and the
+                // declaration after it starts from the file again.
+                const source = "Outer := module{\n    C := module:\n        D := module:\n            Q:int = 1\n}\nAfter := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Outer", "Outer.C", "Outer.C.D", "Outer.C.D.Q", "After"]);
+            });
+
             it("keeps a module open whose brace depth a stray closing brace drove below zero", () => {
                 // A `}` ahead of any declaration makes the depth negative, so a
                 // module opened after it records a negative close depth. The

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -222,5 +222,59 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
             const source = "Systems<public> := module{\nusing{\n    /Verse.org/Simulation\n}\nB<public> := class {}\n}\nLoose<public> := class {}\n";
             expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.B", "Loose"]);
         });
+
+        // A colon module written left of the braced declaration it sits inside
+        // reads as open on indentation at every line indented past it, so
+        // closing only from the top of the stack stops there and never reaches
+        // the braced entry whose `}` has already passed. The braced entry then
+        // prefixes everything after it, and a `fullPath` one or more segments
+        // too long names a module that does not exist at that path.
+        describe("a closed braced body is left by the modules it shields", () => {
+            it("returns a sibling to the enclosing module when the braced body it follows was written left of its declaration", () => {
+                const source = "Outer := module:\n    A := module{\nB := module:\n    Q:int = 1\n    }\n    C := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Outer", "Outer.A", "Outer.A.B", "Outer.A.B.Q", "Outer.C"]);
+            });
+
+            it("returns the sibling through two colon levels above the brace", () => {
+                const source = "L1 := module:\n    L2 := module:\n        A := module{\nB := module:\n    Q:int = 1\n        }\n        C := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["L1", "L1.L2", "L1.L2.A", "L1.L2.A.B", "L1.L2.A.B.Q", "L1.L2.C"]);
+            });
+
+            it("returns the sibling where it is written past the closed body's own indent", () => {
+                // The truncation is driven by the depth alone, so a sibling
+                // indented deeper than the body it follows still leaves it.
+                const source = "Outer := module:\n    A := module{\nB := module:\n    Q:int = 1\n    }\n        C := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Outer", "Outer.A", "Outer.A.B", "Outer.A.B.Q", "Outer.C"]);
+            });
+
+            it("returns the sibling the same way when the brace opened the body on the next line", () => {
+                const source = "Outer := module:\n    Inner := module\n    {\nMember := module:\n    Q:int = 1\n    }\n    Kept := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Outer", "Outer.Inner", "Outer.Inner.Member", "Outer.Inner.Member.Q", "Outer.Kept"]);
+            });
+
+            it("closes one braced body of several without closing those still open around it", () => {
+                const source = "Systems := module{\nB := module:\n    C := module{\nD := module:\n        Z:int = 1\n    }\n    E := module {}\n}\nSibling := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Systems", "Systems.B", "Systems.B.C", "Systems.B.C.D", "Systems.B.C.D.Z", "Systems.B.E", "Sibling"]);
+            });
+
+            it("closes the inner body where the shielding module's own body ended at column zero", () => {
+                const source = "A := module{\nB := module:\n    C := module{\nD := module:\n    Q:int = 1\n}\n    E := module {}\n}\nZ := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["A", "A.B", "A.B.C", "A.B.C.D", "A.B.C.D.Q", "A.B.E", "Z"]);
+            });
+
+            it("keeps a module open whose brace depth a stray closing brace drove below zero", () => {
+                // A `}` ahead of any declaration makes the depth negative, so a
+                // module opened after it records a negative close depth. The
+                // truncation test has to keep holding there, rather than firing
+                // at the outermost entry for every later line.
+                const source = "}\nOuter := module{\nInner := module:\n    Q:int = 1\n}\nAfter := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Outer", "Outer.Inner", "Outer.Inner.Q", "After"]);
+            });
+
+            it("leaves a braced module a stray closing brace ended before the next one opens", () => {
+                const source = "A := module{\nX:int = 1\n}\n}\nB := module{\nY:int = 1\n}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["A", "A.X", "B", "B.Y"]);
+            });
+        });
     });
 });

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -128,6 +128,38 @@ export function indentOf(content: string, lineStart: number): number {
     return width;
 }
 
+/**
+ * The brace depth after the half-open range, starting from the depth before it.
+ * Counted on masked text, so a brace in a comment or a string contributes none.
+ *
+ * Both module scans delimit a braced body by this depth, and they must agree:
+ * one reads it over the gap between two declarations, the other over a single
+ * line, so the range is theirs to choose.
+ */
+export function countBraces(searchable: string, start: number, end: number, depth: number): number {
+    let braceDepth = depth;
+
+    for (let i = start; i < end; i++) {
+        const character = searchable[i];
+        if (character !== "{" && character !== "}") {
+            continue;
+        }
+
+        // A single-quoted brace delimits nothing. Masking leaves single quotes
+        // alone because one opens a char literal and an identifier's quoted
+        // suffix alike, but neither reading makes this brace a body's, and
+        // counting one would strand the depth for the rest of the file with
+        // nothing left to recover it.
+        if (searchable[i - 1] === "'" && searchable[i + 1] === "'") {
+            continue;
+        }
+
+        braceDepth += character === "{" ? 1 : -1;
+    }
+
+    return braceDepth;
+}
+
 /** Replaces one character with a space, keeping newlines so line numbers still hold. */
 function blank(masked: string[], content: string, index: number): void {
     if (content[index] !== "\n") {

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -9,7 +9,7 @@
  * quoted suffix.
  */
 
-import { indentOf, maskCommentsAndStrings } from "../utils/verseText";
+import { countBraces, indentOf, maskCommentsAndStrings } from "../utils/verseText";
 
 /**
  * A declaration in any of the three styles a macro body is written in:
@@ -248,34 +248,6 @@ function outermostClosedBrace(open: readonly OpenModule[], braceDepth: number): 
  */
 function closedByIndent(open: OpenModule, indent: number, line: number): boolean {
     return open.closeDepth === null && open.line !== line && indent <= open.indent;
-}
-
-/**
- * The brace depth after the half-open range, starting from the depth before it.
- * Counted on masked text, so a brace in a comment or a string contributes none.
- */
-function countBraces(searchable: string, start: number, end: number, depth: number): number {
-    let braceDepth = depth;
-
-    for (let i = start; i < end; i++) {
-        const character = searchable[i];
-        if (character !== "{" && character !== "}") {
-            continue;
-        }
-
-        // A single-quoted brace delimits nothing. Masking leaves single quotes
-        // alone because one opens a char literal and an identifier's quoted
-        // suffix alike, but neither reading makes this brace a body's, and
-        // counting one would strand the depth for the rest of the file with
-        // nothing left to recover it.
-        if (searchable[i - 1] === "'" && searchable[i + 1] === "'") {
-            continue;
-        }
-
-        braceDepth += character === "{" ? 1 : -1;
-    }
-
-    return braceDepth;
 }
 
 /** Offset of the first character of every line, so a line number is a binary search. */


### PR DESCRIPTION
Closes #336

The project scan popped its module stack from the top only, so an entry indentation still held open shielded a braced entry beneath it whose `}` had already returned the depth to where its body opened. Everything after it kept that module as a path prefix, and a `fullPath` one or more segments too long is an import path for a module that does not exist there.

## What changed

- `src/services/ProjectPathScanner.ts` — the close runs in two phases, as `findExplicitModuleDeclarations` has since #335. `outermostClosedBrace` cuts the stack at the lowest entry whose braced body has closed, because one takes every module inside it along; what is left pops innermost out through `closedByIndent`, which is false for a braced entry and so stops at a body still awaiting its `}`. The inline stack-entry type is now a named `OpenModule`.
- `src/utils/verseText.ts` — `countBraces` moves here, beside the `maskCommentsAndStrings` and `indentOf` both scans already consume.
- `src/visibility/moduleDeclarations.ts` — drops its own copy of `countBraces` and imports the shared one.
- Tests — the ticket's six shapes asserted on `fullPath`, plus the three retention hazards and the two stray-brace hazards the port had to avoid reintroducing.

`currentModulePath` needed no change: it is already reassigned from whatever entry the stack leaves on top, so a truncation removing several entries at once restores it correctly.

## One correction to the ticket

The ticket's table says row 6 (`A := module{...` → `A.B.E`) is a diverging shape. It is not — the scanner already returns the correct `A.B.E` on `main`. That row escapes because the scanner also runs its close loop on the `}` line itself, which pops the shielding `D` where `D` sits at indent 0 and the `}` is at indent 0. The other five rows reproduce exactly as written. The test for it is kept as a pin rather than a regression.

## Verification

```
npm run compile
> tsc -p ./
(clean)

npm test
Test Suites: 40 passed, 40 total
Tests:       970 passed, 970 total

npm run format:check
All matched files use Prettier code style!
```

The six shapes and both stray-brace hazards were run against the unfixed code first: five of the six failed with exactly the wrong values the ticket predicts.

## Review

One round, verdict PASS_WITH_SUGGESTIONS, no Critical. The reviewer fuzzed 20,000 generated files across all three body styles and free member indentation: 0 wrong after the fix, 558 wrong before it, and 0 disagreements between the two scans — which is what #336 asked for. Two suggestions are applied here: the missing "two colon levels" retention test, and a close-depth invariant that was stated more absolutely than the code guarantees.

One `Important` finding is deliberately not applied. `outermostClosedBrace` is byte-identical to its twin in `moduleDeclarations.ts`, and the reviewer proposed hoisting it into `verseText.ts` beside `countBraces`. It is left local: `verseText.ts` is for reading Verse source as text, and this reads a module stack, so that module is the wrong home for it. Unifying the two scans' nesting logic is #45's job.

## Found while reviewing, not fixed here

`"Priv<private> := module:\n    Inner := module{\nX := module {}\n    }\nY := module {}\n"` returns `X` and `Y` as top-level candidates, where the true path is `Priv.Inner.X`. Nothing is pushed onto the stack inside a skipped module, so the braced `Inner` body is untracked and the skipped colon entry closes on indentation at `X` — a private subtree offered as an import candidate, the harm class #330 was filed for, reached by a different route. Present on `main` before this change and unaffected by it.
