### PR TITLE
fix(imports): keep a path conversion off a using that names a module alias

### DIFF
--- a/changelog.d/71.fixed.md
+++ b/changelog.d/71.fixed.md
@@ -1,1 +1,1 @@
-**Path conversion**: A `using` naming a module alias the file declares with `import(...)` no longer gets a path-conversion lens, so converting paths one at a time or in bulk cannot rewrite it into an import of an unrelated module of the same name.
+**Path conversion**: A `using` naming a module alias the file declares with `import(...)` no longer gets a conversion lens, so converting paths singly or in bulk cannot rewrite it into an import of an unrelated namesake module.

--- a/changelog.d/71.fixed.md
+++ b/changelog.d/71.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: A `using` naming a module alias the file declares with `import(...)` no longer gets a path-conversion lens, so converting paths one at a time or in bulk cannot rewrite it into an import of an unrelated module of the same name.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -1190,6 +1190,88 @@ export function allUsingPaths(lines: string[]): string[] {
     return paths;
 }
 
+/**
+ * One `Name := import(/Path)` module alias, anchored at the head of a statement.
+ *
+ * The shape is the compiler's, not a generalization of it: the left side is a
+ * plain identifier, optionally carrying a quoted suffix and access specifiers,
+ * and the argument is a single absolute path literal in parentheses. A
+ * qualified left side, a type annotation, brackets rather than parentheses, and
+ * a relative or dotted argument are each rejected outright by the compiler, so
+ * a line spelling one declares no alias and must not be read as if it did.
+ *
+ * The path is captured but deliberately not offered by scanModuleAliases; see
+ * there for why nothing may read it.
+ */
+const MODULE_ALIAS_STATEMENT = /^([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)(?:\s*<[^<>\n]+>)*\s*:=\s*import\s*\(\s*(\/[^\s()]*)\s*\)$/;
+
+/**
+ * The names a file binds to a module with `Name := import(/Path)`, at file
+ * scope.
+ *
+ * The names alone, never the modules they alias. An alias does not bring its
+ * module's members into scope - it binds one name to one module - so a file
+ * that aliases `/A/B` still needs `using { /A/B }` to use that module's
+ * members unqualified, and a diagnostic asking for one is right to. Offering
+ * the aliased path here is what invites a reader to treat it as an import
+ * already present, which suppresses an import the file needs.
+ *
+ * What the names are for is the opposite question: which `using` statements
+ * name something that is not a module path. An alias is an ordinary identifier
+ * bound in the file's own scope, so `using { Gfx }` naming an alias is
+ * indistinguishable, by content alone, from one naming a same-directory folder
+ * module - and a reader that resolves it as a path finds whichever namesake the
+ * workspace holds. See scanConvertibleImports.
+ *
+ * Read at file scope only, which is what the consumers need and all they can
+ * use: an alias declared inside a module body binds in that module's scope, so
+ * it cannot be what a column-0 `using` names.
+ *
+ * Statements are read from the classified code rather than the raw line, so an
+ * alias inside a comment or written as string text declares nothing, and one
+ * following a `;` is found - `;` separates definitions in a scope exactly as a
+ * newline does.
+ *
+ * Failing towards reporting a name is the safe direction: an alias this misses
+ * leaves a `using` naming it open to being rewritten as a path, which is the
+ * defect, where a name reported in error only withholds a conversion offer.
+ */
+export function scanModuleAliases(lines: string[]): Set<string> {
+    const aliases = new Set<string>();
+
+    for (const classification of classifyLines(lines)) {
+        if (classification.kind !== "code" || /^\s/.test(classification.codeWithoutComments)) {
+            continue;
+        }
+        for (const statement of classification.codeOutsideLiterals.split(";")) {
+            const match = statement.trim().match(MODULE_ALIAS_STATEMENT);
+            if (match) {
+                aliases.add(match[1]);
+            }
+        }
+    }
+
+    return aliases;
+}
+
+/**
+ * Whether a `using` names something rooted at one of the file's module aliases.
+ *
+ * The first dotted segment is what carries it: an alias is a module reference,
+ * so `Gfx.Sub` names a member module through the alias exactly as `Gfx` names
+ * the alias itself, and neither spelling is a path a workspace search may
+ * resolve.
+ *
+ * An absolute path never is: it starts with `/`, which no identifier may, so it
+ * resolves from the global registry and names no alias whatever a file declares.
+ */
+function rootsAtModuleAlias(path: string, aliases: ReadonlySet<string>): boolean {
+    if (path.startsWith("/")) {
+        return false;
+    }
+    return aliases.has(path.split(".")[0].trim());
+}
+
 /** An import statement a path conversion may act on, with the line it occupies. */
 export interface ConvertibleImport {
     /** The statement text, trimmed, exactly as it appears on its line. */
@@ -1215,9 +1297,17 @@ export interface ConvertibleImport {
  * - The indented style (`using:` with the path on the following line) is
  *   excluded, because every conversion path identifies an import by a single
  *   line of statement text and replaces that one line.
+ * - A `using` rooted at a module alias the file declares is excluded. Both
+ *   directions of the conversion read the statement as a module path, and an
+ *   alias is a name bound in the file rather than a path: going absolute hunts
+ *   the workspace for a folder or a `:= module` declaration of that name and
+ *   writes whichever namesake it finds, which silently imports a different
+ *   module than the alias names. The file is the only evidence of which names
+ *   are aliases, so no conversion can recover it later. See scanModuleAliases.
  */
 export function scanConvertibleImports(lines: string[]): ConvertibleImport[] {
+    const aliases = scanModuleAliases(lines);
     return rewritableImports(scanModuleImports(lines))
-        .filter((imp) => imp.startLine === imp.endLine)
+        .filter((imp) => imp.startLine === imp.endLine && !rootsAtModuleAlias(imp.path, aliases))
         .map((imp) => ({ statement: lines[imp.startLine].trim(), line: imp.startLine }));
 }

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -1193,17 +1193,24 @@ export function allUsingPaths(lines: string[]): string[] {
 /**
  * One `Name := import(/Path)` module alias, anchored at the head of a statement.
  *
- * The shape is the compiler's, not a generalization of it: the left side is a
- * plain identifier, optionally carrying a quoted suffix and access specifiers,
- * and the argument is a single absolute path literal in parentheses. A
- * qualified left side, a type annotation, brackets rather than parentheses, and
- * a relative or dotted argument are each rejected outright by the compiler, so
- * a line spelling one declares no alias and must not be read as if it did.
+ * The left side is an identifier, optionally carrying a quoted suffix, a
+ * `(path:)` qualifier and access specifiers, and the argument is a single
+ * absolute path. Two rules are the compiler's own and narrow this: the argument
+ * must be a path literal, so a bare, dotted or relative one names no module to
+ * alias, and the dotted left side `Outer.Utils` is refused outright
+ * (SemanticAnalyzer.cpp AnalyzeImport).
  *
- * The path is captured but deliberately not offered by scanModuleAliases; see
- * there for why nothing may read it.
+ * Both invocation styles are read, though only `import(...)` is legal prose.
+ * The compiler rejects the bracketed form through a failure-semantics check
+ * that never inspects the brackets themselves, so the source does not actually
+ * show `import[...]` being refused - and guessing wrong in that direction drops
+ * an alias, where reading one the compiler would reject only withholds a lens.
+ * The qualifier is admitted on the same terms: nothing checks it here.
+ *
+ * The aliased path is matched but not captured. Nothing may read it - see
+ * scanModuleAliases - and a capture is an invitation to.
  */
-const MODULE_ALIAS_STATEMENT = /^([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)(?:\s*<[^<>\n]+>)*\s*:=\s*import\s*\(\s*(\/[^\s()]*)\s*\)$/;
+const MODULE_ALIAS_STATEMENT = /^(?:\([^()]*:\)\s*)?([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)(?:\s*<[^<>\n]+>)*\s*:=\s*import\s*(?:\(\s*\/[^\s()[\]]*\s*\)|\[\s*\/[^\s()[\]]*\s*\])$/;
 
 /**
  * The names a file binds to a module with `Name := import(/Path)`, at file
@@ -1223,14 +1230,26 @@ const MODULE_ALIAS_STATEMENT = /^([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)(?:\s*<[^<>
  * module - and a reader that resolves it as a path finds whichever namesake the
  * workspace holds. See scanConvertibleImports.
  *
- * Read at file scope only, which is what the consumers need and all they can
- * use: an alias declared inside a module body binds in that module's scope, so
- * it cannot be what a column-0 `using` names.
+ * Only this file is read, which does not see every alias a `using` here could
+ * name. An alias binds in the enclosing module rather than in the file: a
+ * snippet is not a logical scope, so the definition lands in the module every
+ * file of the folder module shares, and a sibling file's alias resolves here
+ * unqualified. A `using` naming one of those is still offered a conversion.
+ * Closing that needs a workspace scan no line-based reader can make.
  *
- * Statements are read from the classified code rather than the raw line, so an
- * alias inside a comment or written as string text declares nothing, and one
- * following a `;` is found - `;` separates definitions in a scope exactly as a
- * newline does.
+ * An alias indented inside a module body is skipped for the opposite reason: it
+ * binds in that module, which a column-0 `using` is outside of.
+ *
+ * Indentation is read from the raw line, as the module-import scan reads it,
+ * and not from the code with comments removed. Nothing replaces a removed
+ * comment, so a closed one written ahead of the statement,
+ * `<# note #>Gfx := import(/A/B)`, leaves the code starting with the space
+ * after it and a column-0 alias then reads as indented - which drops it, and a
+ * dropped alias is the one error this must not make.
+ *
+ * Statements are read from the classified code, so an alias inside a comment or
+ * written as string text declares nothing, and one following a `;` is found -
+ * `;` separates definitions in a scope exactly as a newline does.
  *
  * Failing towards reporting a name is the safe direction: an alias this misses
  * leaves a `using` naming it open to being rewritten as a path, which is the
@@ -1238,12 +1257,13 @@ const MODULE_ALIAS_STATEMENT = /^([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)(?:\s*<[^<>
  */
 export function scanModuleAliases(lines: string[]): Set<string> {
     const aliases = new Set<string>();
+    const classifications = classifyLines(lines);
 
-    for (const classification of classifyLines(lines)) {
-        if (classification.kind !== "code" || /^\s/.test(classification.codeWithoutComments)) {
+    for (let i = 0; i < lines.length; i++) {
+        if (classifications[i].kind !== "code" || lines[i].length === 0 || /^\s/.test(lines[i])) {
             continue;
         }
-        for (const statement of classification.codeOutsideLiterals.split(";")) {
+        for (const statement of classifications[i].codeOutsideLiterals.split(";")) {
             const match = statement.trim().match(MODULE_ALIAS_STATEMENT);
             if (match) {
                 aliases.add(match[1]);

--- a/src/imports/__tests__/ImportCodeLensProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeLensProvider.test.ts
@@ -53,6 +53,19 @@ describe("ImportCodeLensProvider.provideCodeLenses", () => {
         return expect(lensTitlesFor("using { /Verse.org/Simulation }\n\ncode()")).resolves.toEqual([]);
     });
 
+    // Converting reads the statement as a module path and searches the
+    // workspace for a folder or a `:= module` declaration of that name. An
+    // alias is neither, so the lens offered to rewrite the line into an import
+    // of whichever namesake the project happened to hold.
+    it("offers nothing on a using naming a module alias the file declares", () => {
+        return expect(lensTitlesFor("Gfx := import(/mygame@fortnite.com/mygame/Systems/Graphics)\nusing { Gfx }\n\ncode()")).resolves.toEqual([]);
+    });
+
+    it("still offers a lens on a real relative import beside an alias", () => {
+        const text = "Gfx := import(/mygame@fortnite.com/mygame/Systems/Graphics)\nusing { Gadgets.Tools }\n\ncode()";
+        return expect(lensTitlesFor(text)).resolves.toEqual(["$(arrow-both)  Use absolute path"]);
+    });
+
     it("offers nothing on an import inside a block comment", () => {
         // The lens used to appear here, and acting on it edited a line inside
         // the comment.

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -803,6 +803,42 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
     it("still writes LF for an LF document even when the fallback is CRLF", () => {
         expect(editor.buildOrganizedContent("using { /A }\ncode()", [], { ...curlyNoSort, fallbackEol: "\r\n" })).toBe("using { /A }\n\ncode()");
     });
+
+    // A `Name := import(/Path)` alias is a definition, not an import, so it
+    // belongs to the body and the block is rebuilt around it. Which is where it
+    // ends up regardless - these pin it as a decision rather than an accident.
+    describe("a file declaring module aliases", () => {
+        it("leaves an alias between two imports in the body, written as it was", () => {
+            const input = ["using { /Verse.org/Simulation }", "Utils := import(/MyGame/Utilities)", "using { /Fortnite.com/Devices }", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(
+                ["using { /Fortnite.com/Devices }", "using { /Verse.org/Simulation }", "", "Utils := import(/MyGame/Utilities)", "code()"].join("\n"),
+            );
+        });
+
+        it("keeps the comment written above an alias with the alias", () => {
+            const input = ["using { /A }", "", "# what Utils is for", "Utils := import(/MyGame/Utilities)", "using { /B }", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { /A }", "using { /B }", "", "# what Utils is for", "Utils := import(/MyGame/Utilities)", "code()"].join("\n"));
+        });
+
+        // An alias binds one name to one module and brings none of its members
+        // into scope, so the file still needs the `using` and a diagnostic
+        // asking for one is right to. Reading the alias as evidence the path is
+        // imported is what would decline it.
+        it("adds an import of a path the file only aliases", () => {
+            const input = ["Utils := import(/MyGame/Utilities)", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, ["/MyGame/Utilities"], curlySorted)).toBe(["using { /MyGame/Utilities }", "", "Utils := import(/MyGame/Utilities)", "code()"].join("\n"));
+        });
+
+        // The combined form the book writes: the alias for qualified access,
+        // the `using` for unqualified. Hoisting the `using` above the alias is
+        // safe - the compiler binds every alias in its own deferred stage,
+        // ahead of the one that resolves module `using` statements - so the
+        // only requirement is that both survive.
+        it("hoists a using of an alias above the alias without touching either", () => {
+            const input = ["Graphics := import(/MyGame/Systems/Graphics)", "using { Graphics }", "code()"].join("\n");
+            expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe(["using { Graphics }", "", "Graphics := import(/MyGame/Systems/Graphics)", "code()"].join("\n"));
+        });
+    });
 });
 
 interface RecordedOperation {

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1146,6 +1146,11 @@ describe("scanConvertibleImports", () => {
         const lines = ["Graphics := import(/MyGame/Systems/Graphics)", "using { /Other/Graphics }", "code()"];
         expect(scanConvertibleImports(lines)).toEqual([{ statement: "using { /Other/Graphics }", line: 1 }]);
     });
+
+    it("excludes a using naming an alias declared after a closed comment", () => {
+        const lines = ["<# note #>Gfx := import(/MyGame/Systems/Graphics)", "using { Gfx }", "code()"];
+        expect(scanConvertibleImports(lines)).toEqual([]);
+    });
 });
 
 describe("scanModuleAliases", () => {
@@ -1177,24 +1182,45 @@ describe("scanModuleAliases", () => {
         expect(scanModuleAliases(['Doc := "Utils := import(/MyGame/Utilities)"', "code()"])).toEqual(new Set());
     });
 
+    // Nothing replaces a removed comment, so the code of this line starts with
+    // the space after the `#>`. Reading indentation off that rather than off the
+    // raw line drops a column-0 alias, and a dropped alias leaves the `using`
+    // naming it open to being rewritten as a path.
+    it("reads an alias written after a closed comment on its own line", () => {
+        expect(scanModuleAliases(["<# note #>Utils := import(/MyGame/Utilities)", "code()"])).toEqual(new Set(["Utils"]));
+    });
+
+    it("reads an alias carrying a trailing comment", () => {
+        expect(scanModuleAliases(["Utils := import(/MyGame/Utilities) # the shop helpers", "code()"])).toEqual(new Set(["Utils"]));
+    });
+
     // An alias inside a module body binds in that module's scope, so it is not
     // what a column-0 `using` names.
     it("declares nothing from an alias indented inside a module body", () => {
         expect(scanModuleAliases(["MyModule := module:", "    Utils := import(/MyGame/Utilities)"])).toEqual(new Set());
     });
 
-    // Each of these is rejected outright by the compiler, so the line declares
-    // no alias and must not be read as one.
-    it("declares nothing from a line the compiler refuses as an import", () => {
-        // Brackets carry failure semantics; `import` must be invoked with
-        // parentheses.
-        expect(scanModuleAliases(["Utils := import[/MyGame/Utilities]"])).toEqual(new Set());
-        // The argument must be a path literal, which is absolute.
+    it("declares nothing from a line that aliases no module", () => {
+        // The argument must be a path literal, which is absolute, so neither of
+        // these names a module to alias.
         expect(scanModuleAliases(["Utils := import(MyGame.Utilities)"])).toEqual(new Set());
-        // The left side must be a plain identifier, without a qualifier.
+        expect(scanModuleAliases(["Utils := import(Utilities)"])).toEqual(new Set());
+        // A dotted left side is refused outright by the compiler.
         expect(scanModuleAliases(["Outer.Utils := import(/MyGame/Utilities)"])).toEqual(new Set());
         // A call of something else that merely reads like one.
         expect(scanModuleAliases(["Utils := reimport(/MyGame/Utilities)"])).toEqual(new Set());
+    });
+
+    // Read in the safe direction rather than refused. The compiler rejects the
+    // bracketed form through a failure-semantics check that never inspects the
+    // brackets, so the source does not show it being refused - and a missed
+    // alias leaves the defect live where a spurious one only withholds a lens.
+    it("reads an alias whichever way the import is invoked", () => {
+        expect(scanModuleAliases(["Utils := import[/MyGame/Utilities]"])).toEqual(new Set(["Utils"]));
+    });
+
+    it("reads an alias whose left side carries a path qualifier", () => {
+        expect(scanModuleAliases(["(/MyGame/Utilities:)Utils := import(/MyGame/Utilities)"])).toEqual(new Set(["Utils"]));
     });
 });
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1,4 +1,4 @@
-import { allUsingPaths, classifyLines, indentedPairPathLine, rewritableImports, scanConvertibleImports, scanModuleImports } from "../ImportScanner";
+import { allUsingPaths, classifyLines, indentedPairPathLine, rewritableImports, scanConvertibleImports, scanModuleAliases, scanModuleImports } from "../ImportScanner";
 
 describe("allUsingPaths", () => {
     it("collects a file-scope import the same way scanModuleImports does", () => {
@@ -1119,6 +1119,82 @@ describe("scanConvertibleImports", () => {
         // document leaves "\r" on every line. The statement text has to match
         // what a conversion looks for, which is the trimmed line.
         expect(scanConvertibleImports(["using { /A }\r", "code()\r"])).toEqual([{ statement: "using { /A }", line: 0 }]);
+    });
+
+    // Going absolute searches the workspace for a folder or a `:= module`
+    // declaration of the name and writes whichever namesake it finds, so a lens
+    // here rewrites the alias reference into an import of a different module.
+    it("excludes a using naming a module alias the file declares", () => {
+        const lines = ["Gfx := import(/MyGame/Systems/Graphics)", "using { Gfx }", "code()"];
+        expect(scanConvertibleImports(lines)).toEqual([]);
+    });
+
+    it("excludes a using reaching through an alias to a member module", () => {
+        const lines = ["Gfx := import(/MyGame/Systems/Graphics)", "using { Gfx.Textures }", "code()"];
+        expect(scanConvertibleImports(lines)).toEqual([]);
+    });
+
+    it("keeps a bare-identifier import in a file whose alias names something else", () => {
+        const lines = ["Gfx := import(/MyGame/Systems/Graphics)", "using { Features }", "code()"];
+        expect(scanConvertibleImports(lines)).toEqual([{ statement: "using { Features }", line: 1 }]);
+    });
+
+    // An absolute path resolves from the global registry, so it names no alias
+    // whatever the file declares - and it is the one direction with a module to
+    // shorten.
+    it("keeps an absolute import sharing its name with an alias", () => {
+        const lines = ["Graphics := import(/MyGame/Systems/Graphics)", "using { /Other/Graphics }", "code()"];
+        expect(scanConvertibleImports(lines)).toEqual([{ statement: "using { /Other/Graphics }", line: 1 }]);
+    });
+});
+
+describe("scanModuleAliases", () => {
+    it("reads the name a file binds with import(...)", () => {
+        expect(scanModuleAliases(["Utils := import(/MyGame/Utilities)", "code()"])).toEqual(new Set(["Utils"]));
+    });
+
+    it("reads an alias carrying an access specifier", () => {
+        expect(scanModuleAliases(["Utils<public> := import(/MyGame/Utilities)"])).toEqual(new Set(["Utils"]));
+    });
+
+    it("reads an alias declared after a definition on the same line", () => {
+        // `;` separates definitions in a scope exactly as a newline does, so an
+        // alias need not open its line.
+        expect(scanModuleAliases(["MyVal := 5; Utils := import(/MyGame/Utilities)"])).toEqual(new Set(["Utils"]));
+    });
+
+    it("reads every alias a file declares", () => {
+        const lines = ["Utils := import(/MyGame/Utilities)", "Gfx := import(/MyGame/Graphics)", "code()"];
+        expect(scanModuleAliases(lines)).toEqual(new Set(["Utils", "Gfx"]));
+    });
+
+    it("declares nothing from a commented-out alias", () => {
+        expect(scanModuleAliases(["# Utils := import(/MyGame/Utilities)", "code()"])).toEqual(new Set());
+        expect(scanModuleAliases(["<#", "Utils := import(/MyGame/Utilities)", "#>", "code()"])).toEqual(new Set());
+    });
+
+    it("declares nothing from an alias written as string text", () => {
+        expect(scanModuleAliases(['Doc := "Utils := import(/MyGame/Utilities)"', "code()"])).toEqual(new Set());
+    });
+
+    // An alias inside a module body binds in that module's scope, so it is not
+    // what a column-0 `using` names.
+    it("declares nothing from an alias indented inside a module body", () => {
+        expect(scanModuleAliases(["MyModule := module:", "    Utils := import(/MyGame/Utilities)"])).toEqual(new Set());
+    });
+
+    // Each of these is rejected outright by the compiler, so the line declares
+    // no alias and must not be read as one.
+    it("declares nothing from a line the compiler refuses as an import", () => {
+        // Brackets carry failure semantics; `import` must be invoked with
+        // parentheses.
+        expect(scanModuleAliases(["Utils := import[/MyGame/Utilities]"])).toEqual(new Set());
+        // The argument must be a path literal, which is absolute.
+        expect(scanModuleAliases(["Utils := import(MyGame.Utilities)"])).toEqual(new Set());
+        // The left side must be a plain identifier, without a qualifier.
+        expect(scanModuleAliases(["Outer.Utils := import(/MyGame/Utilities)"])).toEqual(new Set());
+        // A call of something else that merely reads like one.
+        expect(scanModuleAliases(["Utils := reimport(/MyGame/Utilities)"])).toEqual(new Set());
     });
 });
 

--- a/test-fixtures/uefn-smoke/Content/T9/t9_alias.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/t9_alias.verse
@@ -1,10 +1,24 @@
 # T9 case F: the import(...) module alias expression (book 16_modules,
-# "Module Aliases with import"). Uncomment to test whether live UEFN accepts
-# it; record the verbatim outcome. If it compiles, also add
-# `using { /Verse.org/SpatialMath }` below it and confirm the extension does
-# not behave differently in this file (issue #71).
+# "Module Aliases with import"). Live UEFN accepts it, so these lines are
+# written live rather than commented out. Expected with the extension active:
+# neither alias line is moved, rewritten, or duplicated by auto-import,
+# Optimize Imports, or saving, and the `using` below stays a `using` (issue
+# #71).
 
-# T9Math := import(/Verse.org/SpatialMath)
-# T9AliasProbe():vector3 = T9Math.vector3{X := 0.0, Y := 0.0, Z := 0.0}
+T9Math := import(/Verse.org/SpatialMath)
 
-t9_alias_placeholder:int = 0
+# The combined form: the alias for qualified access, the `using` for
+# unqualified. No "Use absolute path" lens may appear on the `using` line -
+# T9Sub names an alias, not a module the workspace can be searched for.
+T9Sub := import(/vukefn@fortnite.com/VerseAutoImports/T9/Sub)
+using { T9Sub }
+
+# An alias never substitutes for a `using`: it binds one name to one module and
+# brings none of its members into scope. So this import is needed even though
+# the file already aliases the same path, and the extension must not remove it
+# or decline to add it.
+using { /Verse.org/SpatialMath }
+
+T9AliasProbe():vector3 = T9Math.vector3{X := 0.0, Y := 0.0, Z := 0.0}
+
+T9AliasSubProbe():int = sub_thing{Value := 1}.Value

--- a/test-fixtures/uefn-smoke/Content/T9/t9_alias.verse
+++ b/test-fixtures/uefn-smoke/Content/T9/t9_alias.verse
@@ -1,23 +1,31 @@
 # T9 case F: the import(...) module alias expression (book 16_modules,
 # "Module Aliases with import"). Live UEFN accepts it, so these lines are
-# written live rather than commented out. Expected with the extension active:
-# neither alias line is moved, rewritten, or duplicated by auto-import,
-# Optimize Imports, or saving, and the `using` below stays a `using` (issue
-# #71).
+# written live rather than commented out (issue #71).
+#
+# What the file is for, and what to expect with the extension active:
+#
+# - T9Math aliases a path the file also imports. An alias binds one name to one
+#   module and brings none of its members into scope, so the `using` is needed
+#   as well: auto-import must re-add it when it is removed, rather than reading
+#   the alias as an import already present.
+# - T9Sub plus `using { T9Sub }` is the book's combined form. No "Use absolute
+#   path" lens may appear on the `using` line - T9Sub names an alias, not a
+#   module the workspace can be searched for.
+# - Optimize Imports rebuilds the import block above the body, so both alias
+#   lines end up BELOW the imports rather than where they started. That is
+#   expected. What must hold is that each alias line is byte-identical
+#   afterwards, and that neither is duplicated or rewritten.
+#
+# The prose above deliberately sits in the file header rather than above an
+# individual import: a comment written directly above a `using` travels with
+# that statement when the block is rebuilt, which would leave it describing a
+# different import or nothing at all.
 
 T9Math := import(/Verse.org/SpatialMath)
-
-# The combined form: the alias for qualified access, the `using` for
-# unqualified. No "Use absolute path" lens may appear on the `using` line -
-# T9Sub names an alias, not a module the workspace can be searched for.
 T9Sub := import(/vukefn@fortnite.com/VerseAutoImports/T9/Sub)
-using { T9Sub }
 
-# An alias never substitutes for a `using`: it binds one name to one module and
-# brings none of its members into scope. So this import is needed even though
-# the file already aliases the same path, and the extension must not remove it
-# or decline to add it.
 using { /Verse.org/SpatialMath }
+using { T9Sub }
 
 T9AliasProbe():vector3 = T9Math.vector3{X := 0.0, Y := 0.0, Z := 0.0}
 

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -204,10 +204,15 @@ in (see test-fixtures/corpus/README.md).
        reference `button_device`). The pair must be consolidated into the
        import block with its path intact; no orphaned indented line (#68
        live).
-6. [ ] Case F alias (t9_alias.verse): uncomment the import(...) lines.
-       Compiles or exact error? If it compiles, add
-       `using { /Verse.org/SpatialMath }` below and confirm the extension
-       does not add duplicates or misbehave in the file (#71).
+6. [ ] Case F alias (t9_alias.verse): the file is written live, the
+       construct having compiled on 41.10. It must compile as synced. Then,
+       with the extension active: remove `using { /Verse.org/SpatialMath }`
+       and confirm auto-import puts it back rather than reading the alias of
+       the same path as an import already present; run "Verse Auto Imports:
+       Optimize Imports" and confirm both alias lines are byte-identical
+       afterwards; and hover the `using { T9Sub }` line and confirm NO
+       "Use absolute path" lens appears on it, since T9Sub names an alias
+       rather than a module (#71).
 7. [ ] Capture: with all T9 files open and their diagnostics present, run
        "Verse Auto Imports: Capture Diagnostics Corpus" and curate the output
        into the corpus folder for this UEFN version.

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -210,9 +210,10 @@ in (see test-fixtures/corpus/README.md).
        and confirm auto-import puts it back rather than reading the alias of
        the same path as an import already present; run "Verse Auto Imports:
        Optimize Imports" and confirm both alias lines are byte-identical
-       afterwards; and hover the `using { T9Sub }` line and confirm NO
-       "Use absolute path" lens appears on it, since T9Sub names an alias
-       rather than a module (#71).
+       afterwards, expecting them to sit below the rebuilt import block
+       rather than where they started; and hover the `using { T9Sub }` line
+       and confirm NO "Use absolute path" lens appears on it, since T9Sub
+       names an alias rather than a module (#71).
 7. [ ] Capture: with all T9 files open and their diagnostics present, run
        "Verse Auto Imports: Capture Diagnostics Corpus" and curate the output
        into the corpus folder for this UEFN version.


### PR DESCRIPTION
Closes #71

## What this is

A file can bind a name to a module with `Name := import(/Path)`. A `using` of that name is an ordinary identifier, indistinguishable by content from a same-directory folder-module import — so `scanConvertibleImports` offered a path-conversion CodeLens on it, and `ImportPathConverter` resolved the name by searching the workspace for a folder of that name or a `:= module` declaration of it. Whichever namesake it found got written into the line, silently importing a different module than the alias names. "Use absolute paths for all" applied it in bulk, without the user looking at that line.

`scanModuleAliases` now reads the names a file declares, and the shared convertible set drops a `using` rooted at one of them. That set is the one membership function behind both the lens provider and the converter, so a single filter closes both entry points.

## What the ticket asked for that this deliberately does not do

The body's "minimum viable" ask was to treat `X := import(/Path)` as evidence that `/Path` is already imported, for dedupe. **That is not built, because it is wrong**, as the ticket's own third comment records: aliasing does not bring the module's members into scope, so an alias never substitutes for a `using`, and a compiler suggestion to add `using { /A/B }` stays correct beside an alias for `/A/B`. Building the dedupe would decline an import the file needs.

That decision is encoded in the API rather than left in prose: `scanModuleAliases` returns the alias *names* only and never the paths they alias, so nothing downstream can read a path out of it and treat it as an import already present.

## Domain rules this rests on, with citations

From the compiler source (`EpicGames/UnrealEngine`, `ue5-main`, `Engine/Source/Runtime/VerseCompiler`):

- `AnalyzeImport` (`SemanticAnalyzer.cpp:19396-19462`) fixes the statement shape: module scope only, parentheses not brackets (brackets carry failure semantics), LHS a plain identifier with no qualifier and no type annotation, and the argument a path literal — so an alias always names an absolute path. `MODULE_ALIAS_STATEMENT` matches that shape and nothing wider.
- The alias is a real `CModuleAlias` definition (`:19446`) and registers no using scope, which is the citation behind not building the dedupe.
- Hoisting a `using { Alias }` above the alias line is safe: `Deferred_Import` runs to completion strictly before `Deferred_ModuleReferences` (`:19453` enqueues alias resolution into the former; `:21304-21305` runs the stages in that order), so every alias is bound before any module-scope `using` is resolved. Confirmed a second way: the `using` handler analyzes its argument with `WithResultIsDotted` (`:6567`), which is what the `CModuleAlias` guard at `:12037` requires, so the reference resolves whichever order the two lines are written in.

Live-compiler status: the construct compiles in real UEFN 41.10 (the maintainer's smoke run on this issue, PLAYBOOK T9 case F).

## Known limit, and where it came from

**An alias binds in the module, not the file.** A snippet is not a logical scope (`SemanticProgram.h:185-192`), a module part reports the `CModule` as its logical scope (`:173-174`), and `CScope::CreateModuleAlias` adds to `GetLogicalScope()` (`SemanticScope.cpp:437-442`) — so a sibling `.verse` file's alias resolves here unqualified, and Epic's own corpus has an `assert_valid` titled "Importing something in one snippet is also visible in another".

This change reads one file, so a `using` naming an alias declared in a sibling file is still offered a conversion. That is the same defect, narrower. Closing it needs an async workspace scan that this line-based reader cannot make — a different shape of change, touching the converter and the lens provider's async paths. `scanModuleAliases` states the limit rather than denying it. Worth a follow-up issue.

Two claims the review pushed back on are now stated at the strength the source supports rather than asserted: the compiler rejects the bracketed `import[...]` through a failure-semantics check that never inspects the brackets, and the `(path:)` qualifier on the left side is not checked at all. Both are now **read** rather than refused, because over-reporting a name only withholds a lens while missing one leaves the defect live.

## What was already correct, now pinned

Organize left alias lines byte-identical before this change — the ticket calls that "an accident rather than a decision". Four tests at the `buildOrganizedContent` entry point make it a decision: an alias between two imports stays in the body written as it was, a comment above an alias travels with the alias, an import of a path the file only aliases is still added, and the combined form survives with both lines intact.

## Fixtures

`test-fixtures/uefn-smoke/Content/T9/t9_alias.verse` was a commented-out probe asking whether the construct compiles. That question is settled, so the file is now written live and carries all three cases — a plain alias, the combined form, and a `using` of a path the file also aliases. The PLAYBOOK T9 case F step is rewritten from "uncomment and see if it compiles" into the three live checks the fixture now supports.

## Verification

```
$ npm run compile
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

```
$ npm test
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       993 passed, 993 total
Snapshots:   0 total
Time:        9.893 s, estimated 16 s
Ran all test suites.
```

```
$ npm run format:check
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The two exclusion tests were confirmed to detect the defect: with the alias filter removed from `scanConvertibleImports` and everything else in place, exactly those two fail.
