### PR TITLE
fix(imports): keep the digest group above the relative locals under localFirst

### DIFF
--- a/changelog.d/400.fixed.md
+++ b/changelog.d/400.fixed.md
@@ -1,0 +1,1 @@
+**Import grouping**: `localFirst` no longer writes a digest import below a relative import that resolves through it, which produced a file that would not compile.

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
             "localFirst"
           ],
           "default": "none",
-          "description": "Controls grouping of digest imports (/Verse.org, /Fortnite.com, /UnrealEngine.com) vs local imports. 'none' disables grouping, 'digestFirst' places digest imports before local, 'localFirst' places local imports before digest.",
+          "description": "Controls grouping of digest imports (/Verse.org, /Fortnite.com, /UnrealEngine.com) vs local imports. 'none' disables grouping, 'digestFirst' places digest imports before local, 'localFirst' places local imports before digest except where a local import uses a relative path, which Verse requires to stay below the imports it may resolve through.",
           "order": 13
         },
         "verseAutoImports.behavior.emptyLinesAfterImports": {

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -513,9 +513,10 @@ export class ImportDocumentEditor {
      * pushed it below. A pinned line cannot be moved or grouped, so nothing
      * chose that order; the grouping strategy is the user choosing this one.
      *
-     * Within one block no strategy carries an absolute import below a relative
-     * one (ImportFormatter.groupAndFormatImports). This guard is what the block
-     * that function cannot see still needs.
+     * Within one block localFirst no longer carries a digest import below a
+     * relative one (ImportFormatter.groupAndFormatImports), which leaves this
+     * guard the block that function cannot see. Only that pairing: a strategy
+     * preserving written order still emits whatever order the file had.
      */
     private blockKeepsRelativeOrder(importBlocks: ImportBlock[], blockIndex: number, path: string): boolean {
         if (!this.formatter.resolvesAgainstScopeAbove(path)) {
@@ -711,7 +712,8 @@ export class ImportDocumentEditor {
 
             if (hasGrouping && importBlocks.length >= 2) {
                 let digestBlockIndex = -1;
-                let localBlockIndex = -1;
+                let firstLocalBlockIndex = -1;
+                let lastLocalBlockIndex = -1;
 
                 importBlocks.forEach((block, index) => {
                     const blockPaths = block.imports.map((imp) => imp.path);
@@ -724,18 +726,31 @@ export class ImportDocumentEditor {
                     if (hasDigest && !hasLocal) {
                         digestBlockIndex = index;
                     } else if (hasLocal && !hasDigest) {
-                        localBlockIndex = index;
+                        firstLocalBlockIndex = firstLocalBlockIndex === -1 ? index : firstLocalBlockIndex;
+                        lastLocalBlockIndex = index;
                     }
                 });
 
+                // localFirst writes the local imports as two groups either side
+                // of the digest one (ImportFormatter.groupAndFormatImports), so
+                // a file it organized offers two local blocks rather than one.
+                // Which of them a new local path belongs in is the question
+                // selectTargetBlockIndex already answers: an absolute path
+                // needs nothing in scope and goes in the first, a relative one
+                // may resolve through anything above it and goes in the last.
+                // The two indices coincide under every other strategy, which
+                // leaves one local block and the same answer either way.
                 const newDigestPaths: string[] = [];
-                const newLocalPaths: string[] = [];
+                const newLocalAbsolutePaths: string[] = [];
+                const newLocalRelativePaths: string[] = [];
 
                 for (const path of newImportPaths) {
                     if (this.formatter.isDigestImport(path)) {
                         newDigestPaths.push(path);
+                    } else if (this.formatter.resolvesAgainstScopeAbove(path)) {
+                        newLocalRelativePaths.push(path);
                     } else {
-                        newLocalPaths.push(path);
+                        newLocalAbsolutePaths.push(path);
                     }
                 }
 
@@ -765,21 +780,32 @@ export class ImportDocumentEditor {
                     return { taken, unhandled };
                 };
 
-                const digest = splitForBlock(digestBlockIndex, newDigestPaths);
-                const local = splitForBlock(localBlockIndex, newLocalPaths);
+                // Collected per block before any edit is made, because the two
+                // local routes reach the same block under every strategy but
+                // localFirst. Rewriting that block once per route would leave
+                // two replacements over the same lines, and the second would
+                // drop what the first added.
+                const takenByBlock = new Map<number, string[]>();
+                const unhandledPaths: string[] = [];
 
-                if (digest.taken.length > 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[digestBlockIndex], digest.taken, preferDotSyntax, sortAlphabetically, eol);
+                for (const [blockIndex, paths] of [
+                    [digestBlockIndex, newDigestPaths],
+                    [firstLocalBlockIndex, newLocalAbsolutePaths],
+                    [lastLocalBlockIndex, newLocalRelativePaths],
+                ] as Array<[number, string[]]>) {
+                    const { taken, unhandled } = splitForBlock(blockIndex, paths);
+                    if (taken.length > 0) {
+                        takenByBlock.set(blockIndex, [...(takenByBlock.get(blockIndex) ?? []), ...taken]);
+                    }
+                    // Imports no block took: one with no matching block, and
+                    // one its matching block cannot hold - because a pinned
+                    // import keeps it out, or a relative import below it does.
+                    unhandledPaths.push(...unhandled);
                 }
 
-                if (local.taken.length > 0) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[localBlockIndex], local.taken, preferDotSyntax, sortAlphabetically, eol);
+                for (const blockIndex of [...takenByBlock.keys()].sort((a, b) => a - b)) {
+                    this.createBlockReplacementEdit(edit, document, importBlocks[blockIndex], takenByBlock.get(blockIndex)!, preferDotSyntax, sortAlphabetically, eol);
                 }
-
-                // Imports no block took: one with no matching block, and one
-                // its matching block cannot hold - because a pinned import
-                // keeps it out, or because a relative import below it does.
-                const unhandledPaths = [...digest.unhandled, ...local.unhandled];
 
                 if (unhandledPaths.length > 0) {
                     const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -503,16 +503,19 @@ export class ImportDocumentEditor {
      * compiles is the worse of the two.
      *
      * Only the relative imports below count, and an absolute one below is
-     * knowingly let through. A grouped file writes one group above the other by
-     * definition, so under localFirst every digest import sits below the local
-     * group: reading an absolute import as a possible provider would refuse
-     * that group to every relative path and leave the strategy with nothing to
-     * do. The residual is real, and is not the same judgement pinnedBounds
-     * makes - a relative path can still land above an absolute import in a
-     * later block that could be bringing its first segment into scope, where a
-     * pinned absolute import of the same shape would have pushed it below.
-     * A pinned line cannot be moved or grouped, so nothing chose that order;
-     * the grouping strategy is the user choosing this one.
+     * knowingly let through. Refusing a block for an absolute import below it
+     * would refuse every block to every relative path, since a grouped file
+     * writes one group above another and an absolute import ends up below some
+     * relative one either way. The residual is real, and is not the same
+     * judgement pinnedBounds makes - a relative path can still land above an
+     * absolute import in a later block that could be bringing its first segment
+     * into scope, where a pinned absolute import of the same shape would have
+     * pushed it below. A pinned line cannot be moved or grouped, so nothing
+     * chose that order; the grouping strategy is the user choosing this one.
+     *
+     * Within one block no strategy carries an absolute import below a relative
+     * one (ImportFormatter.groupAndFormatImports). This guard is what the block
+     * that function cannot see still needs.
      */
     private blockKeepsRelativeOrder(importBlocks: ImportBlock[], blockIndex: number, path: string): boolean {
         if (!this.formatter.resolvesAgainstScopeAbove(path)) {

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -365,7 +365,20 @@ export class ImportFormatter {
 
     /**
      * The formatted `using` statements for a set of paths, with an empty string
-     * between the two groups when a grouping strategy puts imports in both.
+     * between each pair of groups a grouping strategy puts imports in.
+     *
+     * `localFirst` writes three groups rather than two once the paths include a
+     * digest import: the local absolute paths, then the digest ones, then the
+     * local relative paths. A relative path resolves its first segment against
+     * what the `using` statements above it brought into scope
+     * (resolvesAgainstScopeAbove), so a digest import written below one that
+     * resolves through it stops the file compiling. The preference is honoured
+     * wherever it is free - an absolute path needs nothing above it, so the
+     * local absolutes stay on top - and yields only where the compiler forbids
+     * it.
+     *
+     * `digestFirst` needs no such split: it already writes every absolute path
+     * above every relative one.
      *
      * @param sortAlphabetically Enables the rank sort, which is not alphabetical
      *   order - see sortImportsByRank for why plain alphabetical order breaks
@@ -398,18 +411,34 @@ export class ImportFormatter {
             localImports = this.sortImportsByRank(localImports);
         }
 
-        const formattedDigestImports = digestImports.map((path) => this.formatImportStatement(path, preferDotSyntax));
-        const formattedLocalImports = localImports.map((path) => this.formatImportStatement(path, preferDotSyntax));
+        const format = (paths: string[]): string[] => paths.map((path) => this.formatImportStatement(path, preferDotSyntax));
 
-        // Only the two grouped strategies reach here, so the pair covers both.
-        const [firstGroup, secondGroup] = importGrouping === "digestFirst" ? [formattedDigestImports, formattedLocalImports] : [formattedLocalImports, formattedDigestImports];
-
-        const formattedImports: string[] = [...firstGroup];
-        if (firstGroup.length > 0 && secondGroup.length > 0) {
-            formattedImports.push("");
+        if (importGrouping === "digestFirst") {
+            return this.joinGroups([format(digestImports), format(localImports)]);
         }
-        formattedImports.push(...secondGroup);
 
-        return formattedImports;
+        // With nothing to write between them the local imports stay one group:
+        // splitting them by rank would separate imports the strategy never had
+        // a reason to move apart.
+        if (digestImports.length === 0) {
+            return format(localImports);
+        }
+
+        return this.joinGroups([
+            format(localImports.filter((path) => !this.resolvesAgainstScopeAbove(path))),
+            format(digestImports),
+            format(localImports.filter((path) => this.resolvesAgainstScopeAbove(path))),
+        ]);
+    }
+
+    /**
+     * The groups run together with one empty string between each adjacent pair.
+     *
+     * An empty group contributes no separator of its own, so a strategy whose
+     * groups do not all have imports writes one blank line between the ones that
+     * do, rather than opening or closing the run with a stray blank line.
+     */
+    private joinGroups(groups: string[][]): string[] {
+        return groups.filter((group) => group.length > 0).reduce<string[]>((result, group) => (result.length === 0 ? [...group] : [...result, "", ...group]), []);
     }
 }

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -377,8 +377,9 @@ export class ImportFormatter {
      * local absolutes stay on top - and yields only where the compiler forbids
      * it.
      *
-     * `digestFirst` needs no such split: it already writes every absolute path
-     * above every relative one.
+     * `digestFirst` needs no such split: the only imports it moves are the
+     * digest ones, and it moves them up. Whatever order the local imports were
+     * written in survives, so nothing it does crosses a provider.
      *
      * @param sortAlphabetically Enables the rank sort, which is not alphabetical
      *   order - see sortImportsByRank for why plain alphabetical order breaks
@@ -417,18 +418,26 @@ export class ImportFormatter {
             return this.joinGroups([format(digestImports), format(localImports)]);
         }
 
-        // With nothing to write between them the local imports stay one group:
-        // splitting them by rank would separate imports the strategy never had
-        // a reason to move apart.
+        // With no digest group to write between them the local imports stay one
+        // group: splitting them would separate imports nothing needs apart, and
+        // with the sort off it would reorder what the author wrote. Where there
+        // is a digest group the split happens whatever the sort setting says,
+        // since crossing that group is what stops the file compiling.
         if (digestImports.length === 0) {
             return format(localImports);
         }
 
-        return this.joinGroups([
-            format(localImports.filter((path) => !this.resolvesAgainstScopeAbove(path))),
-            format(digestImports),
-            format(localImports.filter((path) => this.resolvesAgainstScopeAbove(path))),
-        ]);
+        // Partitioned in one pass rather than filtered twice, so the two groups
+        // are complements by construction: predicates that have to stay each
+        // other's negation put a path in both, or in neither, once one is
+        // edited alone.
+        const localAbsolute: string[] = [];
+        const localRelative: string[] = [];
+        for (const path of localImports) {
+            (this.resolvesAgainstScopeAbove(path) ? localRelative : localAbsolute).push(path);
+        }
+
+        return this.joinGroups([format(localAbsolute), format(digestImports), format(localRelative)]);
     }
 
     /**

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1169,6 +1169,28 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(insertsAtTop).toHaveLength(0);
     });
 
+    // Regrouping an ungrouped block writes the whole block, so localFirst gets
+    // to move the digest import there. Below a relative import that may resolve
+    // through it, the file stops compiling.
+    it("preserve + localFirst: regrouping a block keeps the digest import above the relative ones", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "localFirst",
+        });
+        const header = ["# Header comment line 1", "# Header comment line 2", ""];
+        const input = [...header, "using { /Verse.org/Simulation }", "using { Economy.Shop }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+
+        const replace = operations.find((op) => op.kind === "replace");
+        expect(replace).toBeDefined();
+        expect(replace!.text.indexOf("/Verse.org/Simulation")).toBeLessThan(replace!.text.indexOf("Economy.Shop"));
+        expect(replace!.text.indexOf("/Verse.org/Simulation")).toBeLessThan(replace!.text.indexOf("Features"));
+    });
+
     it("preserve + digestFirst: a new bare local import lands after the dotted local import already in its block", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1191,6 +1191,32 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(replace!.text.indexOf("/Verse.org/Simulation")).toBeLessThan(replace!.text.indexOf("Features"));
     });
 
+    // A file localFirst organized has two local blocks, one either side of the
+    // digest one. A new absolute local import belongs in the upper one: sending
+    // every local path to the last local block would put it below the digest
+    // group the strategy exists to hoist it above.
+    it("preserve + localFirst: a new absolute local import joins the block above the digest group, a relative one the block below", async () => {
+        mockConfig({
+            "behavior.preserveImportLocations": true,
+            "behavior.importGrouping": "localFirst",
+        });
+        const input = ["using { /mygame@fortnite.com/mygame/Utils }", "", "using { /Verse.org/Simulation }", "", "using { Economy.Shop }", "", "hello := 1"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /mygame@fortnite.com/mygame/Combat }", "using { Features }"]);
+
+        expect(success).toBe(true);
+        const replaces = appliedOperations(0).filter((op) => op.kind === "replace");
+
+        const upper = replaces.find((op) => op.range!.start.line === 0);
+        expect(upper).toBeDefined();
+        expect(upper!.text).toContain("/mygame@fortnite.com/mygame/Combat");
+
+        const lower = replaces.find((op) => op.range!.start.line === 4);
+        expect(lower).toBeDefined();
+        expect(lower!.text).toContain("Features");
+        expect(lower!.text).not.toContain("Combat");
+    });
+
     it("preserve + digestFirst: a new bare local import lands after the dotted local import already in its block", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -298,9 +298,33 @@ describe("ImportFormatter.groupAndFormatImports", () => {
         expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Zeta }", "using { Economy.Shop }"]);
     });
 
-    it("localFirst with sorting: local group precedes the digest group", () => {
-        const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Economy.Shop", "Features"], false, true, "localFirst");
-        expect(result).toEqual(["using { Economy.Shop }", "using { Features }", "", "using { /Verse.org/Simulation }"]);
+    it("localFirst with sorting: the local absolute group precedes the digest group", () => {
+        const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "/mygame@fortnite.com/mygame/Utils", "/mygame@fortnite.com/mygame/Combat"], false, true, "localFirst");
+        expect(result).toEqual(["using { /mygame@fortnite.com/mygame/Combat }", "using { /mygame@fortnite.com/mygame/Utils }", "", "using { /Verse.org/Simulation }"]);
+    });
+
+    // A relative path resolves its first segment against what the `using`
+    // statements above it brought into scope, so a digest import written below
+    // one that resolves through it stops the file compiling. localFirst yields
+    // for the relative imports and keeps the preference for the absolute ones.
+    it("localFirst: the relative local imports go below the digest group, the absolute ones stay above it", () => {
+        const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Economy.Shop", "/mygame@fortnite.com/mygame/Utils", "Features"], false, true, "localFirst");
+        expect(result).toEqual(["using { /mygame@fortnite.com/mygame/Utils }", "", "using { /Verse.org/Simulation }", "", "using { Economy.Shop }", "using { Features }"]);
+    });
+
+    it("localFirst without sorting: the relative locals keep their written order below the digest group", () => {
+        const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Features", "Economy.Shop"], false, false, "localFirst");
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Features }", "using { Economy.Shop }"]);
+    });
+
+    it("localFirst with no absolute local import opens no blank line above the digest group", () => {
+        const result = formatter.groupAndFormatImports(["/Verse.org/Simulation", "Economy.Shop"], false, true, "localFirst");
+        expect(result).toEqual(["using { /Verse.org/Simulation }", "", "using { Economy.Shop }"]);
+    });
+
+    it("localFirst with no digest import writes one group and no blank line", () => {
+        const result = formatter.groupAndFormatImports(["/mygame@fortnite.com/mygame/Utils", "Economy.Shop"], false, true, "localFirst");
+        expect(result).toEqual(["using { /mygame@fortnite.com/mygame/Utils }", "using { Economy.Shop }"]);
     });
 
     // An out-of-enum value reaches here from a hand-edited settings.json, a case

--- a/src/test-integration/suite/importStyles.itest.ts
+++ b/src/test-integration/suite/importStyles.itest.ts
@@ -52,20 +52,22 @@ describe("import styles matrix (playbook T6)", () => {
         assert.ok(!/^using\./m.test(text), "dot form must be gone after flipping back");
     });
 
-    it("importGrouping digestFirst puts digest imports before local ones; localFirst reverses", async () => {
-        await settings.set("behavior.importGrouping", "digestFirst");
-        let text = await runOptimizeImports(document);
-        let digestIndex = importLineIndex(text, "/Fortnite.com/Devices");
-        let localIndex = importLineIndex(text, "Gadgets.Tools");
-        assert.ok(digestIndex !== -1 && localIndex !== -1, `imports missing after optimize:\n${text}`);
-        assert.ok(digestIndex < localIndex, `digestFirst violated:\n${text}`);
-
-        await settings.set("behavior.importGrouping", "localFirst");
-        text = await runOptimizeImports(document);
-        digestIndex = importLineIndex(text, "/Fortnite.com/Devices");
-        localIndex = importLineIndex(text, "Gadgets.Tools");
-        assert.ok(digestIndex !== -1 && localIndex !== -1, `imports missing after optimize:\n${text}`);
-        assert.ok(localIndex < digestIndex, `localFirst violated:\n${text}`);
+    // `Gadgets.Tools` is the fixture's only local import and it is relative, so
+    // localFirst may not hoist it: a relative path resolves its first segment
+    // against what the `using` statements above it brought into scope, and a
+    // digest import moved below it can be the one bringing that segment. Both
+    // strategies therefore write the same order here, and the unit tests in
+    // ImportFormatter.test.ts cover the local absolute path localFirst does
+    // hoist.
+    it("importGrouping digestFirst puts digest imports before local ones; localFirst leaves a relative local below them", async () => {
+        for (const grouping of ["digestFirst", "localFirst"]) {
+            await settings.set("behavior.importGrouping", grouping);
+            const text = await runOptimizeImports(document);
+            const digestIndex = importLineIndex(text, "/Fortnite.com/Devices");
+            const localIndex = importLineIndex(text, "Gadgets.Tools");
+            assert.ok(digestIndex !== -1 && localIndex !== -1, `imports missing after optimize:\n${text}`);
+            assert.ok(digestIndex < localIndex, `${grouping} violated:\n${text}`);
+        }
 
         await settings.set("behavior.importGrouping", "none");
     });

--- a/test-fixtures/uefn-smoke/PLAYBOOK.md
+++ b/test-fixtures/uefn-smoke/PLAYBOOK.md
@@ -144,7 +144,10 @@ live digest emits `<scoped {...}>` specifiers and instance declarations).
 1. [ ] importSyntax curly -> dot: optimize rewrites the block to `using.`
        style; flip back and it returns (idempotent on repeat runs).
 2. [ ] importGrouping digestFirst: digest imports first, blank line, then
-       `Gadgets.Tools`. localFirst reverses. none keeps flat.
+       `Gadgets.Tools`. localFirst matches it here -- `Gadgets.Tools` is a
+       relative path, which stays below the imports it may resolve through,
+       and the fixture has no absolute local import for localFirst to hoist.
+       none keeps flat.
 3. [ ] sortImportsAlphabetically respected within groups.
 4. [ ] behavior.emptyLinesAfterImports honored after each optimize.
 


### PR DESCRIPTION
Closes #400

## What

`groupAndFormatImports` inverted the two groups unconditionally under `localFirst`, so a digest import could be written below a relative import that resolves its first segment through it. That file no longer compiles.

`localFirst` now writes three groups once digest imports are present: the local absolute paths, the digest ones, then the local relative paths. An absolute path needs nothing above it, so the preference still applies to the local absolutes and yields only where the compiler forbids it. `digestFirst` and `none` are unchanged, as is `localFirst` for a set with no digest import.

## Why this shape

The ticket's literal "smallest fix" — refuse the inversion outright — was weighed against the deliberate decision already recorded at `ImportDocumentEditor.blockKeepsRelativeOrder`, which rejected exactly that guard because it "would refuse that group to every relative path and leave the strategy with nothing to do". In UEFN most project modules are referenced by bare or dotted names, so a blanket guard makes `localFirst` inert. Splitting the local group by rank is correct in every case and keeps the preference wherever the compiler allows it. The maintainer chose this reading.

## The rule, from the compiler source

- Ordinary identifier resolution walks a scope's `using` set position-free — `SemanticScope.cpp:522-543`. Most reordering is therefore safe.
- A `using` whose own context is a relative reference is the exception: each `using`'s context analysis is deferred into a source-order queue that calls `AddUsingScope` as it runs — `SemanticAnalyzer.cpp:6531`, `:6591`. So an absolute import must precede any relative import resolving through it.
- An absolute path resolves via `ResolvePathToModule` off the path literal rather than by scope lookup — `SemanticAnalyzer.cpp:6559`. Nothing has to precede it, which is what makes hoisting the local absolutes free.

## Second commit

The review gate found that the three-group layout leaves two local blocks where `ImportDocumentEditor`'s block classifier knew only one, so under `preserveImportLocations` every new local path went to the last of them — an absolute local import added to an organized file landed below the digest group. It now routes by rank, which is the rule `selectTargetBlockIndex` already documents: an absolute path to the first local block, a relative one to the last. Compile-safe either way, but the strategy was no longer honouring its own preference.

The same commit corrects the `behavior.importGrouping` setting description, smoke playbook step T6.2, and two comment claims the new layout made false.

## Tests

Four of the added tests fail against the unfixed code, the `ImportDocumentEditor` entry-point one among them. Verified by reverting `ImportFormatter.ts`, running the suite, and restoring it. The block-routing test fails against the first commit alone, verified the same way.

The `localFirst` assertion in `importStyles.itest.ts` was rewritten: its fixture's only local import is `Gadgets.Tools`, which is relative, so `localFirst` must now leave it below the digest group. The local absolute path that `localFirst` does hoist is covered by the unit tests instead.

## Verification

```
$ npm run compile

> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

```
$ npm test

> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 42 passed, 42 total
Tests:       1082 passed, 1082 total
Snapshots:   0 total
Time:        10.847 s
Ran all test suites.
```

```
$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```
