### PR TITLE
refactor(services): share the digest indentation walk and file manifest

### DIFF
--- a/src/scripts/parseDigestFiles.ts
+++ b/src/scripts/parseDigestFiles.ts
@@ -10,9 +10,10 @@
 
 import * as fs from "fs";
 import * as path from "path";
-// Import the shared parser directly (not via the services barrel, which pulls in
-// `vscode` and would break ts-node).
+// Import the shared parser and manifest directly (not via the services barrel,
+// which pulls in `vscode` and would break ts-node).
 import { parseDigestContent, rootDomainForDigestFile } from "../services/digestParsing";
+import { BUNDLED_DIGEST_NAMES, digestDataFile, digestSourceFile } from "../services/digestManifest";
 
 interface PrecompiledDigest {
     version: string;
@@ -22,8 +23,6 @@ interface PrecompiledDigest {
     entries: ReturnType<typeof parseDigestContent>["entries"];
     moduleIndex: ReturnType<typeof parseDigestContent>["moduleIndex"];
 }
-
-const DIGEST_FILES = ["Fortnite.digest.verse", "UnrealEngine.digest.verse", "Verse.digest.verse"];
 
 const VERSION = "1.0.0";
 
@@ -75,7 +74,8 @@ function main() {
 
     let totalEntries = 0;
 
-    for (const digestFile of DIGEST_FILES) {
+    for (const digestName of BUNDLED_DIGEST_NAMES) {
+        const digestFile = digestSourceFile(digestName);
         const inputPath = path.join(utilsDir, digestFile);
 
         if (!fs.existsSync(inputPath)) {
@@ -90,7 +90,7 @@ function main() {
         const moduleCount = Object.keys(digest.moduleIndex).length;
         totalEntries += entryCount;
 
-        const outputFile = digestFile.replace(".verse", ".json");
+        const outputFile = digestDataFile(digestName);
         const outputPath = path.join(dataDir, outputFile);
 
         fs.writeFileSync(outputPath, JSON.stringify(digest, null, 2));

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { logger } from "../utils";
+import { lineIndentWidth, popClosedBlocks } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 
 /**
@@ -144,6 +145,11 @@ export class AssetsDigestParser {
      * members (which share the instance declaration shape) are not mistaken for
      * asset names.
      *
+     * Comments are skipped only where `#` opens the line, which is narrower than
+     * Verse's own rule: `<# #>` and `<#>` comments, a `#` after code, and a `#`
+     * inside a string are all missed. UEFN generates this file and writes only
+     * whole-line `#` comments into it, so the narrow rule holds here.
+     *
      * @param content Raw text of the Assets.digest.verse file.
      * @returns The distinct asset type names, in first-seen order.
      */
@@ -154,15 +160,13 @@ export class AssetsDigestParser {
         const classBodyIndents: number[] = [];
 
         for (const rawLine of content.split("\n")) {
-            const indent = AssetsDigestParser.indentOf(rawLine);
+            const indent = lineIndentWidth(rawLine);
             const line = rawLine.trim();
             if (line === "" || line.startsWith("#")) {
                 continue;
             }
 
-            while (classBodyIndents.length > 0 && indent <= classBodyIndents[classBodyIndents.length - 1]) {
-                classBodyIndents.pop();
-            }
+            popClosedBlocks(classBodyIndents, indent);
 
             const classMatch = line.match(CLASS_OR_STRUCT_DECL);
             if (classMatch) {
@@ -181,15 +185,6 @@ export class AssetsDigestParser {
         }
 
         return [...names];
-    }
-
-    /**
-     * Returns the leading indentation width of a line, counting each tab as four
-     * spaces so mixed indentation compares consistently.
-     */
-    private static indentOf(rawLine: string): number {
-        const match = rawLine.match(/^[ \t]*/);
-        return match ? match[0].replace(/\t/g, "    ").length : 0;
     }
 
     /**

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -145,10 +145,11 @@ export class AssetsDigestParser {
      * members (which share the instance declaration shape) are not mistaken for
      * asset names.
      *
-     * Comments are skipped only where `#` opens the line, which is narrower than
-     * Verse's own rule: `<# #>` and `<#>` comments, a `#` after code, and a `#`
-     * inside a string are all missed. UEFN generates this file and writes only
-     * whole-line `#` comments into it, so the narrow rule holds here.
+     * Comments are skipped only where `#` is the line's first non-whitespace
+     * character, which is narrower than Verse's own rule: `<# #>` and `<#>`
+     * comments, a `#` after code, and a `#` inside a string are all missed.
+     * UEFN generates this file and writes only whole-line `#` comments into it,
+     * so the narrow rule holds here.
      *
      * @param content Raw text of the Assets.digest.verse file.
      * @returns The distinct asset type names, in first-seen order.

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { logger } from "../utils";
 import { DigestEntry } from "./DigestParser";
+import { BUNDLED_DIGEST_NAMES, digestDataFile } from "./digestManifest";
 
 /**
  * One `src/data/*.digest.json` payload, as written by `npm run parse-digest`.
@@ -32,8 +33,6 @@ export class PrecompiledDigestLoader {
     private moduleIndex: Map<string, string[]> = new Map();
     private loaded: boolean = false;
     private loadError: Error | null = null;
-
-    private static readonly DIGEST_FILES = ["Fortnite.digest.json", "UnrealEngine.digest.json", "Verse.digest.json"];
 
     constructor(private extensionContext: vscode.ExtensionContext) {}
 
@@ -88,7 +87,8 @@ export class PrecompiledDigestLoader {
     private async loadFromDirectory(dataDir: string): Promise<number> {
         let successCount = 0;
 
-        for (const fileName of PrecompiledDigestLoader.DIGEST_FILES) {
+        for (const digestName of BUNDLED_DIGEST_NAMES) {
+            const fileName = digestDataFile(digestName);
             const filePath = path.join(dataDir, fileName);
 
             if (!fs.existsSync(filePath)) {
@@ -100,8 +100,9 @@ export class PrecompiledDigestLoader {
                 const content = fs.readFileSync(filePath, "utf8");
                 const digest: PrecompiledDigest = JSON.parse(content);
 
-                // First file to declare an identifier wins, so DIGEST_FILES
-                // order is the precedence between the three domains.
+                // First file to declare an identifier wins, so
+                // BUNDLED_DIGEST_NAMES order is the precedence between the
+                // three domains.
                 for (const [identifier, entry] of Object.entries(digest.entries)) {
                     if (!this.digestCache.has(identifier)) {
                         this.digestCache.set(identifier, entry);

--- a/src/services/digestManifest.ts
+++ b/src/services/digestManifest.ts
@@ -1,0 +1,25 @@
+/**
+ * The bundled Verse API digests, named in one place for both halves of the
+ * pipeline: `npm run parse-digest` reads the `.verse` sources under
+ * `src/utils`, and PrecompiledDigestLoader reads the `.json` it writes to
+ * `src/data`. Adding or renaming a digest is one edit here.
+ *
+ * No VS Code dependencies: the generator runs under ts-node outside the
+ * extension host.
+ */
+
+/**
+ * The bundled digests, in load precedence order. The first file to declare an
+ * identifier wins, so reordering this changes which domain answers a lookup.
+ */
+export const BUNDLED_DIGEST_NAMES = ["Fortnite", "UnrealEngine", "Verse"];
+
+/** The checked-in Verse source a digest is generated from. */
+export function digestSourceFile(digestName: string): string {
+    return `${digestName}.digest.verse`;
+}
+
+/** The generated JSON a digest is loaded from. */
+export function digestDataFile(digestName: string): string {
+    return `${digestName}.digest.json`;
+}

--- a/src/services/digestManifest.ts
+++ b/src/services/digestManifest.ts
@@ -2,7 +2,12 @@
  * The bundled Verse API digests, named in one place for both halves of the
  * pipeline: `npm run parse-digest` reads the `.verse` sources under
  * `src/utils`, and PrecompiledDigestLoader reads the `.json` it writes to
- * `src/data`. Adding or renaming a digest is one edit here.
+ * `src/data`. Both file-name lists derive from this one.
+ *
+ * A new digest needs a second edit that this module cannot carry:
+ * `digestParsing.rootDomainForDigestFile` keys the root module domain off the
+ * file name and returns "" for a name it does not know, which roots every
+ * top-level declaration in the new file at "" rather than failing.
  *
  * No VS Code dependencies: the generator runs under ts-node outside the
  * extension host.
@@ -12,7 +17,7 @@
  * The bundled digests, in load precedence order. The first file to declare an
  * identifier wins, so reordering this changes which domain answers a lookup.
  */
-export const BUNDLED_DIGEST_NAMES = ["Fortnite", "UnrealEngine", "Verse"];
+export const BUNDLED_DIGEST_NAMES = ["Fortnite", "UnrealEngine", "Verse"] as const;
 
 /** The checked-in Verse source a digest is generated from. */
 export function digestSourceFile(digestName: string): string {

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -14,11 +14,12 @@
  * explicit `# Module import path:` comment, a scope qualifier `(/path:)`, the
  * enclosing module on the stack, or the file's root domain.
  *
- * Comments are skipped only where `#` opens the line. Verse also has `<# #>` and
- * `<#>` comments, and a `#` after code or inside a string is not a comment at
- * all, so this is a narrower rule than the language's. It holds because the
- * digests are machine-generated and carry only whole-line `#` comments; a
- * hand-written file would need the masking that ProjectPathScanner does.
+ * Comments are skipped only where `#` is the line's first non-whitespace
+ * character. Verse also has `<# #>` and `<#>` comments, and a `#` after code or
+ * inside a string is not a comment at all, so this is a narrower rule than the
+ * language's. It holds because the digests are machine-generated and carry only
+ * whole-line `#` comments; a hand-written file would need the masking that
+ * ProjectPathScanner does.
  */
 
 import { lineIndentWidth, popClosedBlocks } from "../utils/verseText";
@@ -211,6 +212,8 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
         }
 
         const indent = lineIndentWidth(rawLine);
+        // Holds frames rather than bare indents, so it cannot use
+        // popClosedBlocks; the closing rule has to stay in step with it.
         while (moduleStack.length > 0 && indent <= moduleStack[moduleStack.length - 1].indent) {
             moduleStack.pop();
         }

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -13,7 +13,15 @@
  * importable). Module import paths are resolved from, in precedence order, an
  * explicit `# Module import path:` comment, a scope qualifier `(/path:)`, the
  * enclosing module on the stack, or the file's root domain.
+ *
+ * Comments are skipped only where `#` opens the line. Verse also has `<# #>` and
+ * `<#>` comments, and a `#` after code or inside a string is not a comment at
+ * all, so this is a narrower rule than the language's. It holds because the
+ * digests are machine-generated and carry only whole-line `#` comments; a
+ * hand-written file would need the masking that ProjectPathScanner does.
  */
+
+import { lineIndentWidth, popClosedBlocks } from "../utils/verseText";
 
 /** A single importable declaration extracted from a digest file. */
 export interface DigestEntry {
@@ -93,15 +101,6 @@ export function rootDomainForDigestFile(fileName: string): string {
         return "/Verse.org";
     }
     return "";
-}
-
-/**
- * Returns the leading indentation width of a line, counting each tab as four
- * spaces so mixed indentation compares consistently.
- */
-function indentOf(rawLine: string): number {
-    const match = rawLine.match(/^[ \t]*/);
-    return match ? match[0].replace(/\t/g, "    ").length : 0;
 }
 
 /**
@@ -211,13 +210,11 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
             continue;
         }
 
-        const indent = indentOf(rawLine);
+        const indent = lineIndentWidth(rawLine);
         while (moduleStack.length > 0 && indent <= moduleStack[moduleStack.length - 1].indent) {
             moduleStack.pop();
         }
-        while (classBodyIndents.length > 0 && indent <= classBodyIndents[classBodyIndents.length - 1]) {
-            classBodyIndents.pop();
-        }
+        popClosedBlocks(classBodyIndents, indent);
 
         // Anything still inside a class/struct/interface/enum body is a member.
         if (classBodyIndents.length > 0) {

--- a/src/utils/__tests__/verseText.test.ts
+++ b/src/utils/__tests__/verseText.test.ts
@@ -1,0 +1,58 @@
+import { lineIndentWidth, popClosedBlocks } from "../verseText";
+
+/**
+ * The line-based indentation pair both digest parsers track block bodies with.
+ * Each parser reads only the aggregate result, so these pin the boundaries -
+ * tab width, and which blocks a given dedent closes - directly.
+ */
+describe("lineIndentWidth", () => {
+    it("counts spaces", () => {
+        expect(lineIndentWidth("Foo := class:")).toBe(0);
+        expect(lineIndentWidth("    Field:int = 1")).toBe(4);
+    });
+
+    it("counts a tab as four spaces, so mixed indentation compares", () => {
+        expect(lineIndentWidth("\tField:int = 1")).toBe(4);
+        expect(lineIndentWidth("\t\tField:int = 1")).toBe(8);
+        expect(lineIndentWidth("  \tField:int = 1")).toBe(6);
+    });
+
+    it("stops at the first non-whitespace character", () => {
+        expect(lineIndentWidth("    Foo := class: # trailing")).toBe(4);
+    });
+
+    it("reads a whitespace-only line as its full width", () => {
+        expect(lineIndentWidth("    ")).toBe(4);
+        expect(lineIndentWidth("")).toBe(0);
+    });
+
+    it("does not count a CRLF carriage return as indentation", () => {
+        expect(lineIndentWidth("  Foo := class:\r")).toBe(2);
+    });
+});
+
+describe("popClosedBlocks", () => {
+    it("leaves a deeper line inside every open block", () => {
+        const open = [0, 4];
+        popClosedBlocks(open, 8);
+        expect(open).toEqual([0, 4]);
+    });
+
+    it("closes a block the line has returned to the indent of", () => {
+        const open = [0, 4];
+        popClosedBlocks(open, 4);
+        expect(open).toEqual([0]);
+    });
+
+    it("closes every block a dedent has left, not just the innermost", () => {
+        const open = [0, 4, 8];
+        popClosedBlocks(open, 0);
+        expect(open).toEqual([]);
+    });
+
+    it("is a no-op on an empty stack", () => {
+        const open: number[] = [];
+        popClosedBlocks(open, 0);
+        expect(open).toEqual([]);
+    });
+});

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -113,6 +113,30 @@ export function maskCommentsAndStrings(content: string): string {
     return masked.join("");
 }
 
+/**
+ * Leading whitespace width of a whole line, for a scan that already holds the
+ * line rather than an offset into the file.
+ */
+export function lineIndentWidth(rawLine: string): number {
+    return indentOf(rawLine, 0);
+}
+
+/**
+ * Pops every open block the line at `indent` has left, so the stack is left
+ * holding only the blocks that still enclose it.
+ *
+ * A block's body is the lines indented past its head, so a line back at or
+ * inside the head's own indent closes it. The compiler decides that byte-wise,
+ * extending the opening line's whitespace prefix; comparing widths agrees on any
+ * consistently indented file and diverges only where tabs and spaces mix inside
+ * one body.
+ */
+export function popClosedBlocks(openBlockIndents: number[], indent: number): void {
+    while (openBlockIndents.length > 0 && indent <= openBlockIndents[openBlockIndents.length - 1]) {
+        openBlockIndents.pop();
+    }
+}
+
 /** Leading whitespace of a line, each tab counted as four spaces so mixed indentation compares. */
 export function indentOf(content: string, lineStart: number): number {
     let width = 0;

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -114,8 +114,8 @@ export function maskCommentsAndStrings(content: string): string {
 }
 
 /**
- * Leading whitespace width of a whole line, for a scan that already holds the
- * line rather than an offset into the file.
+ * Leading whitespace width of a whole line, each tab counted as four spaces, for
+ * a scan that already holds the line rather than an offset into the file.
  */
 export function lineIndentWidth(rawLine: string): number {
     return indentOf(rawLine, 0);


### PR DESCRIPTION
Closes #356

`digestParsing.ts` and `AssetsDigestParser.ts` each carried a private copy of the line-indent reader and the class/struct body-indent stack walk. Both now use one pair of helpers, and the two digest file lists become one manifest.

## What changed

**`src/utils/verseText.ts`** gains `lineIndentWidth(rawLine)` — the line-based signature, delegating to the existing offset-based `indentOf` — and `popClosedBlocks(openBlockIndents, indent)`, the stack walk both parsers ran their own copy of.

**`src/services/digestManifest.ts`** is new: `BUNDLED_DIGEST_NAMES` plus `digestSourceFile` / `digestDataFile`. `parseDigestFiles.ts` and `PrecompiledDigestLoader.ts` both derive their file names from it, so the array order is now the single expression of the loader's precedence. The module doc names the one edit the manifest cannot carry — `rootDomainForDigestFile` also keys off the file name, and returns `""` for a name it does not know rather than failing.

**Both parsers** keep their own declaration policy unchanged, and each now states its comment-skip rule: a `#` first non-whitespace character, which is narrower than Verse's own rule (`<# #>`, `<#>`, a `#` after code and a `#` inside a string are all missed) and holds only because digests are machine-generated.

`digestParsing`'s `moduleStack` pop stays an inline loop — it holds `ModuleFrame`s rather than bare indents and is not duplicated anywhere — with a note that its closing rule has to stay in step with the shared one.

## The rule this relies on

A block's body is the lines indented past its head. The compiler decides that byte-wise: `VerseGrammar.h` `Ind()` (:1636-1645) sets `BlockInd` to the opening line's start, and `Line()` matches a following line's leading whitespace against that prefix character by character (:1666), requiring at least one more space or tab to stay in the block (:1669). The parsers compare indent *widths* with a tab counted as four, which approximates that rule — the two agree on any consistently indented file and diverge only where tabs and spaces mix inside one body. That divergence is pre-existing and preserved; `popClosedBlocks`' doc states it.

## Verification

```
$ npm run compile
> tsc -p ./
(clean)

$ npm test
Test Suites: 42 passed, 42 total
Tests:       1076 passed, 1076 total

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

Baseline before the change was 41 suites / 1067 tests; the 9 added tests pin `lineIndentWidth` and `popClosedBlocks` directly.

The acceptance criterion is byte-identical generated data. `npm run parse-digest` reproduces the checked-in `src/data/*.digest.json` with exactly one differing line per file:

```
-  "generatedAt": "2026-08-07T14:31:23.562Z",
+  "generatedAt": "2026-08-13T12:32:07.361Z",
```

`parseDigestFiles.ts` stamps `new Date().toISOString()` on every run, so literal byte-identity is unreachable and was before this branch too. With that field stripped, the sha256 of each file matches the pre-change baseline exactly:

| digest | sha256 (generatedAt stripped) | before | after |
| --- | --- | --- | --- |
| Fortnite | `cce79e32e7676e40` | yes | yes |
| UnrealEngine | `64f65c8dcc3b5114` | yes | yes |
| Verse | `364865c7d7fe5148` | yes | yes |

Entry counts are unchanged: 1855 / 170 / 469.

## Review

One round, verdict `PASS_WITH_SUGGESTIONS`, no Critical findings. The reviewer probed rather than read: an exhaustive 41,390-input differential between `lineIndentWidth` and the two deleted implementations (0 mismatches, including CR, vertical tab, form feed, NBSP, U+2003, BOM and whitespace-only lines); both parsers run against the three real digests plus CRLF and tabified variants and 26 synthetic cases (0 mismatches); a 4,000-file seeded fuzz on the assets parser (0 mismatches); and loader precedence checked end-to-end against a synthetic data directory written in reverse order, including the missing-file fallthrough.

All five findings were comment and type accuracy, and all five are fixed in 447add4: the manifest doc no longer claims a new digest is one edit, the comment-skip wording says first non-whitespace character (nearly every comment in the bundled digests is indented, so the looser wording described the opposite of what happens), `BUNDLED_DIGEST_NAMES` is `as const`, the `moduleStack` loop carries its desync note, and `lineIndentWidth` keeps the tab-width contract its deleted predecessors documented.

## No changelog fragment

Behaviour is unchanged and nothing here is user-facing.
