### PR TITLE
feat(imports): register a SourceOrganizeImports code action

### DIFF
--- a/changelog.d/387.added.md
+++ b/changelog.d/387.added.md
@@ -1,0 +1,1 @@
+**Imports**: VS Code's own Organize Imports now reaches the extension, so Shift+Alt+O and `editor.codeActionsOnSave` rebuild the import block in `.verse` files.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
         "category": "Verse Auto Imports"
       },
       {
+        "command": "verseAutoImports.organizeImportsInDocument",
+        "title": "Organize Imports in Document",
+        "category": "Verse Auto Imports"
+      },
+      {
         "command": "verseAutoImports.addSingleImport",
         "title": "Add Import",
         "category": "Verse Auto Imports"
@@ -127,6 +132,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "verseAutoImports.organizeImportsInDocument",
+          "when": "false"
+        },
         {
           "command": "verseAutoImports.addSingleImport",
           "when": "false"

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -430,7 +430,9 @@ const FileType = {
 class CodeActionKind {
     static readonly QuickFix = new CodeActionKind("quickfix");
     static readonly Source = new CodeActionKind("source");
-    static readonly SourceOrganizeImports = new CodeActionKind("source.organizeImports");
+    // Built by append, as the real API builds it, so a provider that appends
+    // the wrong sub-kind cannot agree with a mock that hardcoded the answer.
+    static readonly SourceOrganizeImports = CodeActionKind.Source.append("organizeImports");
 
     constructor(public readonly value: string) {}
 

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -429,6 +429,8 @@ const FileType = {
  */
 class CodeActionKind {
     static readonly QuickFix = new CodeActionKind("quickfix");
+    static readonly Source = new CodeActionKind("source");
+    static readonly SourceOrganizeImports = new CodeActionKind("source.organizeImports");
 
     constructor(public readonly value: string) {}
 

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -58,9 +58,9 @@ export class CommandsHandler {
      * them on deactivation.
      *
      * Each id here must also be declared in package.json under
-     * `contributes.commands`, and the five that take caller-supplied arguments
-     * must stay hidden from the Command Palette there - invoking one from the
-     * palette dereferences an undefined document. Both halves are pinned:
+     * `contributes.commands`, and every one that takes a caller-supplied
+     * argument must stay hidden from the Command Palette there - invoking one
+     * from the palette dereferences an undefined document. Both halves are pinned:
      * commandManifest.test.ts checks the manifest, CommandsHandler.test.ts
      * checks this method registers every id once, and the integration suite
      * checks they are registered once the extension has activated.
@@ -86,6 +86,7 @@ export class CommandsHandler {
         return [
             ["verseAutoImports.addSingleImport", this.addSingleImport.bind(this)],
             ["verseAutoImports.optimizeImports", this.optimizeImports.bind(this)],
+            ["verseAutoImports.organizeImportsInDocument", this.organizeImportsInDocument.bind(this)],
         ];
     }
 
@@ -152,16 +153,7 @@ export class CommandsHandler {
         try {
             const document = editor.document;
 
-            // Read straight from the current diagnostics rather than waiting on
-            // the auto-import debounce, so the command does not race it.
-            const diagnostics = vscode.languages.getDiagnostics(document.uri);
-            const missingImportPaths = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
-            logger.debug("CommandsHandler", `Found ${missingImportPaths.length} missing import(s) in current diagnostics`);
-
-            // The missing paths are handed to the organizer rather than added
-            // first, so the block is rewritten once and the document is never
-            // left between the two states.
-            const applied = await this.deps.importHandler.organizeImports(document, missingImportPaths);
+            const applied = await this.organizeImportsInDocument(document);
 
             // Saving a document whose edit was rejected writes the unorganized
             // content back to disk and makes the failure look like a success.
@@ -179,6 +171,30 @@ export class CommandsHandler {
             logger.error("CommandsHandler", "Error optimizing imports", error);
             vscode.window.showErrorMessage(`Failed to optimize imports: ${error}`);
         }
+    }
+
+    /**
+     * Rebuilds one document's import block, adding anything the compiler
+     * currently reports as a missing import. True when the document holds the
+     * organized content afterwards, which includes it having needed no change.
+     *
+     * Deliberately does not save: this is what the Organize Imports source
+     * action runs, and `editor.codeActionsOnSave` runs that during a save.
+     *
+     * The document comes from the code action that was asked for it, which is
+     * why the command is hidden from the Command Palette.
+     */
+    async organizeImportsInDocument(document: vscode.TextDocument): Promise<boolean> {
+        // Read straight from the current diagnostics rather than waiting on
+        // the auto-import debounce, so the command does not race it.
+        const diagnostics = vscode.languages.getDiagnostics(document.uri);
+        const missingImportPaths = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
+        logger.debug("CommandsHandler", `Found ${missingImportPaths.length} missing import(s) in current diagnostics`);
+
+        // The missing paths are handed to the organizer rather than added
+        // first, so the block is rewritten once and the document is never
+        // left between the two states.
+        return this.deps.importHandler.organizeImports(document, missingImportPaths);
     }
 
     private menuCommands(): CommandEntry[] {

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -153,13 +153,10 @@ export class CommandsHandler {
         try {
             const document = editor.document;
 
-            const applied = await this.organizeImportsInDocument(document);
-
             // Saving a document whose edit was rejected writes the unorganized
             // content back to disk and makes the failure look like a success.
-            if (!applied) {
-                logger.warn("CommandsHandler", "Import organization was not applied to the document");
-                vscode.window.showWarningMessage("Could not optimize imports. The document may have changed or be read-only.");
+            // organizeImportsInDocument has already told the user why.
+            if (!(await this.organizeImportsInDocument(document))) {
                 return;
             }
 
@@ -178,23 +175,38 @@ export class CommandsHandler {
      * currently reports as a missing import. True when the document holds the
      * organized content afterwards, which includes it having needed no change.
      *
-     * Deliberately does not save: this is what the Organize Imports source
-     * action runs, and `editor.codeActionsOnSave` runs that during a save.
+     * Deliberately does not save: the Organize Imports source action runs this,
+     * and `editor.codeActionsOnSave` runs that action during a save.
      *
-     * The document comes from the code action that was asked for it, which is
-     * why the command is hidden from the Command Palette.
+     * Reports its own failures rather than returning a bare false, and swallows
+     * what it reports. The source action's caller is VS Code, which discards
+     * the return value and logs a thrown error where nobody looks, so anything
+     * left for the caller to say is said to nobody.
      */
     async organizeImportsInDocument(document: vscode.TextDocument): Promise<boolean> {
-        // Read straight from the current diagnostics rather than waiting on
-        // the auto-import debounce, so the command does not race it.
-        const diagnostics = vscode.languages.getDiagnostics(document.uri);
-        const missingImportPaths = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
-        logger.debug("CommandsHandler", `Found ${missingImportPaths.length} missing import(s) in current diagnostics`);
+        try {
+            // Read straight from the current diagnostics rather than waiting on
+            // the auto-import debounce, so the command does not race it.
+            const diagnostics = vscode.languages.getDiagnostics(document.uri);
+            const missingImportPaths = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
+            logger.debug("CommandsHandler", `Found ${missingImportPaths.length} missing import(s) in current diagnostics`);
 
-        // The missing paths are handed to the organizer rather than added
-        // first, so the block is rewritten once and the document is never
-        // left between the two states.
-        return this.deps.importHandler.organizeImports(document, missingImportPaths);
+            // The missing paths are handed to the organizer rather than added
+            // first, so the block is rewritten once and the document is never
+            // left between the two states.
+            const applied = await this.deps.importHandler.organizeImports(document, missingImportPaths);
+
+            if (!applied) {
+                logger.warn("CommandsHandler", "Import organization was not applied to the document");
+                vscode.window.showWarningMessage("Could not optimize imports. The document may have changed or be read-only.");
+            }
+
+            return applied;
+        } catch (error) {
+            logger.error("CommandsHandler", "Error optimizing imports", error);
+            vscode.window.showErrorMessage(`Failed to optimize imports: ${error}`);
+            return false;
+        }
     }
 
     private menuCommands(): CommandEntry[] {

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -46,6 +46,7 @@ afterEach(() => {
 const REGISTERED_COMMANDS: Array<[string, string]> = [
     ["verseAutoImports.addSingleImport", "addSingleImport"],
     ["verseAutoImports.optimizeImports", "optimizeImports"],
+    ["verseAutoImports.organizeImportsInDocument", "organizeImportsInDocument"],
     ["verseAutoImports.showStatusMenu", "showStatusMenu"],
     ["verseAutoImports.toggleAutoImport", "toggleAutoImport"],
     ["verseAutoImports.togglePreserveLocations", "togglePreserveLocations"],
@@ -152,6 +153,46 @@ describe("CommandsHandler.optimizeImports", () => {
         expect(document.save).toHaveBeenCalledTimes(1);
         expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("Imports optimized successfully");
         expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+});
+
+// Regression for #387: what the Organize Imports source action runs. It shares
+// the organizing with optimizeImports and differs in what it deliberately does
+// not do - editor.codeActionsOnSave runs it during a save, so a save of its own
+// would re-enter that one.
+describe("CommandsHandler.organizeImportsInDocument", () => {
+    it("organizes the document it is given, with the paths the diagnostics report missing", async () => {
+        const document = makeDocument();
+        const organizeImports = jest.fn().mockResolvedValue(true);
+        const handler = makeHandler({
+            organizeImports,
+            extractImportsFromDiagnostics: jest.fn().mockReturnValue(["/Fortnite.com/Devices"]),
+        });
+
+        const applied = await handler.organizeImportsInDocument(document);
+
+        expect(applied).toBe(true);
+        expect(organizeImports).toHaveBeenCalledWith(document, ["/Fortnite.com/Devices"]);
+    });
+
+    it("does not save, and does not fall back to the active editor", async () => {
+        const active = makeDocument("C:\\Project\\Content\\other.verse");
+        setActiveEditor({ document: active } as unknown as vscode.TextEditor);
+        const document = makeDocument();
+        const organizeImports = jest.fn().mockResolvedValue(true);
+        const handler = makeHandler({ organizeImports });
+
+        await handler.organizeImportsInDocument(document);
+
+        expect(organizeImports).toHaveBeenCalledWith(document, []);
+        expect(document.save).not.toHaveBeenCalled();
+        expect(active.save).not.toHaveBeenCalled();
+    });
+
+    it("reports the rejection when the edit does not apply", async () => {
+        const handler = makeHandler({ organizeImports: jest.fn().mockResolvedValue(false) });
+
+        await expect(handler.organizeImportsInDocument(makeDocument())).resolves.toBe(false);
     });
 });
 

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -189,10 +189,36 @@ describe("CommandsHandler.organizeImportsInDocument", () => {
         expect(active.save).not.toHaveBeenCalled();
     });
 
-    it("reports the rejection when the edit does not apply", async () => {
+    // VS Code discards what the command returns, so a bare false reaching it is
+    // the silence #387 was filed about, arriving at the new entry point.
+    it("warns the user when the edit does not apply", async () => {
         const handler = makeHandler({ organizeImports: jest.fn().mockResolvedValue(false) });
 
         await expect(handler.organizeImportsInDocument(makeDocument())).resolves.toBe(false);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showWarningMessage as jest.Mock).mock.calls[0][0]).toMatch(/Could not optimize imports/);
+    });
+
+    // codeActionsOnSave runs this as a save participant, and VS Code logs a
+    // participant's failure where nobody looks rather than surfacing it.
+    it("reports a throw rather than letting it escape into the save", async () => {
+        const handler = makeHandler({ organizeImports: jest.fn().mockRejectedValue(new Error("boom")) });
+
+        await expect(handler.organizeImportsInDocument(makeDocument())).resolves.toBe(false);
+
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showErrorMessage as jest.Mock).mock.calls[0][0]).toMatch(/Failed to optimize imports/);
+    });
+
+    it("says nothing when the organize succeeds", async () => {
+        const handler = makeHandler({ organizeImports: jest.fn().mockResolvedValue(true) });
+
+        await handler.organizeImportsInDocument(makeDocument());
+
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+        expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
     });
 });
 

--- a/src/commands/__tests__/commandManifest.test.ts
+++ b/src/commands/__tests__/commandManifest.test.ts
@@ -1,12 +1,13 @@
 import * as fs from "fs";
 import * as path from "path";
 
-// Regression for #136: six commands need caller-supplied arguments - the import
-// quick fix passes them to addSingleImport, the CodeLens passes them to the four
-// conversion commands, and the module-visibility quick fix passes the parsed
-// diagnostic to makeModulePublic. Without a commandPalette entry hiding them,
-// every declared command is palette-visible, and invoking one of these from the
-// palette dereferences an undefined argument.
+// Regression for #136: several commands need caller-supplied arguments - the
+// import quick fix passes them to addSingleImport, the CodeLens passes them to
+// the four conversion commands, the module-visibility quick fix passes the
+// parsed diagnostic to makeModulePublic, and the organize source action passes
+// the document to organizeImportsInDocument. Without a commandPalette entry
+// hiding them, every declared command is palette-visible, and invoking one of
+// these from the palette dereferences an undefined argument.
 
 interface CommandContribution {
     command: string;
@@ -32,6 +33,7 @@ const ARGUMENT_REQUIRING_COMMANDS = [
     "verseAutoImports.convertToRelativePath",
     "verseAutoImports.convertAllToRelativePath",
     "verseAutoImports.makeModulePublic",
+    "verseAutoImports.organizeImportsInDocument",
 ];
 
 const manifest: Manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json"), "utf8"));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { logger, collectEnvironment, formatHostSummary, readSessionState } from "./utils";
 import { DiagnosticsHandler } from "./diagnostics";
-import { ImportHandler, ImportPathConverter, ImportCodeActionProvider, ImportCodeLensProvider, ImportFormatter } from "./imports";
+import { ImportHandler, ImportPathConverter, ImportCodeActionProvider, ImportOrganizeCodeActionProvider, ImportCodeLensProvider, ImportFormatter } from "./imports";
 import { CommandsHandler, CommandsDependencies } from "./commands";
 import { StatusBarHandler } from "./ui";
 import { ProjectPathHandler } from "./project";
@@ -140,6 +140,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ImportCodeActionProvider(outputChannel, importHandler)),
         vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ModuleVisibilityCodeActionProvider()),
+        // The metadata is not optional here as it is for the quick fixes above:
+        // it is what tells VS Code this provider answers source.organizeImports,
+        // and so what puts Shift+Alt+O and editor.codeActionsOnSave through it.
+        vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ImportOrganizeCodeActionProvider(), {
+            providedCodeActionKinds: ImportOrganizeCodeActionProvider.providedCodeActionKinds,
+        }),
         vscode.languages.registerCodeLensProvider({ language: "verse" }, importCodeLensProvider),
         importCodeLensProvider,
     );

--- a/src/imports/ImportOrganizeCodeActionProvider.ts
+++ b/src/imports/ImportOrganizeCodeActionProvider.ts
@@ -1,0 +1,40 @@
+import * as vscode from "vscode";
+import { logger } from "../utils";
+
+/**
+ * Puts the extension's import organizing behind VS Code's own Organize Imports:
+ * Shift+Alt+O, the Source Action menu, and `editor.codeActionsOnSave`.
+ *
+ * The action carries no edit of its own. Organizing rebuilds the whole import
+ * block and adds whatever the current diagnostics report as missing, which is
+ * the same work the Optimize Imports command does, so it is delegated to a
+ * command rather than reimplemented as a workspace edit that would drift from
+ * it.
+ */
+export class ImportOrganizeCodeActionProvider implements vscode.CodeActionProvider {
+    /**
+     * Declared to the registration so VS Code skips this provider whenever a
+     * different kind is requested. Without it every quick-fix request would
+     * also build this action.
+     */
+    static readonly providedCodeActionKinds: readonly vscode.CodeActionKind[] = [vscode.CodeActionKind.SourceOrganizeImports];
+
+    /**
+     * The organize action, always. A source action is only ever requested
+     * explicitly, and organizing a block that is already organized is a no-op
+     * the editor never sees, so there is nothing to withhold it for.
+     */
+    provideCodeActions(document: vscode.TextDocument): vscode.CodeAction[] {
+        logger.debug("ImportOrganizeCodeActionProvider", "Offering the organize imports source action");
+
+        const action = new vscode.CodeAction("Organize Imports", vscode.CodeActionKind.SourceOrganizeImports);
+
+        action.command = {
+            title: "Organize Imports",
+            command: "verseAutoImports.organizeImportsInDocument",
+            arguments: [document],
+        };
+
+        return [action];
+    }
+}

--- a/src/imports/__tests__/ImportOrganizeCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportOrganizeCodeActionProvider.test.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode";
+import { ImportOrganizeCodeActionProvider } from "../ImportOrganizeCodeActionProvider";
+
+// Regression for #387: the extension registered quick-fix providers only, so
+// VS Code's own Organize Imports - Shift+Alt+O, the Source Action menu, and
+// editor.codeActionsOnSave - reached nothing in a .verse file and gave the user
+// no sign that nothing had happened.
+
+function makeDocument(): vscode.TextDocument {
+    return {
+        uri: vscode.Uri.file("C:\\Project\\Content\\device.verse"),
+        languageId: "verse",
+    } as unknown as vscode.TextDocument;
+}
+
+describe("ImportOrganizeCodeActionProvider", () => {
+    it("declares source.organizeImports to the registration", () => {
+        expect(ImportOrganizeCodeActionProvider.providedCodeActionKinds.map((kind) => kind.value)).toEqual(["source.organizeImports"]);
+    });
+
+    it("offers one action, of kind source.organizeImports", () => {
+        const actions = new ImportOrganizeCodeActionProvider().provideCodeActions(makeDocument());
+
+        expect(actions).toHaveLength(1);
+        expect(actions[0].kind?.value).toBe("source.organizeImports");
+    });
+
+    it("wires the action to the organize command, on the document it was asked about", () => {
+        const document = makeDocument();
+
+        const [action] = new ImportOrganizeCodeActionProvider().provideCodeActions(document);
+
+        expect(action.command?.command).toBe("verseAutoImports.organizeImportsInDocument");
+        expect(action.command?.arguments).toEqual([document]);
+    });
+
+    it("carries no edit of its own", () => {
+        const [action] = new ImportOrganizeCodeActionProvider().provideCodeActions(makeDocument());
+
+        expect(action.edit).toBeUndefined();
+    });
+});

--- a/src/imports/index.ts
+++ b/src/imports/index.ts
@@ -1,11 +1,12 @@
 // ImportHandler is the entry point for import handling: outside this module,
-// take it, the converter, the two providers, or ImportFormatter for its static
-// classification. ImportSuggestionExtractor and ImportDocumentEditor are the
-// facade's own collaborators and have no caller outside it.
+// take it, the converter, the three providers, or ImportFormatter for its
+// static classification. ImportSuggestionExtractor and ImportDocumentEditor are
+// the facade's own collaborators and have no caller outside it.
 export { ImportHandler } from "./ImportHandler";
 export { ImportFormatter } from "./ImportFormatter";
 export { ImportSuggestionExtractor } from "./ImportSuggestionExtractor";
 export { ImportDocumentEditor } from "./ImportDocumentEditor";
 export { ImportPathConverter } from "./ImportPathConverter";
 export { ImportCodeActionProvider } from "./ImportCodeActionProvider";
+export { ImportOrganizeCodeActionProvider } from "./ImportOrganizeCodeActionProvider";
 export { ImportCodeLensProvider } from "./ImportCodeLensProvider";


### PR DESCRIPTION
## What

VS Code's native Organize Imports never reached this extension in a `.verse` file. Both registered code action providers are quick-fix only, so Shift+Alt+O, the Source Action menu and `editor.codeActionsOnSave: { "source.organizeImports": ... }` all found nothing to run — and gave the user no sign that nothing had happened. The organizing logic was already there and already tested; only the entry point was missing.

A new `ImportOrganizeCodeActionProvider` returns one action of kind `source.organizeImports`, registered with `providedCodeActionKinds` metadata so VS Code knows to route the request through it. The action carries a hidden `verseAutoImports.organizeImportsInDocument` command rather than a `WorkspaceEdit`.

Two decisions were settled with the maintainer before implementation:

- **Full parity with Optimize Imports**, missing-import addition from the current diagnostics included, so "organize" means one thing everywhere in the extension.
- **A command, not a `WorkspaceEdit`.** The command path keeps exact parity, including the pre-apply rewrite guard from #406 and the `ensureEmptyLinesAfterImports` normalization, both of which live inside `ImportDocumentEditor.organizeImports`. A `WorkspaceEdit` would have needed a compute-only path that diverges from it whenever `behavior.emptyLinesAfterImports` is not the default. The cost is no diff preview in the code-action widget.

The new command deliberately does not save: `editor.codeActionsOnSave` runs it *during* a save, and `optimizeImports` keeps the save, the editor lookup and the `languageId` guard that belong to the palette command.

It does report its own failures, though. VS Code discards what a code action's command returns and logs a thrown error where nobody looks, so a rejected edit — a stale document version, a read-only file, or the rewrite guard refusing — would otherwise be silent on exactly the path this PR adds. That is the ticket's own complaint reappearing at the new entry point, so the warning and the error message moved into `organizeImportsInDocument`, which swallows what it reports; `optimizeImports` keeps only the decision to save.

## Changes

- `src/imports/ImportOrganizeCodeActionProvider.ts` — new provider, one action, no import logic of its own.
- `src/extension.ts` — registers it with `providedCodeActionKinds`; the two existing registrations are untouched.
- `src/commands/CommandsHandler.ts` — `organizeImportsInDocument(document)` holds the organizing and the failure reporting that `optimizeImports` used to inline; `optimizeImports` delegates to it and keeps the editor lookup, the guards and the save.
- `package.json` — declares the new command and hides it from the Command Palette, as the repo requires of every command taking a caller-supplied argument.
- `src/__mocks__/vscode.ts` — `CodeActionKind` gains `Source` and `SourceOrganizeImports`, the latter built by `append` as the real API builds it.
- Tests: a new entry-point regression on the provider, five on `organizeImportsInDocument`, and the two manifest/registration pins extended.

## Verification

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 45 passed, 45 total
Tests:       1302 passed, 1302 total
Snapshots:   0 total
Time:        7.988 s, estimated 8 s
Ran all test suites.
```

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The new tests were confirmed to detect the defect: with the provider file and the `CommandsHandler`/`package.json` changes removed, `ImportOrganizeCodeActionProvider.test.ts` and the three new `CommandsHandler` cases fail to compile against the missing symbols, and `commandManifest.test.ts` fails its palette assertion at runtime.

## Review

One round, fresh reviewer, verdict `PASS_WITH_SUGGESTIONS`: no Critical, one Important, six Suggestions. The Important is the silent-rejection finding, fixed above. Three Suggestions were taken: the missing `try`/`catch` on the save-participant path, the mock's hardcoded kind string, and a doc comment that named the code action as the method's only caller when `optimizeImports` calls it too.

Three were left, deliberately:

- **No `languageId` guard on `organizeImportsInDocument`.** Unreachable through the provider, which registers for `{ language: "verse" }`, and the command is hidden from the palette. Defence-in-depth against a keybinding or another extension calling it, not a defect.
- **The two existing providers still declare no `providedCodeActionKinds`**, so VS Code must invoke them for every request including this one, and their quick fixes are built and then discarded on kind. A real cost on the save path and a one-line fix each, but it changes code this ticket does not touch — better as its own issue.
- **A manual F5 smoke test with a non-default `behavior.emptyLinesAfterImports`**, where the organizer's own spacing edit and the `onWillSaveTextDocument` participant both run inside one save. Reading says they converge; unit tests cannot reach the permutation. Flagged below.

## Open

Not smoke-tested in the Extension Development Host — the repo has no end-to-end coverage for this and CLAUDE.md leaves it to a manual F5. Worth checking Shift+Alt+O and organize-on-save in a `.verse` file, and the `emptyLinesAfterImports` permutation above, before release.

Closes #387
