### PR TITLE
fix(services): bound a braced body opened inside a skipped module

### DIFF
--- a/changelog.d/342.fixed.md
+++ b/changelog.d/342.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: A module inside a private or scoped module's braced body is no longer offered as a top-level import candidate, where it named a path the compiler rejects and collided with any real module of that name.

--- a/changelog.d/342.fixed.md
+++ b/changelog.d/342.fixed.md
@@ -1,1 +1,1 @@
-**Project scan**: A module inside a private or scoped module's braced body is no longer offered as a top-level import candidate, where it named a path the compiler rejects and collided with any real module of that name.
+**Project scan**: A module inside the braced body of a module dropped for its access level is no longer offered as a top-level import candidate at a path the compiler rejects.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -304,11 +304,9 @@ export class ProjectPathScanner {
             // and is dropped with it. The pop loop above has already closed
             // the module for a line that left it.
             //
-            // Read rather than acted on here, because a module declared inside
-            // the subtree still has to reach the stack: only an entry of its
-            // own carries the depth its braced body closes at, and without one
-            // the enclosing skipped entry is popped by the first member written
-            // back at its indent, which a braced body permits.
+            // Read rather than acted on, because a module declared in there
+            // still has to reach the stack to bound its own body; only the
+            // declarations below it are dropped where they stand.
             const insideSkipped = moduleStack.length > 0 && moduleStack[moduleStack.length - 1].skipped;
 
             currentModulePath = moduleStack.length > 0 ? moduleStack[moduleStack.length - 1].name : "";

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -11,10 +11,12 @@ const SCAN_CONCURRENCY = 8;
  * A module whose body the scan is inside, held while its declarations are read
  * so each can be given the path it sits at.
  *
- * A skipped module is on the stack for its indent alone, so that what it
+ * A skipped module is on the stack for its bounds alone, so that what it
  * contains is dropped with it rather than losing the enclosing segment from its
- * path. Nothing is ever pushed above a skipped entry, because every declaration
- * under one is skipped before it can be.
+ * path. A module declared inside one is pushed too, marked skipped in turn: a
+ * braced body opened in there closes on its brace, and an entry no one tracks
+ * leaves that depth unaccounted for, which returns the scan to file scope while
+ * it is still inside the subtree.
  */
 interface OpenModule {
     /** Dotted path of the module itself, enclosing segments included. */
@@ -301,9 +303,13 @@ export class ProjectPathScanner {
             // still inside a skipped module is as unreachable as the module
             // and is dropped with it. The pop loop above has already closed
             // the module for a line that left it.
-            if (moduleStack.length > 0 && moduleStack[moduleStack.length - 1].skipped) {
-                continue;
-            }
+            //
+            // Read rather than acted on here, because a module declared inside
+            // the subtree still has to reach the stack: only an entry of its
+            // own carries the depth its braced body closes at, and without one
+            // the enclosing skipped entry is popped by the first member written
+            // back at its indent, which a braced body permits.
+            const insideSkipped = moduleStack.length > 0 && moduleStack[moduleStack.length - 1].skipped;
 
             currentModulePath = moduleStack.length > 0 ? moduleStack[moduleStack.length - 1].name : "";
 
@@ -323,12 +329,16 @@ export class ProjectPathScanner {
 
                 const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
 
-                if (shouldSkipDeclaration(visibility, true)) {
-                    moduleStack.push({ name: fullPath, indent, skipped: true, awaitingBrace, closeDepth });
+                // Skipped is inherited: a module the specifier alone would keep
+                // is still unreachable when an enclosing one is not.
+                const skipped = insideSkipped || shouldSkipDeclaration(visibility, true);
+
+                moduleStack.push({ name: fullPath, indent, skipped, awaitingBrace, closeDepth });
+
+                if (skipped) {
                     continue;
                 }
 
-                moduleStack.push({ name: fullPath, indent, skipped: false, awaitingBrace, closeDepth });
                 currentModulePath = fullPath;
 
                 nodes.push({
@@ -339,6 +349,12 @@ export class ProjectPathScanner {
                     sourceFile: filePath,
                     sourceLine: i + 1,
                 });
+                continue;
+            }
+
+            // Every declaration below opens no body, so none of them needs an
+            // entry to bound; inside a skipped module they are simply dropped.
+            if (insideSkipped) {
                 continue;
             }
 

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -284,5 +284,42 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
                 expect(declare(source).map((node) => node.fullPath)).toEqual(["A", "A.X", "B", "B.Y"]);
             });
         });
+
+        // A skipped module the colon form delimits is held open by indentation
+        // alone, and a braced body opened inside it may write its members back
+        // at that indent - which pops the skipped entry unless the braced body
+        // has an entry of its own carrying the depth it closes at. Without one
+        // the scan believes it is at file scope while still inside the subtree,
+        // and offers its modules as top-level candidates: paths the compiler
+        // rejects at their first segment, colliding with any genuine top-level
+        // module of the same name.
+        describe("a braced body inside a skipped module", () => {
+            it("holds the skipped module open across a member written back at its indent", () => {
+                const source = "Systems<private> := module:\n    Inner := module{\nX := module {}\n    }\nInventory := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory"]);
+            });
+
+            it("holds it open for a scoped module the same way", () => {
+                const source = "Systems<scoped{ModuleA}> := module:\n    Inner := module{\nX := module {}\n    }\nInventory := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory"]);
+            });
+
+            it("holds it open where the brace opened the body on the next line", () => {
+                const source = "Systems<private> := module:\n    Inner := module\n    {\nX := module {}\n    }\nInventory := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory"]);
+            });
+
+            it("returns a sibling after the skipped body to file scope, its own members included", () => {
+                // A sibling recorded without its members, or with a `Systems.`
+                // prefix, is the same wrong pop bound reported the other way up.
+                const source = "Systems<private> := module:\n    Inner := module{\nX := module {}\n    }\nInventory := module:\n    Item := class {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
+            });
+
+            it("drops the colon-only form, which closed correctly without any entry of its own", () => {
+                const source = "Systems<private> := module:\n    Inner := module:\n        X := module:\n            Deep := class {}\nInventory := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory"]);
+            });
+        });
     });
 });

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -316,9 +316,26 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
                 expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory", "Inventory.Item"]);
             });
 
-            it("drops the colon-only form, which closed correctly without any entry of its own", () => {
+            it("keeps dropping the colon-only form, which indentation alone already bounded", () => {
                 const source = "Systems<private> := module:\n    Inner := module:\n        X := module:\n            Deep := class {}\nInventory := module {}\n";
                 expect(declare(source).map((node) => node.fullPath)).toEqual(["Inventory"]);
+            });
+
+            it("returns a kept parent's sibling to the parent rather than to file scope", () => {
+                // The other harm the untracked body caused: the scan reached
+                // file scope inside the subtree, so a declaration after it
+                // rejoined at no prefix instead of at the module it sits in.
+                const source = "Keep := module:\n    Systems<private> := module:\n        Inner := module{\nX := module {}\n        }\n    Kept := class {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual(["Keep", "Keep.Kept"]);
+            });
+
+            it("runs an unclosed body inside the skipped module to the file end", () => {
+                // Not valid Verse, so this pins degradation rather than a shape
+                // a user can compile: the body no brace closed costs the
+                // declarations after it, which is what the kept path already
+                // does, rather than offering them at a path that does not exist.
+                const source = "Systems<private> := module:\n    Inner := module{\nX := module {}\nInventory := module {}\n";
+                expect(declare(source).map((node) => node.fullPath)).toEqual([]);
             });
         });
     });


### PR DESCRIPTION
Closes #342

A module declared inside a skipped one was never pushed onto the module stack, so a braced body opened in there had no entry carrying the depth its `}` closes at. The skipped entry above it is delimited by indentation, and a braced body's members may be written back at that indent, so the first one popped it — and the scan carried on believing it was at file scope while still inside the subtree.

## What changed

- `src/services/ProjectPathScanner.ts` — `skipped` is now inherited. The stack-top-is-skipped test becomes a read (`insideSkipped`) instead of a `continue`, so a module declared inside the subtree is still pushed, marked skipped in turn; every declaration below the module branch is dropped where it stands. The two `moduleStack.push` calls collapse into one. The `OpenModule` doc drops its "nothing is ever pushed above a skipped entry" invariant, which this change replaces.
- Tests — the ticket's four shapes, a next-line-brace variant, and the two the review gate asked for.

`outermostClosedBrace` and `closedByIndent` needed no change: a skipped entry now carries the same `closeDepth`/`indent` as a kept one, so #336's two-phase close bounds it without knowing the difference.

## One correction to the ticket

The acceptance sentence says the input "yields no nodes at all". That cannot hold alongside the same sentence's second half, "a sibling declared after the skipped module's body still resolves at file scope" — `Y := module {}` in that very input *is* that sibling. It sits at indent 0, back at `Priv`'s own indent, so it dedents out of `Priv`'s colon body and is a genuine top-level module; dropping it would be a new defect. The ticket's own "Why" names only `X` as wrong.

The implemented expectation is therefore `["Y"]`, not `[]`. The review gate was asked to judge this independently and reached the same conclusion on three grounds, confirming `origin/main` returns exactly `["X", "Y"]`.

## Verification

```
npm run compile
> tsc -p ./
(clean)

npm test
Test Suites: 40 passed, 40 total
Tests:       977 passed, 977 total

npm run format:check
All matched files use Prettier code style!
```

The five ticket-shaped tests were run against the unfixed scanner first: four failed with exactly the stray top-level `X` the ticket predicts, and the fifth — the colon-only pin — passed, which is what the ticket says it should do. The two tests added after review also fail on `origin/main`.

## Review

One round, verdict PASS_WITH_SUGGESTIONS, no Critical and no Important. The reviewer probed rather than only read: 40-odd shapes across all four dropped specifiers, `includePrivate` on each, kept-parent controls compared byte-for-byte against `origin/main`, deep brace/colon interleavings, stray braces, a braced `using` clause and a `'{'` char literal inside the skipped subtree, `<#>` comments, CRLF and tab input, next-line-brace timing, all seven non-module declaration forms, and two mutation tests against the new guards. Every kept path and every `includePrivate` path it probed is identical to `origin/main`.

Five of its six suggestions are applied here:

- **Kept-parent coverage gap.** The fix repairs a second harm nothing pinned: with a kept enclosing module, `origin/main` returned `["Keep", "X", "Sib", "Y"]` — the leaked `X`, *and* a kept sibling stripped of its `Keep.` prefix. Now pinned.
- **Unclosed-brace degradation.** An unclosed body inside the skipped subtree now costs the declarations after it where `main` offered them at a path that does not exist. It does not compile either way, and the kept path already behaves identically. Pinned as degradation, in the spirit of the existing "a module missing its body cannot swallow the rest of the file" test.
- The `insideSkipped` comment restated the `OpenModule` doc nearly clause for clause; trimmed to what is local to the read.
- A test name claimed the colon-only form closes "without any entry of its own", which this change makes false.
- The changelog fragment named only private and scoped; `<protected>` and `<epic_internal>` drop through the same code and had the same leak.

The sixth is out of scope and left unapplied: `block:`, `if:` and `loop:` inside a function body match `variablePattern` and are recorded as junk `variable` nodes in the declaration cache. It reproduces identically on `origin/main` and is unrelated to this ticket — worth its own issue.
