### PR TITLE
fix(services): reject a parenthesised Verse block macro as a declaration

### DIFF
--- a/changelog.d/350.fixed.md
+++ b/changelog.d/350.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: a Verse block macro written with a parenthesised head, such as `if (Cond):` or `for (Item : Items):`, is no longer recorded as a function declaration or offered as an import candidate.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -9,12 +9,12 @@ const SCAN_CONCURRENCY = 8;
 
 /**
  * The keywords a Verse block macro is spelled with, and the operators and types
- * that share their shape closely enough to reach the same fall-through.
+ * that share their shape closely enough to reach a declaration pattern.
  *
- * Membership is not "every reserved word": it is the words seen to reach the
- * fall-through as a bare `keyword:`, plus the ones the language groups with
- * them. What makes rejecting them safe is that Verse reserves each, so none can
- * name a declaration - the parser demotes a reserved word to an identifier only
+ * Membership is not "every reserved word": it is the words seen to open a line
+ * a declaration pattern matches, plus the ones the language groups with them.
+ * What makes rejecting them safe is that Verse reserves each, so none can name
+ * a declaration - the parser demotes a reserved word to an identifier only
  * where `:=` follows it, and that is an object-notation key rather than a
  * declaration either way. `block`, `loop`, `race`, `rush`, `sync`, `branch`,
  * `defer`, `spawn`, `case`, `for`, `and`, `or`, `option` and `logic` are
@@ -248,6 +248,8 @@ export class ProjectPathScanner {
         /** `(Type:type).Name<specifiers>(params)<effects>:` */
         const extensionMethodPattern = /^\([^)]+\)\.(\w+)((?:<[^>]+>)*)\s*\([^)]*\)/;
         const variablePattern = /^(\w+)((?:<[^>]+>)*)\s*:/;
+        /** The word a line opens with, absent where it opens with anything else. */
+        const leadingWordPattern = /^(\w+)/;
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i].trim();
@@ -327,6 +329,22 @@ export class ProjectPathScanner {
             const insideSkipped = moduleStack.length > 0 && moduleStack[moduleStack.length - 1].skipped;
 
             currentModulePath = moduleStack.length > 0 ? moduleStack[moduleStack.length - 1].name : "";
+
+            // Ahead of every pattern rather than inside one: a reserved word
+            // cannot name any declaration, so what follows it cannot make the
+            // line one. A block macro is written `keyword:` and
+            // `keyword (Cond):`, and those reach different patterns - the
+            // variable fall-through and the function pattern - so a guard on
+            // either branch alone leaves the other spelling recorded. The scan
+            // does not track function bodies, so position cannot reject a block
+            // macro and the name is what is left.
+            //
+            // Below the brace counting and the module stack, which every line
+            // owes whether or not it declares anything.
+            const leadingWord = line.match(leadingWordPattern);
+            if (leadingWord && RESERVED_LINE_KEYWORDS.has(leadingWord[1])) {
+                continue;
+            }
 
             const moduleMatch = line.match(modulePattern);
             if (moduleMatch) {
@@ -535,15 +553,6 @@ export class ProjectPathScanner {
                 }
 
                 if (/\([^)]*\)\s*(?:<[^>]+>)?\s*:/.test(line)) {
-                    continue;
-                }
-
-                // The two guards above are backstops for a declaration; this
-                // one is not. A block macro inside a function body is spelled
-                // `keyword:`, which is all this pattern asks for, and the scan
-                // does not track function bodies, so position cannot reject one
-                // and the name is what is left.
-                if (RESERVED_LINE_KEYWORDS.has(name)) {
                     continue;
                 }
 

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -330,17 +330,17 @@ export class ProjectPathScanner {
 
             currentModulePath = moduleStack.length > 0 ? moduleStack[moduleStack.length - 1].name : "";
 
-            // Ahead of every pattern rather than inside one: a reserved word
-            // cannot name any declaration, so what follows it cannot make the
-            // line one. A block macro is written `keyword:` and
-            // `keyword (Cond):`, and those reach different patterns - the
-            // variable fall-through and the function pattern - so a guard on
-            // either branch alone leaves the other spelling recorded. The scan
-            // does not track function bodies, so position cannot reject a block
-            // macro and the name is what is left.
+            // A reserved word cannot name any declaration, so what follows it
+            // cannot make the line one - which is why this sits ahead of every
+            // pattern rather than inside one. The scan does not track function
+            // bodies, so position cannot reject a block macro and the name is
+            // what is left.
             //
-            // Below the brace counting and the module stack, which every line
-            // owes whether or not it declares anything.
+            // Load-bearing placement, in both directions. Below the brace
+            // counting and the module stack maintenance, which every line owes
+            // whether or not it declares anything; above the module push, so a
+            // word wrongly added to the set would not merely drop its own line
+            // but re-parent every declaration nested under it.
             const leadingWord = line.match(leadingWordPattern);
             if (leadingWord && RESERVED_LINE_KEYWORDS.has(leadingWord[1])) {
                 continue;

--- a/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
+++ b/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
@@ -2,11 +2,13 @@ import { ProjectPathScanner } from "../ProjectPathScanner";
 import { ProjectPathNode } from "../../types";
 
 /**
- * The fall-through variable pattern needs only a name and a colon, which the
- * keyword opening a Verse block macro satisfies, so a `block:` written inside a
- * function body was recorded as a variable declaration and offered downstream
- * as an import candidate. Verse reserves every one of those keywords, so none
- * of them can name a declaration.
+ * A Verse block macro reaches two of the declaration patterns: the fall-through
+ * variable pattern needs only a name and a colon, which a bare `block:`
+ * satisfies, and the function pattern needs a name, a parenthesised list and a
+ * colon, which `if (X > 0):` satisfies. Either way one was recorded as a
+ * declaration and offered downstream as an import candidate. Verse reserves
+ * every one of those keywords, so none of them can name a declaration, whatever
+ * shape follows it.
  *
  * extractDeclarations is pure, so these run without the VS Code runtime.
  */
@@ -54,6 +56,32 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
             expect(paths(`Inventory := module:\n    ${keyword}:\n`)).toEqual(["module:Inventory"]);
         },
     );
+
+    it("records the declarations in a function body and none of its parenthesised block macros", () => {
+        const source = [
+            "Inventory := module:",
+            "    Run<public>()<suspends>:void =",
+            "        if (X > 0):",
+            "            Print(:)",
+            "        for (Item : Items):",
+            "            Print(:)",
+            "        case (X):",
+            "            Print(:)",
+            "",
+        ].join("\n");
+
+        expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.Run"]);
+    });
+
+    it.each(["if (X > 0)", "for (Item : Items)", "case (X)", "race (A, B)", "sync (A, B)", "branch (A)", "spawn (A)", "loop (A)"])("records no declaration for `%s:`", (head) => {
+        expect(paths(`Inventory := module:\n    ${head}:\n`)).toEqual(["module:Inventory"]);
+    });
+
+    it("records a function whose name merely starts with one of them", () => {
+        const source = ["Inventory := module:", "    ifMatches(X:int)<transacts>:logic = true", "    forEach(X:int):void = block:", "    caseOf(X:int):int = X", ""].join("\n");
+
+        expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.ifMatches", "function:Inventory.forEach", "function:Inventory.caseOf"]);
+    });
 
     it("records a variable whose name is none of them", () => {
         expect(paths("Inventory := module:\n    Count:int = 0\n")).toEqual(["module:Inventory", "variable:Inventory.Count"]);

--- a/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
+++ b/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
@@ -73,7 +73,9 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
         expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.Run"]);
     });
 
-    it.each(["if (X > 0)", "for (Item : Items)", "case (X)", "race (A, B)", "sync (A, B)", "branch (A)", "spawn (A)", "loop (A)"])("records no declaration for `%s:`", (head) => {
+    // `if(X > 0)` carries no space, which is what the function pattern keys on:
+    // a shape reaching it without one must be rejected too.
+    it.each(["if (X > 0)", "if(X > 0)", "for (Item : Items)", "case (X)", "race (A, B)", "sync (A, B)", "branch (A)", "spawn (A)", "loop (A)"])("records no declaration for `%s:`", (head) => {
         expect(paths(`Inventory := module:\n    ${head}:\n`)).toEqual(["module:Inventory"]);
     });
 


### PR DESCRIPTION
Closes #350

`functionPattern` in `ProjectPathScanner.extractDeclarations` needs a name, a parenthesised list and a colon, which the parenthesised spelling of a Verse block macro satisfies. `if (X > 0):`, `for (Item : Items):` and `case (X):` were each recorded as a `function` declaration and offered downstream as an import and completion candidate — and typed `function`, so the cleanup #344 aimed at bogus `variable` nodes left them in place.

#344's `RESERVED_LINE_KEYWORDS` guard sits on the variable fall-through alone, so it never sees a line the function branch has already claimed.

## The fork the ticket raised

The ticket asked for a deliberate choice between a per-branch check and one ahead of all branches. This takes the hoisted form: a reserved word cannot name *any* declaration, so the rule is not specific to a branch, and a block macro reaches two different patterns depending on how it is written — the variable fall-through for `keyword:`, the function pattern for `keyword (Cond):`. A guard on either branch alone leaves the other spelling recorded, which is how the bare-colon fix left this one open.

The guard replaces the variable branch's copy, so the rule is stated once.

## The rule this relies on, and its authority

A word Verse reserves cannot name a declaration.

- `case` and `for` are `EIsReservedSymbolResult::Reserved` in `VerseCompiler/Public/uLang/Parser/ReservedSymbols.inl:25,59`.
- `if` is absent from that file by design — its header says language-level reservations live in the parser token list instead — and is in `VerseGrammar.h`'s `Tokens[]` table at line 674.
- The one demotion of a reserved word to an identifier is `VerseGrammar.h:1174-1189`, and it requires `:=` to follow. That is an object-notation key rather than a declaration, and the type patterns all require `:=` plus a declaration keyword, so hoisting the guard above them cannot drop a legal declaration. The extension-method branch has no leading `\w+` at all, since its line opens with `(`.
- The parenthesised heads are the real spelling: `if (…):`, `for (Item : Items):` and `case (Dir):` throughout the Book of Verse, and `VerseGrammar.h:2744` comments on `if(a)` at the grammar level.

## Changes

- `src/services/ProjectPathScanner.ts` — a `leadingWordPattern`, and a guard above the pattern dispatch rejecting a line whose leading word is in `RESERVED_LINE_KEYWORDS`. The variable branch's copy is removed. Placement is load-bearing in both directions and the comment says so: below the brace counting and module-stack maintenance, above the module push.
- `src/services/__tests__/ProjectPathScannerBlockMacros.test.ts` — the ticket's exact input, nine parenthesised heads including the no-space `if(X > 0):`, and functions whose names merely start with a keyword (`ifMatches`, `forEach`, `caseOf`). The bare-colon cases #344 pinned are unchanged.
- `changelog.d/350.fixed.md`.

The tests were confirmed to detect the defect: written first, they failed 9 for 9 against the unfixed code, each reporting the junk node the ticket names (`function:Inventory.if`, `function:Inventory.loop`, …).

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.0 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.0 test
> jest --verbose

Test Suites: 41 passed, 41 total
Tests:       1049 passed, 1049 total
Snapshots:   0 total
Time:        13.63 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh Opus reviewer, verdict `PASS_WITH_SUGGESTIONS`, 0 Critical, 0 Important.

It attacked the hoist's safety argument with a 75-input old-versus-new differential — 30 synthetic sources, all 43 `test-fixtures/*.verse`, and the three bundled digests — and found 68 identical, with all 7 differences pure removals of junk nodes and no legal declaration lost. It also probed every block-macro spelling, keyword-prefixed real declarations, braced and nested module bodies, extension methods, skipped private modules, CRLF, tabs, comments and string literals holding keywords, uppercase spellings, and specifiers.

Two of its four suggestions are applied here: the comment stated only one half of the guard's load-bearing placement, and the suite did not pin the no-space spelling.

One is deliberately not: it trimmed further comment argumentation, and the remaining text is the constraint rather than the defence.

Its last is out of this ticket's scope — `array` and `map` are `:`-headed macros absent from `RESERVED_LINE_KEYWORDS`, so `array:` on its own line is still recorded as a variable. Identical on both sides of this diff. Worth filing separately.
