### PR TITLE
fix(visibility): default the definitions file to _definitions.verse

### DIFF
--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
         },
         "verseAutoImports.moduleVisibility.definitionsFileName": {
           "type": "string",
-          "default": "definitions.verse",
+          "default": "_definitions.verse",
           "description": "Name of the file at the Content root that the 'Make Module Public' quick fix writes <public> module declarations into. Existing declarations elsewhere in the project are edited in place instead, whatever this is set to.",
           "order": 35
         },

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -187,7 +187,7 @@ export class ModuleVisibilityWriter {
      * reported success.
      */
     private definitionsUri(contentRoot: vscode.Uri): vscode.Uri | null {
-        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "definitions.verse").trim();
+        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "_definitions.verse").trim();
 
         if (!/^[^\\/:*?"<>|]+\.verse$/.test(fileName)) {
             return null;

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -66,7 +66,7 @@ describe("ModuleVisibilityWriter", () => {
 
         const operations = appliedOperations();
         expect(operations[0]).toMatchObject({ kind: "createFile" });
-        expect(forwardSlashed(operations[0].uri)).toBe(`${ROOT}/Content/definitions.verse`);
+        expect(forwardSlashed(operations[0].uri)).toBe(`${ROOT}/Content/_definitions.verse`);
         expect(operations[1]).toMatchObject({ kind: "insert", text: "Gadgets := module:\n    Tools<public> := module {}\n" });
     });
 
@@ -98,7 +98,7 @@ describe("ModuleVisibilityWriter", () => {
 
     it("extends an existing definitions file rather than replacing it", async () => {
         givenProject({
-            "Content/definitions.verse": "Other<public> := module {}\n",
+            "Content/_definitions.verse": "Other<public> := module {}\n",
             "Content/Scripts/main.verse": "using { Gadgets.Tools }\n",
         });
 
@@ -111,7 +111,7 @@ describe("ModuleVisibilityWriter", () => {
     it("folds a specifier edit inside the definitions file into the same replacement", async () => {
         // Two operations on one file would overlap, which VS Code rejects, and
         // half-applying would leave two parts of Deep disagreeing.
-        givenProject({ "Content/definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
+        givenProject({ "Content/_definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
 
         await writer().makeModulePublic({
             targetPath: `${PROJECT}/Gadgets/Deep/Tools`,


### PR DESCRIPTION
Changes the default of `verseAutoImports.moduleVisibility.definitionsFileName` from `definitions.verse` to `_definitions.verse`, so the file the **Make Module Public** quick fix creates sorts to the top of the Content root.

**This must land before the v0.11.0 draft is published.** The draft targets `main`, so it tags whatever `main`'s tip is at publish time — merging this first ships the new default as part of v0.11.0 rather than as a later change to a default users already have.

## What changed

- `package.json` — the contributed setting's `default`
- `src/visibility/ModuleVisibilityWriter.ts` — the fallback passed to `getConfiguration().get()`, which is what applies when the setting is unset
- `src/visibility/__tests__/ModuleVisibilityWriter.test.ts` — the three cases that assert the path derived from the default

Both copies of the default had to move; either one left behind is a silent disagreement between what the settings UI shows and what the writer does.

## No changelog fragment

`v0.11.0` is not published, so no user has ever had `definitions.verse`. The `[#61]` entry already in the `0.11.0` section does not name the file — it says "writing a definitions file at the Content root" — so it stays accurate. A fragment here would describe a change from a default that never shipped.

## Verse rule this relies on

That a `.verse` file may be named with a leading underscore. Settled against the Book of Verse, `docs/16_modules.md` lines 24-36: a module's name comes from its **folder**, and every `.verse` file in that folder contributes to that folder's module. A file name is never an identifier, so no identifier rule constrains it. The writer's own guard (`/^[^\\/:*?"<>|]+\.verse$/`) accepts the name unchanged.

## Verification

```
$ npm run compile

> verse-auto-imports@0.11.0 compile
> tsc -p ./
```

```
$ npm test

> verse-auto-imports@0.11.0 test
> jest --verbose

Test Suites: 40 passed, 40 total
Tests:       1016 passed, 1016 total
Snapshots:   0 total
Time:        10.97 s
Ran all test suites.
```

```
$ npm run format:check

> verse-auto-imports@0.11.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The three tests were confirmed to detect the change: with the writer's fallback reverted to `definitions.verse` and the tests left as they are, `creates the definitions file when the target is a plain folder module`, `extends an existing definitions file rather than replacing it` and `folds a specifier edit inside the definitions file into the same replacement` all fail.

No tracked issue — taken under `policy.trivialEscape`, at the maintainer's direct request during release.
