### PR TITLE
fix(services): reject a Verse block macro as a project-scan declaration

### DIFF
--- a/changelog.d/344.fixed.md
+++ b/changelog.d/344.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: A Verse block macro written inside a function body is no longer recorded as a variable declaration, so keywords such as `block`, `loop` and `if` stop appearing as import and completion candidates.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -8,17 +8,19 @@ import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 const SCAN_CONCURRENCY = 8;
 
 /**
- * The Verse words that open a line as a bare `keyword:` - the block macros, and
- * the reserved types written the same way.
+ * The keywords a Verse block macro is spelled with, and the operators and types
+ * that share their shape closely enough to reach the same fall-through.
  *
- * Verse reserves every one of them, so none can name a declaration: the parser
- * demotes a reserved word to an identifier only where `:=` follows it, and that
- * is an object-notation key rather than a declaration either way. `block`,
- * `loop`, `race`, `rush`, `sync`, `branch`, `defer`, `spawn`, `case`, `for`,
- * `and`, `or`, `option` and `logic` are reserved in the compiler's
- * ReservedSymbols.inl; `if`, `then`, `else` and `not` are reserved by the
- * parser's own token table instead, which is where that file says
- * language-level reservations live.
+ * Membership is not "every reserved word": it is the words seen to reach the
+ * fall-through as a bare `keyword:`, plus the ones the language groups with
+ * them. What makes rejecting them safe is that Verse reserves each, so none can
+ * name a declaration - the parser demotes a reserved word to an identifier only
+ * where `:=` follows it, and that is an object-notation key rather than a
+ * declaration either way. `block`, `loop`, `race`, `rush`, `sync`, `branch`,
+ * `defer`, `spawn`, `case`, `for`, `and`, `or`, `option` and `logic` are
+ * reserved in the compiler's ReservedSymbols.inl; `if`, `then`, `else` and
+ * `not` are reserved by the parser's own token table instead, which is where
+ * that file says language-level reservations live.
  */
 const RESERVED_LINE_KEYWORDS = new Set(["block", "loop", "if", "then", "else", "race", "rush", "sync", "branch", "defer", "spawn", "case", "for", "and", "or", "not", "option", "logic"]);
 

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -8,6 +8,21 @@ import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 const SCAN_CONCURRENCY = 8;
 
 /**
+ * The Verse words that open a line as a bare `keyword:` - the block macros, and
+ * the reserved types written the same way.
+ *
+ * Verse reserves every one of them, so none can name a declaration: the parser
+ * demotes a reserved word to an identifier only where `:=` follows it, and that
+ * is an object-notation key rather than a declaration either way. `block`,
+ * `loop`, `race`, `rush`, `sync`, `branch`, `defer`, `spawn`, `case`, `for`,
+ * `and`, `or`, `option` and `logic` are reserved in the compiler's
+ * ReservedSymbols.inl; `if`, `then`, `else` and `not` are reserved by the
+ * parser's own token table instead, which is where that file says
+ * language-level reservations live.
+ */
+const RESERVED_LINE_KEYWORDS = new Set(["block", "loop", "if", "then", "else", "race", "rush", "sync", "branch", "defer", "spawn", "case", "for", "and", "or", "not", "option", "logic"]);
+
+/**
  * A module whose body the scan is inside, held while its declarations are read
  * so each can be given the path it sits at.
  *
@@ -518,6 +533,15 @@ export class ProjectPathScanner {
                 }
 
                 if (/\([^)]*\)\s*(?:<[^>]+>)?\s*:/.test(line)) {
+                    continue;
+                }
+
+                // The two guards above are backstops for a declaration; this
+                // one is not. A block macro inside a function body is spelled
+                // `keyword:`, which is all this pattern asks for, and the scan
+                // does not track function bodies, so position cannot reject one
+                // and the name is what is left.
+                if (RESERVED_LINE_KEYWORDS.has(name)) {
                     continue;
                 }
 

--- a/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
+++ b/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
@@ -19,7 +19,10 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
 
     const paths = (source: string): string[] => declare(source).map((node) => `${node.type}:${node.fullPath}`);
 
-    it("records neither the block macros in a function body nor anything but the two real declarations", () => {
+    // `X` is a function-local, which this scan records under the module path
+    // because it tracks module nesting alone. That is the behaviour on either
+    // side of the block macro guard, so it is asserted here rather than fixed.
+    it("records the declarations in a function body and none of its block macros", () => {
         const source = [
             "Inventory := module:",
             "    Run<public>()<suspends>:void =",

--- a/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
+++ b/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
@@ -1,0 +1,68 @@
+import { ProjectPathScanner } from "../ProjectPathScanner";
+import { ProjectPathNode } from "../../types";
+
+/**
+ * The fall-through variable pattern needs only a name and a colon, which the
+ * keyword opening a Verse block macro satisfies, so a `block:` written inside a
+ * function body was recorded as a variable declaration and offered downstream
+ * as an import candidate. Verse reserves every one of those keywords, so none
+ * of them can name a declaration.
+ *
+ * extractDeclarations is pure, so these run without the VS Code runtime.
+ */
+describe("ProjectPathScanner.extractDeclarations block macros", () => {
+    type ScannerParams = ConstructorParameters<typeof ProjectPathScanner>;
+
+    const scanner = new ProjectPathScanner({ appendLine: jest.fn() } as unknown as ScannerParams[0], {} as unknown as ScannerParams[1]);
+
+    const declare = (source: string): ProjectPathNode[] => scanner.extractDeclarations(source, "Content/Inventory.verse");
+
+    const paths = (source: string): string[] => declare(source).map((node) => `${node.type}:${node.fullPath}`);
+
+    it("records neither the block macros in a function body nor anything but the two real declarations", () => {
+        const source = [
+            "Inventory := module:",
+            "    Run<public>()<suspends>:void =",
+            "        block:",
+            "            X:int = 1",
+            "        loop:",
+            "            Sleep(1.0)",
+            "        if:",
+            "            true",
+            "        then:",
+            "            Print(:)",
+            "        race:",
+            "            Sleep(1.0)",
+            "        sync:",
+            "            Sleep(1.0)",
+            "        branch:",
+            "            Sleep(1.0)",
+            "        defer:",
+            "            Print(:)",
+            "",
+        ].join("\n");
+
+        expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.Run", "variable:Inventory.X"]);
+    });
+
+    it.each(["block", "loop", "if", "then", "else", "race", "rush", "sync", "branch", "defer", "spawn", "case", "for", "and", "or", "not", "option", "logic"])(
+        "records no declaration for a bare `%s:`",
+        (keyword) => {
+            expect(paths(`Inventory := module:\n    ${keyword}:\n`)).toEqual(["module:Inventory"]);
+        },
+    );
+
+    it("records a variable whose name is none of them", () => {
+        expect(paths("Inventory := module:\n    Count:int = 0\n")).toEqual(["module:Inventory", "variable:Inventory.Count"]);
+    });
+
+    it("records a declaration whose name merely starts with one of them", () => {
+        const source = ["Inventory := module:", "    blockCount:int = 1", "    ifState:logic = true", "    forEachItem:int = 2", ""].join("\n");
+
+        expect(paths(source)).toEqual(["module:Inventory", "variable:Inventory.blockCount", "variable:Inventory.ifState", "variable:Inventory.forEachItem"]);
+    });
+
+    it("records a module-scope variable as before", () => {
+        expect(paths("Count<public>:int = 0\n")).toEqual(["variable:Count"]);
+    });
+});


### PR DESCRIPTION
Closes #344

The fall-through variable pattern in `ProjectPathScanner.extractDeclarations` needs only a name and a colon, which a bare `block:` satisfies. Every block macro opening a line inside a function body was therefore recorded as a `variable` declaration and offered downstream as an import and completion candidate — one junk node per block macro per function across the project. The two guards already on that branch are backstops for a *declaration* whose specific pattern did not match; a block macro is not a declaration at all, so neither was aimed at it.

The scan does not track function bodies, so no enclosing-scope test is available and the name is what separates them.

## The rule this relies on, and its authority

A word Verse reserves cannot name a declaration.

- `block`, `loop`, `race`, `rush`, `sync`, `branch`, `defer`, `spawn`, `case`, `for`, `and`, `or`, `option`, `logic` — `EIsReservedSymbolResult::Reserved` in `VerseCompiler/Public/uLang/Parser/ReservedSymbols.inl`.
- `if`, `then`, `else`, `not` — absent from that file by design; its header says language-level reservations live in the parser token list instead, and they are in `VerseGrammar.h`'s `Tokens[]` table.
- The one exception is `VerseGrammar.h:1177-1181`: a reserved word *followed by `:=`* is demoted to an identifier, for simple object notation. That is an object-notation key rather than a declaration, so rejecting it on the name alone is correct too.

Two corrections to the list the issue proposed, from that check: `rush` was missing, a concurrency block macro of the same family; and `option`/`logic` are reserved types rather than block macros, so the constant is named for what it holds rather than for block macros alone.

## Changes

- `src/services/ProjectPathScanner.ts` — a `RESERVED_LINE_KEYWORDS` set, and a third guard on the fall-through branch rejecting a match whose name is in it. Placed after the two existing guards, which it does not alter.
- `src/services/__tests__/ProjectPathScannerBlockMacros.test.ts` — new. The issue's exact input, each keyword as a bare `keyword:`, a variable named after none of them, names that merely start with one (`blockCount`, `ifState`, `forEachItem`), and module-scope fall-through behaviour unchanged.
- `changelog.d/344.fixed.md`.

The tests were confirmed to detect the defect: with `ProjectPathScanner.ts` stashed, 19 of the 22 fail; the 3 that pass are the unchanged-behaviour cases.

## Verification

`npm run compile`

```
> verse-auto-imports@0.10.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.10.0 test
> jest --verbose

Test Suites: 41 passed, 41 total
Tests:       1038 passed, 1038 total
Snapshots:   0 total
Time:        12.058 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.10.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh Opus reviewer, verdict `PASS_WITH_SUGGESTIONS`, 0 Critical. It probed the ticket input, all 18 keywords, `then:`/`else:` following another block, object notation, CRLF, tabs, braced module bodies, comments and string literals, specifiers on a keyword, and uppercase spellings.

Two findings applied here: the doc comment stated a membership rule the set does not follow, and a test was titled for two declarations while asserting three. The missing changelog fragment was its other Important finding.

Its remaining Important finding is out of this ticket's scope and filed as #350: the parenthesised spelling `if (X > 0):` matches `functionPattern` first, a different branch, and is still recorded — as `function:Inventory.if`. Verified independently before filing.
