### PR TITLE
feat(imports): verify the rewrite before applying it

### DIFF
--- a/changelog.d/386.added.md
+++ b/changelog.d/386.added.md
@@ -1,0 +1,1 @@
+**Import writing**: Optimize Imports and automatic import insertion now check their own output before writing it, and refuse the edit instead of applying one that would drop a line of your code.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -123,6 +123,43 @@ class WorkspaceEdit {
             }
         }
     }
+
+    /**
+     * The text edits recorded here, grouped by uri as real VS Code returns
+     * them: an insert is a TextEdit over the empty range at its position, and a
+     * delete one with no text, which is how the editor stores both. A createFile
+     * is not a text edit and does not appear.
+     */
+    entries(): [unknown, TextEdit[]][] {
+        const byUri = new Map<string, { uri: unknown; edits: TextEdit[] }>();
+
+        for (const operation of this.operations) {
+            const textEdit = WorkspaceEdit.asTextEdit(operation);
+            if (!textEdit) {
+                continue;
+            }
+
+            const key = String(operation.uri);
+            const entry = byUri.get(key) ?? { uri: operation.uri, edits: [] };
+            entry.edits.push(textEdit);
+            byUri.set(key, entry);
+        }
+
+        return [...byUri.values()].map(({ uri, edits }) => [uri, edits]);
+    }
+
+    private static asTextEdit(operation: RecordedEditOperation): TextEdit | null {
+        switch (operation.kind) {
+            case "insert":
+                return new TextEdit(new Range(operation.position!, operation.position!), operation.text!);
+            case "delete":
+                return new TextEdit(operation.range!, "");
+            case "replace":
+                return new TextEdit(operation.range!, operation.text!);
+            default:
+                return null;
+        }
+    }
 }
 
 /**

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1015,9 +1015,9 @@ export class ImportDocumentEditor {
             }
         }
 
-        const unsafe = verifyImportEdits(lines, queuedEditsFor(edit, document.uri));
-        if (unsafe) {
-            logger.error("ImportDocumentEditor", `Refusing to update imports: ${unsafe}`);
+        const refusal = verifyImportEdits(lines, queuedEditsFor(edit, document.uri), newImportPaths);
+        if (refusal) {
+            logger.error("ImportDocumentEditor", `Refusing to update imports: ${refusal}`);
             return false;
         }
 
@@ -1294,9 +1294,9 @@ export class ImportDocumentEditor {
             return true;
         }
 
-        const unsafe = verifyOrganizedRewrite(text, organized, additionalPaths);
-        if (unsafe) {
-            logger.error("ImportDocumentEditor", `Refusing to organize imports: ${unsafe}`);
+        const refusal = verifyOrganizedRewrite(text, organized, additionalPaths);
+        if (refusal) {
+            logger.error("ImportDocumentEditor", `Refusing to organize imports: ${refusal}`);
             return false;
         }
 

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
 import { ImportFormatter } from "./ImportFormatter";
+import { QueuedEdit, verifyImportEdits, verifyOrganizedRewrite } from "./ImportRewriteGuard";
 import { allUsingPaths, classifyLines, indentedPairPathLine, LINE_SPLIT, LineClassification, pinnedImports, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
 
 /**
@@ -50,6 +51,27 @@ function documentEol(document: vscode.TextDocument): LineEnding {
  */
 function resolveEol(document: vscode.TextDocument, text: string): LineEnding {
     return detectEol(text) ?? documentEol(document);
+}
+
+/**
+ * The edits queued for one document, in the shape ImportRewriteGuard reads.
+ *
+ * Taken from the WorkspaceEdit rather than recorded as the writers build it, so
+ * the guard answers for what is about to be applied rather than for what some
+ * parallel bookkeeping says was meant.
+ */
+function queuedEditsFor(edit: vscode.WorkspaceEdit, uri: vscode.Uri): QueuedEdit[] {
+    return edit
+        .entries()
+        .filter(([entryUri]) => entryUri.toString() === uri.toString())
+        .flatMap(([, edits]) => edits)
+        .map((textEdit) => ({
+            startLine: textEdit.range.start.line,
+            startCharacter: textEdit.range.start.character,
+            endLine: textEdit.range.end.line,
+            endCharacter: textEdit.range.end.character,
+            newText: textEdit.newText,
+        }));
 }
 
 /**
@@ -993,6 +1015,12 @@ export class ImportDocumentEditor {
             }
         }
 
+        const unsafe = verifyImportEdits(lines, queuedEditsFor(edit, document.uri));
+        if (unsafe) {
+            logger.error("ImportDocumentEditor", `Refusing to update imports: ${unsafe}`);
+            return false;
+        }
+
         try {
             const success = await vscode.workspace.applyEdit(edit);
             logger.info("ImportDocumentEditor", success ? "Successfully updated imports in document" : "Failed to update imports in document");
@@ -1264,6 +1292,12 @@ export class ImportDocumentEditor {
         if (organized === null || organized === text) {
             logger.debug("ImportDocumentEditor", "No import changes needed by organize");
             return true;
+        }
+
+        const unsafe = verifyOrganizedRewrite(text, organized, additionalPaths);
+        if (unsafe) {
+            logger.error("ImportDocumentEditor", `Refusing to organize imports: ${unsafe}`);
+            return false;
         }
 
         const edit = new vscode.WorkspaceEdit();

--- a/src/imports/ImportRewriteGuard.ts
+++ b/src/imports/ImportRewriteGuard.ts
@@ -26,6 +26,13 @@ function importSpanLines(imports: readonly ScannedImport[]): Set<number> {
     return covered;
 }
 
+/** A line of code outside the imports, with the line it was read from. */
+interface BodyLine {
+    text: string;
+    /** 0-based, in the text this line was read from. */
+    line: number;
+}
+
 /**
  * The lines carrying code that is not part of any import statement.
  *
@@ -37,27 +44,40 @@ function importSpanLines(imports: readonly ScannedImport[]): Set<number> {
  *
  * What remains is the text no import rewrite has any business touching.
  */
-function bodyLines(lines: string[]): string[] {
+function bodyLines(lines: string[]): BodyLine[] {
     const classifications = classifyLines(lines);
     const inImportSpan = importSpanLines(scanModuleImports(lines));
 
-    return lines.filter((_, index) => classifications[index].kind === "code" && !inImportSpan.has(index));
+    const body: BodyLine[] = [];
+    for (let line = 0; line < lines.length; line++) {
+        if (classifications[line].kind === "code" && !inImportSpan.has(line)) {
+            body.push({ text: lines[line], line });
+        }
+    }
+    return body;
 }
 
-/** Where two body-line sequences first disagree, or null when they match. */
-function firstBodyDifference(before: string[], after: string[]): string | null {
+/**
+ * Where two body-line sequences first disagree, or null when they match.
+ *
+ * Line numbers in the message are the input document's, not positions in the
+ * filtered sequence: this string is the whole of what a maintainer gets when
+ * the guard fires in the field, and a number that looks like a line number but
+ * is not sends them to the wrong line.
+ */
+function firstBodyDifference(before: BodyLine[], after: BodyLine[]): string | null {
     const shared = Math.min(before.length, after.length);
     for (let index = 0; index < shared; index++) {
-        if (before[index] !== after[index]) {
-            return `code line ${index + 1} outside the imports became ${JSON.stringify(after[index])}, was ${JSON.stringify(before[index])}`;
+        if (before[index].text !== after[index].text) {
+            return `line ${before[index].line + 1} became ${JSON.stringify(after[index].text)}, was ${JSON.stringify(before[index].text)}`;
         }
     }
 
     if (before.length > after.length) {
-        return `${before.length - after.length} code line(s) outside the imports were lost, from ${JSON.stringify(before[shared])}`;
+        return `${before.length - after.length} code line(s) were lost, from line ${before[shared].line + 1}: ${JSON.stringify(before[shared].text)}`;
     }
     if (after.length > before.length) {
-        return `${after.length - before.length} code line(s) outside the imports appeared, from ${JSON.stringify(after[shared])}`;
+        return `${after.length - before.length} code line(s) appeared, from ${JSON.stringify(after[shared].text)}`;
     }
     return null;
 }
@@ -102,6 +122,11 @@ export function verifyOrganizedRewrite(before: string, after: string, requestedP
     return firstBodyDifference(bodyLines(beforeLines), bodyLines(afterLines));
 }
 
+/** Whether the edit writes text in without taking any away. */
+function isInsertion(edit: QueuedEdit): boolean {
+    return edit.startLine === edit.endLine && edit.startCharacter === edit.endCharacter;
+}
+
 /**
  * Every line index the edits delete or overwrite.
  *
@@ -112,7 +137,7 @@ export function verifyOrganizedRewrite(before: string, after: string, requestedP
 function removedLines(edits: readonly QueuedEdit[]): Set<number> {
     const removed = new Set<number>();
     for (const edit of edits) {
-        if (edit.startLine === edit.endLine && edit.startCharacter === edit.endCharacter) {
+        if (isInsertion(edit)) {
             continue;
         }
 
@@ -140,12 +165,26 @@ function removedLines(edits: readonly QueuedEdit[]): Set<number> {
  * building them, so this answers for what will be applied rather than for what
  * was meant. It carries the same limitation as verifyOrganizedRewrite: the
  * scanner decides what counts as an import on both sides.
+ *
+ * @param intendedPaths The paths the caller decided to add. Only these may be
+ *   written in that the document does not already import.
  */
-export function verifyImportEdits(lines: string[], edits: readonly QueuedEdit[]): string | null {
+export function verifyImportEdits(lines: string[], edits: readonly QueuedEdit[], intendedPaths: Iterable<string>): string | null {
     const classifications = classifyLines(lines);
     const imports = scanModuleImports(lines);
     const inImportSpan = importSpanLines(imports);
     const removed = removedLines(edits);
+
+    // An insertion takes no text away, but one landing in the middle of a line
+    // splices its statement onto whatever is already there and leaves one
+    // unreadable line where two belong. Writing past the last line is the
+    // legitimate reason to start anywhere but column 0, and that text opens
+    // with the line break that keeps the two apart. See insertImportLines.
+    for (const edit of edits) {
+        if (isInsertion(edit) && edit.startCharacter !== 0 && !/^\r?\n/.test(edit.newText)) {
+            return `the queued edits splice ${JSON.stringify(edit.newText)} into the middle of line ${edit.startLine + 1}`;
+        }
+    }
 
     for (const line of [...removed].sort((a, b) => a - b)) {
         // A position past the end is one VS Code clamps; no line of the
@@ -159,12 +198,21 @@ export function verifyImportEdits(lines: string[], edits: readonly QueuedEdit[])
         }
     }
 
-    const surviving = new Set<string>();
+    const written = new Set<string>();
     for (const edit of edits) {
         for (const imp of scanModuleImports(edit.newText.split(LINE_SPLIT))) {
-            surviving.add(imp.path);
+            written.add(imp.path);
         }
     }
+
+    const existingPaths = new Set(imports.map((imp) => imp.path));
+    const allowed = new Set([...existingPaths, ...intendedPaths]);
+    const invented = [...written].filter((path) => !allowed.has(path));
+    if (invented.length > 0) {
+        return `the queued edits import ${invented.join(", ")}, which nothing asked for`;
+    }
+
+    const surviving = new Set(written);
     // A path written on two lines survives while either is left alone, so the
     // question is asked per statement rather than per path.
     for (const imp of imports) {
@@ -177,7 +225,7 @@ export function verifyImportEdits(lines: string[], edits: readonly QueuedEdit[])
         }
     }
 
-    const dropped = [...new Set(imports.map((imp) => imp.path))].filter((path) => !surviving.has(path));
+    const dropped = [...existingPaths].filter((path) => !surviving.has(path));
     if (dropped.length > 0) {
         return `the queued edits remove ${dropped.join(", ")} without writing it back`;
     }

--- a/src/imports/ImportRewriteGuard.ts
+++ b/src/imports/ImportRewriteGuard.ts
@@ -1,0 +1,186 @@
+import { classifyLines, LINE_SPLIT, ScannedImport, scanModuleImports } from "./ImportScanner";
+
+/**
+ * A text edit queued for the document, with no dependency on `vscode`.
+ *
+ * Positions are 0-based and carry the same meaning `vscode.Range` gives them,
+ * so a range reaching character 0 of a line stops above that line. An edit
+ * whose start and end coincide is an insertion and removes nothing.
+ */
+export interface QueuedEdit {
+    startLine: number;
+    startCharacter: number;
+    endLine: number;
+    endCharacter: number;
+    newText: string;
+}
+
+/** Every line index an import statement covers, its own span only. */
+function importSpanLines(imports: readonly ScannedImport[]): Set<number> {
+    const covered = new Set<number>();
+    for (const imp of imports) {
+        for (let line = imp.startLine; line <= imp.endLine; line++) {
+            covered.add(line);
+        }
+    }
+    return covered;
+}
+
+/**
+ * The lines carrying code that is not part of any import statement.
+ *
+ * Comment and blank lines are left out because a rewrite is allowed to move or
+ * drop them: the comments written for a withheld import are deliberately
+ * deleted with it, and the blank lines a hoisted block leaves behind are
+ * trimmed. Lines inside an import span are left out because a rewrite re-emits
+ * them from the path, so their text legitimately changes.
+ *
+ * What remains is the text no import rewrite has any business touching.
+ */
+function bodyLines(lines: string[]): string[] {
+    const classifications = classifyLines(lines);
+    const inImportSpan = importSpanLines(scanModuleImports(lines));
+
+    return lines.filter((_, index) => classifications[index].kind === "code" && !inImportSpan.has(index));
+}
+
+/** Where two body-line sequences first disagree, or null when they match. */
+function firstBodyDifference(before: string[], after: string[]): string | null {
+    const shared = Math.min(before.length, after.length);
+    for (let index = 0; index < shared; index++) {
+        if (before[index] !== after[index]) {
+            return `code line ${index + 1} outside the imports became ${JSON.stringify(after[index])}, was ${JSON.stringify(before[index])}`;
+        }
+    }
+
+    if (before.length > after.length) {
+        return `${before.length - after.length} code line(s) outside the imports were lost, from ${JSON.stringify(before[shared])}`;
+    }
+    if (after.length > before.length) {
+        return `${after.length - before.length} code line(s) outside the imports appeared, from ${JSON.stringify(after[shared])}`;
+    }
+    return null;
+}
+
+/**
+ * The reason a rebuilt document must not be applied over `before`, or null when
+ * it is safe to apply.
+ *
+ * The organize path replaces the whole document, so a composition bug in the
+ * rebuild - a body line claimed twice, a hoisted line never re-emitted, an
+ * off-by-one in the partition - reaches the file as silent text loss. Reading
+ * the rebuilt text back turns that class into a refused edit.
+ *
+ * Both texts are read through the same scanner, so this answers whether the
+ * writer and the scanner agree, not whether either is right about Verse: a bug
+ * inside scanModuleImports is invisible here, because both sides read it the
+ * same wrong way.
+ *
+ * @param requestedPaths The additional paths the caller asked for. Only these
+ *   may appear in `after` without appearing in `before`.
+ */
+export function verifyOrganizedRewrite(before: string, after: string, requestedPaths: readonly string[]): string | null {
+    const beforeLines = before.split(LINE_SPLIT);
+    const afterLines = after.split(LINE_SPLIT);
+
+    const beforePaths = new Set(scanModuleImports(beforeLines).map((imp) => imp.path));
+    const afterPaths = new Set(scanModuleImports(afterLines).map((imp) => imp.path));
+
+    const lost = [...beforePaths].filter((path) => !afterPaths.has(path));
+    if (lost.length > 0) {
+        return `the rebuilt document no longer imports ${lost.join(", ")}`;
+    }
+
+    // Trimmed as buildOrganizedContent trims them, or a caller's untrimmed path
+    // reads as one the rebuild invented.
+    const allowed = new Set([...beforePaths, ...requestedPaths.map((path) => path.trim())]);
+    const invented = [...afterPaths].filter((path) => !allowed.has(path));
+    if (invented.length > 0) {
+        return `the rebuilt document imports ${invented.join(", ")}, which nothing asked for`;
+    }
+
+    return firstBodyDifference(bodyLines(beforeLines), bodyLines(afterLines));
+}
+
+/**
+ * Every line index the edits delete or overwrite.
+ *
+ * A line an edit only partly covers counts as removed: the part it takes is
+ * text loss just the same, and no writer here produces such a range, so
+ * counting it costs nothing.
+ */
+function removedLines(edits: readonly QueuedEdit[]): Set<number> {
+    const removed = new Set<number>();
+    for (const edit of edits) {
+        if (edit.startLine === edit.endLine && edit.startCharacter === edit.endCharacter) {
+            continue;
+        }
+
+        for (let line = edit.startLine; line <= edit.endLine; line++) {
+            // The range stops above a line it reaches at character 0.
+            if (line === edit.endLine && edit.endCharacter === 0) {
+                continue;
+            }
+            removed.add(line);
+        }
+    }
+    return removed;
+}
+
+/**
+ * The reason a set of queued edits must not be applied to `lines`, or null when
+ * they are safe to apply.
+ *
+ * The add path never builds one output text, so there is nothing to read back:
+ * the edits themselves are what gets checked. Everything it removes should be an
+ * import statement it writes again somewhere else, which is what the two
+ * questions below ask.
+ *
+ * Read from the edits actually queued rather than from a record kept while
+ * building them, so this answers for what will be applied rather than for what
+ * was meant. It carries the same limitation as verifyOrganizedRewrite: the
+ * scanner decides what counts as an import on both sides.
+ */
+export function verifyImportEdits(lines: string[], edits: readonly QueuedEdit[]): string | null {
+    const classifications = classifyLines(lines);
+    const imports = scanModuleImports(lines);
+    const inImportSpan = importSpanLines(imports);
+    const removed = removedLines(edits);
+
+    for (const line of [...removed].sort((a, b) => a - b)) {
+        // A position past the end is one VS Code clamps; no line of the
+        // document is under it.
+        if (line >= lines.length) {
+            continue;
+        }
+
+        if (classifications[line].kind === "code" && !inImportSpan.has(line)) {
+            return `the queued edits remove line ${line + 1}, which is code rather than an import: ${JSON.stringify(lines[line])}`;
+        }
+    }
+
+    const surviving = new Set<string>();
+    for (const edit of edits) {
+        for (const imp of scanModuleImports(edit.newText.split(LINE_SPLIT))) {
+            surviving.add(imp.path);
+        }
+    }
+    // A path written on two lines survives while either is left alone, so the
+    // question is asked per statement rather than per path.
+    for (const imp of imports) {
+        let spanRemoved = true;
+        for (let line = imp.startLine; line <= imp.endLine && spanRemoved; line++) {
+            spanRemoved = removed.has(line);
+        }
+        if (!spanRemoved) {
+            surviving.add(imp.path);
+        }
+    }
+
+    const dropped = [...new Set(imports.map((imp) => imp.path))].filter((path) => !surviving.has(path));
+    if (dropped.length > 0) {
+        return `the queued edits remove ${dropped.join(", ")} without writing it back`;
+    }
+
+    return null;
+}

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -2212,9 +2212,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
 });
 
 /**
- * Both writers read their own output back before applying it (#386), so a
- * composition bug reaches the user as a refused edit rather than as text
- * silently missing from the file.
+ * Both writers read their own output back before applying it, so a composition
+ * bug reaches the user as a refused edit rather than as text silently missing
+ * from the file.
  *
  * The bug has to be injected: the point of the check is the bug nobody has
  * written yet, and a writer that is currently correct cannot demonstrate it.
@@ -2282,6 +2282,82 @@ describe("ImportDocumentEditor rewrite verification", () => {
 
         expect(success).toBe(true);
         expect(appliedOperations(0)[0].text).toContain("using { /B }");
+    });
+
+    // insertImportLines documents its past-the-end branch as the thing standing
+    // between the writer and "one unreadable line where two belong". An
+    // insertion carries no range, so nothing else here would notice.
+    it("refuses to add imports when an insertion splices onto a line of code", async () => {
+        type InsertImportLines = (edit: vscode.WorkspaceEdit, document: vscode.TextDocument, line: number, statements: string[], eol: string, blankLineAfter: boolean) => void;
+        jest.spyOn(editor as unknown as { insertImportLines: InsertImportLines }, "insertImportLines").mockImplementation((edit, document, _line, statements, eol) => {
+            edit.insert(document.uri, new vscode.Position(0, "code()".length), statements.join(eol) + eol);
+        });
+
+        const success = await editor.addImportsToDocument(fakeDocument("code()"), ["using { /B }"]);
+
+        expect(success).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The guard refuses edits, so a false positive is the extension silently
+     * ceasing to import. This is the net for that: every document shape the
+     * writers treat differently, against every setting combination that picks a
+     * different branch, all of which must still reach applyEdit.
+     */
+    describe("does not refuse a correct rewrite", () => {
+        const documents: Array<[string, string]> = [
+            ["an empty file", ""],
+            ["no trailing newline", "using { /A }\ncode()"],
+            ["a trailing newline", "using { /A }\ncode()\n"],
+            ["CRLF", "using { /A }\r\ncode()\r\n"],
+            ["only imports", "using { /A }\nusing { /B }"],
+            ["no imports at all", "code()\nmore()"],
+            ["a header comment", "# licence\n\nusing { /A }\n\ncode()"],
+            ["an annotated import", "# why /A is here\nusing { /A }\n\ncode()"],
+            ["an import pinned by a second statement", "X := 1; using { /A }\ncode()"],
+            ["a commented-out import", "<#\nusing { /Old }\n#>\nusing { /A }\n\ncode()"],
+            ["an indented using pair", "using{\n    /A\n}\ncode()"],
+            ["a using inside a module body", "using { /A }\n\nM := module:\n    using { /B }\n    F():void = {}"],
+            ["two gapped blocks", "using { /A }\n\nusing { Local.One }\n\ncode()"],
+            ["a relative import under an absolute one", "using { /A }\nusing { Local.One }\n\ncode()"],
+        ];
+
+        const settings: Array<[string, Record<string, unknown>]> = [
+            ["defaults", {}],
+            ["consolidating", { "behavior.preserveImportLocations": false }],
+            ["consolidating, unsorted", { "behavior.preserveImportLocations": false, "behavior.sortImportsAlphabetically": false }],
+            ["grouped local first", { "behavior.importGrouping": "localFirst" }],
+            ["grouped digest first, consolidating", { "behavior.importGrouping": "digestFirst", "behavior.preserveImportLocations": false }],
+            ["dot syntax, consolidating", { "behavior.importSyntax": "dot", "behavior.preserveImportLocations": false }],
+        ];
+
+        /** Answers `overrides`, and the declared default for everything else. */
+        function useSettings(overrides: Record<string, unknown>): void {
+            (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+                get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key in overrides ? overrides[key] : defaultValue)),
+                update: jest.fn().mockResolvedValue(undefined),
+            });
+        }
+
+        for (const [documentName, input] of documents) {
+            for (const [settingsName, overrides] of settings) {
+                it(`adds an import to ${documentName} with ${settingsName}`, async () => {
+                    useSettings(overrides);
+
+                    const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+                    expect(success).toBe(true);
+                    expect(applyEditMock()).toHaveBeenCalled();
+                });
+
+                it(`organizes ${documentName} with ${settingsName}`, async () => {
+                    useSettings(overrides);
+
+                    await expect(editor.organizeImports(fakeDocument(input), ["/Fortnite.com/Devices"])).resolves.toBe(true);
+                });
+            }
+        }
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -2211,6 +2211,80 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
     });
 });
 
+/**
+ * Both writers read their own output back before applying it (#386), so a
+ * composition bug reaches the user as a refused edit rather than as text
+ * silently missing from the file.
+ *
+ * The bug has to be injected: the point of the check is the bug nobody has
+ * written yet, and a writer that is currently correct cannot demonstrate it.
+ */
+describe("ImportDocumentEditor rewrite verification", () => {
+    let editor: ImportDocumentEditor;
+    const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
+
+    beforeEach(() => {
+        const outputChannel = vscode.window.createOutputChannel("test");
+        editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
+        applyEditMock().mockClear();
+    });
+
+    it("refuses to organize when the rebuild loses a line of code", async () => {
+        const input = "using { /B }\nusing { /A }\ncode()\nmore()";
+        jest.spyOn(editor, "buildOrganizedContent").mockReturnValue("using { /A }\nusing { /B }\n\ncode()");
+
+        const success = await editor.organizeImports(fakeDocument(input), []);
+
+        expect(success).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("refuses to organize when the rebuild drops an import", async () => {
+        const input = "using { /B }\nusing { /A }\ncode()";
+        jest.spyOn(editor, "buildOrganizedContent").mockReturnValue("using { /A }\n\ncode()");
+
+        const success = await editor.organizeImports(fakeDocument(input), []);
+
+        expect(success).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("organizes as usual when the rebuild is sound", async () => {
+        const input = "using { /B }\nusing { /A }\ncode()";
+
+        const success = await editor.organizeImports(fakeDocument(input), []);
+
+        expect(success).toBe(true);
+        expect(appliedOperations(0)[0].text).toBe("using { /A }\nusing { /B }\n\ncode()");
+    });
+
+    // The off-by-one the ticket names, on the path that has no output text to
+    // read: a hoisted run reaching one line past its block deletes the code
+    // line below it.
+    it("refuses to add imports when a queued deletion reaches onto code", async () => {
+        const input = "using { /A }\ncode()";
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key === "behavior.preserveImportLocations" ? false : defaultValue)),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+        jest.spyOn(editor as unknown as { hoistedRuns: () => Array<{ start: number; end: number }> }, "hoistedRuns").mockReturnValue([{ start: 0, end: 1 }]);
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
+
+        expect(success).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("adds imports as usual when the queued edits touch nothing but imports", async () => {
+        const input = "using { /A }\ncode()";
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
+
+        expect(success).toBe(true);
+        expect(appliedOperations(0)[0].text).toContain("using { /B }");
+    });
+});
+
 describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {
     let editor: ImportDocumentEditor;
     const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;

--- a/src/imports/__tests__/ImportRewriteGuard.test.ts
+++ b/src/imports/__tests__/ImportRewriteGuard.test.ts
@@ -39,26 +39,28 @@ describe("verifyOrganizedRewrite", () => {
     });
 
     // The whole point of the guard: a rebuild that loses a line of the user's
-    // own code must never reach applyEdit.
-    it("reports a body line the rebuild lost", () => {
+    // own code must never reach applyEdit. The line in the message is the input
+    // document's, not a position in the filtered sequence, since it is all a
+    // maintainer gets when the guard fires.
+    it("reports a body line the rebuild lost, by its line in the input", () => {
         const before = "using { /A }\ncode()\nmore()";
         const after = "using { /A }\n\ncode()";
 
-        expect(verifyOrganizedRewrite(before, after, [])).toBe('1 code line(s) outside the imports were lost, from "more()"');
+        expect(verifyOrganizedRewrite(before, after, [])).toBe('1 code line(s) were lost, from line 3: "more()"');
     });
 
     it("reports a body line the rebuild claimed twice", () => {
         const before = "using { /A }\ncode()\nmore()";
         const after = "using { /A }\n\ncode()\ncode()\nmore()";
 
-        expect(verifyOrganizedRewrite(before, after, [])).toContain("code line 2 outside the imports");
+        expect(verifyOrganizedRewrite(before, after, [])).toBe('line 3 became "code()", was "more()"');
     });
 
     it("reports a body line the rebuild rewrote", () => {
         const before = "using { /A }\ncode()";
         const after = "using { /A }\n\ncodeX()";
 
-        expect(verifyOrganizedRewrite(before, after, [])).toBe('code line 1 outside the imports became "codeX()", was "code()"');
+        expect(verifyOrganizedRewrite(before, after, [])).toBe('line 2 became "codeX()", was "code()"');
     });
 
     // Withholding an already-made import deletes the comments written for it on
@@ -93,20 +95,20 @@ describe("verifyImportEdits", () => {
     it("passes an edit that only inserts", () => {
         const lines = ["code()"];
 
-        expect(verifyImportEdits(lines, [insertion(0, "using { /A }\n")])).toBeNull();
+        expect(verifyImportEdits(lines, [insertion(0, "using { /A }\n")], ["/A"])).toBeNull();
     });
 
     it("passes a block replacement that writes its paths back", () => {
         const lines = ["using { /B }", "using { /A }", "code()"];
 
-        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\nusing { /B }\n")])).toBeNull();
+        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\nusing { /B }\n")], [])).toBeNull();
     });
 
     it("passes a consolidation that deletes a block and rewrites it at the top", () => {
         const lines = ["code()", "using { /A }", "using { /B }"];
         const edits = [insertion(0, "using { /A }\nusing { /B }\n"), removal(1, 3)];
 
-        expect(verifyImportEdits(lines, edits)).toBeNull();
+        expect(verifyImportEdits(lines, edits, [])).toBeNull();
     });
 
     // The off-by-one the ticket names: a run reaching one line past the block
@@ -114,13 +116,13 @@ describe("verifyImportEdits", () => {
     it("refuses a range that reaches past the imports onto code", () => {
         const lines = ["using { /A }", "code()"];
 
-        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\n")])).toBe('the queued edits remove line 2, which is code rather than an import: "code()"');
+        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\n")], [])).toBe('the queued edits remove line 2, which is code rather than an import: "code()"');
     });
 
     it("refuses a deletion that never writes the path back", () => {
         const lines = ["using { /A }", "using { /B }", "code()"];
 
-        expect(verifyImportEdits(lines, [removal(0, 2)])).toBe("the queued edits remove /A, /B without writing it back");
+        expect(verifyImportEdits(lines, [removal(0, 2)], [])).toBe("the queued edits remove /A, /B without writing it back");
     });
 
     // A path written twice is still imported while either line is left alone,
@@ -128,19 +130,19 @@ describe("verifyImportEdits", () => {
     it("passes a deletion that leaves another statement for the same path", () => {
         const lines = ["using { /A }", "using { /A }", "code()"];
 
-        expect(verifyImportEdits(lines, [removal(1, 2)])).toBeNull();
+        expect(verifyImportEdits(lines, [removal(1, 2)], [])).toBeNull();
     });
 
     it("treats a range ending at character 0 as stopping above that line", () => {
         const lines = ["using { /A }", "code()"];
 
-        expect(verifyImportEdits(lines, [removal(0, 1, "using { /A }\n")])).toBeNull();
+        expect(verifyImportEdits(lines, [removal(0, 1, "using { /A }\n")], [])).toBeNull();
     });
 
     it("counts a line a range only partly covers as removed", () => {
         const lines = ["using { /A }", "code()"];
 
-        expect(verifyImportEdits(lines, [{ startLine: 0, startCharacter: 0, endLine: 1, endCharacter: 3, newText: "using { /A }\n" }])).toContain("line 2, which is code");
+        expect(verifyImportEdits(lines, [{ startLine: 0, startCharacter: 0, endLine: 1, endCharacter: 3, newText: "using { /A }\n" }], [])).toContain("line 2, which is code");
     });
 
     // VS Code clamps a range past the end onto the document, so there is no
@@ -148,16 +150,32 @@ describe("verifyImportEdits", () => {
     it("ignores the part of a range that reaches past the last line", () => {
         const lines = ["using { /A }"];
 
-        expect(verifyImportEdits(lines, [removal(0, 5, "using { /A }\n")])).toBeNull();
+        expect(verifyImportEdits(lines, [removal(0, 5, "using { /A }\n")], [])).toBeNull();
     });
 
     // insertImportLines writes past the last line from the end of that line
     // rather than from column 0, which is still an insertion and removes
-    // nothing.
+    // nothing. Its text opens with the break that keeps it off that line.
     it("passes an insertion anchored at the end of the last line", () => {
         const lines = ["using { /A }", "code()"];
         const endOfLastLine: QueuedEdit = { startLine: 1, startCharacter: 6, endLine: 1, endCharacter: 6, newText: "\nusing { /B }" };
 
-        expect(verifyImportEdits(lines, [endOfLastLine])).toBeNull();
+        expect(verifyImportEdits(lines, [endOfLastLine], ["/B"])).toBeNull();
+    });
+
+    // The hazard insertImportLines documents its past-the-end branch to avoid:
+    // the same position with the break missing splices the statement onto the
+    // code already there and leaves one unreadable line where two belong.
+    it("refuses an insertion that splices into the middle of a line", () => {
+        const lines = ["code()"];
+        const spliced: QueuedEdit = { startLine: 0, startCharacter: 6, endLine: 0, endCharacter: 6, newText: "using { /B }\n" };
+
+        expect(verifyImportEdits(lines, [spliced], ["/B"])).toBe('the queued edits splice "using { /B }\\n" into the middle of line 1');
+    });
+
+    it("refuses an import no caller asked for", () => {
+        const lines = ["using { /A }", "code()"];
+
+        expect(verifyImportEdits(lines, [insertion(0, "using { /EVIL }\n")], [])).toBe("the queued edits import /EVIL, which nothing asked for");
     });
 });

--- a/src/imports/__tests__/ImportRewriteGuard.test.ts
+++ b/src/imports/__tests__/ImportRewriteGuard.test.ts
@@ -1,0 +1,163 @@
+import { QueuedEdit, verifyImportEdits, verifyOrganizedRewrite } from "../ImportRewriteGuard";
+
+/** A whole-line removal, the only shape the writers produce. */
+function removal(startLine: number, endLineExclusive: number, newText = ""): QueuedEdit {
+    return { startLine, startCharacter: 0, endLine: endLineExclusive, endCharacter: 0, newText };
+}
+
+function insertion(line: number, newText: string): QueuedEdit {
+    return { startLine: line, startCharacter: 0, endLine: line, endCharacter: 0, newText };
+}
+
+describe("verifyOrganizedRewrite", () => {
+    it("passes a consolidation that keeps every path and every body line", () => {
+        const before = "using { /B }\nusing { /A }\ncode()";
+        const after = "using { /A }\nusing { /B }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBeNull();
+    });
+
+    it("reports an import the rebuild dropped", () => {
+        const before = "using { /A }\nusing { /B }\ncode()";
+        const after = "using { /A }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBe("the rebuilt document no longer imports /B");
+    });
+
+    it("reports an import nothing asked for", () => {
+        const before = "using { /A }\ncode()";
+        const after = "using { /A }\nusing { /C }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBe("the rebuilt document imports /C, which nothing asked for");
+    });
+
+    it("accepts an import the caller asked to add", () => {
+        const before = "using { /A }\ncode()";
+        const after = "using { /A }\nusing { /C }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, ["/C"])).toBeNull();
+    });
+
+    // The whole point of the guard: a rebuild that loses a line of the user's
+    // own code must never reach applyEdit.
+    it("reports a body line the rebuild lost", () => {
+        const before = "using { /A }\ncode()\nmore()";
+        const after = "using { /A }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBe('1 code line(s) outside the imports were lost, from "more()"');
+    });
+
+    it("reports a body line the rebuild claimed twice", () => {
+        const before = "using { /A }\ncode()\nmore()";
+        const after = "using { /A }\n\ncode()\ncode()\nmore()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toContain("code line 2 outside the imports");
+    });
+
+    it("reports a body line the rebuild rewrote", () => {
+        const before = "using { /A }\ncode()";
+        const after = "using { /A }\n\ncodeX()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBe('code line 1 outside the imports became "codeX()", was "code()"');
+    });
+
+    // Withholding an already-made import deletes the comments written for it on
+    // purpose, so a check demanding every comment survive would refuse correct
+    // output. See ImportDocumentEditor.buildOrganizedContent.
+    it("accepts a rewrite that dropped a comment", () => {
+        const before = "using { /A }\n# why /B is here\nusing { /B }\ncode()";
+        const after = "using { /A }\nusing { /B }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBeNull();
+    });
+
+    it("accepts a rewrite that trimmed the blank lines a hoisted block left behind", () => {
+        const before = "using { /A }\n\n\n\ncode()";
+        const after = "using { /A }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBeNull();
+    });
+
+    // A line holding both an import and code is pinned rather than rebuilt, so
+    // it is inside an import span on both sides and neither side compares its
+    // text. The path check is what covers it.
+    it("reports the lost path when a rewrite drops a line holding an import and code", () => {
+        const before = "using { /A }\nX := 1; using. /B\ncode()";
+        const after = "using { /A }\n\ncode()";
+
+        expect(verifyOrganizedRewrite(before, after, [])).toBe("the rebuilt document no longer imports /B");
+    });
+});
+
+describe("verifyImportEdits", () => {
+    it("passes an edit that only inserts", () => {
+        const lines = ["code()"];
+
+        expect(verifyImportEdits(lines, [insertion(0, "using { /A }\n")])).toBeNull();
+    });
+
+    it("passes a block replacement that writes its paths back", () => {
+        const lines = ["using { /B }", "using { /A }", "code()"];
+
+        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\nusing { /B }\n")])).toBeNull();
+    });
+
+    it("passes a consolidation that deletes a block and rewrites it at the top", () => {
+        const lines = ["code()", "using { /A }", "using { /B }"];
+        const edits = [insertion(0, "using { /A }\nusing { /B }\n"), removal(1, 3)];
+
+        expect(verifyImportEdits(lines, edits)).toBeNull();
+    });
+
+    // The off-by-one the ticket names: a run reaching one line past the block
+    // takes a line of the user's code with it.
+    it("refuses a range that reaches past the imports onto code", () => {
+        const lines = ["using { /A }", "code()"];
+
+        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\n")])).toBe('the queued edits remove line 2, which is code rather than an import: "code()"');
+    });
+
+    it("refuses a deletion that never writes the path back", () => {
+        const lines = ["using { /A }", "using { /B }", "code()"];
+
+        expect(verifyImportEdits(lines, [removal(0, 2)])).toBe("the queued edits remove /A, /B without writing it back");
+    });
+
+    // A path written twice is still imported while either line is left alone,
+    // so removing one copy is a deduplication rather than a loss.
+    it("passes a deletion that leaves another statement for the same path", () => {
+        const lines = ["using { /A }", "using { /A }", "code()"];
+
+        expect(verifyImportEdits(lines, [removal(1, 2)])).toBeNull();
+    });
+
+    it("treats a range ending at character 0 as stopping above that line", () => {
+        const lines = ["using { /A }", "code()"];
+
+        expect(verifyImportEdits(lines, [removal(0, 1, "using { /A }\n")])).toBeNull();
+    });
+
+    it("counts a line a range only partly covers as removed", () => {
+        const lines = ["using { /A }", "code()"];
+
+        expect(verifyImportEdits(lines, [{ startLine: 0, startCharacter: 0, endLine: 1, endCharacter: 3, newText: "using { /A }\n" }])).toContain("line 2, which is code");
+    });
+
+    // VS Code clamps a range past the end onto the document, so there is no
+    // line under those indices to classify.
+    it("ignores the part of a range that reaches past the last line", () => {
+        const lines = ["using { /A }"];
+
+        expect(verifyImportEdits(lines, [removal(0, 5, "using { /A }\n")])).toBeNull();
+    });
+
+    // insertImportLines writes past the last line from the end of that line
+    // rather than from column 0, which is still an insertion and removes
+    // nothing.
+    it("passes an insertion anchored at the end of the last line", () => {
+        const lines = ["using { /A }", "code()"];
+        const endOfLastLine: QueuedEdit = { startLine: 1, startCharacter: 6, endLine: 1, endCharacter: 6, newText: "\nusing { /B }" };
+
+        expect(verifyImportEdits(lines, [endOfLastLine])).toBeNull();
+    });
+});


### PR DESCRIPTION
Closes #386

Neither writer read its own output back before applying it, so a composition bug in the rebuild reached the user's file as silent text loss with the undo stack as the only recovery. Both paths now check before applying and refuse on a mismatch.

The two seams needed different mechanisms, because they have different shapes.

**Organize** produces one rebuilt text, so `verifyOrganizedRewrite` compares it against the input directly:

- no import lost, and none invented beyond what the caller asked for;
- every line of code outside the imports byte-identical and in the same order.

**Add** produces no output text at all, only a `WorkspaceEdit`, so `verifyImportEdits` reads the queued edits back off it:

- nothing but an import statement may be removed;
- a path whose statement is removed has to be written somewhere else;
- no path may be written in that nothing asked for;
- no insertion may splice into the middle of a line. An insertion carries no range, so the removal check cannot see one, and writing past the last line is the only legitimate reason to start off column 0 — that text opens with the line break that keeps the statement off the code already there. This is the hazard `insertImportLines` documents its past-the-end branch to prevent.

Reading the edits back with `entries()` rather than recording them while building is deliberate: the ticket's complaint is that the tool never checks what it is about to apply, and a parallel record would only ever confirm what it meant.

### What is deliberately excluded

Comment and blank lines. Withholding an already-made import deletes the comments written for it (`ImportDocumentEditor.ts:1094-1097`), and the blank lines a hoisted block leaves behind are trimmed (`:1222-1228`), so demanding either survive would refuse correct output. A line holding both an import and code is inside an import span on both sides and so is not compared as text; the path check is what covers it.

The guard reads both sides through the same scanner, so it answers whether the writer and the scanner agree — not whether either is right about Verse. A bug inside `scanModuleImports` is invisible to it. That limitation is recorded in the module's doc comment.

Refusal is limited to text loss. A requested path some branch declines to write is not text loss, and refusing the whole edit over it would also withhold the imports that were correct, so "every requested path was written" is not an invariant here.

### Scope

#384 is open and is not a dependency. Where it lands, the add path gains one output text and its range-level guard is replaced by the text-level one.

### Verification

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 43 passed, 43 total
Tests:       1272 passed, 1272 total
Snapshots:   0 total
Time:        7.989 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

196 tests are new, most of them the false-positive net: because the guard refuses edits, its worst failure mode is the extension silently ceasing to import. Fourteen document shapes — CRLF, no trailing newline, empty, imports only, a pinned import, a `using` in a `module:` body, a commented-out import, an indented `using:` pair, gapped blocks, a header comment — run against six setting combinations through both entry points, and every one must still reach `applyEdit`.

Every refusal test was confirmed to detect the defect it pins: with the corresponding check removed, each fails, and passes again once restored.

A fresh-context review returned PASS_WITH_SUGGESTIONS over ~130 probes with zero false positives found. Its two `Important` findings are the third and fourth bullets above, both now closed, and its remaining suggestions were applied except two recorded below.

### Left undone

- `verifyImportEdits` recomputes `classifyLines` and `scanModuleImports` that `addImportsToDocument` already holds. Threading them in would remove two scans from the debounced path, at the cost of two more parameters.
- A refusal returns `false`, which surfaces "the document may have changed or be read-only" — naming two causes, neither of them the real one. A guard that fires is a bug in the extension, so the message sends the report to the wrong place. Worth its own ticket.
