### PR TITLE
fix(visibility): fail closed when a declaration file cannot be read

### DIFF
--- a/changelog.d/391.fixed.md
+++ b/changelog.d/391.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: the quick fix that declares a module public now refuses when a project file cannot be read, instead of writing a change that could stop the project compiling.

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -24,6 +24,16 @@ interface ScannedFile {
 }
 
 /**
+ * A project file the scan listed but could not open.
+ *
+ * Not a file that declares nothing: a part written in ignorance of one it holds
+ * can disagree with it, which the compiler rejects.
+ */
+interface UnreadableFile {
+    unreadable: vscode.Uri;
+}
+
+/**
  * Applies the `<public>` declarations that make an internal module reachable.
  *
  * The whole project is scanned before anything is written, because a second
@@ -102,7 +112,12 @@ export class ModuleVisibilityWriter {
         // Every module on the path is looked up, the reachable prefix included:
         // the chain written into the definitions file has to nest through them,
         // and a part it writes must repeat whatever they already declare.
-        const { declarations, scanned } = await this.findDeclarations(workspaceFolder, [...prefix, ...segments.map((segment) => segment.name)], definitionsKey);
+        const scan = await this.findDeclarations(workspaceFolder, [...prefix, ...segments.map((segment) => segment.name)], definitionsKey);
+        if ("unreadable" in scan) {
+            return { reason: `'${vscode.workspace.asRelativePath(scan.unreadable, false)}' could not be read, so whether it declares part of '${request.moduleName}' is unknown.` };
+        }
+
+        const { declarations, scanned } = scan;
         const resolved = resolveVisibility(prefix, segments, declarations);
 
         if (resolved.conflicts.length > 0) {
@@ -148,7 +163,11 @@ export class ModuleVisibilityWriter {
         for (const specifierEdit of specifierEdits) {
             const file = scanned.get(specifierEdit.file);
             if (!file) {
-                continue;
+                // Every SpecifierEdit.file is a key findDeclarations put in
+                // `scanned`, so a miss means the two disagree about which files
+                // were read. Skipping the edit would half-apply the module.
+                logger.error("ModuleVisibilityWriter", `No scanned text for ${specifierEdit.file}`);
+                throw new Error(`ModuleVisibilityWriter: no scanned text for ${specifierEdit.file}`);
             }
 
             const { start, end } = specifierEdit.span;
@@ -200,6 +219,9 @@ export class ModuleVisibilityWriter {
      * The definitions file's text, "" when it does not exist, or undefined when
      * it exists but could not be read - which must not be treated as empty,
      * since that would discard whatever it holds.
+     *
+     * The undefined is now rare rather than gone: where findFiles listed the
+     * file, findDeclarations opens it first and refuses there instead.
      */
     private async readDefinitions(uri: vscode.Uri): Promise<string | undefined> {
         try {
@@ -217,14 +239,17 @@ export class ModuleVisibilityWriter {
 
     /**
      * Every explicit declaration of any of these module names in the project,
-     * bound to its Content-relative path, with the text each was read from.
+     * bound to its Content-relative path, with the text each was read from, or
+     * the first file the scan could not open.
      *
      * The whole project is read rather than a capped sample: a declaration
      * missed here becomes a second, possibly conflicting part written into the
      * definitions file, which is a compile error rather than a worse
-     * suggestion. Text comes from openTextDocument, as ProjectPathScanner's
-     * does, so an offset addresses the buffer the edit will be applied to
-     * rather than what is currently on disk.
+     * suggestion. The scan is therefore all-or-nothing: a file it cannot open
+     * stops it, and the caller must fail closed on that rather than proceed on
+     * a partial answer. Text comes from openTextDocument, as
+     * ProjectPathScanner's does, so an offset addresses the buffer the edit will
+     * be applied to rather than what is currently on disk.
      *
      * @param definitionsKey the definitions file, whose text is kept even when
      * it declares none of these modules, because the caller appends to it. A
@@ -235,7 +260,7 @@ export class ModuleVisibilityWriter {
         workspaceFolder: vscode.WorkspaceFolder,
         names: readonly string[],
         definitionsKey: string,
-    ): Promise<{ declarations: FoundDeclaration[]; scanned: Map<string, ScannedFile> }> {
+    ): Promise<{ declarations: FoundDeclaration[]; scanned: Map<string, ScannedFile> } | UnreadableFile> {
         const workspaceIsContent = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER;
         const searchPattern = workspaceIsContent ? "**/*.verse" : `${CONTENT_FOLDER}/**/*.verse`;
         const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, searchPattern), "**/*.digest.verse");
@@ -249,6 +274,12 @@ export class ModuleVisibilityWriter {
                 if (!result) {
                     continue;
                 }
+                if ("unreadable" in result) {
+                    // The caller refuses on this, and reports it, so the rest
+                    // of the scan has nothing left to answer.
+                    logger.debug("ModuleVisibilityWriter", `Stopped the scan at unreadable file ${result.unreadable.toString()}`);
+                    return result;
+                }
                 const key = result.file.uri.toString();
                 if (result.declarations.length > 0 || key === definitionsKey) {
                     scanned.set(key, result.file);
@@ -261,13 +292,21 @@ export class ModuleVisibilityWriter {
         return { declarations, scanned };
     }
 
-    /** The wanted declarations in one file, or null when it holds none, cannot be read, or sits outside Content. */
+    /**
+     * The wanted declarations in one file, null when it holds none or sits
+     * outside Content, or the file itself when it could not be opened.
+     *
+     * The last is not one of the nulls: those two files declare nothing, where
+     * an unopened one is unknown. The outside-Content test runs first and
+     * deliberately - a file there is skipped without ever being opened, so an
+     * unreadable one cannot refuse the request.
+     */
     private async readDeclarations(
         uri: vscode.Uri,
         workspaceFolder: vscode.WorkspaceFolder,
         workspaceIsContent: boolean,
         wanted: ReadonlySet<string>,
-    ): Promise<{ file: ScannedFile; declarations: FoundDeclaration[] } | null> {
+    ): Promise<{ file: ScannedFile; declarations: FoundDeclaration[] } | UnreadableFile | null> {
         const directory = this.contentRelativeDirectory(uri, workspaceFolder, workspaceIsContent);
         if (directory === null) {
             return null;
@@ -277,7 +316,10 @@ export class ModuleVisibilityWriter {
             (document) => document.getText(),
             () => null,
         );
-        if (text === null || !text.includes("module")) {
+        if (text === null) {
+            return { unreadable: uri };
+        }
+        if (!text.includes("module")) {
             return null;
         }
 

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -17,7 +17,7 @@ const REQUEST = {
  * Text is served through openTextDocument, which is where production reads it,
  * so an offset a test asserts on addresses the same string the writer parsed.
  */
-const givenProject = (files: Record<string, string>, root = ROOT): void => {
+const givenProject = (files: Record<string, string>, root = ROOT): vscode.Uri[] => {
     (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file(root), name: root.split("/").pop(), index: 0 }];
 
     const uris = Object.keys(files).map((relative) => vscode.Uri.file(`${root}/${relative}`));
@@ -34,6 +34,18 @@ const givenProject = (files: Record<string, string>, root = ROOT): void => {
         const content = byUri.get(uri.toString());
         return content === undefined ? Promise.reject(new Error("ENOENT")) : Promise.resolve({ getText: () => content });
     });
+
+    return uris;
+};
+
+/**
+ * Adds a file the scan lists but cannot open, as one deleted between findFiles
+ * and the read behaves. Call after givenProject, whose URIs it extends.
+ */
+const alsoListsUnreadable = (listed: readonly vscode.Uri[], relative: string): vscode.Uri => {
+    const uri = vscode.Uri.file(`${ROOT}/${relative}`);
+    (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([...listed, uri]);
+    return uri;
 };
 
 const writer = (): ModuleVisibilityWriter => {
@@ -265,6 +277,43 @@ describe("ModuleVisibilityWriter", () => {
         await writer().makeModulePublic(REQUEST);
 
         expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("could not write"));
+    });
+
+    it("refuses when a project file the scan listed cannot be read", async () => {
+        const listed = givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+        alsoListsUnreadable(listed, "Content/Gadgets/hidden.verse");
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        // A success notification here would report a half-written module as
+        // done, so its absence is half of what the refusal is worth.
+        expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("Content/Gadgets/hidden.verse"));
+    });
+
+    it("refuses even where the files it could read already answer the request", async () => {
+        // Completeness of the scan gates the write, not its result: the file
+        // that could not be read may hold a part of Tools that rewriting this
+        // one would contradict.
+        const listed = givenProject({ "Content/Gadgets/tools.verse": "Tools := module:\n    X:int = 1\n" });
+        alsoListsUnreadable(listed, "Content/Gadgets/more-tools.verse");
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+    });
+
+    it("proceeds when the file it could not read sits outside Content", async () => {
+        // The outside-Content test has to stay ahead of the open: a file there
+        // declares nothing the request can contradict, and refusing on one
+        // would stop every project that keeps .verse files outside Content.
+        const listed = givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+        alsoListsUnreadable(listed, "Plugins/other.verse");
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(appliedOperations()[0]).toMatchObject({ kind: "createFile" });
     });
 
     it("resolves paths without the Content prefix when the workspace is Content itself", async () => {


### PR DESCRIPTION
Closes #391

## What changed

`ModuleVisibilityWriter`'s project scan returned the same `null` for three unrelated things: a file outside Content, a file holding no `module`, and a file `findFiles` listed but `openTextDocument` could not open. The first two declare nothing. The third is *unknown*, and treating it as the first two let a request proceed on a partial scan and write a module part that disagrees with a hidden one.

- `readDeclarations` returns the file itself when the open fails, instead of folding that into the `null` it returns for the two legitimate skips. The outside-Content test deliberately stays ahead of the open, so a file there is still skipped without being read.
- `findDeclarations` stops the scan at the first unopened file and returns it. Its return type is now a union, so destructuring `{ declarations, scanned }` without checking is a compile error rather than a policy a future caller can forget.
- `buildEdit` refuses the whole request, naming the file, matching the policy `readDefinitions` already held twenty lines away.
- The skip in `addSpecifierEdits` — unreachable, but encoding the same fail-open rule a third time — becomes an invariant failure.

Both the pre-change fail-open paths are now pinned by tests: writing a `<public>` chain into the definitions file, and rewriting a visible part `<public>`, each while a sibling file went unread.

## Why a refusal is the right answer

A hidden part whose specifier disagrees with the one being written does not degrade the suggestion — it stops the project compiling, in both states of `treatModulesAsImplicit`. Verified against the compiler source rather than taken from the issue:

- `SemanticAnalyzer.cpp:4536` compares `Module->SelfAccessLevel() != AccessLevel` in the later-part lambda and appends `ErrSemantic_MismatchedPartialAttributes` against both definitions at `4538-4540`; `Glitch.h:228` defines that as 3623.
- With the flag unset in a `PublicUser` package, `SemanticAnalyzer.cpp:4438-4447` glitches `ErrSemantic_AmbiguousDefinition` (3532, `Glitch.h:138`) and returns at `4443-4446` before the attribute compare is ever attached.
- `PartialModuleDefinitions.versetest` pins `A<internal>` + `A<public>` as `assert_semantic_error(3623,3623)`, with `<public>`/`<public>` and `<internal>`/`<internal>` both `assert_valid`.
- A hidden *bare* part stays out of scope: `SemanticAnalyzer.cpp:9292-9296` returns before enqueueing the compare when the attribute list is empty.

## Verification

```
> npm run compile
> tsc -p ./
(no output, exit 0)
```

```
> npm test
> jest --verbose

Test Suites: 42 passed, 42 total
Tests:       1079 passed, 1079 total
Snapshots:   0 total
Time:        9.274 s
Ran all test suites.
```

```
> npm run format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Each new test was run against the unfixed code and observed to fail. The two refusal tests reproduced the reported symptom exactly — `createFile` + `insert` of a `<public>` chain, and an `insert` of `<public>` into a visible part, both while a file went unread. The boundary test was checked by moving the open above the outside-Content guard, which it caught.

## Review

One round, fresh-context reviewer, `PASS_WITH_SUGGESTIONS`, no Critical. It traced the `addSpecifierEdits` guard's unreachability independently and confirmed it, and probed eleven permutations including the workspace-is-Content shape, an unreadable definitions file, batching past `SCAN_CONCURRENCY`, and Windows-style paths. Its two Important findings — a missing changelog fragment, and that nothing pinned the outside-Content non-refusal — are both fixed here; the outside-Content pin is the higher-value of the three tests, since that ordering became load-bearing with this change.
