### PR TITLE
fix(services): reject every reserved block macro heading a line

### DIFF
--- a/changelog.d/353.fixed.md
+++ b/changelog.d/353.fixed.md
@@ -1,0 +1,1 @@
+**Project scan**: a line opening with a Verse block macro such as `array:`, `map:`, `assert:` or `let:` is no longer recorded as a declaration, so it stops appearing as an import candidate or completion entry.

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -21,17 +21,20 @@ const SCAN_CONCURRENCY = 8;
  * ReservedSymbols.inl, which is where that file says language-level
  * reservations live; every other member is reserved in that file.
  *
- * Only a word ReservedSymbols.inl marks `Reserved` may join. A `ReservedFuture`
- * word is still a legal identifier today, so `profile`, `await` and `upon` -
- * block macros in every other respect - are knowingly left out, and a line one
- * of them heads is knowingly misrecorded. Adding one would drop a declaration
- * that legally carries that name.
+ * A word may join only where ReservedSymbols.inl marks it `Reserved` and the
+ * version gate on that entry is already met. The classification alone is not
+ * the test: an unmet gate falls through to NotReserved, leaving the word a
+ * legal identifier. That keeps out `profile`, `await` and `upon`, which are
+ * `ReservedFuture`, and `dictate`, which is `Reserved` behind a gate of
+ * `Latest + 1` that no shipped version meets. All four are block macros in
+ * every other respect, so a line one of them heads is knowingly misrecorded -
+ * the alternative is dropping a declaration that legally carries the name.
  *
  * `batch`, `when` and `first` name macros the language has not released, and
- * are held anyway: they are already reserved, so the guarantee above holds now
- * and the set needs no revisit when they ship. `batch` alone is reserved from
- * uploaded-at version 4000 rather than from the beginning, so a file uploaded
- * before that could name a declaration with it.
+ * are held anyway: each is reserved and gated at a version that has shipped,
+ * which is the whole of what makes rejecting its line safe. `batch`'s gate is
+ * uploaded-at 4000 rather than the beginning, so only a file uploaded before
+ * that could still carry a declaration named for it.
  */
 const RESERVED_LINE_KEYWORDS = new Set([
     "block",

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -16,18 +16,22 @@ const SCAN_CONCURRENCY = 8;
  * What makes rejecting them safe is that Verse reserves each, so none can name
  * a declaration - the parser demotes a reserved word to an identifier only
  * where `:=` follows it, and that is an object-notation key rather than a
- * declaration either way. All but four are reserved in the compiler's
- * ReservedSymbols.inl; `if`, `then`, `else` and `not` are reserved by the
- * parser's own token table instead, which is where that file says
- * language-level reservations live.
+ * declaration either way. `if`, `then`, `else`, `not` and `do` are reserved by
+ * the parser's own token table rather than in the compiler's
+ * ReservedSymbols.inl, which is where that file says language-level
+ * reservations live; every other member is reserved in that file.
  *
  * Only a word ReservedSymbols.inl marks `Reserved` may join. A `ReservedFuture`
- * word is still a legal identifier today, so `profile` - a block macro in every
- * other respect - would drop a real declaration if it were added here.
+ * word is still a legal identifier today, so `profile`, `await` and `upon` -
+ * block macros in every other respect - are knowingly left out, and a line one
+ * of them heads is knowingly misrecorded. Adding one would drop a declaration
+ * that legally carries that name.
  *
  * `batch`, `when` and `first` name macros the language has not released, and
  * are held anyway: they are already reserved, so the guarantee above holds now
- * and the set needs no revisit when they ship.
+ * and the set needs no revisit when they ship. `batch` alone is reserved from
+ * uploaded-at version 4000 rather than from the beginning, so a file uploaded
+ * before that could name a declaration with it.
  */
 const RESERVED_LINE_KEYWORDS = new Set([
     "block",
@@ -48,6 +52,7 @@ const RESERVED_LINE_KEYWORDS = new Set([
     "not",
     "option",
     "logic",
+    "do",
     "array",
     "map",
     "assert",

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -16,13 +16,46 @@ const SCAN_CONCURRENCY = 8;
  * What makes rejecting them safe is that Verse reserves each, so none can name
  * a declaration - the parser demotes a reserved word to an identifier only
  * where `:=` follows it, and that is an object-notation key rather than a
- * declaration either way. `block`, `loop`, `race`, `rush`, `sync`, `branch`,
- * `defer`, `spawn`, `case`, `for`, `and`, `or`, `option` and `logic` are
- * reserved in the compiler's ReservedSymbols.inl; `if`, `then`, `else` and
- * `not` are reserved by the parser's own token table instead, which is where
- * that file says language-level reservations live.
+ * declaration either way. All but four are reserved in the compiler's
+ * ReservedSymbols.inl; `if`, `then`, `else` and `not` are reserved by the
+ * parser's own token table instead, which is where that file says
+ * language-level reservations live.
+ *
+ * Only a word ReservedSymbols.inl marks `Reserved` may join. A `ReservedFuture`
+ * word is still a legal identifier today, so `profile` - a block macro in every
+ * other respect - would drop a real declaration if it were added here.
+ *
+ * `batch`, `when` and `first` name macros the language has not released, and
+ * are held anyway: they are already reserved, so the guarantee above holds now
+ * and the set needs no revisit when they ship.
  */
-const RESERVED_LINE_KEYWORDS = new Set(["block", "loop", "if", "then", "else", "race", "rush", "sync", "branch", "defer", "spawn", "case", "for", "and", "or", "not", "option", "logic"]);
+const RESERVED_LINE_KEYWORDS = new Set([
+    "block",
+    "loop",
+    "if",
+    "then",
+    "else",
+    "race",
+    "rush",
+    "sync",
+    "branch",
+    "defer",
+    "spawn",
+    "case",
+    "for",
+    "and",
+    "or",
+    "not",
+    "option",
+    "logic",
+    "array",
+    "map",
+    "assert",
+    "let",
+    "batch",
+    "when",
+    "first",
+]);
 
 /**
  * A module whose body the scan is inside, held while its declarations are read

--- a/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
+++ b/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
@@ -50,12 +50,43 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
         expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.Run", "variable:Inventory.X"]);
     });
 
-    it.each(["block", "loop", "if", "then", "else", "race", "rush", "sync", "branch", "defer", "spawn", "case", "for", "and", "or", "not", "option", "logic"])(
-        "records no declaration for a bare `%s:`",
-        (keyword) => {
-            expect(paths(`Inventory := module:\n    ${keyword}:\n`)).toEqual(["module:Inventory"]);
-        },
-    );
+    // The container macros are the shape the issue reported: `array:` and
+    // `map:` opening a block whose body is the literal's elements.
+    it("records the declarations returning a container literal and neither container macro", () => {
+        const source = ["Inventory := module:", "    Xs<public>():[]int =", "        array:", "            1", "    Ys<public>():[int]int =", "        map:", "            1 => 2", ""].join("\n");
+
+        expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.Xs", "function:Inventory.Ys"]);
+    });
+
+    it.each([
+        "block",
+        "loop",
+        "if",
+        "then",
+        "else",
+        "race",
+        "rush",
+        "sync",
+        "branch",
+        "defer",
+        "spawn",
+        "case",
+        "for",
+        "and",
+        "or",
+        "not",
+        "option",
+        "logic",
+        "array",
+        "map",
+        "assert",
+        "let",
+        "batch",
+        "when",
+        "first",
+    ])("records no declaration for a bare `%s:`", (keyword) => {
+        expect(paths(`Inventory := module:\n    ${keyword}:\n`)).toEqual(["module:Inventory"]);
+    });
 
     it("records the declarations in a function body and none of its parenthesised block macros", () => {
         const source = [
@@ -75,9 +106,12 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
 
     // `if(X > 0)` carries no space, which is what the function pattern keys on:
     // a shape reaching it without one must be rejected too.
-    it.each(["if (X > 0)", "if(X > 0)", "for (Item : Items)", "case (X)", "race (A, B)", "sync (A, B)", "branch (A)", "spawn (A)", "loop (A)"])("records no declaration for `%s:`", (head) => {
-        expect(paths(`Inventory := module:\n    ${head}:\n`)).toEqual(["module:Inventory"]);
-    });
+    it.each(["if (X > 0)", "if(X > 0)", "for (Item : Items)", "case (X)", "race (A, B)", "sync (A, B)", "branch (A)", "spawn (A)", "loop (A)", "when(X)", "when (X > 1 and Y < 10)"])(
+        "records no declaration for `%s:`",
+        (head) => {
+            expect(paths(`Inventory := module:\n    ${head}:\n`)).toEqual(["module:Inventory"]);
+        },
+    );
 
     it("records a function whose name merely starts with one of them", () => {
         const source = ["Inventory := module:", "    ifMatches(X:int)<transacts>:logic = true", "    forEach(X:int):void = block:", "    caseOf(X:int):int = X", ""].join("\n");
@@ -90,9 +124,28 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
     });
 
     it("records a declaration whose name merely starts with one of them", () => {
-        const source = ["Inventory := module:", "    blockCount:int = 1", "    ifState:logic = true", "    forEachItem:int = 2", ""].join("\n");
+        const source = [
+            "Inventory := module:",
+            "    blockCount:int = 1",
+            "    ifState:logic = true",
+            "    forEachItem:int = 2",
+            "    arrayOf:int = 3",
+            "    mapping:int = 4",
+            "    assertion:logic = false",
+            "    letter:int = 5",
+            "",
+        ].join("\n");
 
-        expect(paths(source)).toEqual(["module:Inventory", "variable:Inventory.blockCount", "variable:Inventory.ifState", "variable:Inventory.forEachItem"]);
+        expect(paths(source)).toEqual([
+            "module:Inventory",
+            "variable:Inventory.blockCount",
+            "variable:Inventory.ifState",
+            "variable:Inventory.forEachItem",
+            "variable:Inventory.arrayOf",
+            "variable:Inventory.mapping",
+            "variable:Inventory.assertion",
+            "variable:Inventory.letter",
+        ]);
     });
 
     it("records a module-scope variable as before", () => {

--- a/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
+++ b/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
@@ -89,13 +89,15 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
         expect(paths(`Inventory := module:\n    ${keyword}:\n`)).toEqual(["module:Inventory"]);
     });
 
-    // `do:` is not optional decoration on the block form of `first`: it is what
-    // separates the iteration clauses from the body, so rejecting one word of
-    // the pair and not the other leaves the construct half-handled. `X` is the
-    // iteration binding, recorded under the module path for the reason the
-    // first case above gives.
-    it("records no declaration for either line of the `first:`/`do:` pair", () => {
-        const source = ["Inventory := module:", "    Top<public>(Xs:[]int)<decides>:int =", "        first:", "            X : Xs", "            X > 0", "        do:", "            X", ""].join("\n");
+    // `do:` is not optional decoration on the block form of `first` or of
+    // `for`: it is what separates the iteration clauses from the body, so
+    // rejecting one word of the pair and not the other leaves the construct
+    // half-handled. `X` is the iteration binding, recorded under the module
+    // path for the reason the first case above gives.
+    it.each(["first", "for"])("records no declaration for either line of the `%s:`/`do:` pair", (keyword) => {
+        const source = ["Inventory := module:", "    Top<public>(Xs:[]int)<decides>:int =", `        ${keyword}:`, "            X : Xs", "            X > 0", "        do:", "            X", ""].join(
+            "\n",
+        );
 
         expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.Top", "variable:Inventory.X"]);
     });
@@ -178,10 +180,11 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
         ]);
     });
 
-    // Every ReservedFuture word the sweep for this set considered and left out.
-    // Each is a block macro in every other respect, so what keeps it out is only
-    // that Verse still lets a declaration carry the name.
-    it.each(["profile", "await", "upon"])("records a variable named `%s`, which Verse has not yet reserved", (name) => {
+    // Every word the sweep for this set considered and left out. Each is a
+    // block macro in every other respect, so what keeps it out is only that
+    // Verse still lets a declaration carry the name - `dictate` because its
+    // version gate is unreachable, the rest because they are ReservedFuture.
+    it.each(["profile", "await", "upon", "dictate"])("records a variable named `%s`, which Verse has not yet reserved", (name) => {
         expect(paths(`Inventory := module:\n    ${name}:int = 5\n`)).toEqual(["module:Inventory", `variable:Inventory.${name}`]);
     });
 

--- a/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
+++ b/src/services/__tests__/ProjectPathScannerBlockMacros.test.ts
@@ -77,6 +77,7 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
         "not",
         "option",
         "logic",
+        "do",
         "array",
         "map",
         "assert",
@@ -86,6 +87,17 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
         "first",
     ])("records no declaration for a bare `%s:`", (keyword) => {
         expect(paths(`Inventory := module:\n    ${keyword}:\n`)).toEqual(["module:Inventory"]);
+    });
+
+    // `do:` is not optional decoration on the block form of `first`: it is what
+    // separates the iteration clauses from the body, so rejecting one word of
+    // the pair and not the other leaves the construct half-handled. `X` is the
+    // iteration binding, recorded under the module path for the reason the
+    // first case above gives.
+    it("records no declaration for either line of the `first:`/`do:` pair", () => {
+        const source = ["Inventory := module:", "    Top<public>(Xs:[]int)<decides>:int =", "        first:", "            X : Xs", "            X > 0", "        do:", "            X", ""].join("\n");
+
+        expect(paths(source)).toEqual(["module:Inventory", "function:Inventory.Top", "variable:Inventory.X"]);
     });
 
     it("records the declarations in a function body and none of its parenthesised block macros", () => {
@@ -106,12 +118,22 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
 
     // `if(X > 0)` carries no space, which is what the function pattern keys on:
     // a shape reaching it without one must be rejected too.
-    it.each(["if (X > 0)", "if(X > 0)", "for (Item : Items)", "case (X)", "race (A, B)", "sync (A, B)", "branch (A)", "spawn (A)", "loop (A)", "when(X)", "when (X > 1 and Y < 10)"])(
-        "records no declaration for `%s:`",
-        (head) => {
-            expect(paths(`Inventory := module:\n    ${head}:\n`)).toEqual(["module:Inventory"]);
-        },
-    );
+    it.each([
+        "if (X > 0)",
+        "if(X > 0)",
+        "for (Item : Items)",
+        "case (X)",
+        "race (A, B)",
+        "sync (A, B)",
+        "branch (A)",
+        "spawn (A)",
+        "loop (A)",
+        "when(X)",
+        "when (X > 1 and Y < 10)",
+        "first(I -> Y : Xs; X = Y)",
+    ])("records no declaration for `%s:`", (head) => {
+        expect(paths(`Inventory := module:\n    ${head}:\n`)).toEqual(["module:Inventory"]);
+    });
 
     it("records a function whose name merely starts with one of them", () => {
         const source = ["Inventory := module:", "    ifMatches(X:int)<transacts>:logic = true", "    forEach(X:int):void = block:", "    caseOf(X:int):int = X", ""].join("\n");
@@ -133,6 +155,10 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
             "    mapping:int = 4",
             "    assertion:logic = false",
             "    letter:int = 5",
+            "    whenever:int = 6",
+            "    firstly:int = 7",
+            "    batched:int = 8",
+            "    doOnce:logic = true",
             "",
         ].join("\n");
 
@@ -145,7 +171,18 @@ describe("ProjectPathScanner.extractDeclarations block macros", () => {
             "variable:Inventory.mapping",
             "variable:Inventory.assertion",
             "variable:Inventory.letter",
+            "variable:Inventory.whenever",
+            "variable:Inventory.firstly",
+            "variable:Inventory.batched",
+            "variable:Inventory.doOnce",
         ]);
+    });
+
+    // Every ReservedFuture word the sweep for this set considered and left out.
+    // Each is a block macro in every other respect, so what keeps it out is only
+    // that Verse still lets a declaration carry the name.
+    it.each(["profile", "await", "upon"])("records a variable named `%s`, which Verse has not yet reserved", (name) => {
+        expect(paths(`Inventory := module:\n    ${name}:int = 5\n`)).toEqual(["module:Inventory", `variable:Inventory.${name}`]);
     });
 
     it("records a module-scope variable as before", () => {


### PR DESCRIPTION
Closes #353

`ProjectPathScanner.extractDeclarations` skips a line whose leading word is in `RESERVED_LINE_KEYWORDS`, ahead of every declaration pattern. The set missed the container macros, so a bare `array:` or `map:` fell through to the variable pattern and was recorded as `variable:<Module>.array` — offered downstream as an import candidate that cannot be imported.

The issue also asked to sweep for any other `:`-headed macro the set still misses, so the class closes here rather than opening a fourth round. The sweep found six more.

## What was added, and why each is safe

A reserved word can never name a declaration: at expression position it is always a macro invocation, and `VerseGrammar.h:2658` errors on a "reserved word not followed by macro". That is the guarantee the set already ran on.

| Word | Authority | Reserved since |
| --- | --- | --- |
| `array` | `ReservedSymbols.inl:15`, `AnalyzeMacroCall_Array` | Primordial |
| `map` | `ReservedSymbols.inl:84`, `AnalyzeMacroCall_Map` | Primordial |
| `assert` | `ReservedSymbols.inl:17`, `AnalyzeMacroCall_AssertKeep` | Primordial |
| `let` | `ReservedSymbols.inl:80`, `AnalyzeMacroCall_Let` | Primordial |
| `batch` | `ReservedSymbols.inl:21`, `AnalyzeMacroCall_Batch` | uploaded-at 4000 |
| `when` | `ReservedSymbols.inl:142`, `AnalyzeMacroCall_When` | Primordial |
| `first` | `ReservedSymbols.inl:52`, `AnalyzeMacroCall_First` | Primordial |
| `do` | `VerseGrammar.h:670` parser token table | — |

`do` is the parser-token-table case, the same basis `if`, `then`, `else` and `not` are in the set on. It separates the iteration clauses of a `first:` block from its body, so `first` without it would have left that construct half-handled.

`batch`, `when` and `first` name macros the language has not released. They are included because they are already reserved, so the guarantee holds today and the set needs no revisit when they ship.

## What was deliberately left out

The admission test is not the classification alone. A `ReservedSymbols.inl` entry carries a version gate, and `ReservedSymbols.cpp:69-73` falls a `Reserved` symbol through to `NotReserved` when the gate is unmet — so a word joins only where it is `Reserved` **and** its gate has already shipped.

That keeps out four block macros that are otherwise indistinguishable from the ones added:

- `profile`, `await`, `upon` — `ReservedFuture`.
- `dictate` — `Reserved`, but gated at `Latest + 1`, which no shipped version meets. It names declarations legally today.

A line one of the four heads is knowingly misrecorded; the alternative is dropping a real declaration. A test pins that a variable named for each is still recorded.

Also out: `set`, `type` and `external`, each probed and found unable to reach a declaration pattern in any spelling the grammar admits — `set` takes an operand rather than opening a clause, and the other two are brace-form only. `class`, `struct`, `interface`, `enum` and `module` reach a line only after `Name :=`; `using` is already skipped ahead of the guard.

## Verification

```
$ npm run compile
> tsc -p ./
(clean)

$ npm test
Test Suites: 41 passed, 41 total
Tests:       1067 passed, 1067 total
Time:        7.865 s

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

The new assertions were checked against the unfixed scanner: reverting `src/services/ProjectPathScanner.ts` alone fails 10 of them, and removing the single `do` entry fails exactly the two cases that pin it. Both pass restored.

## Review

Two rounds, both Opus with a fresh context, each finding one Important issue.

Round one returned FAIL on `do` missing — traced to the parser token table, and to the `first:`/`do:` pairing this PR had just introduced half of.

Round two returned PASS_WITH_SUGGESTIONS but caught that the admission rule written into the comment was unsound: it named the classification and not the version gate, so it would have told the next round to add `dictate`. The third commit states the real test. The same round cleared `set`, `type` and `external` as artefacts of a synthetic probe rather than genuine gaps.

## Noted, not done here

`VerseGrammar.h:2658` implies a stronger rule than a curated word list — reject every `Reserved` word heading a line — which would end this ticket class outright rather than one round at a time. That reverses the set's stated membership rule and is a redesign this issue does not ask for. Worth its own ticket.
