### PR TITLE
fix(visibility): refuse to write when the scan went stale

### DIFF
--- a/changelog.d/398.fixed.md
+++ b/changelog.d/398.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: The make-public quick fix now refuses, naming the file, when a project file changes while it scans, instead of writing at stale offsets or reverting the definitions file.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -313,8 +313,10 @@ const workspace = {
     },
     createFileSystemWatcher: jest.fn().mockImplementation((globPattern: unknown) => new FileSystemWatcher(globPattern)),
     // Empty by default so a test that only needs the scan to complete does not
-    // have to stub it; tests that care about parse timing replace it.
-    openTextDocument: jest.fn().mockResolvedValue({ getText: () => "" }),
+    // have to stub it; tests that care about parse timing replace it. The
+    // version is carried because callers compare it across two reads to detect
+    // an edit made in between, and an undefined would compare equal to itself.
+    openTextDocument: jest.fn().mockResolvedValue({ getText: () => "", version: 1 }),
     /**
      * Renders a path relative to the first workspace folder, forward-slashed, as
      * the scanner and the cache watchers expect; anything outside it comes back

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -17,10 +17,27 @@ const SCAN_CONCURRENCY = 8;
 /** Why an attempt to publicize a module produced no edit. */
 type Refusal = { reason: string };
 
+/** The version recorded for a file that did not exist when it was read. */
+const ABSENT = -1;
+
 /** A scanned file, and the exact text every offset taken from it addresses. */
 interface ScannedFile {
     uri: vscode.Uri;
     text: string;
+    version: number;
+}
+
+/**
+ * A file as it stood when its text was read, so a change made while the rest of
+ * the project was still being scanned can be caught before anything is written.
+ *
+ * `version` is ABSENT for a file that did not exist. The definitions file is
+ * created with `ignoreIfExists`, so one that appears during the scan would
+ * otherwise be prepended to rather than created.
+ */
+interface Snapshot {
+    uri: vscode.Uri;
+    version: number;
 }
 
 /**
@@ -64,6 +81,16 @@ export class ModuleVisibilityWriter {
             return;
         }
 
+        // As late as possible, and never earlier: every moment between this
+        // check and applyEdit is window the check cannot cover.
+        const drifted = await this.findDrift(outcome.snapshots);
+        if (drifted) {
+            const name = vscode.workspace.asRelativePath(drifted, false);
+            logger.warn("ModuleVisibilityWriter", `Stale scan for ${request.targetPath}: ${drifted.toString()} changed`);
+            vscode.window.showWarningMessage(`Verse Auto Imports: '${name}' changed while the project was scanned, so nothing was written. Run the fix again.`);
+            return;
+        }
+
         const applied = await vscode.workspace.applyEdit(outcome.edit);
         if (!applied) {
             logger.warn("ModuleVisibilityWriter", `Edit rejected for ${request.targetPath}`);
@@ -75,8 +102,11 @@ export class ModuleVisibilityWriter {
         vscode.window.showInformationMessage(`Verse Auto Imports: ${outcome.summary}`);
     }
 
-    /** The single edit that satisfies a request, or why there is none. */
-    private async buildEdit(request: ModuleVisibilityRequest): Promise<{ edit: vscode.WorkspaceEdit; summary: string } | Refusal> {
+    /**
+     * The single edit that satisfies a request, with what every file it was
+     * computed from looked like at read time, or why there is none.
+     */
+    private async buildEdit(request: ModuleVisibilityRequest): Promise<{ edit: vscode.WorkspaceEdit; summary: string; snapshots: Snapshot[] } | Refusal> {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
         if (!workspaceFolder) {
             return { reason: "no workspace folder is open." };
@@ -130,6 +160,11 @@ export class ModuleVisibilityWriter {
 
         const edit = new vscode.WorkspaceEdit();
 
+        // Every scanned file, not only the ones an edit addresses: the text of
+        // each fed resolveVisibility's ruling, so a change to any of them
+        // invalidates the whole result rather than one offset.
+        const snapshots: Snapshot[] = [...scanned.values()].map((file) => ({ uri: file.uri, version: file.version }));
+
         // A specifier edit inside the definitions file would overlap the
         // whole-file replace below, which VS Code rejects, so it is folded into
         // that replacement's text instead of being applied separately.
@@ -139,15 +174,20 @@ export class ModuleVisibilityWriter {
         this.addSpecifierEdits(edit, elsewhere, scanned);
 
         if (resolved.chain.length > 0) {
-            const existing = scanned.get(definitionsKey)?.text ?? (await this.readDefinitions(definitionsUri));
-            if (existing === undefined) {
+            const scannedDefinitions = scanned.get(definitionsKey);
+            const definitions = scannedDefinitions ?? (await this.readDefinitions(definitionsUri));
+            if (definitions === undefined) {
                 return { reason: "the definitions file could not be read." };
             }
+            if (!scannedDefinitions) {
+                snapshots.push({ uri: definitionsUri, version: definitions.version });
+            }
 
+            const existing = definitions.text;
             const withEdits = applySpecifierEdits(existing, inDefinitions);
             const content = appendDeclarationBlock(withEdits, buildDeclarationBlock(resolved.chain));
 
-            if (existing.length === 0 && !scanned.has(definitionsKey)) {
+            if (existing.length === 0 && !scannedDefinitions) {
                 edit.createFile(definitionsUri, { ignoreIfExists: true });
                 edit.insert(definitionsUri, new vscode.Position(0, 0), content);
             } else {
@@ -155,7 +195,42 @@ export class ModuleVisibilityWriter {
             }
         }
 
-        return { edit, summary: this.summarize(request.moduleName, resolved.edits, resolved.chain.length > 0) };
+        return { edit, summary: this.summarize(request.moduleName, resolved.edits, resolved.chain.length > 0), snapshots };
+    }
+
+    /**
+     * The first file that changed since its text was read, or null when every
+     * one still stands as it was.
+     *
+     * A file that no longer opens counts as changed: it was readable when the
+     * offsets were taken from it, so whatever happened to it since invalidates
+     * them. VS Code offers nothing atomic here - WorkspaceEdit carries no
+     * version and applyEdit accepts none - so this narrows the window to the
+     * gap before the apply rather than closing it.
+     */
+    private async findDrift(snapshots: readonly Snapshot[]): Promise<vscode.Uri | null> {
+        for (const snapshot of snapshots) {
+            if (snapshot.version === ABSENT) {
+                const created = await vscode.workspace.fs.stat(snapshot.uri).then(
+                    () => true,
+                    () => false,
+                );
+                if (created) {
+                    return snapshot.uri;
+                }
+                continue;
+            }
+
+            const version = await vscode.workspace.openTextDocument(snapshot.uri).then(
+                (document) => document.version,
+                () => null,
+            );
+            if (version !== snapshot.version) {
+                return snapshot.uri;
+            }
+        }
+
+        return null;
     }
 
     /** Adds one specifier rewrite per existing declaration, resolving offsets against the text they came from. */
@@ -216,22 +291,24 @@ export class ModuleVisibilityWriter {
     }
 
     /**
-     * The definitions file's text, "" when it does not exist, or undefined when
-     * it exists but could not be read - which must not be treated as empty,
-     * since that would discard whatever it holds.
+     * The definitions file's text and the version it was read at, "" at ABSENT
+     * when it does not exist, or undefined when it exists but could not be read
+     * - which must not be treated as empty, since that would discard whatever
+     * it holds.
      *
      * The undefined is now rare rather than gone: where findFiles listed the
      * file, findDeclarations opens it first and refuses there instead.
      */
-    private async readDefinitions(uri: vscode.Uri): Promise<string | undefined> {
+    private async readDefinitions(uri: vscode.Uri): Promise<{ text: string; version: number } | undefined> {
         try {
             await vscode.workspace.fs.stat(uri);
         } catch {
-            return "";
+            return { text: "", version: ABSENT };
         }
 
         try {
-            return (await vscode.workspace.openTextDocument(uri)).getText();
+            const document = await vscode.workspace.openTextDocument(uri);
+            return { text: document.getText(), version: document.version };
         } catch {
             return undefined;
         }
@@ -312,13 +389,16 @@ export class ModuleVisibilityWriter {
             return null;
         }
 
-        const text = await vscode.workspace.openTextDocument(uri).then(
-            (document) => document.getText(),
+        // Text and version come off the same document object, so the version
+        // recorded is the one this exact text was read at.
+        const read = await vscode.workspace.openTextDocument(uri).then(
+            (document) => ({ text: document.getText(), version: document.version }),
             () => null,
         );
-        if (text === null) {
+        if (read === null) {
             return { unreadable: uri };
         }
+        const { text } = read;
         if (!text.includes("module")) {
             return null;
         }
@@ -332,7 +412,7 @@ export class ModuleVisibilityWriter {
                 declaration,
             }));
 
-        return { file: { uri, text }, declarations };
+        return { file: { uri, text, version: read.version }, declarations };
     }
 
     /**

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -12,30 +12,67 @@ const REQUEST = {
 };
 
 /**
+ * What happens to a file between the scan that reads it and the check that runs
+ * before the write, keyed by URI. Empty means every file holds still.
+ */
+const afterScan = new Map<string, "changed" | "gone" | "created">();
+
+/**
  * Stands the workspace up from one map of workspace-relative path to file text.
  *
  * Text is served through openTextDocument, which is where production reads it,
  * so an offset a test asserts on addresses the same string the writer parsed.
+ * Each read is counted, because the writer reads a file once to scan it and
+ * again to check it still stands: an entry in `afterScan` changes what the
+ * second read answers.
  */
 const givenProject = (files: Record<string, string>, root = ROOT): vscode.Uri[] => {
     (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file(root), name: root.split("/").pop(), index: 0 }];
 
     const uris = Object.keys(files).map((relative) => vscode.Uri.file(`${root}/${relative}`));
     const byUri = new Map(uris.map((uri, index) => [uri.toString(), files[Object.keys(files)[index]]]));
+    const opens = new Map<string, number>();
+    const stats = new Map<string, number>();
 
     (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(uris);
     (vscode.workspace.fs.stat as jest.Mock).mockImplementation((uri: vscode.Uri) => {
         if (uri.fsPath.replace(/\\/g, "/").endsWith("/Content")) {
             return Promise.resolve({ type: vscode.FileType.Directory });
         }
-        return byUri.has(uri.toString()) ? Promise.resolve({ type: vscode.FileType.File }) : Promise.reject(new Error("ENOENT"));
+        const key = uri.toString();
+        if (afterScan.get(key) === "created") {
+            const seen = (stats.get(key) ?? 0) + 1;
+            stats.set(key, seen);
+            return seen === 1 ? Promise.reject(new Error("ENOENT")) : Promise.resolve({ type: vscode.FileType.File });
+        }
+        return byUri.has(key) ? Promise.resolve({ type: vscode.FileType.File }) : Promise.reject(new Error("ENOENT"));
     });
     (vscode.workspace.openTextDocument as jest.Mock).mockImplementation((uri: vscode.Uri) => {
-        const content = byUri.get(uri.toString());
-        return content === undefined ? Promise.reject(new Error("ENOENT")) : Promise.resolve({ getText: () => content });
+        const key = uri.toString();
+        const content = byUri.get(key);
+        if (content === undefined) {
+            return Promise.reject(new Error("ENOENT"));
+        }
+
+        const seen = (opens.get(key) ?? 0) + 1;
+        opens.set(key, seen);
+        const fate = seen === 1 ? undefined : afterScan.get(key);
+        if (fate === "gone") {
+            return Promise.reject(new Error("ENOENT"));
+        }
+        return Promise.resolve({ getText: () => content, version: fate === "changed" ? 2 : 1 });
     });
 
     return uris;
+};
+
+/**
+ * Says what happens to a file after the scan has read it: an edit that moves
+ * its version on, a delete, or a creation of a file that was not there. Call
+ * after givenProject.
+ */
+const duringScan = (relative: string, fate: "changed" | "gone" | "created", root = ROOT): void => {
+    afterScan.set(vscode.Uri.file(`${root}/${relative}`).toString(), fate);
 };
 
 /**
@@ -64,6 +101,7 @@ const forwardSlashed = (uri: { fsPath: string }): string => String(uri.fsPath).r
 describe("ModuleVisibilityWriter", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        afterScan.clear();
         (vscode.workspace.applyEdit as jest.Mock).mockResolvedValue(true);
         (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
             get: jest.fn().mockImplementation((_key: string, fallback?: unknown) => fallback),
@@ -178,6 +216,40 @@ describe("ModuleVisibilityWriter", () => {
         // The declaration reads `<scoped{Scripts}>`; printing `<scoped>` would
         // quote the file as saying something that does not compile.
         expect(warning).not.toContain("<scoped>");
+    });
+
+    it("refuses when a scanned file was edited during the scan, naming it", async () => {
+        // The offsets came from text that is no longer what the file holds, so
+        // applying the edit would put the specifier in the wrong place.
+        givenProject({ "Content/Gadgets/tools.verse": "Tools := module {}\n" });
+        duringScan("Content/Gadgets/tools.verse", "changed");
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("'Content/Gadgets/tools.verse' changed while the project was scanned"));
+    });
+
+    it("refuses when a scanned file can no longer be read before the write", async () => {
+        givenProject({ "Content/Gadgets/tools.verse": "Tools := module {}\n" });
+        duringScan("Content/Gadgets/tools.verse", "gone");
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("'Content/Gadgets/tools.verse' changed while the project was scanned"));
+    });
+
+    it("refuses when the definitions file appeared during the scan", async () => {
+        // The create carries ignoreIfExists, so without this the insert would
+        // prepend the block to whatever the user just wrote in that file.
+        givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+        duringScan("Content/_definitions.verse", "created");
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("'Content/_definitions.verse' changed while the project was scanned"));
     });
 
     it("does nothing when the module is already public", async () => {


### PR DESCRIPTION
Closes #398

`ModuleVisibilityWriter` read every project file, computed one `WorkspaceEdit` from that text, then applied it without recording what it had read. An edit made during the scan was lost twice over: a `<public>` specifier landed at an offset computed against a stale snapshot, and the whole-file replace of the definitions file reverted whatever the user had typed meanwhile — with no error and no undo entry attributable to the extension.

## What changed

- `ScannedFile` carries the `version` its text was read at. `readDeclarations` takes both off the same `TextDocument`, so the version recorded is the one that exact text came from.
- `readDefinitions` returns `{ text, version }`. A file that does not exist reports an `ABSENT` sentinel rather than a version, which is what makes the create path checkable: the create carries `ignoreIfExists`, so a definitions file that appears during the scan would otherwise be prepended to instead of created.
- `buildEdit` returns a snapshot per file the resolution was computed from — every entry of `scanned`, not only the ones an edit addresses, because each one's text fed `resolveVisibility`'s conflict ruling.
- `makeModulePublic` re-checks those snapshots immediately before `applyEdit` and refuses on drift, naming the file:

  > Verse Auto Imports: 'Content/Scripts/main.verse' changed while the project was scanned, so nothing was written. Run the fix again.

A file that no longer opens counts as drift: it was readable when the offsets were taken from it.

## What this does not do

It narrows the window from the whole project scan to the gap before the apply; it does not close it. `WorkspaceEdit` carries no version and `applyEdit` accepts none (`@types/vscode` `index.d.ts:13321`, with `WorkspaceEditMetadata` at `:3890` holding only `isRefactoring`), so there is nothing atomic available at this seam.

Rescan-and-retry was considered and dropped: it doubles the worst-case scan and makes the outcome depend on typing speed.

## Tests

Three regression cases at the `makeModulePublic` entry point — a scanned file edited during the scan, one that becomes unreadable, and a definitions file that appears during the scan. All three fail against the unfixed `ModuleVisibilityWriter.ts` and pass with it; the 23 existing cases pass either way.

## Verification

```
$ npm run compile

> verse-auto-imports@0.11.1 compile
> tsc -p ./

$ npm test

> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 44 passed, 44 total
Tests:       1295 passed, 1295 total
Snapshots:   0 total
Time:        10.053 s
Ran all test suites.

$ npm run format:check

> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
