### PR TITLE
fix(imports): find a folder module anywhere in the project, not only near the file

### DIFF
--- a/changelog.d/60.fixed.md
+++ b/changelog.d/60.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: converting a relative import now finds a folder module anywhere in the project, not only beside the current file or at the Content root.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -4,6 +4,7 @@ import { logger } from "../utils";
 import { maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathCache } from "../services";
+import { resolveFolderModuleLocations } from "../services/moduleLocationLookup";
 import { ImportFormatter } from "./ImportFormatter";
 import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
@@ -32,6 +33,14 @@ interface ImportConversionResult {
 }
 
 const CONTENT_FOLDER = "Content";
+
+/**
+ * How many `.verse` files the project-wide folder search enumerates. Far above
+ * the explicit-declaration scan's 100 because this one reads no file contents:
+ * it derives folder modules from the paths alone, so a file costs a string
+ * split rather than a read.
+ */
+const FOLDER_SCAN_FILE_LIMIT = 5000;
 
 /**
  * Converts a `using` between the absolute Verse path of a module and the
@@ -323,14 +332,28 @@ export class ImportPathConverter {
      * Capped at 100 files scanned, so a project larger than that resolves from
      * whichever of them the search returned.
      */
+    /**
+     * Where a workspace-wide `.verse` scan has to look, and whether the
+     * workspace folder is itself the Content folder - which decides both the
+     * glob and how a found path maps back to a Content-relative one.
+     *
+     * Shared by the two scanning phases so they cannot disagree about the
+     * layout: a phase reading one rule and a phase reading the other would
+     * resolve the same project differently.
+     */
+    private static workspaceScanTargets(workspaceFolder: { uri: vscode.Uri }): { searchPattern: string; workspaceIsContent: boolean } {
+        const workspaceIsContent = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER;
+        return {
+            searchPattern: workspaceIsContent ? "**/*.verse" : `${CONTENT_FOLDER}/**/*.verse`,
+            workspaceIsContent,
+        };
+    }
+
     private async searchExplicitModuleDefinitions(modulePath: string, moduleName: string, pathSegments: string[], locations: string[]): Promise<void> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) return;
 
-        let searchPattern = `${CONTENT_FOLDER}/**/*.verse`;
-        const workspaceFolderName = path.basename(workspaceFolders[0].uri.fsPath);
-        const workspaceIsContent = workspaceFolderName === CONTENT_FOLDER;
-        if (workspaceIsContent) searchPattern = "**/*.verse";
+        const { searchPattern, workspaceIsContent } = ImportPathConverter.workspaceScanTargets(workspaceFolders[0]);
 
         // Scope the scan to the project folder. The UEFN-generated workspace is
         // multi-root (Content plus Epic's digest folders); a bare string glob
@@ -388,18 +411,70 @@ export class ImportPathConverter {
     }
 
     /**
+     * Appends the locations of folder modules anywhere in the project, which
+     * searchImplicitModules reaches only near the current file and the
+     * declaration scan cannot see at all - a folder module has no declaration
+     * to match, so a chain like Systems/Combat/Weapons is invisible to every
+     * other phase from an unrelated branch of the tree.
+     *
+     * Folders are derived from the paths of the project's `.verse` files, never
+     * from their contents, so this reads no file. The blind spot that leaves is
+     * a folder holding no `.verse` file anywhere beneath it; such a module has
+     * no members to import, so nothing would name it.
+     *
+     * Capped at FOLDER_SCAN_FILE_LIMIT files enumerated.
+     */
+    private async searchProjectFolderModules(modulePath: string, locations: string[]): Promise<void> {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) return;
+
+        const { searchPattern, workspaceIsContent } = ImportPathConverter.workspaceScanTargets(workspaceFolders[0]);
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", FOLDER_SCAN_FILE_LIMIT);
+
+        const contentRelativeDirs = new Set<string>();
+        for (const file of verseFiles) {
+            let directory = path.dirname(path.relative(workspaceFolders[0].uri.fsPath, file.fsPath)).replace(/\\/g, "/");
+            if (directory === ".") directory = "";
+
+            // A workspace opened at Content already yields Content-relative
+            // paths; anywhere else they carry the Content/ segment, and a file
+            // outside Content contributes no importable module.
+            if (!workspaceIsContent) {
+                if (directory === CONTENT_FOLDER) {
+                    directory = "";
+                } else if (directory.startsWith(`${CONTENT_FOLDER}/`)) {
+                    directory = directory.substring(CONTENT_FOLDER.length + 1);
+                } else {
+                    continue;
+                }
+            }
+
+            contentRelativeDirs.add(directory);
+        }
+
+        for (const location of resolveFolderModuleLocations(modulePath, contentRelativeDirs)) {
+            if (!locations.includes(location)) locations.push(location);
+        }
+    }
+
+    /**
      * Every place in the workspace the module could be, as locations relative
      * to the Content root: "" for the root itself, "/Dir/Sub" below it. Empty
      * when the module is nowhere to be found, and longer than one entry when
      * the name is ambiguous.
      *
-     * Two searches, in preference order, and the second runs only if the first
-     * found nothing: a folder near the current file (searchImplicitModules),
-     * then an explicit declaration anywhere in the project
-     * (searchExplicitModuleDefinitions). Ordered that way because proximity is
-     * the better evidence of which module was meant, and because a folder
-     * module exists only on the filesystem, where no declaration cache can see
-     * it.
+     * Three searches, each running only if the ones before it found nothing: a
+     * folder near the current file (searchImplicitModules), then an explicit
+     * declaration anywhere in the project (searchExplicitModuleDefinitions),
+     * then a folder module anywhere in the project
+     * (searchProjectFolderModules). Ordered that way because proximity is the
+     * better evidence of which module was meant, and because a folder module
+     * exists only on the filesystem, where no declaration cache can see it.
+     *
+     * The last phase is the compiler's own recovery for this failure: where the
+     * scope walk resolves nothing, it searches every module in the program and
+     * collects all the matches rather than the first, which is why an ambiguous
+     * answer here is a result and not a fault.
      */
     async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<string[]> {
         const locations: string[] = [];
@@ -446,6 +521,15 @@ export class ImportPathConverter {
                 await this.searchExplicitModuleDefinitions(modulePath, moduleName, pathSegments, locations);
             } catch (error) {
                 logger.debug("ImportPathConverter", `Error in Phase 2 (explicit modules): ${error}`);
+            }
+        }
+
+        if (locations.length === 0) {
+            logger.debug("ImportPathConverter", `Phase 3: Searching folder modules across the project`);
+            try {
+                await this.searchProjectFolderModules(modulePath, locations);
+            } catch (error) {
+                logger.debug("ImportPathConverter", `Error in Phase 3 (project folder modules): ${error}`);
             }
         }
 

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -4,7 +4,7 @@ import { logger } from "../utils";
 import { maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathCache } from "../services";
-import { resolveFolderModuleLocations } from "../services/moduleLocationLookup";
+import { resolveFolderModuleLocations, toContentRelativeDir } from "../services/moduleLocationLookup";
 import { ImportFormatter } from "./ImportFormatter";
 import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
@@ -325,14 +325,6 @@ export class ImportPathConverter {
     }
 
     /**
-     * Appends the locations of the `.verse` files explicitly declaring this
-     * name as a module, which is the other way a module comes to exist and the
-     * one no folder attests to.
-     *
-     * Capped at 100 files scanned, so a project larger than that resolves from
-     * whichever of them the search returned.
-     */
-    /**
      * Where a workspace-wide `.verse` scan has to look, and whether the
      * workspace folder is itself the Content folder - which decides both the
      * glob and how a found path maps back to a Content-relative one.
@@ -349,6 +341,14 @@ export class ImportPathConverter {
         };
     }
 
+    /**
+     * Appends the locations of the `.verse` files explicitly declaring this
+     * name as a module, which is the other way a module comes to exist and the
+     * one no folder attests to.
+     *
+     * Capped at 100 files scanned, so a project larger than that resolves from
+     * whichever of them the search returned.
+     */
     private async searchExplicitModuleDefinitions(modulePath: string, moduleName: string, pathSegments: string[], locations: string[]): Promise<void> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) return;
@@ -433,23 +433,12 @@ export class ImportPathConverter {
 
         const contentRelativeDirs = new Set<string>();
         for (const file of verseFiles) {
-            let directory = path.dirname(path.relative(workspaceFolders[0].uri.fsPath, file.fsPath)).replace(/\\/g, "/");
-            if (directory === ".") directory = "";
+            const workspaceRelative = path.relative(workspaceFolders[0].uri.fsPath, file.fsPath).replace(/\\/g, "/");
+            const directory = toContentRelativeDir(workspaceRelative, workspaceIsContent);
 
-            // A workspace opened at Content already yields Content-relative
-            // paths; anywhere else they carry the Content/ segment, and a file
-            // outside Content contributes no importable module.
-            if (!workspaceIsContent) {
-                if (directory === CONTENT_FOLDER) {
-                    directory = "";
-                } else if (directory.startsWith(`${CONTENT_FOLDER}/`)) {
-                    directory = directory.substring(CONTENT_FOLDER.length + 1);
-                } else {
-                    continue;
-                }
-            }
-
-            contentRelativeDirs.add(directory);
+            // null is a file outside Content, which contributes no importable
+            // module.
+            if (directory !== null) contentRelativeDirs.add(directory);
         }
 
         for (const location of resolveFolderModuleLocations(modulePath, contentRelativeDirs)) {
@@ -467,9 +456,14 @@ export class ImportPathConverter {
      * folder near the current file (searchImplicitModules), then an explicit
      * declaration anywhere in the project (searchExplicitModuleDefinitions),
      * then a folder module anywhere in the project
-     * (searchProjectFolderModules). Ordered that way because proximity is the
-     * better evidence of which module was meant, and because a folder module
-     * exists only on the filesystem, where no declaration cache can see it.
+     * (searchProjectFolderModules).
+     *
+     * Ordered by how well each answers "which module was meant". Proximity
+     * comes first, being the strongest signal of intent. A declaration
+     * outranks a distant folder because it names the module outright, where a
+     * folder chain across the project is positional evidence alone - which is
+     * also why the last phase is the likeliest of the three to come back with
+     * several candidates rather than one.
      *
      * The last phase is the compiler's own recovery for this failure: where the
      * scope walk resolves nothing, it searches every module in the program and

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -669,3 +669,81 @@ describe("ImportPathConverter.findModuleLocations explicit declaration scan", ()
         expect(await locationsFor('Doc := "Inventory := module:"\n')).toEqual([]);
     });
 });
+
+describe("ImportPathConverter.convertToFullPath project-wide folder module search", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+
+    // The tree from the report: the same Combat/Weapons chain under two roots,
+    // and an importing file on a third branch that reaches neither of them by
+    // any local step - not a sibling, not an ancestor, not a child of Content.
+    const verseFiles = ["Content/Scripts/Main.verse", "Content/Systems/Combat/Weapons/Rifle.verse", "Content/Features/Combat/Weapons/Bow.verse"];
+    const folders = ["Scripts", "Systems", "Systems/Combat", "Systems/Combat/Weapons", "Features", "Features/Combat", "Features/Combat/Weapons"];
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(verseFiles.map((file) => vscode.Uri.file(`${workspaceRoot}/${file}`)));
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${workspaceRoot}/Content/`, "");
+            if (!folders.includes(contentRelative)) throw new Error("ENOENT");
+            return { type: vscode.FileType.Directory };
+        });
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    const convert = (statement: string, contentRelativeFile: string) =>
+        converterWithProjectPath(projectVersePath).convertToFullPath(statement, vscode.Uri.file(`${workspaceRoot}/Content/${contentRelativeFile}`), 0);
+
+    // No folder module has a declaration to read, so before this phase existed
+    // every search missed the chain and the user was told the module could not
+    // be found - with two copies of it in the project.
+    it("finds a folder chain outside the file's own ancestry, on every branch holding one", async () => {
+        const result = await convert("using { Combat.Weapons }", "Scripts/Main.verse");
+
+        expect(result?.isAmbiguous).toBe(true);
+        expect(result?.possiblePaths).toEqual([`${projectVersePath}/Features/Combat/Weapons`, `${projectVersePath}/Systems/Combat/Weapons`]);
+    });
+
+    it("converts outright when only one branch holds the chain", async () => {
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([
+            vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`),
+            vscode.Uri.file(`${workspaceRoot}/Content/Systems/Combat/Weapons/Rifle.verse`),
+        ]);
+
+        const result = await convert("using { Combat.Weapons }", "Scripts/Main.verse");
+
+        expect(result?.isAmbiguous).toBe(false);
+        expect(result?.convertedImport).toBe(`using { ${projectVersePath}/Systems/Combat/Weapons }`);
+    });
+
+    it("keeps the dotted style the author wrote", async () => {
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([vscode.Uri.file(`${workspaceRoot}/Content/Systems/Combat/Weapons/Rifle.verse`)]);
+
+        expect((await convert("using. Combat.Weapons", "Scripts/Main.verse"))?.convertedImport).toBe(`using. ${projectVersePath}/Systems/Combat/Weapons`);
+    });
+
+    // The phase is a fallback, not a widening: a module the local search
+    // already places must not be dragged into an ambiguity by a namesake on
+    // another branch.
+    it("leaves a locally resolved module unambiguous", async () => {
+        const result = await convert("using { Combat.Weapons }", "Systems/Economy/Feature.verse");
+
+        expect(result?.isAmbiguous).toBe(false);
+        expect(result?.convertedImport).toBe(`using { ${projectVersePath}/Systems/Combat/Weapons }`);
+    });
+
+    it("still reports a module no folder in the project holds", async () => {
+        expect(await convert("using { Economy.Shop }", "Scripts/Main.verse")).toBeNull();
+    });
+});

--- a/src/services/__tests__/moduleLocationLookup.test.ts
+++ b/src/services/__tests__/moduleLocationLookup.test.ts
@@ -1,4 +1,4 @@
-import { buildProjectIndexes, resolveModuleLocations } from "../moduleLocationLookup";
+import { buildProjectIndexes, resolveFolderModuleLocations, resolveModuleLocations } from "../moduleLocationLookup";
 import { ProjectPathNode } from "../../types";
 
 function moduleNode(name: string, fullPath: string, sourceFile: string): ProjectPathNode {
@@ -163,5 +163,60 @@ describe("resolveModuleLocations", () => {
         for (const request of ["HUD/Textures", "Inventory", "Widget"]) {
             expect(resolve(request, roundTripped)).toEqual(resolve(request, nodes));
         }
+    });
+});
+
+describe("resolveFolderModuleLocations", () => {
+    // The tree from the report: one Combat/Weapons chain under each of two
+    // roots, with the importing file on a third branch that reaches neither.
+    const projectDirs = ["Scripts", "Systems/Combat/Weapons", "Features/Combat/Weapons"];
+
+    it("finds a folder chain on every branch that holds one", () => {
+        expect(resolveFolderModuleLocations("Combat/Weapons", projectDirs)).toEqual(["/Features", "/Systems"]);
+    });
+
+    it("finds a module in an ancestor of a directory holding verse files", () => {
+        expect(resolveFolderModuleLocations("Combat", projectDirs)).toEqual(["/Features", "/Systems"]);
+    });
+
+    it("reports the Content root for a chain that starts at it", () => {
+        expect(resolveFolderModuleLocations("Systems/Combat", projectDirs)).toEqual([""]);
+    });
+
+    it("finds a module directly under the Content root", () => {
+        expect(resolveFolderModuleLocations("Combat", ["Combat"])).toEqual([""]);
+    });
+
+    // A location the module does not live in is worse than none: it either
+    // makes a single, correct conversion ambiguous, or writes a path to a
+    // module that is not there.
+    it("matches whole segments, not a name a segment merely ends with", () => {
+        expect(resolveFolderModuleLocations("Combat/Weapons", ["Systems/XCombat/Weapons"])).toEqual([]);
+    });
+
+    it("does not match a partial trailing segment", () => {
+        expect(resolveFolderModuleLocations("Weapon", ["Systems/Combat/Weapons"])).toEqual([]);
+    });
+
+    it("is case-sensitive, as module resolution is", () => {
+        expect(resolveFolderModuleLocations("combat/weapons", projectDirs)).toEqual([]);
+    });
+
+    it("reports one location for a chain several directories attest to", () => {
+        expect(resolveFolderModuleLocations("Combat", ["Systems/Combat", "Systems/Combat/Weapons", "Systems/Combat/Armor"])).toEqual(["/Systems"]);
+    });
+
+    // Directory enumeration has no guaranteed order, and these become an
+    // ordered list of paths the user picks from.
+    it("orders its answers independently of the order the directories arrive in", () => {
+        expect(resolveFolderModuleLocations("Combat/Weapons", [...projectDirs].reverse())).toEqual(resolveFolderModuleLocations("Combat/Weapons", projectDirs));
+    });
+
+    it("answers nothing for a path no directory holds", () => {
+        expect(resolveFolderModuleLocations("Economy/Shop", projectDirs)).toEqual([]);
+    });
+
+    it("answers nothing for an empty request", () => {
+        expect(resolveFolderModuleLocations("", projectDirs)).toEqual([]);
     });
 });

--- a/src/services/moduleLocationLookup.ts
+++ b/src/services/moduleLocationLookup.ts
@@ -224,10 +224,16 @@ export function resolveFolderModuleLocations(modulePath: string, contentRelative
 /**
  * The Content-relative directory of a workspace-relative source file, or null
  * when the file sits outside the Content folder and so cannot provide an
- * importable module location. Mirrors the path normalization of the converter's
- * filesystem scan.
+ * importable module location.
+ *
+ * Exported so the converter's filesystem scan maps paths through this rather
+ * than through a second copy of the rule: the two must agree on where Content
+ * starts, or the same project resolves differently depending on which of them
+ * asked.
+ *
+ * @param sourceFile workspace-relative, separated by "/"
  */
-function toContentRelativeDir(sourceFile: string, workspaceIsContent: boolean): string | null {
+export function toContentRelativeDir(sourceFile: string, workspaceIsContent: boolean): string | null {
     const lastSlash = sourceFile.lastIndexOf("/");
     const dir = lastSlash === -1 ? "" : sourceFile.slice(0, lastSlash);
 

--- a/src/services/moduleLocationLookup.ts
+++ b/src/services/moduleLocationLookup.ts
@@ -168,6 +168,60 @@ export function resolveModuleLocations(modulePath: string, moduleNameIndex: Read
 }
 
 /**
+ * The locations a module import path could refer to as a chain of folders,
+ * given every Content-relative directory the project holds `.verse` files in.
+ *
+ * Folders are implicit modules, so a directory attests to a module chain with
+ * no declaration anywhere to read. Each input directory therefore stands for
+ * itself and for every ancestor of it: only `Systems/Combat/Weapons` need hold
+ * a `.verse` file for `Systems` and `Systems/Combat` to be modules too.
+ *
+ * Matching is case-sensitive and on whole segments, so `Systems/XCombat/Weapons`
+ * does not answer a request for `Combat/Weapons`. Results are sorted, because
+ * they are put to the user as an ordered list of paths to choose between and
+ * the directory enumeration behind them has no guaranteed order.
+ *
+ * @param modulePath separated by "/", as extractModuleFromImport produces
+ * @param contentRelativeDirs directories relative to the Content root, "" for the root itself
+ * @returns distinct locations under the contract at the top of this file: "" or "/Dir/Sub"
+ */
+export function resolveFolderModuleLocations(modulePath: string, contentRelativeDirs: Iterable<string>): string[] {
+    const requested = modulePath
+        .replace(/^\//, "")
+        .split("/")
+        .filter((s) => s.length > 0);
+    if (requested.length === 0) {
+        return [];
+    }
+
+    const locations = new Set<string>();
+
+    for (const dir of contentRelativeDirs) {
+        const segments = dir.split("/").filter((s) => s.length > 0);
+
+        // Every ancestor of the directory, the directory itself included, is a
+        // module chain the request could name the tail of.
+        for (let depth = segments.length; depth >= requested.length; depth--) {
+            let matches = true;
+            for (let i = 0; i < requested.length; i++) {
+                if (segments[depth - requested.length + i] !== requested[i]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (!matches) {
+                continue;
+            }
+
+            const locationSegments = segments.slice(0, depth - requested.length);
+            locations.add(locationSegments.length > 0 ? "/" + locationSegments.join("/") : "");
+        }
+    }
+
+    return Array.from(locations).sort();
+}
+
+/**
  * The Content-relative directory of a workspace-relative source file, or null
  * when the file sits outside the Content folder and so cannot provide an
  * importable module location. Mirrors the path normalization of the converter's


### PR DESCRIPTION
Closes #60

## What was wrong

A folder is an implicit module, so it has no declaration anywhere to read. That left a folder chain visible to only one of the converter's searches, and only when it sat near the importing file:

- `searchImplicitModules` finds folder modules, but reaches only the file's own directory, its siblings, its ancestors and the Content root.
- `searchExplicitModuleDefinitions` searches the whole project, but matches `X := module` in file text, which a folder module never has.
- The declaration cache is explicit-only by design (`ProjectPathCache.ts:113`).

So `using { Combat.Weapons }` written in `Scripts/`, with `Combat/Weapons` chains under both `Systems/` and `Features/`, resolved to nothing and reported "Could not find module 'Weapons'" — with two copies of the module in the project. Confirmed still live before starting; not a 0.7 regression.

## The change

A third search phase, run only when Phase 1, the cache and Phase 2 have all come back empty. It derives folder modules from the paths of the project's `.verse` files — one `findFiles` call, each file's directory plus all its ancestors — and matches whole segments. It reads no file contents.

Being a fallback makes it purely additive: every input that resolves today resolves identically, and only the outright failure gains an answer. Two of the tests assert exactly that.

The matching itself went into `moduleLocationLookup.ts` as `resolveFolderModuleLocations`, beside the sibling lookup it mirrors — that file is already pure and VS Code free, so the core of the fix is unit-testable without the extension host. `toContentRelativeDir` is now exported and shared, so the new scan and the cache lookup cannot disagree about where Content starts.

### Why a project-wide search is right here

This mirrors the compiler. When the scope walk resolves nothing, `SemanticAnalyzer.cpp:12813-12827` walks **every** module in the program — *"No definition was found; try to find the definition in another module that could be imported to solve the problem"* — and returns `EVisitResult::Continue`, so it collects **all** the matches rather than stopping at the first. An ambiguous answer from this phase is therefore a result, not a fault.

Worth noting: `Combat.Weapons` from `Scripts/` is not itself valid Verse, since a relative reference resolves against the current scope chain only. The conversion's output is an absolute path, which needs nothing in scope — repairing the first into the second is what this feature is for.

### Decisions

- **Folders derived from `.verse` file paths**, not a `readDirectory` walk. This keeps the phase independent of #45: folder entries come from directory paths, never from parsing text, which was the condition set on that dependency. Blind spot, stated in the code: a folder with no `.verse` file anywhere beneath it never appears — such a module has no members to import.
- **No new setting.** Direction 1 in the issue names `pathConversion.scanDepth`, which #135 deleted as never-consulted. The cap is an internal constant, set well above Phase 2's 100 because this phase reads no files.
- **Not touched:** `ProjectPathCache` / `ProjectPathScanner` (no schema or cache-version bump) and `ImportSuggestionExtractor` (the issue's direction 3).

## A correction to the issue

The body quotes the compiler error on one line as `Did you mean any of: Systems.Combat, Features.Combat`. `SemanticAnalyzer.cpp:12260-12266` emits `"any of: "` followed by a **newline before each path**. The triage comment argued against direction 3 on the ground that the multi-option extractor pattern "requires a newline after the colon, which this single-line form lacks" — that objection rests on the paraphrase, and the real message does carry the newlines. Direction 3 stays out of scope here, but the recorded objection to it does not stand.

## Tests

`resolveFolderModuleLocations` gets pure unit tests: ancestor derivation, whole-segment rejection of `XCombat/Weapons`, case sensitivity, the Content-root location, deduplication and stable ordering.

The regression test is pinned at the entry point the issue names — `convertToFullPath` over the issue's exact tree — and asserts both candidates come back ambiguous. It was proven to detect the defect: with Phase 3 disabled, the three tests that depend on it fail and the two additivity guards still pass.

## Verification

```
$ npm run compile
> verse-auto-imports@0.10.0 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       986 passed, 986 total
Snapshots:   0 total
Time:        28.783 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, verdict `PASS_WITH_SUGGESTIONS`, no Critical findings. The reviewer probed both workspace layouts, Windows backslash paths, the additivity claim by `findFiles` call count, and roughly twenty input shapes against the pure function.

Two Important findings were real and are fixed in `43fd6e1`: the `workspaceScanTargets` extraction had stranded `searchExplicitModuleDefinitions`' doc comment above the wrong method, and the new phase carried its own copy of the Content-relative mapping that `toContentRelativeDir` already owned.

Left unfixed, deliberately:

- **Phase 3 carries no proximity signal**, so among several distant candidates it cannot rank the branch nearest the current file first. Real, but ranking is beyond what this ticket asks; worth its own issue if it bites.
- **The enumeration repeats per import** when a document converts several unresolvable imports at once. Phase 2's file *reads* already dominate that cost; memoizing the directory set would remove it.
- `.sort()` is ordinal rather than locale-aware — moot for PascalCase folder names.
- The `workspaceIsContent` branch has no `..` containment guard. Unreachable, since `RelativePattern` scopes `findFiles` to the workspace folder.
