### PR TITLE
fix(deps): pin @types/vscode to the engines floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "deps"
+    ignore:
+      # Held at the engines.vscode floor so every compile type-checks against
+      # the oldest host the extension claims to support. Raising it is a
+      # deliberate change to that promise, made together with engines.vscode -
+      # and an automerged bump here would undo the guard unnoticed.
+      - dependency-name: "@types/vscode"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.1.2",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "1.85.0",
         "@vscode/test-electron": "^3.1.0",
         "jest": "^30.3.0",
         "mocha": "^11.8.0",
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.96.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
-      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
     "@types/jest": "^30.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.1.2",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "1.85.0",
     "@vscode/test-electron": "^3.1.0",
     "jest": "^30.3.0",
     "mocha": "^11.8.0",


### PR DESCRIPTION
Closes #364

`@types/vscode` was declared `^1.85.0`, so npm resolved 1.96.0 and nothing type-checked against the 1.85 API surface `engines.vscode` promises. Pinned exactly, per the ticket's stated smallest fix; the lockfile follows.

The review gate found the pin does not hold on its own. Dependabot runs npm weekly with no ignore rules, and `dependabot-automerge.yml:23` auto-merges anything that is not `semver-major` — `1.85.0` to `1.96.x` is minor, so the guard would have reverted itself within a week, unattended. The `ignore` entry in `.github/dependabot.yml` is what keeps it. That entry is blanket rather than `update-types`-scoped because `@types/vscode` publishes one release per VS Code minor and has no patch stream for a narrower rule to admit. Known trade: `ignore` covers security advisories too, which costs nothing for a declarations-only devDependency that carries no runtime code, no install scripts and no transitive dependencies, and never reaches a user.

`engines.vscode: "^1.85.0"` is untouched — the caret there is the supported-host range, the exact pin is the compile surface, and they agree at the floor.

No changelog fragment: `changelog.d/README` scopes the directory to what changed in the editor experience, and the compiled output is unchanged.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 42 passed, 42 total
Tests:       1076 passed, 1076 total
Snapshots:   0 total
Time:        10.951 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The guard is proven to fire rather than only assumed to. Installed version reads `1.85.0`; a throwaway file using `vscode.window.onDidStartTerminalShellExecution` (added in 1.93) is now rejected by `tsc`:

```
error TS2339: Property 'onDidStartTerminalShellExecution' does not exist on type 'typeof window'
```

Against the pre-fix 1.96 typings that same file compiled clean, which is the whole defect. `tsconfig.integration.json` also type-checks clean at the floor.

## Review

Two rounds, both by a reviewer with its own context. Round 1 `PASS_WITH_SUGGESTIONS` on the pin, raising the dependabot revert as `Important`; that finding is fixed here. Round 2 `PASS` on the added hunk, confirming the `ignore` shape against the Dependabot options reference.

Left unfixed, both reported as `Suggestion` and out of this ticket's scope: `@vscode/test-electron` passes no `version` to `runTests`, so integration tests run on current stable and never exercise the 1.85 host — a pre-existing gap in runtime floor coverage, not a conflict with the pin. And two agent workflows carry `Bash(npm install:*)`, which no dependabot rule binds; the practical guard there is that `npm install --package-lock-only` resolves an exact pin to itself.
