### PR TITLE
fix(services): span nested parentheses in digest type-parameter heads

### DIFF
--- a/changelog.d/372.fixed.md
+++ b/changelog.d/372.fixed.md
@@ -1,0 +1,1 @@
+**Digest lookup**: identifiers that exist only as members of a parametric type, such as `Name` or `AddMember`, no longer resolve to a bundled module, so the experimental digest files stop inserting imports that do not fix the error.

--- a/src/data/Fortnite.digest.json
+++ b/src/data/Fortnite.digest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-07T14:31:23.562Z",
+  "generatedAt": "2026-08-14T12:40:55.229Z",
   "sourceFile": "Fortnite.digest.verse",
   "sourceBuild": "++Fortnite+Release-41.30-CL-56430492",
   "entries": {

--- a/src/data/UnrealEngine.digest.json
+++ b/src/data/UnrealEngine.digest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-07T14:31:23.568Z",
+  "generatedAt": "2026-08-14T12:40:55.268Z",
   "sourceFile": "UnrealEngine.digest.verse",
   "sourceBuild": "++Fortnite+Release-41.30-CL-56430492",
   "entries": {

--- a/src/data/Verse.digest.json
+++ b/src/data/Verse.digest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-07T14:31:23.586Z",
+  "generatedAt": "2026-08-14T12:40:55.458Z",
   "sourceFile": "Verse.digest.verse",
   "sourceBuild": "++Fortnite+Release-41.30-CL-56430492",
   "entries": {
@@ -13,19 +13,7 @@
     "chat_channel": {
       "identifier": "chat_channel",
       "modulePath": "/Verse.org/Chat",
-      "type": "function",
-      "isPublic": true
-    },
-    "Name": {
-      "identifier": "Name",
-      "modulePath": "/Verse.org/Chat",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Group": {
-      "identifier": "Group",
-      "modulePath": "/Verse.org/Chat",
-      "type": "variable",
+      "type": "class",
       "isPublic": true
     },
     "has_voice_member_info": {
@@ -37,7 +25,7 @@
     "voice_channel": {
       "identifier": "voice_channel",
       "modulePath": "/Verse.org/Chat",
-      "type": "function",
+      "type": "class",
       "isPublic": true
     },
     "add_channel_error": {
@@ -1015,49 +1003,13 @@
     "agent_group_interface": {
       "identifier": "agent_group_interface",
       "modulePath": "/Verse.org/AgentGroup",
-      "type": "function",
-      "isPublic": true
-    },
-    "GetMemberMap": {
-      "identifier": "GetMemberMap",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "function",
-      "isPublic": true
-    },
-    "AddMemberEvent": {
-      "identifier": "AddMemberEvent",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "variable",
-      "isPublic": true
-    },
-    "RemoveMemberEvent": {
-      "identifier": "RemoveMemberEvent",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MemberInfoChangeEvent": {
-      "identifier": "MemberInfoChangeEvent",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "variable",
+      "type": "class",
       "isPublic": true
     },
     "agent_group": {
       "identifier": "agent_group",
       "modulePath": "/Verse.org/AgentGroup",
-      "type": "function",
-      "isPublic": true
-    },
-    "AddMember": {
-      "identifier": "AddMember",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "function",
-      "isPublic": true
-    },
-    "RemoveMember": {
-      "identifier": "RemoveMember",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "function",
+      "type": "class",
       "isPublic": true
     },
     "add_member_error": {
@@ -2823,8 +2775,6 @@
     "/Verse.org/Chat": [
       "Chat",
       "chat_channel",
-      "Name",
-      "Group",
       "has_voice_member_info",
       "voice_channel",
       "add_channel_error",
@@ -3010,13 +2960,7 @@
       "AgentGroup",
       "member_info_interface",
       "agent_group_interface",
-      "GetMemberMap",
-      "AddMemberEvent",
-      "RemoveMemberEvent",
-      "MemberInfoChangeEvent",
       "agent_group",
-      "AddMember",
-      "RemoveMember",
       "add_member_error",
       "remove_member_error"
     ],

--- a/src/services/__tests__/digestParsing.test.ts
+++ b/src/services/__tests__/digestParsing.test.ts
@@ -184,6 +184,49 @@ describe("parseDigestContent - declaration recognition", () => {
         expect(entries["Length"]).toBeUndefined();
     });
 
+    it("records a parametric type head whose parameter list nests parentheses", () => {
+        // A parameter constrained by `subtype(...)` closes a paren inside the
+        // parameter list, so a list matched as `([^)]*)` ends at the wrong `)`.
+        const digest = [
+            "AgentGroup<public> := module:",
+            "    agent_group<native><public>(member_info:subtype(member_info_interface)) := class<unique>(agent_group_interface(member_info)):",
+            "        AddMember<public>(Agent:agent, MemberInfo:member_info)<transacts>:result(void, add_member_error) = external {}",
+            "        AddMemberEvent<override><native><final>:listenable(tuple(agent, member_info)) = external {}",
+        ].join("\n");
+
+        const { entries, moduleIndex } = parseDigestContent(digest, "/Verse.org");
+
+        expect(entries["agent_group"]).toMatchObject({
+            modulePath: "/Verse.org/AgentGroup",
+            type: "class",
+            isPublic: true,
+        });
+        expect(entries["AddMember"]).toBeUndefined();
+        expect(entries["AddMemberEvent"]).toBeUndefined();
+        expect(moduleIndex["/Verse.org/AgentGroup"]).not.toContain("AddMember");
+    });
+
+    it("records a parametric type head whose parameter list nests parentheses more than one deep", () => {
+        // The nesting depth is a property of the digest Epic ships, not of the
+        // language, so the parameter list is walked rather than matched at a depth.
+        const digest = ["Verse<public> := module:", "    deep<public>(t:subtype(container(payload(inner)))) := interface:", "        Unwrap<public>()<transacts>:t = external {}"].join("\n");
+
+        const { entries } = parseDigestContent(digest, "/Verse.org");
+
+        expect(entries["deep"]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "class" });
+        expect(entries["Unwrap"]).toBeUndefined();
+    });
+
+    it("still reads a function whose parameter list nests parentheses as a function", () => {
+        // The balanced walk must not turn every nested-paren head into a type: only
+        // `:=` plus a declaration keyword after the list makes one.
+        const digest = ["Verse<public> := module:", "    MakeGroup<public>(Members:[]tuple(agent, int))<transacts>:agent_group = external {}"].join("\n");
+
+        const { entries } = parseDigestContent(digest, "/Verse.org");
+
+        expect(entries["MakeGroup"]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "function" });
+    });
+
     it("skips receiver-style extension methods", () => {
         const digest = ["Devices<public> := module:", "    (Target:agent).GetName<public>()<transacts>:string = external {}"].join("\n");
 

--- a/src/services/__tests__/digestSourceInvariants.test.ts
+++ b/src/services/__tests__/digestSourceInvariants.test.ts
@@ -1,0 +1,185 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parseDigestContent, rootDomainForDigestFile } from "../digestParsing";
+import { BUNDLED_DIGEST_NAMES, digestSourceFile } from "../digestManifest";
+
+/**
+ * Refresh-time invariant sweep over the bundled `.verse` digests.
+ *
+ * Every other digest test pins hand-picked identifiers, which is why the parser
+ * shipped four misparsed parametric heads and eight leaked members while its
+ * "records parametric types but not their members" test stayed green. These
+ * assertions instead hold for every declaration in every bundled digest, so a
+ * future Epic drop carrying a shape the parser does not handle fails here rather
+ * than reaching `src/data`.
+ *
+ * The walk below is deliberately a second, independent implementation. Deriving
+ * the expectation from the parser under test would only restate whatever the
+ * parser does, which is the failure mode this file exists to catch. It stays
+ * coarse on purpose: it reads any module-scope line as declaring its leading
+ * identifier, so it can only ever admit more names than the parser should, never
+ * fewer.
+ */
+
+const UTILS_DIR = path.resolve(__dirname, "..", "..", "utils");
+
+/** A scope qualifier prefix such as `(/Verse.org/Chat:)`, which precedes the declared name. */
+const QUALIFIER = /^\((\/[^()]*):\)/;
+
+/** The leading identifier of a declaration, with any specifier groups. */
+const LEADING_NAME = /^(\w+)((?:<[^>]+>)*)/;
+
+/** A type head with no type-parameter list: `name<...> := class(...):`. */
+const PLAIN_TYPE = /^\w+(?:<[^>]+>)*\s*:=\s*(module|class|struct|interface|enum)\b/;
+
+/** A parametric head's opening: the name, its specifiers, and the `(` of its parameter list. */
+const PARAM_HEAD = /^(\w+)((?:<[^>]+>)*)\(/;
+
+/** What must follow a parametric head's parameter list for it to be a type. */
+const PARAM_TAIL = /^\s*:=\s*(module|class|struct|interface|enum)\b/;
+
+interface ParametricHead {
+    name: string;
+    keyword: string;
+    line: number;
+}
+
+interface DigestWalk {
+    /** Identifiers declared on a line that no class/struct/interface/enum body encloses. */
+    moduleScopeNames: Set<string>;
+    /** Every parametric type head found at module scope. */
+    parametricHeads: ParametricHead[];
+}
+
+function indentWidth(rawLine: string): number {
+    let width = 0;
+    for (const character of rawLine) {
+        if (character === " ") {
+            width += 1;
+        } else if (character === "\t") {
+            width += 4;
+        } else {
+            break;
+        }
+    }
+    return width;
+}
+
+/**
+ * The keyword a parametric head declares, or null where the line does not open
+ * one. Walks the parameter list for its matching `)` so nesting of any depth is
+ * spanned, then requires `:=` and a declaration keyword after it.
+ */
+function parametricKeyword(work: string): string | null {
+    const head = work.match(PARAM_HEAD);
+    if (!head) {
+        return null;
+    }
+
+    let depth = 0;
+    let index = head[0].length - 1;
+    for (; index < work.length; index++) {
+        if (work[index] === "(") {
+            depth++;
+        } else if (work[index] === ")") {
+            depth--;
+            if (depth === 0) {
+                index++;
+                break;
+            }
+        }
+    }
+    if (depth !== 0) {
+        return null;
+    }
+
+    const tail = work.slice(index).match(PARAM_TAIL);
+    return tail ? tail[1] : null;
+}
+
+/**
+ * Walks one digest's raw text, tracking which lines a type body encloses. A type
+ * body is the lines indented past its head, so a line back at or inside the
+ * head's own indent closes it.
+ */
+function walkDigest(content: string): DigestWalk {
+    const moduleScopeNames = new Set<string>();
+    const parametricHeads: ParametricHead[] = [];
+    const typeBodyIndents: number[] = [];
+
+    let lineNumber = 0;
+    for (const rawLine of content.split("\n")) {
+        lineNumber++;
+        const line = rawLine.trim();
+        if (line === "" || line.startsWith("#") || line.startsWith("@") || line.startsWith("using")) {
+            continue;
+        }
+
+        const indent = indentWidth(rawLine);
+        while (typeBodyIndents.length > 0 && indent <= typeBodyIndents[typeBodyIndents.length - 1]) {
+            typeBodyIndents.pop();
+        }
+        if (typeBodyIndents.length > 0) {
+            continue; // A member, not a module-scope declaration.
+        }
+
+        let work = line;
+        const qualifier = line.match(QUALIFIER);
+        if (qualifier) {
+            work = line.slice(qualifier[0].length);
+        } else if (line.startsWith("(")) {
+            continue; // Receiver-style extension method.
+        }
+
+        const named = work.match(LEADING_NAME);
+        if (!named || named[1] === "") {
+            continue;
+        }
+        moduleScopeNames.add(named[1]);
+
+        const parametric = parametricKeyword(work);
+        if (parametric) {
+            parametricHeads.push({ name: named[1], keyword: parametric, line: lineNumber });
+            if (parametric !== "module") {
+                typeBodyIndents.push(indent);
+            }
+            continue;
+        }
+
+        const plain = work.match(PLAIN_TYPE);
+        if (plain && plain[1] !== "module") {
+            typeBodyIndents.push(indent);
+        }
+    }
+
+    return { moduleScopeNames, parametricHeads };
+}
+
+describe.each(BUNDLED_DIGEST_NAMES)("bundled digest invariants (%s)", (digestName) => {
+    const fileName = digestSourceFile(digestName);
+    const content = fs.readFileSync(path.join(UTILS_DIR, fileName), "utf8");
+    const { entries } = parseDigestContent(content, rootDomainForDigestFile(fileName));
+    const { moduleScopeNames, parametricHeads } = walkDigest(content);
+
+    it("classifies every parametric type head as a type", () => {
+        // A head whose parameter list the parser cannot span falls through to the
+        // plain declaration branch and is recorded as a function.
+        expect(parametricHeads.length).toBeGreaterThan(0);
+
+        const misclassified = parametricHeads
+            .filter((head) => entries[head.name] !== undefined)
+            .filter((head) => entries[head.name].type !== (head.keyword === "module" ? "module" : "class"))
+            .map((head) => `${fileName}:${head.line} ${head.name} recorded as ${entries[head.name].type}, expected ${head.keyword === "module" ? "module" : "class"}`);
+
+        expect(misclassified).toEqual([]);
+    });
+
+    it("records no identifier that only a type body declares", () => {
+        // A head that never opened its body leaks the members indented under it,
+        // and each leaked name resolves as a high-confidence import for an
+        // identifier the user never declared.
+        const leaked = Object.keys(entries).filter((identifier) => !moduleScopeNames.has(identifier));
+
+        expect(leaked).toEqual([]);
+    });
+});

--- a/src/services/__tests__/digestSourceInvariants.test.ts
+++ b/src/services/__tests__/digestSourceInvariants.test.ts
@@ -2,23 +2,27 @@ import * as fs from "fs";
 import * as path from "path";
 import { parseDigestContent, rootDomainForDigestFile } from "../digestParsing";
 import { BUNDLED_DIGEST_NAMES, digestSourceFile } from "../digestManifest";
+import { lineIndentWidth } from "../../utils/verseText";
 
 /**
  * Refresh-time invariant sweep over the bundled `.verse` digests.
  *
- * Every other digest test pins hand-picked identifiers, which is why the parser
- * shipped four misparsed parametric heads and eight leaked members while its
- * "records parametric types but not their members" test stayed green. These
- * assertions instead hold for every declaration in every bundled digest, so a
- * future Epic drop carrying a shape the parser does not handle fails here rather
- * than reaching `src/data`.
+ * Every other digest test pins hand-picked identifiers, so it holds only for the
+ * names someone thought to list. These assertions hold for every declaration in
+ * all three bundled digests, so a refresh carrying a shape the parser mishandles
+ * fails here rather than reaching `src/data`.
  *
- * The walk below is deliberately a second, independent implementation. Deriving
- * the expectation from the parser under test would only restate whatever the
- * parser does, which is the failure mode this file exists to catch. It stays
- * coarse on purpose: it reads any module-scope line as declaring its leading
- * identifier, so it can only ever admit more names than the parser should, never
- * fewer.
+ * What the walk below buys, and what it does not, because the difference is easy
+ * to overread: it re-derives head recognition rather than calling the parser, so
+ * it catches a regression in `matchParametricTypeHead`. It does NOT catch a
+ * declaration shape that it and the parser misread alike, because it encodes the
+ * same head grammar - a paren inside a string literal on the head line is one.
+ * Closing that gap needs a rule taken from the compiler grammar, not a second
+ * reading of the same digests.
+ *
+ * The leak check compares names rather than declaration lines, a `DigestEntry`
+ * carrying no line number. A member whose name also occurs at module scope
+ * elsewhere in the same file is therefore invisible to it.
  */
 
 const UTILS_DIR = path.resolve(__dirname, "..", "..", "utils");
@@ -49,20 +53,6 @@ interface DigestWalk {
     moduleScopeNames: Set<string>;
     /** Every parametric type head found at module scope. */
     parametricHeads: ParametricHead[];
-}
-
-function indentWidth(rawLine: string): number {
-    let width = 0;
-    for (const character of rawLine) {
-        if (character === " ") {
-            width += 1;
-        } else if (character === "\t") {
-            width += 4;
-        } else {
-            break;
-        }
-    }
-    return width;
 }
 
 /**
@@ -115,7 +105,7 @@ function walkDigest(content: string): DigestWalk {
             continue;
         }
 
-        const indent = indentWidth(rawLine);
+        const indent = lineIndentWidth(rawLine);
         while (typeBodyIndents.length > 0 && indent <= typeBodyIndents[typeBodyIndents.length - 1]) {
             typeBodyIndents.pop();
         }

--- a/src/services/__tests__/precompiledDigestData.test.ts
+++ b/src/services/__tests__/precompiledDigestData.test.ts
@@ -85,4 +85,28 @@ describe("precompiled digest data (41.30)", () => {
             expect(fortnite.entries[leaked]).toBeUndefined();
         }
     });
+
+    it("records parametric types whose parameter list nests parentheses", () => {
+        // These four heads constrain their parameter with `subtype(...)`, so a
+        // parameter list matched at a fixed nesting depth ends at the wrong `)`
+        // and reads the head as a function.
+        for (const id of ["chat_channel", "voice_channel", "agent_group_interface", "agent_group"]) {
+            expect(verse.entries[id]).toBeDefined();
+            expect(verse.entries[id].type).toBe("class");
+        }
+    });
+
+    it("keeps the members of nested-paren parametric types out of module scope", () => {
+        // Every one of these is an ordinary identifier a user could write, so a
+        // phantom entry turns their own unknown-identifier error into a spurious
+        // high-confidence import.
+        for (const leaked of ["Name", "Group"]) {
+            expect(verse.entries[leaked]).toBeUndefined();
+            expect(verse.moduleIndex["/Verse.org/Chat"]).not.toContain(leaked);
+        }
+        for (const leaked of ["GetMemberMap", "AddMember", "RemoveMember", "AddMemberEvent", "RemoveMemberEvent", "MemberInfoChangeEvent"]) {
+            expect(verse.entries[leaked]).toBeUndefined();
+            expect(verse.moduleIndex["/Verse.org/AgentGroup"]).not.toContain(leaked);
+        }
+    });
 });

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -64,26 +64,62 @@ const QUALIFIER_RE = /^\((\/[^()]*):\)/;
  */
 const DECL_RE = /^(\w+)((?:<[^>]+>)*)\s*(:=|:|\()/;
 
-/**
- * A parametric type head: an identifier, its specifier groups, a type-parameter
- * list, then `:=` and a declaration keyword, e.g.
- * `subscribable<public>(t:type) := interface:` or
- * `event<native><public>(t:type) := class(signalable(t)):`. Captures name,
- * specifiers, and keyword.
- *
- * This must be checked before {@link DECL_RE}, whose `(` alternative would
- * otherwise mistake the type-parameter list for a function signature and leak the
- * type's members. The parameter list is matched as `\([^)]*\)`: in the digests,
- * type-parameter lists never nest parentheses (nested parens only appear after
- * `:=`, in base-type lists).
- */
-const PARAM_TYPE_DECL_RE = /^(\w+)((?:<[^>]+>)*)\([^)]*\)\s*:=\s*(module|class|struct|interface|enum)\b/;
+/** The start of a parametric type head: an identifier, its specifier groups, and the `(` opening its type-parameter list. */
+const PARAM_TYPE_HEAD_RE = /^(\w+)((?:<[^>]+>)*)\(/;
+
+/** The `:=` and declaration keyword that must follow a parametric type's parameter list. */
+const PARAM_TYPE_TAIL_RE = /^\s*:=\s*(module|class|struct|interface|enum)\b/;
 
 /** Recognizes the declaration keyword after `:=` (module, class, struct, ...). */
 const DECL_KEYWORD_RE = /^\s*(module|class|struct|interface|enum)\b/;
 
 /** Extracts the explicit module import path from a `# Module import path:` comment. */
 const MODULE_PATH_COMMENT_RE = /#\s*Module import path:\s*(\S+)/;
+
+/**
+ * A parametric type declared with a type-parameter list, such as
+ * `subscribable<public>(t:type) := interface:` or
+ * `agent_group<native><public>(member_info:subtype(member_info_interface)) := class(...):`,
+ * or null where the line is not one.
+ *
+ * Must be tried before {@link DECL_RE}, whose `(` alternative would otherwise read
+ * the type-parameter list as a function signature and leak the type's members to
+ * module scope.
+ *
+ * The parameter list is walked for its matching `)` rather than matched by a
+ * regex, because a Verse parenthesized parameter list holds general expressions
+ * (`Paren := '(' List ')' Space`, VerseGrammar.h) and a parameter may itself be
+ * an invocation carrying another paren group, to any depth. Any fixed depth here
+ * would hold only until a digest refresh exceeded it.
+ *
+ * @param work The trimmed line with any scope qualifier prefix already removed.
+ */
+function matchParametricTypeHead(work: string): { name: string; specifiers: string; keyword: string } | null {
+    const head = work.match(PARAM_TYPE_HEAD_RE);
+    if (!head) {
+        return null;
+    }
+
+    let depth = 0;
+    let index = head[0].length - 1;
+    for (; index < work.length; index++) {
+        if (work[index] === "(") {
+            depth++;
+        } else if (work[index] === ")") {
+            depth--;
+            if (depth === 0) {
+                index++;
+                break;
+            }
+        }
+    }
+    if (depth !== 0) {
+        return null;
+    }
+
+    const tail = work.slice(index).match(PARAM_TYPE_TAIL_RE);
+    return tail ? { name: head[1], specifiers: head[2], keyword: tail[1] } : null;
+}
 
 /**
  * Maps a digest file name to the root module domain its top-level declarations
@@ -238,10 +274,9 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
         // Parametric type heads (`name<...>(t:type) := interface:`) must be matched
         // before DECL_RE, whose `(` branch would misread the parameter list as a
         // function signature and leak the type's members.
-        const paramType = work.match(PARAM_TYPE_DECL_RE);
+        const paramType = matchParametricTypeHead(work);
         if (paramType) {
-            const paramSpecifiers = paramType[2];
-            recordModuleOrType(paramType[1], paramSpecifiers.includes("<public>"), paramType[3], qualifierPath, indent);
+            recordModuleOrType(paramType.name, paramType.specifiers.includes("<public>"), paramType.keyword, qualifierPath, indent);
             continue;
         }
 

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -271,9 +271,7 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
             continue;
         }
 
-        // Parametric type heads (`name<...>(t:type) := interface:`) must be matched
-        // before DECL_RE, whose `(` branch would misread the parameter list as a
-        // function signature and leak the type's members.
+        // Before DECL_RE: the order is load-bearing, and matchParametricTypeHead says why.
         const paramType = matchParametricTypeHead(work);
         if (paramType) {
             recordModuleOrType(paramType.name, paramType.specifiers.includes("<public>"), paramType.keyword, qualifierPath, indent);


### PR DESCRIPTION
Closes #372

## What

`PARAM_TYPE_DECL_RE` matched a Verse type-parameter list as `\([^)]*\)`, which cannot span a `)` inside the list. The four heads in the bundled `Verse.digest.verse` that constrain their parameter with `subtype(...)` therefore missed the parametric-type branch, fell through to `DECL_RE`, and were recorded as `function`. Because `recordModuleOrType` never ran for them, no class-body indent was pushed and their indented members escaped to module scope.

Eight phantom entries were shipping in `src/data/Verse.digest.json`. Each is an ordinary identifier a user could write, so with `experimental.useDigestFiles` on, the compiler's `Unknown identifier` error for the user's own typo resolved against a phantom at `high` confidence and `general.autoImport` inserted a `using` that fixed nothing.

## Why a balanced walk rather than the one-level regex

The issue offered `\((?:[^()]|\([^()]*\))*\)` as the smallest fix. That would have shipped with a counterexample already in the tree.

`Paren := '(' List ')' Space` — `VerseGrammar.h:2716`, inside `InvokeParens`. The list holds general expressions and `InvokeParens` is reached as a postfix on an expression, so a parameter may itself be an invocation carrying another paren group, recursively. No fixed depth is safe, and `UnrealEngine.digest.verse` already ships a **depth-3** head (`PromptToTalk`).

That matters beyond this fix: the regex being replaced was *correct* when written against the 41.10 digests, and its docblock said so honestly. It expired at the 41.30 refresh with nobody re-checking. Encoding "one level" would have repeated that exactly.

## Changes

- `src/services/digestParsing.ts` — `PARAM_TYPE_DECL_RE` replaced by `PARAM_TYPE_HEAD_RE` + `PARAM_TYPE_TAIL_RE` and a module-private `matchParametricTypeHead`, which walks the parameter list to its matching `)`. Unbalanced, or no `:=` keyword after the list, returns null and falls through to `DECL_RE` exactly as before. The parametric-before-`DECL_RE` order is unchanged.
- `src/data/*.digest.json` — regenerated with `npm run parse-digest`. `src/utils/` is byte-identical to `main`; Fortnite and UnrealEngine differ only in `generatedAt`; `Verse.digest.json` carries exactly four `function` → `class` flips, eight entry removals, and the same eight names out of two `moduleIndex` arrays. `.github/workflows/parse-digest.yml` only fires on `.verse` input changes, so a parser-only fix has to regenerate in the commit.
- `src/services/__tests__/digestParsing.test.ts` — three unit regressions: a nested head, a depth-3 head, and a genuine function whose parameter list nests parens, which must still type as `function`.
- `src/services/__tests__/precompiledDigestData.test.ts` — pins the four heads as `class` and the eight member names absent from the shipped artifact. The existing "records parametric types but not their members (no leak)" test passed while the invariant it names was violated four times.
- `src/services/__tests__/digestSourceInvariants.test.ts` (new) — the refresh-time sweep. Runs `parseDigestContent` over all three real `.verse` digests and asserts invariants rather than sampled names: every parametric head classifies as a type, and no identifier reaches `entries` that only a type body declares. Nothing under `src/` read the `.verse` sources before this.

## Verification

Each new assertion was proved to detect the defect by reverting the parser and data to `main` and re-running: six of the seven fail, and the sweep fails on Verse only, Fortnite and UnrealEngine being legitimately clean. The seventh ("still reads a function ... as a function") passes both ways by design — it guards against over-broadening, not against this defect.

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> jest --verbose

Test Suites: 43 passed, 43 total
Tests:       1087 passed, 1087 total
Snapshots:   0 total
Time:        6.911 s, estimated 8 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, verdict `PASS_WITH_SUGGESTIONS`, no Critical. The reviewer probed 13 groups, including replaying the sweep's walk against the pre-fix data to confirm it is not vacuous (4 misclassified, 8 leaked) and measuring how much slack its name comparison carries (Fortnite 0, UnrealEngine 1.2%, Verse 2.7%).

Its one `Important` finding is fixed in `68f94dc`: the sweep's docblock claimed the walk was independent of the parser, and the reviewer demonstrated two shapes that both misread. The walk re-derives head recognition, so it catches a regression in `matchParametricTypeHead`, but it encodes the same head grammar — the comment now says exactly that, and says that closing the gap needs a rule from the compiler grammar rather than a second reading of the same digests. The same commit drops a copied indent measure for the shared `lineIndentWidth` and leaves one statement of the load-bearing order instead of two.

Left unfixed, both `Suggestion`: the sweep's `parametricHeads.length > 0` guard clears at n=1, and Fortnite and UnrealEngine have exactly one parametric head each — pinning real counts would fight the sweep's purpose of surviving a digest refresh. And the leak check compares names rather than declaration lines, because a `DigestEntry` carries no line number; the docblock now states that deviation and its measured cost.
