### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 Pending changes are kept as one file per change under [changelog.d/](changelog.d/) and assembled here at release.
 
+## [0.11.1] - 2026-08-13
+
+### Fixed
+
+- **Project scan**: A Verse block macro written inside a function body is no longer recorded as a variable declaration, so keywords such as `block`, `loop` and `if` stop appearing as import and completion candidates ([#344])
+- **Project scan**: a Verse block macro written with a parenthesised head, such as `if (Cond):` or `for (Item : Items):`, is no longer recorded as a function declaration or offered as an import candidate ([#350])
+- **Project scan**: a line opening with a Verse block macro such as `array:`, `map:`, `assert:` or `let:` is no longer recorded as a declaration, so it stops appearing as an import candidate or completion entry ([#353])
+
 ## [0.11.0] - 2026-08-12
 
 ### Added
@@ -408,7 +416,8 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 
 <!-- Version comparisons. The chain starts at 0.6.0: no v0.4.x or v0.5.x tags exist. -->
 
-[Unreleased]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/vukefn/verse-auto-imports/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/vukefn/verse-auto-imports/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/vukefn/verse-auto-imports/compare/v0.8.0...v0.9.0
@@ -423,6 +432,9 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 
 <!-- Issue references -->
 
+[#344]: https://github.com/vukefn/verse-auto-imports/issues/344
+[#350]: https://github.com/vukefn/verse-auto-imports/issues/350
+[#353]: https://github.com/vukefn/verse-auto-imports/issues/353
 [#60]: https://github.com/vukefn/verse-auto-imports/issues/60
 [#61]: https://github.com/vukefn/verse-auto-imports/issues/61
 [#71]: https://github.com/vukefn/verse-auto-imports/issues/71

--- a/changelog.d/344.fixed.md
+++ b/changelog.d/344.fixed.md
@@ -1,1 +1,0 @@
-**Project scan**: A Verse block macro written inside a function body is no longer recorded as a variable declaration, so keywords such as `block`, `loop` and `if` stop appearing as import and completion candidates.

--- a/changelog.d/350.fixed.md
+++ b/changelog.d/350.fixed.md
@@ -1,1 +1,0 @@
-**Project scan**: a Verse block macro written with a parenthesised head, such as `if (Cond):` or `for (Item : Items):`, is no longer recorded as a function declaration or offered as an import candidate.

--- a/changelog.d/353.fixed.md
+++ b/changelog.d/353.fixed.md
@@ -1,1 +1,0 @@
-**Project scan**: a line opening with a Verse block macro such as `array:`, `map:`, `assert:` or `let:` is no longer recorded as a declaration, so it stops appearing as an import candidate or completion entry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verse-auto-imports",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verse-auto-imports",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "verse-auto-imports",
   "displayName": "Verse Auto Imports",
   "description": "Automatically adds missing using statements in Verse files",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Cuts v0.11.1 from the three fragments pending in `changelog.d/`. All three are `Fixed`, so the pre-1.0 rule gives a patch bump from 0.11.0.

## Changelog section as it will ship

```markdown
## [0.11.1] - 2026-08-13

### Fixed

- **Project scan**: A Verse block macro written inside a function body is no longer recorded as a variable declaration, so keywords such as `block`, `loop` and `if` stop appearing as import and completion candidates ([#344])
- **Project scan**: a Verse block macro written with a parenthesised head, such as `if (Cond):` or `for (Item : Items):`, is no longer recorded as a function declaration or offered as an import candidate ([#350])
- **Project scan**: a line opening with a Verse block macro such as `array:`, `map:`, `assert:` or `let:` is no longer recorded as a declaration, so it stops appearing as an import candidate or completion entry ([#353])
```

The `[0.11.1]` compare link and the repointed `[Unreleased]` link are written by the assembler. #354 (docs) and #357 (refactor) carry no fragment, correctly — neither is user-facing.

## Changes

- `package.json`, `package-lock.json`: version 0.11.0 to 0.11.1, lockfile refreshed with `npm install --package-lock-only`.
- `CHANGELOG.md`: the dated `[0.11.1]` section, its compare link, and `[Unreleased]` repointed at `v0.11.1`.
- `changelog.d/`: the three consumed fragments removed.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 42 passed, 42 total
Tests:       1076 passed, 1076 total
Snapshots:   0 total
Time:        10.716 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
