### PR TITLE
docs(imports): record the single-file alias scan as a deliberate boundary

### DIFF
--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -1213,8 +1213,7 @@ export function allUsingPaths(lines: string[]): string[] {
 const MODULE_ALIAS_STATEMENT = /^(?:\([^()]*:\)\s*)?([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)(?:\s*<[^<>\n]+>)*\s*:=\s*import\s*(?:\(\s*\/[^\s()[\]]*\s*\)|\[\s*\/[^\s()[\]]*\s*\])$/;
 
 /**
- * The names a file binds to a module with `Name := import(/Path)`, at file
- * scope.
+ * The names a file binds to a module with `Name := import(/Path)`, at column 0.
  *
  * The names alone, never the modules they alias. An alias does not bring its
  * module's members into scope - it binds one name to one module - so a file
@@ -1225,17 +1224,20 @@ const MODULE_ALIAS_STATEMENT = /^(?:\([^()]*:\)\s*)?([A-Za-z_][A-Za-z0-9_]*(?:'[
  *
  * What the names are for is the opposite question: which `using` statements
  * name something that is not a module path. An alias is an ordinary identifier
- * bound in the file's own scope, so `using { Gfx }` naming an alias is
- * indistinguishable, by content alone, from one naming a same-directory folder
- * module - and a reader that resolves it as a path finds whichever namesake the
- * workspace holds. See scanConvertibleImports.
+ * rather than a path, so `using { Gfx }` naming an alias is indistinguishable,
+ * by content alone, from one naming a same-directory folder module - and a
+ * reader that resolves it as a path finds whichever namesake the workspace
+ * holds. See scanConvertibleImports.
  *
- * Only this file is read, which does not see every alias a `using` here could
- * name. An alias binds in the enclosing module rather than in the file: a
- * snippet is not a logical scope, so the definition lands in the module every
- * file of the folder module shares, and a sibling file's alias resolves here
- * unqualified. A `using` naming one of those is still offered a conversion.
- * Closing that needs a workspace scan no line-based reader can make.
+ * Only this file is read. That is a chosen boundary, not the whole rule: an
+ * alias binds in the enclosing module rather than in the file, because a snippet
+ * is not a logical scope, so the definition lands in the module every file of
+ * the folder module shares and a sibling file's alias resolves here unqualified
+ * (Tests/Modules/Import.versetest:33-44, the `assert_valid` block "Importing
+ * something in one snippet is also visible in another"). A `using` naming a
+ * sibling file's alias is therefore still offered a conversion. Following the
+ * rule across files needs a workspace-wide alias scan no line-based reader can
+ * make, and the gap is left open deliberately rather than for want of noticing.
  *
  * An alias indented inside a module body is skipped for the opposite reason: it
  * binds in that module, which a column-0 `using` is outside of.
@@ -1319,11 +1321,12 @@ export interface ConvertibleImport {
  *   line of statement text and replaces that one line.
  * - A `using` rooted at a module alias the file declares is excluded. Both
  *   directions of the conversion read the statement as a module path, and an
- *   alias is a name bound in the file rather than a path: going absolute hunts
- *   the workspace for a folder or a `:= module` declaration of that name and
- *   writes whichever namesake it finds, which silently imports a different
- *   module than the alias names. The file is the only evidence of which names
- *   are aliases, so no conversion can recover it later. See scanModuleAliases.
+ *   alias is a name rather than a path: going absolute hunts the workspace for
+ *   a folder or a `:= module` declaration of that name and writes whichever
+ *   namesake it finds, which silently imports a different module than the alias
+ *   names. The declaration is the only evidence of which names are aliases, so
+ *   no conversion can recover it later. See scanModuleAliases, whose read stops
+ *   at this file and so misses a sibling file's declaration.
  */
 export function scanConvertibleImports(lines: string[]): ConvertibleImport[] {
     const aliases = scanModuleAliases(lines);


### PR DESCRIPTION
Closes #347

Records the maintainer's decision on the cross-file alias gap. No behaviour change: `scanModuleAliases` still reads one file, and no runtime line is touched.

## What changed

`src/imports/ImportScanner.ts`, doc comments only.

- `scanModuleAliases` — the paragraph on the single-file read now states it as a chosen boundary rather than an incapacity, and cites the corpus for the rule it declines to follow: `Tests/Modules/Import.versetest:33-44`, the `assert_valid` block "Importing something in one snippet is also visible in another", where `Bib := import(...)` is declared in one snippet of `vmodule(Frank)` and used in a second.
- Two claims that the new paragraph contradicted:
  - "An alias is an ordinary identifier bound in the file's own scope" said the opposite of "an alias binds in the enclosing module" four lines below it. The sentence's point is name-vs-path, so the scope clause is gone.
  - `scanConvertibleImports` said "The file is the only evidence of which names are aliases", which the accepted gap makes false — a sibling file is also evidence. Now "The declaration is the only evidence", with the single-file limit named at the cross-reference.
- The opening line said "at file scope" where it means the statement's column, in a comment that now turns on the binding *not* being file-scoped. Now "at column 0".

The comment is careful to keep the maintainer's distinction: the alias *binding* is module-scoped, while the `using` *effect* is file-scoped. It claims only the former.

## Note on the cited range

The issue asks for `Tests/Modules/Import.versetest:34-43`. The block is `34-44` — it ends at `C := class(Bib.B) {}` on 44 — and the quoted title sits at 33, so the comment cites `33-44` to cover both. Confirmed against the file, and independently at the review gate.

## Verification

```
> verse-auto-imports@0.11.0 compile
> tsc -p ./
```

```
> verse-auto-imports@0.11.0 test
> jest --verbose

Test Suites: 41 passed, 41 total
Tests:       1049 passed, 1049 total
Snapshots:   0 total
Time:        7.199 s
Ran all test suites.
```

```
> verse-auto-imports@0.11.0 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

No regression test: nothing executable changed, and the ticket's acceptance for the accept-the-gap branch is the record itself. No changelog fragment: a source comment is not user-facing.

## Review

One round, verdict `PASS_WITH_SUGGESTIONS`, no `Critical`. Both `Important` findings (the two contradicted claims above) are fixed, as are the suggestions on the cited range and "at file scope". The reviewer verified the corpus citation against the file rather than taking it on trust.
