### PR TITLE
refactor(imports): read Verse comment and literal structure in one lexer

### DIFF
--- a/changelog.d/373.fixed.md
+++ b/changelog.d/373.fixed.md
@@ -1,0 +1,1 @@
+**Verse file scanning**: a `using` or declaration written beside a char literal, an interpolated string or a nested comment marker is no longer missed, and a call named after a type keyword is no longer recorded as a type

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -1,4 +1,6 @@
 import { ImportFormatter } from "./ImportFormatter";
+import { LexedLine, LexState, lexVerseLine } from "../utils/verseLexer";
+import { scanBraces } from "../utils/verseText";
 
 /**
  * Splits text into lines without keeping the carriage return of a CRLF pair.
@@ -67,211 +69,27 @@ export interface ScannedImport {
     trailingComment: string;
 }
 
-/** What one line of a document leaves behind for the line below it. */
-interface LineScan {
-    /** The block-comment nesting depth the next line starts at. */
-    depth: number;
-    /** Whether the line carries any text outside a comment. */
-    hasCode: boolean;
-    /**
-     * Nothing is put in a removed comment's place, so text on either side of
-     * one joins. That is what the field is for: a comment splicing a token
-     * apart, `us<##>ing { /A }`, rejoins into a `using` a search of the whole
-     * line can find, and a missed `using` is the one error its callers cannot
-     * survive. Putting a space there instead loses that, and buys only
-     * `X := 1<# note #>using { /A }` - a shape two statements with nothing
-     * between them do not compile as anyway.
-     */
-    codeWithoutComments: string;
-    /**
-     * `codeWithoutComments` with the contents of every `"` string replaced by
-     * spaces, so a `using` written as string text is not offered as a statement
-     * the line makes.
-     *
-     * Read this wherever a path is going to count as imported. The text of a
-     * string is data, not a statement, and recording a path from it both
-     * suppresses an import the file needs and - because a path that counts as
-     * pinned withholds the movable import of the same path from the rebuilt
-     * block - deletes the real `using` the author wrote.
-     *
-     * A `'` is deliberately not masked, though the lexer opens a char literal
-     * on one. The same character closes a path's quoted segment suffix,
-     * `Economy.Shop'Loc'`, and masking it truncates the path to `Economy.Shop`,
-     * a different module that exists; see ImportFormatter.DOTTED_STATEMENT.
-     * Nothing is lost by that, because a char literal holds one character and a
-     * `using` cannot fit in one.
-     *
-     * Spaces rather than nothing, so the text on either side of a string does
-     * not join into a token neither side wrote. `codeWithoutComments` removes
-     * comments without replacement on purpose, for the opposite reason; the two
-     * differ because a comment can splice a token apart and a string cannot.
-     *
-     * Equal to `codeWithoutComments` on a line that ended inside an open
-     * literal or interpolation, which the second lexing pass reads with literal
-     * tracking off. Nothing there can be classified, so nothing is masked, and
-     * a `using` written in an unterminated string on such a line still counts
-     * as present.
-     */
-    codeOutsideLiterals: string;
-    /**
-     * Whether the line holds a `<#>` marker, which makes every line below it
-     * indented past it part of the comment it opens.
-     */
-    opensIndentedComment: boolean;
-}
-
 /**
- * Advances `<# ... #>` block-comment nesting across one line, and reports
- * whether anything on the line was code rather than comment text.
+ * One line read with the block-comment depth and `<#>` marker state the lines
+ * above it left open, taking the scanner's fallback for a line that ends inside
+ * a literal.
  *
- * Three Verse rules decide what counts as an opener:
+ * That fallback re-reads the line with literal tracking off, which reads a `#`
+ * as a comment opener wherever it sits. Nothing could be lexed past the point
+ * the literal was left open - a string may legitimately be open there, since an
+ * interpolation block spans lines - so the rest of that line is trivia this
+ * cannot classify, and treating it as literal content is what would let a
+ * `using` written in a trailing comment read as the line's own statement.
  *
- * - Block comments nest, so an inner `#>` closes only the innermost `<#`.
- * - `<#>` is the *indented* comment marker, not a block opener. Its body is
- *   the indented lines below it, which the scanner already skips, so the only
- *   thing that matters here is not mistaking it for a `<#` that never closes.
- *   The rest of its line is comment text.
- * - A `#` line comment runs to the end of the line, so a `<#` inside one is
- *   text rather than an opener.
- * - A bare `#` inside a string or char literal is content, so a line is lexed
- *   far enough to tell the two apart, and no further. A string's `{ ... }`
- *   interpolation holds ordinary code, so the two alternate: a `"` inside one
- *   opens a fresh literal rather than closing the literal around it, and a `#`
- *   written directly in one opens a comment exactly as it would at code scope.
- *   `<#` is the exception in both directions - it really does open a comment
- *   inside a string, so it is read before the literal state is consulted, and a
- *   literal survives across the comment written into it.
- *
- * A line still inside a literal or an interpolation at its end is read again
- * with literals ignored. Nothing could be lexed past the point it was left open
- * - a string may legitimately be open there, since an interpolation block spans
- * lines - so the rest of that line is trivia this cannot classify, and treating
- * it as literal content is what would let a `using` written in a trailing
- * comment read as the line's own statement.
+ * It is the opposite of the fallback maskCommentsAndStrings takes on the same
+ * line, and deliberately so: a `using` this misses is read by a caller as
+ * permission to remove an import, where text the masker wrongly offers as code
+ * becomes a declaration its caller edits as if it were real. See lexVerseLine,
+ * which reports the line as open rather than choosing for either of them.
  */
-function scanLine(line: string, depth: number): LineScan {
-    return lexLine(line, depth, true) ?? lexLine(line, depth, false)!;
-}
-
-/** One literal or interpolation open at a point in a line. */
-type LexFrame =
-    | { kind: "literal"; quote: string }
-    /**
-     * The `{ ... }` blocks written inside the interpolation, which a `}` has to
-     * close before one can close the interpolation itself. Without the count a
-     * `}` ending a map or a block, `"a{map{1=>2}}b"`, reads as the end of the
-     * interpolation and the string's remaining text is lexed as code.
-     */
-    | { kind: "interpolation"; braces: number };
-
-/**
- * One pass of scanLine, or null when literal tracking was asked for and the
- * line ended inside a literal or an interpolation.
- *
- * @param trackLiterals false reads a `#` as a comment opener wherever it sits.
- */
-function lexLine(line: string, depth: number, trackLiterals: boolean): LineScan | null {
-    let nesting = depth;
-    let hasCode = false;
-    let codeWithoutComments = "";
-    let codeOutsideLiterals = "";
-    let i = 0;
-    // What is open at this point, innermost last, and empty at code scope. A
-    // stack rather than one quote because interpolation alternates the two:
-    // `"a{F("b")}c"` writes a string inside the interpolation of a string.
-    //
-    // Kept across the `nesting > 0` branch, because a block comment written
-    // inside a string does not end it: `"a<#c#>#b"` is the string `"a#b"`.
-    const open: LexFrame[] = [];
-
-    while (i < line.length) {
-        if (nesting > 0) {
-            if (line.startsWith("<#", i)) {
-                nesting += 1;
-                i += 2;
-            } else if (line.startsWith("#>", i)) {
-                nesting -= 1;
-                i += 2;
-            } else {
-                i += 1;
-            }
-            continue;
-        }
-
-        if (line.startsWith("<#>", i)) {
-            return { depth: nesting, hasCode, codeWithoutComments, codeOutsideLiterals, opensIndentedComment: true };
-        }
-
-        const innermost = trackLiterals ? open[open.length - 1] : undefined;
-
-        // Inside an interpolation this is code scope again, so a `#` there ends
-        // the line as one at the head of it would. Returning the line read so
-        // far, rather than null, is what keeps the text before it: the fallback
-        // pass ends at the first `#` on the line, which may sit further back
-        // inside string text this pass has already read as content.
-        if (line[i] === "#" && innermost?.kind !== "literal") {
-            return { depth: nesting, hasCode, codeWithoutComments, codeOutsideLiterals, opensIndentedComment: false };
-        }
-
-        if (line.startsWith("<#", i)) {
-            nesting += 1;
-            i += 2;
-            continue;
-        }
-
-        if (innermost?.kind === "literal") {
-            // An escape and the character it escapes are one unit, or `"a\"b"`
-            // closes at the quote it escapes and the rest of the line is read
-            // as code. `\{` is the same rule, and is what keeps an escaped brace
-            // from opening an interpolation.
-            if (line[i] === "\\") {
-                codeWithoutComments += line.slice(i, i + 2);
-                codeOutsideLiterals += innermost.quote === '"' ? "  " : line.slice(i, i + 2);
-                i += 2;
-                continue;
-            }
-
-            if (line[i] === innermost.quote) {
-                open.pop();
-            } else if (line[i] === "{" && innermost.quote === '"') {
-                // Only a `"` string interpolates. A char literal is one
-                // character or one escape, so the `{` of `'{'` is content.
-                open.push({ kind: "interpolation", braces: 0 });
-            }
-        } else if (trackLiterals) {
-            if (line[i] === '"' || line[i] === "'") {
-                open.push({ kind: "literal", quote: line[i] });
-            } else if (innermost?.kind === "interpolation") {
-                if (line[i] === "{") {
-                    innermost.braces += 1;
-                } else if (line[i] === "}") {
-                    if (innermost.braces > 0) {
-                        innermost.braces -= 1;
-                    } else {
-                        open.pop();
-                    }
-                }
-            }
-        }
-
-        if (!/\s/.test(line[i])) {
-            hasCode = true;
-        }
-        codeWithoutComments += line[i];
-        // Only a `"` string. A `'` opens a char literal here, but the same
-        // character ends a path's quoted segment suffix, `Economy.Shop'Loc'`,
-        // and masking that truncates the path to `Economy.Shop` - a different
-        // module that exists. Nothing is lost by leaving `'` alone: a char
-        // literal holds one character, which cannot be a `using`.
-        codeOutsideLiterals += innermost?.kind === "literal" && innermost.quote === '"' ? " " : line[i];
-        i += 1;
-    }
-
-    return open.length === 0 ? { depth: nesting, hasCode, codeWithoutComments, codeOutsideLiterals, opensIndentedComment: false } : null;
-}
-
-function indentWidth(line: string): number {
-    return line.length - line.trimStart().length;
+function scanLine(line: string, state: LexState): LexedLine {
+    const tracked = lexVerseLine(line, state);
+    return tracked.endedOpen ? lexVerseLine(line, state, false) : tracked;
 }
 
 /** What a line contributes at file scope. */
@@ -302,7 +120,7 @@ export interface LineClassification {
     /**
      * `codeWithoutComments` with every literal's contents masked. Read this, not
      * `codeWithoutComments`, wherever a path found on the line is going to count
-     * as imported; see LineScan.codeOutsideLiterals.
+     * as imported; see LexedLine.codeOutsideLiterals.
      */
     codeOutsideLiterals: string;
 }
@@ -323,37 +141,24 @@ export interface LineClassification {
  */
 export function classifyLines(lines: string[]): LineClassification[] {
     const classifications: LineClassification[] = new Array(lines.length);
-    let depth = 0;
-    // The indentation of the `<#>` marker whose body we are inside, if any.
-    let indentedCommentIndent: number | null = null;
+    const state: LexState = { depth: 0, markerIndent: null };
 
     for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        const insideBlockComment = depth > 0;
-        const blank = line.trim() === "";
-
-        // An indented comment runs until a line that is neither blank nor
-        // indented past its marker. Blank lines do not end it.
-        if (indentedCommentIndent !== null && !blank && indentWidth(line) <= indentedCommentIndent) {
-            indentedCommentIndent = null;
-        }
-        const insideIndentedComment = indentedCommentIndent !== null && !insideBlockComment;
-
-        const scan = scanLine(line, depth);
-        const kind: LineKind = blank ? (insideBlockComment ? "comment" : "blank") : insideIndentedComment || !scan.hasCode ? "comment" : "code";
+        const scan = scanLine(lines[i], state);
+        const insideBlockComment = scan.depthBefore > 0;
+        const blank = lines[i].trim() === "";
+        const kind: LineKind = blank ? (insideBlockComment ? "comment" : "blank") : scan.insideIndentedComment || !scan.hasCode ? "comment" : "code";
 
         classifications[i] = {
             kind,
             insideBlockComment,
-            continuesCommentAbove: insideBlockComment || insideIndentedComment,
+            continuesCommentAbove: insideBlockComment || scan.insideIndentedComment,
             codeWithoutComments: scan.codeWithoutComments,
             codeOutsideLiterals: scan.codeOutsideLiterals,
         };
 
-        if (!insideBlockComment && !insideIndentedComment && scan.opensIndentedComment) {
-            indentedCommentIndent = indentWidth(line);
-        }
-        depth = scan.depth;
+        state.depth = scan.depth;
+        state.markerIndent = scan.markerIndent;
     }
 
     return classifications;
@@ -469,26 +274,21 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     // The `}` that returns the depth to where the clause opened, with the
     // column it sits at, so the content is cut at that brace rather than at the
     // last one on its line.
+    //
+    // Counted by scanBraces, the one brace primitive, rather than by a loop of
+    // its own. A second counter is a second opinion about which `{` delimits a
+    // body, and the two here reached different answers on `'{'`.
     let depth = 0;
     let endLine = -1;
     let closeAt = -1;
     for (let line = braceLine; line < classifications.length && endLine === -1; line++) {
         const code = classifications[line].codeOutsideLiterals;
-        for (let column = 0; column < code.length; column++) {
-            if (code[column] === "{") {
-                depth++;
-                continue;
-            }
-            if (code[column] !== "}") {
-                continue;
-            }
-            depth--;
-            if (depth <= 0) {
-                endLine = line;
-                closeAt = column;
-                break;
-            }
+        const scan = scanBraces(code, 0, code.length, depth);
+        if (scan.closedAt !== -1) {
+            endLine = line;
+            closeAt = scan.closedAt;
         }
+        depth = scan.depth;
     }
 
     // A `}` that is itself comment text closes nothing, so there is no clause
@@ -594,7 +394,7 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
  * - A path is only ever read from the line's statements, never from the text of
  *   a `"` string it writes. A `'` is not treated as opening literal text here,
  *   because it also closes a path's quoted segment suffix; see
- *   LineScan.codeOutsideLiterals for why that costs nothing.
+ *   LexedLine.codeOutsideLiterals for why that costs nothing.
  * - A collected import that itself opens a comment over the lines below it is
  *   flagged with `anchorsCommentBelow`. It is a real import and still counts
  *   as present, but no writer may rebuild or move its line, because where the
@@ -622,15 +422,16 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     // on the path line. Only depth 0 yields opensIndentedComment, so a `<#>`
     // inside a block comment on the same span cannot be mistaken for a marker.
     const anchorsCommentBelow = (startLine: number, endLine: number): boolean => {
-        let depth = 0;
+        const state: LexState = { depth: 0, markerIndent: null };
         for (let line = startLine; line <= endLine; line++) {
-            const scan = scanLine(lines[line], depth);
+            const scan = scanLine(lines[line], state);
             if (scan.opensIndentedComment) {
                 return true;
             }
-            depth = scan.depth;
+            state.depth = scan.depth;
+            state.markerIndent = scan.markerIndent;
         }
-        return depth > 0;
+        return state.depth > 0;
     };
 
     // The path the indented pair opened on `opener` takes, with the line
@@ -714,7 +515,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         const codeWithoutComments = classifications[i].codeWithoutComments.trim();
         // Every path recorded below is read from this rather than from
         // `codeWithoutComments`, because every one of them counts as imported.
-        // See LineScan.codeOutsideLiterals for what a path read out of string
+        // See LexedLine.codeOutsideLiterals for what a path read out of string
         // text costs. `codeWithoutComments` still answers what text the line
         // holds, which is a question about the whole line and not about its
         // statements.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -276,8 +276,8 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     // last one on its line.
     //
     // Counted by scanBraces, the one brace primitive, rather than by a loop of
-    // its own. A second counter is a second opinion about which `{` delimits a
-    // body, and the two here reached different answers on `'{'`.
+    // its own: a second counter is a second opinion about which `{` delimits a
+    // body.
     let depth = 0;
     let endLine = -1;
     let closeAt = -1;

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -8,6 +8,19 @@ import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 const SCAN_CONCURRENCY = 8;
 
 /**
+ * A declaration keyword introducing the right-hand side of a `:=`, for the
+ * backstop that catches a type whose own pattern did not match the exact shape
+ * written.
+ *
+ * Anchored at the `:=` and closed with `\b`, because a keyword this recognises
+ * loosely costs a whole declaration: a substring test reads
+ * `Items := classify_items(X)` as a type and drops the line, where the same
+ * missing boundary in the class, struct and interface patterns above only
+ * mistyped it. Nothing here may be tested with `includes`.
+ */
+const DECLARATION_KEYWORD_AFTER_ASSIGN = /:=\s*(?:class|struct|module|interface|enum)\b/;
+
+/**
  * The keywords a Verse block macro is spelled with, and the operators and types
  * that share their shape closely enough to reach a declaration pattern.
  *
@@ -594,7 +607,7 @@ export class ProjectPathScanner {
                 // recognised by `:=` with a declaration keyword, and a function,
                 // recognised by a parameter list before the colon. Either would
                 // otherwise be recorded as a variable.
-                if (line.includes(":=") && (line.includes("class") || line.includes("struct") || line.includes("module") || line.includes("interface") || line.includes("enum"))) {
+                if (DECLARATION_KEYWORD_AFTER_ASSIGN.test(line)) {
                     continue;
                 }
 

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -280,9 +280,14 @@ export class ProjectPathScanner {
         // ended the keyword, and is undefined for the line end alone; the
         // module stack needs that to know a body is still to open.
         const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*(?:([:>{.])|$)/;
-        const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\s*(?:<[^>]+>)*\s*[\(:]?/;
-        const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\s*(?:<[^>]+>)*\s*[\(:]?/;
-        const interfacePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*interface\s*(?:<[^>]+>)*\s*[\(:]?/;
+        // `\b` after the keyword, or `Foo := classify_items(X)` declares a class
+        // named Foo: everything after `class` here is optional, so the pattern
+        // matches the prefix of any identifier beginning with one of these
+        // words. modulePattern and enumPattern need no such boundary - each
+        // requires a terminator that a continuing identifier cannot supply.
+        const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\b\s*(?:<[^>]+>)*\s*[\(:]?/;
+        const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\b\s*(?:<[^>]+>)*\s*[\(:]?/;
+        const interfacePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*interface\b\s*(?:<[^>]+>)*\s*[\(:]?/;
         const enumPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*enum\s*(?:<[^>]+>)?\s*:/;
         /** `Name<specifiers>(params)<effects>:` */
         const functionPattern = /^(\w+)((?:<[^>]+>)*)\s*\([^)]*\)\s*(?:<[^>]+>)*\s*:/;

--- a/src/services/__tests__/ProjectPathScanner.test.ts
+++ b/src/services/__tests__/ProjectPathScanner.test.ts
@@ -340,3 +340,42 @@ describe("ProjectPathScanner.extractDeclarations module forms", () => {
         });
     });
 });
+
+/**
+ * The class, struct and interface patterns ended at their keyword with no word
+ * boundary, and everything after it is optional, so each matched the prefix of
+ * any identifier beginning with one of those words.
+ *
+ * A declaration recorded as a type is what tells a dotted suggestion where the
+ * module path ends, so a call misread as a class makes every segment after it
+ * address members of a type that does not exist.
+ */
+describe("ProjectPathScanner.extractDeclarations declaration keyword boundary", () => {
+    type ScannerParams = ConstructorParameters<typeof ProjectPathScanner>;
+
+    const scanner = new ProjectPathScanner({ appendLine: jest.fn() } as unknown as ScannerParams[0], {} as unknown as ScannerParams[1]);
+
+    const typed = (source: string): Array<{ name: string; type: string }> => scanner.extractDeclarations(source, "Content/Inventory.verse").map((node) => ({ name: node.name, type: node.type }));
+
+    it.each([
+        ["class", "Items", "Items := classify_items(Source)\n"],
+        ["struct", "Layout", "Layout := structure_of(Source)\n"],
+        ["interface", "Bridge", "Bridge := interfaces_for(Source)\n"],
+    ])("does not read a call to a function named after `%s` as a type declaration", (_keyword, name, source) => {
+        // Recorded as the variable it is, rather than dropped: the line really
+        // does declare the name.
+        expect(typed(source)).toEqual([{ name, type: "variable" }]);
+    });
+
+    it.each([
+        ["class", "Item", "Item := class:\n"],
+        ["struct", "Point", "Point := struct:\n"],
+        ["interface", "Usable", "Usable := interface:\n"],
+    ])("still records the `%s` declaration the boundary sits after", (keyword, name, source) => {
+        expect(typed(source)).toEqual([{ name, type: keyword }]);
+    });
+
+    it("still records a type whose keyword carries specifiers", () => {
+        expect(typed("Item := class<final>(base):\n")).toEqual([{ name: "Item", type: "class" }]);
+    });
+});

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -1,0 +1,194 @@
+import { classifyLines, LINE_SPLIT } from "../../imports/ImportScanner";
+import { countBraces, maskCommentsAndStrings } from "../verseText";
+
+/**
+ * One probe corpus read by every entry point built on the lexer, so a rule
+ * learned in one of them cannot quietly go unlearned in the other.
+ *
+ * Each probe is a construct the two readers used to disagree about, and each
+ * assertion is made twice: once that the readers agree with each other, and once
+ * that what they agree on is right. The first half is what a future divergence
+ * trips over - a rule added to one reader and not the other fails here even
+ * where nobody thought to write the case down.
+ *
+ * Sentinels carry the expectation. `L<n>` marks text that is a statement the
+ * file makes; `D<n>` marks text that is comment or literal content and must
+ * reach no reader that decides what the file imports or declares. Both readers
+ * answer that same question - `maskCommentsAndStrings` for the declaration
+ * scans, `codeOutsideLiterals` for the import scan - so both are held to it.
+ */
+
+/** The sentinels a reader left standing, in source order. */
+function surviving(text: string): string[] {
+    return [...text.matchAll(/\b[LD]\d+\b/g)].map((match) => match[0]);
+}
+
+/** What each reader makes of the source, reduced to the sentinels it left as statement text. */
+function readers(source: string): { masker: string[]; scanner: string[] } {
+    return {
+        masker: surviving(maskCommentsAndStrings(source)),
+        scanner: surviving(
+            classifyLines(source.split(LINE_SPLIT))
+                .map((line) => line.codeOutsideLiterals)
+                .join("\n"),
+        ),
+    };
+}
+
+interface Probe {
+    /** What the construct is, phrased as the rule it tests. */
+    name: string;
+    source: string;
+    /** The sentinels that are statement text, in source order. Everything else must be gone. */
+    live: string[];
+}
+
+const probes: Probe[] = [
+    {
+        // The masker had no `'` state at all, so the `#` ended the line.
+        name: "a `#` inside a char literal is content",
+        source: "Hash := '#'; L1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // The masker read this `"` as opening a string that swallowed the rest.
+        name: 'a `"` inside a char literal opens no string',
+        source: "Quote := '\"'; L1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // `'\{'` is a char literal holding a brace, not a brace. The escape put
+        // it past the paired-quote special case countBraces used to carry.
+        name: "an escaped brace in a char literal delimits nothing",
+        source: "Brace := '\\{'; L1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // An interpolation body is ordinary code, so the inner `"` opens a fresh
+        // string rather than closing the outer one. Reading it flat left the `#`
+        // at code scope, commenting out the rest of the line.
+        name: "a `#` inside a string nested in an interpolation is content",
+        source: 'Label := "a{F("#")}b"; L1 := 1\n',
+        live: ["L1"],
+    },
+    {
+        // A bare `#` is legal inside a quoted segment suffix, where it is part
+        // of the path rather than a comment opener.
+        name: "a `#` inside a quoted segment suffix is part of the identifier",
+        source: "using { Economy.Shop'a#b' }\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        name: "a `#` inside a string is content, and the rest of the line is code",
+        source: 'Tag := "a#b"; L1 := 1\n',
+        live: ["L1"],
+    },
+    {
+        // `"a<#c#>#b"` is the string `"a#b"`: a block comment beats a string
+        // literal, and the literal survives across it.
+        name: "a block comment written inside a string is removed, and the string survives it",
+        source: 'Tag := "a<# D1 #>b"; L1 := 1\n',
+        live: ["L1"],
+    },
+    {
+        name: "an escaped quote does not close the string it is written in",
+        source: 'Quote := "he said \\" D1 "; L1 := 1\n',
+        live: ["L1"],
+    },
+    {
+        // Only the masker leaked here: blankCommentRange read the `<#` of a
+        // `<#>` as a block opener, so everything below the body stayed comment.
+        name: "a `<#>` inside a marker body opens no block comment",
+        source: "<#>\n    D1 <#> D2\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // Both readers leaked here, in the same direction: inside a block
+        // comment a `<#>` is three characters of text, so the `#>` that follows
+        // is the one that closes the block.
+        name: "a `<#>` inside a block comment opens no nested block",
+        source: "<# D1 <#> D2 #>\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // The other direction of the same rule, and the one already pinned: a
+        // `<#` in a marker body is a real opener and outlives the body.
+        name: "a `<#` inside a marker body outlives the body",
+        source: "<#>\n    D1 <# D2\nD3 := 1 #>\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // Two indent models ended the body on different lines: a tab counted as
+        // one column in the scanner and four in the masker.
+        name: "a marker body indented with a tab ends where a two-space line meets it",
+        source: "\t<#>\n\t\tD1 := 1\n  L1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        name: "a marker body runs through a blank line",
+        source: "<#>\n    D1 := 1\n\n    D2 := 1\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        name: "a declaration inside a string is not a declaration",
+        source: 'Snippet := "D1 := module {}"\nL1 := 1\n',
+        live: ["L1"],
+    },
+    {
+        // An unterminated literal is the one place the two readers are allowed
+        // to differ, so the sentinel after it is not asserted here; the line
+        // below it must reach both regardless.
+        name: "an unterminated string does not carry past its line",
+        source: 'Broken := "oops\nL1 := 1\n',
+        live: ["L1"],
+    },
+];
+
+describe("verse lexer probe corpus", () => {
+    describe.each(probes)("$name", ({ source, live }) => {
+        it("both readers agree on which text is a statement", () => {
+            const { masker, scanner } = readers(source);
+
+            expect(masker).toEqual(scanner);
+        });
+
+        it("and what they agree on is the language's answer", () => {
+            const { masker, scanner } = readers(source);
+
+            expect(masker).toEqual(live);
+            expect(scanner).toEqual(live);
+        });
+    });
+});
+
+describe("verse lexer probe corpus, brace depth", () => {
+    // countBraces reads masked text, so every brace reaching it is a body's.
+    // Each source below balances, and a literal brace counted as real leaves the
+    // depth stranded for the rest of the file.
+    it.each([
+        ["a brace in a char literal", "Body := module:\n    Brace := '{'\n"],
+        ["an escaped brace in a char literal", "Body := module:\n    Brace := '\\{'\n"],
+        ["a brace in a string", 'Body := module:\n    Text := "{"\n'],
+        ["a brace in a comment", "Body := module:\n    Note := 1 # {\n"],
+        ["a balanced braced body", "Body := module {\n    Field := 1\n}\n"],
+        ["an interpolation holding a map", 'Body := module:\n    Text := "a{map{1=>2}}b"\n'],
+    ])("returns to zero across %s", (_name, source) => {
+        const masked = maskCommentsAndStrings(source);
+
+        expect(countBraces(masked, 0, masked.length, 0)).toBe(0);
+    });
+});
+
+describe("verse lexer probe corpus, comments splicing a token", () => {
+    it("rejoins a token a comment was written into, which only codeWithoutComments may do", () => {
+        // Nothing is put in a removed comment's place, so `us<##>ing` rejoins
+        // into a `using` a search of the line can find. codeOutsideLiterals
+        // carries the same join; the masker deliberately does not, because it
+        // keeps offsets and cannot close a gap.
+        const [line] = classifyLines(["us<# note #>ing { /A }"]);
+
+        expect(line.codeWithoutComments).toBe("using { /A }");
+        expect(line.codeOutsideLiterals).toBe("using { /A }");
+        expect(line.kind).toBe("code");
+    });
+});

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -98,18 +98,21 @@ const probes: Probe[] = [
         live: ["L1"],
     },
     {
-        // The `<#>` arm is reached at three places, and a literal is not one of
-        // them, so this is text rather than a marker and the lines below it are
-        // ordinary code. A bare `<#` in the same position is the opposite - it
-        // opens a comment anywhere - which is why the two are tested apart.
-        name: "a `<#>` inside a string is text, and opens no body over the lines below",
-        source: 'Label := "a<#>b"\nL1 := 1\n    L2 := 2\n',
+        // The `<#>` arm is reached at three places and a literal is not one of
+        // them, so this is text rather than a marker. The line below must be
+        // indented past it for the probe to bite: a marker wrongly opened at
+        // column 0 is closed again by the very next line at column 0, which
+        // hides the defect.
+        name: "a `<#>` inside a string opens no body over the indented lines below it",
+        source: 'Label := "a<#>b"\n    L1 := 1\n        L2 := 2\n',
         live: ["L1", "L2"],
     },
     {
-        name: "a `<#>` inside a char literal is text too",
-        source: "Angle := '<'; L1 := 1\n    L2 := 2\n",
-        live: ["L1", "L2"],
+        // The same marker one scope out, where it is a marker. Kept beside the
+        // case above so the pair says which half of the rule each pins.
+        name: "a `<#>` written outside a literal on the same shape does open one",
+        source: 'Label := "ab" <#>\n    D1 := 1\n        D2 := 2\nL1 := 3\n',
+        live: ["L1"],
     },
     {
         // Only the masker leaked here: blankCommentRange read the `<#` of a
@@ -226,7 +229,9 @@ describe("verse lexer probe corpus, the readers built on it", () => {
     const paths = (source: string): string[] => allUsingPaths(source.split(LINE_SPLIT));
 
     it("keeps what a `<#>` inside a string does not comment out", () => {
-        const source = 'Label := "a<#>b"\nusing { /Verse.org/Simulation }\nInner := module {}\n';
+        // Indented below the string, or a marker wrongly opened at column 0 is
+        // closed again by the next line at column 0 and nothing is lost.
+        const source = 'Label := "a<#>b"\n    Inner := module:\n        using { /Verse.org/Simulation }\n';
 
         expect(paths(source)).toEqual(["/Verse.org/Simulation"]);
         expect(declared(source)).toEqual(["Label", "Inner"]);

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -1,4 +1,6 @@
-import { classifyLines, LINE_SPLIT } from "../../imports/ImportScanner";
+import { allUsingPaths, classifyLines, LINE_SPLIT, scanModuleAliases, scanModuleImports } from "../../imports/ImportScanner";
+import { ProjectPathScanner } from "../../services/ProjectPathScanner";
+import { findExplicitModuleDeclarations } from "../../visibility/moduleDeclarations";
 import { countBraces, maskCommentsAndStrings } from "../verseText";
 
 /**
@@ -96,6 +98,20 @@ const probes: Probe[] = [
         live: ["L1"],
     },
     {
+        // The `<#>` arm is reached at three places, and a literal is not one of
+        // them, so this is text rather than a marker and the lines below it are
+        // ordinary code. A bare `<#` in the same position is the opposite - it
+        // opens a comment anywhere - which is why the two are tested apart.
+        name: "a `<#>` inside a string is text, and opens no body over the lines below",
+        source: 'Label := "a<#>b"\nL1 := 1\n    L2 := 2\n',
+        live: ["L1", "L2"],
+    },
+    {
+        name: "a `<#>` inside a char literal is text too",
+        source: "Angle := '<'; L1 := 1\n    L2 := 2\n",
+        live: ["L1", "L2"],
+    },
+    {
         // Only the masker leaked here: blankCommentRange read the `<#` of a
         // `<#>` as a block opener, so everything below the body stayed comment.
         name: "a `<#>` inside a marker body opens no block comment",
@@ -190,5 +206,60 @@ describe("verse lexer probe corpus, comments splicing a token", () => {
         expect(line.codeWithoutComments).toBe("using { /A }");
         expect(line.codeOutsideLiterals).toBe("using { /A }");
         expect(line.kind).toBe("code");
+    });
+});
+
+/**
+ * The same constructs through the readers built on the two entry points, since
+ * those are where a lexing mistake is finally paid for: a dropped path is read
+ * by its caller as permission to remove an import, and a declaration invented
+ * out of comment text is one its caller edits as if it were real.
+ *
+ * The entry points above are where a divergence can originate; these pin that it
+ * does not survive into an answer.
+ */
+describe("verse lexer probe corpus, the readers built on it", () => {
+    type ScannerParams = ConstructorParameters<typeof ProjectPathScanner>;
+    const scanner = new ProjectPathScanner({ appendLine: jest.fn() } as unknown as ScannerParams[0], {} as unknown as ScannerParams[1]);
+
+    const declared = (source: string): string[] => scanner.extractDeclarations(source, "Content/Probe.verse").map((node) => node.fullPath);
+    const paths = (source: string): string[] => allUsingPaths(source.split(LINE_SPLIT));
+
+    it("keeps what a `<#>` inside a string does not comment out", () => {
+        const source = 'Label := "a<#>b"\nusing { /Verse.org/Simulation }\nInner := module {}\n';
+
+        expect(paths(source)).toEqual(["/Verse.org/Simulation"]);
+        expect(declared(source)).toEqual(["Label", "Inner"]);
+        expect(findExplicitModuleDeclarations(source).map((declaration) => declaration.name)).toEqual(["Inner"]);
+    });
+
+    it("drops what a `<#>` marker body really does comment out", () => {
+        const source = "<#>\n    using { /Verse.org/Simulation }\n    Hidden := module {}\nReal := module {}\n";
+
+        expect(paths(source)).toEqual([]);
+        expect(declared(source)).toEqual(["Real"]);
+        expect(findExplicitModuleDeclarations(source).map((declaration) => declaration.name)).toEqual(["Real"]);
+    });
+
+    it("keeps a statement written after a char literal on the same line", () => {
+        const source = "Hash := '#'; using { /Verse.org/Simulation }\nGfx := import(/A/B)\n";
+
+        expect(paths(source)).toEqual(["/Verse.org/Simulation"]);
+        expect([...scanModuleAliases(source.split(LINE_SPLIT))]).toEqual(["Gfx"]);
+    });
+
+    it("counts no path out of string text where a path counts as imported, and over-counts where it does not", () => {
+        // The two readers face opposite ways on purpose, and this is the shape
+        // that shows it. scanModuleImports decides what the file already
+        // imports, so a path read out of string text withholds an import the
+        // file needs; it reads codeOutsideLiterals and finds nothing.
+        // allUsingPaths decides whether removing an import is safe, so its empty
+        // answer is what a caller acts on; it reads codeWithoutComments and
+        // over-reports rather than risk that.
+        const source = 'Snippet := "using { /Verse.org/Simulation }"\nOther := "Inner := module {}"\n';
+
+        expect(scanModuleImports(source.split(LINE_SPLIT))).toEqual([]);
+        expect(paths(source)).toEqual(["/Verse.org/Simulation"]);
+        expect(findExplicitModuleDeclarations(source)).toEqual([]);
     });
 });

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -257,14 +257,25 @@ describe("verse lexer probe corpus, the readers built on it", () => {
         // The two readers face opposite ways on purpose, and this is the shape
         // that shows it. scanModuleImports decides what the file already
         // imports, so a path read out of string text withholds an import the
-        // file needs; it reads codeOutsideLiterals and finds nothing.
-        // allUsingPaths decides whether removing an import is safe, so its empty
-        // answer is what a caller acts on; it reads codeWithoutComments and
-        // over-reports rather than risk that.
-        const source = 'Snippet := "using { /Verse.org/Simulation }"\nOther := "Inner := module {}"\n';
+        // file needs; it reads codeOutsideLiterals. allUsingPaths decides
+        // whether removing an import is safe, so its empty answer is what a
+        // caller acts on; it reads codeWithoutComments and over-reports rather
+        // than risk that.
+        //
+        // What disqualifies the first source is the blanked `using` keyword, not
+        // the path after it: `{ }` in a string interpolates, so the
+        // interpolation's body is code and `/Verse.org/Simulation }` survives
+        // masking. The second source carries no braces and is masked whole. Both
+        // are here because the contract is what each reader reports, not which
+        // characters it blanked to get there.
+        const interpolating = 'Snippet := "using { /Verse.org/Simulation }"\n';
+        // The dotted style, so the second source carries no brace at all.
+        const plain = 'Snippet := "using. /Verse.org/Simulation"\nOther := "Inner := module {}"\n';
 
-        expect(scanModuleImports(source.split(LINE_SPLIT))).toEqual([]);
-        expect(paths(source)).toEqual(["/Verse.org/Simulation"]);
-        expect(findExplicitModuleDeclarations(source)).toEqual([]);
+        for (const source of [interpolating, plain]) {
+            expect(scanModuleImports(source.split(LINE_SPLIT))).toEqual([]);
+            expect(paths(source)).toEqual(["/Verse.org/Simulation"]);
+            expect(findExplicitModuleDeclarations(source)).toEqual([]);
+        }
     });
 });

--- a/src/utils/__tests__/verseText.test.ts
+++ b/src/utils/__tests__/verseText.test.ts
@@ -1,4 +1,77 @@
-import { lineIndentWidth, popClosedBlocks } from "../verseText";
+import { countBraces, lineIndentWidth, maskCommentsAndStrings, popClosedBlocks, scanBraces } from "../verseText";
+
+/**
+ * The masker's contract, rather than its lexing: which Verse constructs it
+ * removes is the lexer's question and is pinned by the shared probe corpus. What
+ * is pinned here is what its callers depend on and the corpus cannot see - that
+ * an offset into the result still addresses the original text.
+ */
+describe("maskCommentsAndStrings", () => {
+    it("returns text exactly as long as it was given, so offsets still hold", () => {
+        const content = 'Tools := module {} # note\nTag := "a#b"\nMore := 1\n';
+
+        expect(maskCommentsAndStrings(content)).toHaveLength(content.length);
+    });
+
+    it("keeps every newline where it was, so line numbers still hold", () => {
+        const content = "<#\nhidden\n#>\nReal := 1\n";
+        const masked = maskCommentsAndStrings(content);
+
+        expect(masked.split("\n")).toHaveLength(content.split("\n").length);
+        expect(masked.split("\n")[3]).toBe("Real := 1");
+    });
+
+    it("leaves a CRLF carriage return alone outside a comment", () => {
+        const content = "Real := 1\r\nMore := 2\r\n";
+
+        expect(maskCommentsAndStrings(content)).toBe(content);
+    });
+
+    it("blanks a carriage return that falls inside a comment, as it blanks any other character there", () => {
+        // Length is what the offset contract needs, and it holds. The `\r` is
+        // comment text like the rest of the line, so nothing distinguishes it.
+        const content = "Real := 1 # note\r\nMore := 2\r\n";
+        const masked = maskCommentsAndStrings(content);
+
+        expect(masked).toHaveLength(content.length);
+        expect(masked.split("\n")[1]).toBe("More := 2\r");
+    });
+
+    it("blanks rather than deletes, so the text around a comment does not join", () => {
+        expect(maskCommentsAndStrings("A<# note #>B\n")).toBe("A          B\n");
+    });
+});
+
+/**
+ * The brace primitive both module scans delimit a braced body with. It reads
+ * masked text and nothing else: which braces reach it is the masker's question,
+ * so what is pinned here is the counting, the range, and where a body closes.
+ */
+describe("scanBraces", () => {
+    it("counts only within the half-open range", () => {
+        expect(scanBraces("{{}}", 0, 2, 0).depth).toBe(2);
+        expect(scanBraces("{{}}", 2, 4, 2).depth).toBe(0);
+    });
+
+    it("carries the depth it was handed", () => {
+        expect(scanBraces("}", 0, 1, 3).depth).toBe(2);
+    });
+
+    it("reports the brace that returned the depth to zero, not the last one on the line", () => {
+        expect(scanBraces("{ A } { B }", 0, 11, 0).closedAt).toBe(4);
+    });
+
+    it("reports no close where the depth never returned to zero", () => {
+        expect(scanBraces("{ A", 0, 3, 0).closedAt).toBe(-1);
+    });
+
+    it("counts a brace masking left standing, whatever quotes surround it", () => {
+        // The paired-quote special case this used to carry is gone: a char
+        // literal is blanked before it gets here, and a quoted segment suffix
+        // cannot hold a brace at all.
+        expect(countBraces("A'{'B", 0, 5, 0)).toBe(1);
+    });
+});
 
 /**
  * The line-based indentation pair both digest parsers track block bodies with.

--- a/src/utils/__tests__/verseText.test.ts
+++ b/src/utils/__tests__/verseText.test.ts
@@ -65,10 +65,10 @@ describe("scanBraces", () => {
         expect(scanBraces("{ A", 0, 3, 0).closedAt).toBe(-1);
     });
 
-    it("counts a brace masking left standing, whatever quotes surround it", () => {
-        // The paired-quote special case this used to carry is gone: a char
-        // literal is blanked before it gets here, and a quoted segment suffix
-        // cannot hold a brace at all.
+    it("counts a brace the lexer left standing, whatever quotes surround it", () => {
+        // Pins that no quote heuristic lives here: deciding which braces are
+        // real is the lexer's, so text that reached this unlexed is counted
+        // exactly as written.
         expect(countBraces("A'{'B", 0, 5, 0)).toBe(1);
     });
 });

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -1,0 +1,380 @@
+/**
+ * The one lexer for Verse comment, string and indentation structure.
+ *
+ * Every reader in the extension that has to know what a line means - the import
+ * scanner, the comment/string masker, the brace counters - goes through this,
+ * so a lexical fact about Verse is learned in one place. Two readers spelling
+ * the same rule is how the extension came to disagree with itself about which
+ * lines are comment: the masker and the scanner read `X := '#'` differently,
+ * and only one of them was right.
+ *
+ * No VS Code dependencies, so importing this from a pure module is safe.
+ *
+ * The rules below are the compiler's, taken from `VerseGrammar.h` in the
+ * VerseCompiler source rather than from any reader here. Line references are to
+ * that file.
+ *
+ * - `<#>` is the INDENTED comment marker, not a block that closes on the `#>`
+ *   inside it. The rest of its line is comment text, and so is every line
+ *   indented past it, blank lines included. It must be tested before `<#` in
+ *   every scope, code, block comment and marker body alike: at `Text`'s
+ *   `case '<'` (:2115-2137) a `<#` dispatches `BlockCmt()` everywhere, while a
+ *   `<#>` dispatches `IndCmt()` or is consumed as three characters of text, and
+ *   so never advances block-comment depth.
+ * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string really
+ *   does open a comment there. Both digraphs are consumed whole, so the `#` of a
+ *   `<#` cannot also be read as closing one.
+ * - `#` runs to the end of the line, but inside a literal it is content.
+ * - A `"` string interpolates, and `Interp := '{' List '}'` (:2163) makes the
+ *   interpolation body ordinary code: a `"` inside one opens a fresh string and
+ *   a `#` opens a real comment. So literal state is a stack of frames, and an
+ *   interpolation frame counts the plain `{ }` blocks written inside it or a
+ *   map's `}` closes it early.
+ * - A `'` means one of two things, and which one is decided by the character
+ *   before it. `Ident := Alpha {Alnum} !Alnum ["'" {…} "'"]` (:1954) opens the
+ *   quoted segment suffix only directly after an identifier's alphanumeric run,
+ *   while `CharLit` is dispatched from prefix position alone (:3497-3501), where
+ *   an expression may start. So a `'` after `[A-Za-z0-9_]` opens a suffix and a
+ *   `'` anywhere else opens a char literal - a distinction earlier readers here
+ *   declared impossible and then paid for.
+ */
+
+/** Whether the character can appear in an identifier, per `IsAlnum` (VerseGrammar.h:362). */
+function isIdentifierChar(character: string | undefined): boolean {
+    return character !== undefined && /[A-Za-z0-9_]/.test(character);
+}
+
+/**
+ * Whether the frame holds text that stands in for nothing a statement says, and
+ * so is replaced by spaces. Every literal but the quoted suffix, which is part
+ * of the identifier it trails.
+ */
+function isMaskedLiteral(frame: LexFrame | undefined): boolean {
+    return frame?.kind === "literal" && frame.quote !== "suffix";
+}
+
+/** What one line leaves behind for the line below it. */
+export interface LexState {
+    /** Block-comment nesting depth the line starts at. */
+    depth: number;
+    /**
+     * Indentation of the `<#>` marker whose body the line is inside, or null
+     * outside one.
+     */
+    markerIndent: number | null;
+}
+
+/** One literal or interpolation open at a point in a line. */
+type LexFrame =
+    /**
+     * `suffix` is an identifier's quoted segment, `Economy.Shop'Loc'`, and is
+     * kept in every output: masking it truncates the path to `Economy.Shop`, a
+     * different module that exists. `char` is a char literal, which is masked,
+     * because it is never part of a path and `'{'` and `'\{'` would otherwise
+     * reach a brace counter as real braces.
+     */
+    | { kind: "literal"; quote: '"' | "suffix" | "char" }
+    /**
+     * The `{ ... }` blocks written inside the interpolation, which a `}` has to
+     * close before one can close the interpolation itself. Without the count a
+     * `}` ending a map or a block, `"a{map{1=>2}}b"`, reads as the end of the
+     * interpolation and the string's remaining text is lexed as code.
+     */
+    | { kind: "interpolation"; braces: number };
+
+/** How one line of a document reads, and what it leaves for the line below it. */
+export interface LexedLine {
+    /**
+     * Block-comment nesting depth at the start of the line. Non-zero means the
+     * line opened inside a `<# ... #>` and may not be read as code at all.
+     */
+    depthBefore: number;
+    /** Block-comment nesting depth the next line starts at. */
+    depth: number;
+    /** Indentation of the open `<#>` marker for the next line, or null. */
+    markerIndent: number | null;
+    /**
+     * Whether the line sits in the indented body of a `<#>` opened above it. The
+     * whole line is comment text, but it is still lexed rather than skipped,
+     * because a block comment opened inside a marker body survives the body's
+     * end and swallows what follows.
+     */
+    insideIndentedComment: boolean;
+    /** Whether the line holds a `<#>` marker, opening a body over the lines indented past it. */
+    opensIndentedComment: boolean;
+    /** Whether the line carries any text outside a comment. */
+    hasCode: boolean;
+    /**
+     * Whether the line ended inside a literal or an interpolation. Nothing past
+     * that point could be lexed, and the two consumers want opposite things
+     * about it, so neither answer is baked in here - see the note on
+     * {@link lexVerseLine}.
+     */
+    endedOpen: boolean;
+    /**
+     * The line's text with every comment removed and nothing put in its place,
+     * so text on either side of one joins. That is what it is for: a comment
+     * splicing a token apart, `us<##>ing { /A }`, rejoins into a `using` a
+     * search of the whole line can find, and a missed `using` is the one error
+     * its callers cannot survive.
+     */
+    codeWithoutComments: string;
+    /**
+     * `codeWithoutComments` with the contents of every `"` string and char
+     * literal replaced by spaces, so a `using` written as literal text is not
+     * offered as a statement the line makes, and a brace inside one is not
+     * counted as a body's.
+     *
+     * Read this wherever a path is going to count as imported. The text of a
+     * literal is data, not a statement, and recording a path from it both
+     * suppresses an import the file needs and - because a path that counts as
+     * pinned withholds the movable import of the same path from the rebuilt
+     * block - deletes the real `using` the author wrote.
+     *
+     * Spaces rather than nothing, so the text on either side of a literal does
+     * not join into a token neither side wrote. `codeWithoutComments` removes
+     * comments without replacement on purpose, for the opposite reason; the two
+     * differ because a comment can splice a token apart and a literal cannot.
+     */
+    codeOutsideLiterals: string;
+    /**
+     * The whole line with every comment, `"` string and char literal replaced by
+     * spaces, exactly as long as the line it replaces, so an offset into it
+     * still addresses the original text.
+     *
+     * A quoted suffix is left standing, unlike in `codeOutsideLiterals`, and
+     * costs nothing: `IsIdentifierQuotable` (VerseGrammar.h:377) forbids `{`,
+     * `}`, `"` and `\` inside one, so nothing a caller of this reads can hide
+     * there.
+     */
+    masked: string;
+    /** Leading whitespace width, each tab counted as four spaces so mixed indentation compares. */
+    indent: number;
+}
+
+/**
+ * Reads one line, given what the lines above it left open.
+ *
+ * A line that ends inside a literal is reported through `endedOpen` rather than
+ * resolved here, because the two readers built on this want opposite fallbacks
+ * and both are right. A masker must fail towards blanking: text it wrongly
+ * offers as code becomes a declaration its caller edits as if it were real. A
+ * scanner must fail towards keeping: a `using` it misses is read by its caller
+ * as permission to remove an import. Deciding it here would silently impose one
+ * of those on the other.
+ *
+ * @param line one line, with no line terminator. A trailing `\r` from a CRLF
+ *   document is harmless and counts as trailing whitespace.
+ * @param trackLiterals false reads a `#` as a comment opener wherever it sits,
+ *   which is what a caller re-lexing an `endedOpen` line passes.
+ */
+export function lexVerseLine(line: string, state: LexState, trackLiterals: boolean = true): LexedLine {
+    const depthBefore = state.depth;
+    const indent = indentWidthOf(line);
+    const blank = line.trim().length === 0;
+
+    // A marker's body runs while lines stay indented past it; a blank line does
+    // not end it. The comparison is on widths where the compiler extends the
+    // opener's whitespace prefix byte-wise (`Line`, VerseGrammar.h:1666-1690);
+    // the two agree on any consistently indented file, and a line that mixes
+    // tabs and spaces inside one body is error S89 rather than a case the
+    // language admits.
+    let markerIndent = state.markerIndent;
+    if (markerIndent !== null && !blank && indent <= markerIndent) {
+        markerIndent = null;
+    }
+    // A block comment opened above outranks a marker body: the body's text is
+    // already inside it, and it is the `#>` that ends the region.
+    const insideIndentedComment = markerIndent !== null && depthBefore === 0;
+
+    let nesting = depthBefore;
+    let hasCode = false;
+    let codeWithoutComments = "";
+    let codeOutsideLiterals = "";
+    let masked = "";
+    let opensIndentedComment = false;
+    let i = 0;
+
+    // What is open at this point, innermost last, and empty at code scope. A
+    // stack rather than one quote because interpolation alternates the two:
+    // `"a{F("b")}c"` writes a string inside the interpolation of a string.
+    //
+    // Kept across the `nesting > 0` branch, because a block comment written
+    // inside a string does not end it: `"a<#c#>#b"` is the string `"a#b"`.
+    const open: LexFrame[] = [];
+
+    /** Records one character as comment text: blanked in `masked`, absent from both code strings. */
+    const commentChar = (): void => {
+        masked += " ";
+    };
+
+    while (i < line.length) {
+        // Comment text, whether from a block comment opened above or from the
+        // body of a `<#>`. Scanned rather than skipped so a `<#` inside it still
+        // opens a block that outlives the region, which is what the compiler
+        // does at every place (VerseGrammar.h:2115-2137).
+        if (nesting > 0 || insideIndentedComment) {
+            if (line.startsWith("<#>", i)) {
+                // Already comment text, so this opens nothing. Tested before
+                // `<#` or its first two characters read as a block opener that
+                // never closes.
+                commentChar();
+                commentChar();
+                commentChar();
+                i += 3;
+                continue;
+            }
+            if (line.startsWith("<#", i) || line.startsWith("#>", i)) {
+                nesting = line[i] === "<" ? nesting + 1 : Math.max(0, nesting - 1);
+                commentChar();
+                commentChar();
+                i += 2;
+                continue;
+            }
+            commentChar();
+            i += 1;
+            continue;
+        }
+
+        if (line.startsWith("<#>", i)) {
+            // The rest of the marker's own line is comment text, and holds no
+            // opener of its own: at `EPlace::IndCmt` a `<#>` nests another
+            // indented comment rather than a block.
+            opensIndentedComment = true;
+            for (; i < line.length; i++) {
+                commentChar();
+            }
+            break;
+        }
+
+        const innermost = trackLiterals ? open[open.length - 1] : undefined;
+
+        // Inside an interpolation this is code scope again, so a `#` there ends
+        // the line as one at the head of it would. A `#` inside any literal is
+        // content: a `"` string and a char literal both hold it, and
+        // `IsIdentifierQuotable` admits a bare `#` in a quoted suffix.
+        if (line[i] === "#" && innermost?.kind !== "literal") {
+            for (; i < line.length; i++) {
+                commentChar();
+            }
+            break;
+        }
+
+        if (line.startsWith("<#", i)) {
+            nesting += 1;
+            commentChar();
+            commentChar();
+            i += 2;
+            continue;
+        }
+
+        if (innermost?.kind === "literal") {
+            // An escape and the character it escapes are one unit, or `"a\"b"`
+            // closes at the quote it escapes and the rest of the line is read as
+            // code. `\{` is the same rule, and is what keeps an escaped brace
+            // from opening an interpolation - and, in a char literal, what keeps
+            // `'\{'` from reaching a brace counter as a real brace.
+            //
+            // A quoted suffix has no escapes: `IsIdentifierQuotable` excludes
+            // `\` outright, so a backslash there ends the suffix as far as the
+            // compiler is concerned and is read here as ordinary text.
+            if (line[i] === "\\" && innermost.quote !== "suffix") {
+                const unit = line.slice(i, i + 2);
+                codeWithoutComments += unit;
+                codeOutsideLiterals += " ".repeat(unit.length);
+                masked += " ".repeat(unit.length);
+                i += 2;
+                continue;
+            }
+
+            const closes = innermost.quote === '"' ? line[i] === '"' : line[i] === "'";
+            if (closes) {
+                open.pop();
+            } else if (line[i] === "{" && innermost.quote === '"') {
+                // Only a `"` string interpolates. A char literal is one
+                // character or one escape, so the `{` of `'{'` is content, and a
+                // suffix cannot hold a brace at all.
+                open.push({ kind: "interpolation", braces: 0 });
+            }
+        } else if (trackLiterals) {
+            if (line[i] === '"') {
+                open.push({ kind: "literal", quote: '"' });
+            } else if (line[i] === "'") {
+                // Which of the two a `'` opens is decided by the character
+                // before it, and by nothing else: `Ident` reaches for its quoted
+                // suffix only straight after the identifier's alphanumeric run,
+                // where `CharLit` is only ever dispatched from prefix position.
+                open.push({ kind: "literal", quote: isIdentifierChar(line[i - 1]) ? "suffix" : "char" });
+            } else if (innermost?.kind === "interpolation") {
+                if (line[i] === "{") {
+                    innermost.braces += 1;
+                } else if (line[i] === "}") {
+                    if (innermost.braces > 0) {
+                        innermost.braces -= 1;
+                    } else {
+                        open.pop();
+                    }
+                }
+            }
+        }
+
+        if (!/\s/.test(line[i])) {
+            hasCode = true;
+        }
+        codeWithoutComments += line[i];
+
+        // The two masked outputs disagree about a literal's delimiters, and each
+        // keeps the answer its readers already had. `codeOutsideLiterals` asks
+        // only about the frame open before this character, so an opening `"`
+        // survives to tell a reader of that string a literal began there.
+        // `masked` blanks the delimiters too, because it is read as a stand-in
+        // for the original text and a lone quote there is not part of any
+        // statement.
+        //
+        // A quoted suffix is masked in neither: it is part of an identifier, and
+        // blanking it turns `Economy.Shop'Loc'` into a path naming a different
+        // module that exists.
+        const wasInMaskedLiteral = isMaskedLiteral(innermost);
+        const isInMaskedLiteral = isMaskedLiteral(open[open.length - 1]);
+        codeOutsideLiterals += wasInMaskedLiteral ? " " : line[i];
+        masked += wasInMaskedLiteral || isInMaskedLiteral ? " " : line[i];
+        i += 1;
+    }
+
+    return {
+        depthBefore,
+        depth: nesting,
+        markerIndent: opensIndentedComment ? indent : markerIndent,
+        insideIndentedComment,
+        opensIndentedComment,
+        hasCode,
+        endedOpen: open.length > 0,
+        codeWithoutComments,
+        codeOutsideLiterals,
+        masked,
+        indent,
+    };
+}
+
+/**
+ * Leading whitespace width of a line, each tab counted as four spaces.
+ *
+ * One model, because two of them end a `<#>` marker body on different lines of
+ * the same file. The compiler compares the opening line's whitespace prefix
+ * byte for byte instead (`Line`, VerseGrammar.h:1666-1690) and errors S89 on a
+ * line that indents inconsistently, so this agrees with it on every file that
+ * compiles.
+ */
+function indentWidthOf(line: string): number {
+    let width = 0;
+    for (let i = 0; i < line.length; i++) {
+        if (line[i] === " ") {
+            width += 1;
+        } else if (line[i] === "\t") {
+            width += 4;
+        } else {
+            break;
+        }
+    }
+    return width;
+}

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -3,10 +3,10 @@
  *
  * Every reader in the extension that has to know what a line means - the import
  * scanner, the comment/string masker, the brace counters - goes through this,
- * so a lexical fact about Verse is learned in one place. Two readers spelling
- * the same rule is how the extension came to disagree with itself about which
- * lines are comment: the masker and the scanner read `X := '#'` differently,
- * and only one of them was right.
+ * so a lexical fact about Verse is learned in one place. Nothing outside this
+ * file may re-decide what is comment, what is literal text, or how wide an
+ * indent is; a second opinion about any of them is what the readers this
+ * replaced disagreed over.
  *
  * No VS Code dependencies, so importing this from a pure module is safe.
  *
@@ -16,11 +16,18 @@
  *
  * - `<#>` is the INDENTED comment marker, not a block that closes on the `#>`
  *   inside it. The rest of its line is comment text, and so is every line
- *   indented past it, blank lines included. It must be tested before `<#` in
- *   every scope, code, block comment and marker body alike: at `Text`'s
- *   `case '<'` (:2115-2137) a `<#` dispatches `BlockCmt()` everywhere, while a
- *   `<#>` dispatches `IndCmt()` or is consumed as three characters of text, and
- *   so never advances block-comment depth.
+ *   indented past it, blank lines included. It must be tested before `<#`
+ *   wherever both can appear, or its first two characters read as a block
+ *   opener that never closes. At `Text`'s `case '<'` (:2115-2137) a `<#`
+ *   dispatches `BlockCmt()` at every place, while a `<#>` dispatches `IndCmt()`
+ *   only at trivia, code and marker-body place and is three characters of plain
+ *   text inside a block comment or a literal. It advances block-comment depth
+ *   nowhere.
+ *
+ *   One written inside a marker body is left as text here rather than nested,
+ *   which the grammar allows because the two cannot disagree: the body it would
+ *   open is indented past a marker that already sits inside the outer body, so
+ *   it can never outlast it.
  * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string really
  *   does open a comment there. Both digraphs are consumed whole, so the `#` of a
  *   `<#` cannot also be read as closing one.
@@ -35,8 +42,9 @@
  *   quoted segment suffix only directly after an identifier's alphanumeric run,
  *   while `CharLit` is dispatched from prefix position alone (:3497-3501), where
  *   an expression may start. So a `'` after `[A-Za-z0-9_]` opens a suffix and a
- *   `'` anywhere else opens a char literal - a distinction earlier readers here
- *   declared impossible and then paid for.
+ *   `'` anywhere else opens a char literal. The distinction is what lets a char
+ *   literal be masked while a path keeps its suffix, so nothing here may fall
+ *   back to treating the two alike.
  */
 
 /** Whether the character can appear in an identifier, per `IsAlnum` (VerseGrammar.h:362). */
@@ -148,8 +156,6 @@ export interface LexedLine {
      * there.
      */
     masked: string;
-    /** Leading whitespace width, each tab counted as four spaces so mixed indentation compares. */
-    indent: number;
 }
 
 /**
@@ -170,7 +176,7 @@ export interface LexedLine {
  */
 export function lexVerseLine(line: string, state: LexState, trackLiterals: boolean = true): LexedLine {
     const depthBefore = state.depth;
-    const indent = indentWidthOf(line);
+    const indent = indentOf(line, 0);
     const blank = line.trim().length === 0;
 
     // A marker's body runs while lines stay indented past it; a blank line does
@@ -236,7 +242,27 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
             continue;
         }
 
+        const innermost = trackLiterals ? open[open.length - 1] : undefined;
+
         if (line.startsWith("<#>", i)) {
+            if (innermost?.kind === "literal") {
+                // Three characters of literal text rather than a marker. At
+                // `EPlace::String` the `<#>` arm falls past `IndCmt()` to
+                // `Next(3)` and plain text, so only the three named scopes open
+                // a body here. Consumed whole, so the `<#` test below does not
+                // read its first two characters as a block opener - which a
+                // bare `<#` in a literal genuinely is, since `BlockCmt()` is
+                // dispatched at every place.
+                const marker = line.slice(i, i + 3);
+                const spaced = isMaskedLiteral(innermost);
+                codeWithoutComments += marker;
+                codeOutsideLiterals += spaced ? "   " : marker;
+                masked += spaced ? "   " : marker;
+                hasCode = true;
+                i += 3;
+                continue;
+            }
+
             // The rest of the marker's own line is comment text, and holds no
             // opener of its own: at `EPlace::IndCmt` a `<#>` nests another
             // indented comment rather than a block.
@@ -246,8 +272,6 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
             }
             break;
         }
-
-        const innermost = trackLiterals ? open[open.length - 1] : undefined;
 
         // Inside an interpolation this is code scope again, so a `#` there ends
         // the line as one at the head of it would. A `#` inside any literal is
@@ -352,25 +376,26 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         codeWithoutComments,
         codeOutsideLiterals,
         masked,
-        indent,
     };
 }
 
 /**
- * Leading whitespace width of a line, each tab counted as four spaces.
+ * Leading whitespace width from an offset into the text, each tab counted as
+ * four spaces so mixed indentation compares.
  *
- * One model, because two of them end a `<#>` marker body on different lines of
- * the same file. The compiler compares the opening line's whitespace prefix
- * byte for byte instead (`Line`, VerseGrammar.h:1666-1690) and errors S89 on a
- * line that indents inconsistently, so this agrees with it on every file that
- * compiles.
+ * The one width model. The compiler extends the opening line's whitespace
+ * prefix byte for byte instead (`Line`, VerseGrammar.h:1666-1690) and errors S89
+ * on a line that indents inconsistently, so comparing widths agrees with it on
+ * every file that compiles - but two width models do not agree with each other,
+ * and a `<#>` body must end on one line rather than two. Nothing may add a
+ * second.
  */
-function indentWidthOf(line: string): number {
+export function indentOf(content: string, lineStart: number): number {
     let width = 0;
-    for (let i = 0; i < line.length; i++) {
-        if (line[i] === " ") {
+    for (let i = lineStart; i < content.length; i++) {
+        if (content[i] === " ") {
             width += 1;
-        } else if (line[i] === "\t") {
+        } else if (content[i] === "\t") {
             width += 4;
         } else {
             break;

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -3,114 +3,42 @@
  * it. No VS Code dependencies, so importing this from a pure module is safe -
  * take it by file path rather than through the utils barrel, which re-exports
  * the logger and with it vscode.
+ *
+ * The comment, string and indentation rules live in verseLexer, which the import
+ * scanner reads too. Nothing here re-spells them.
  */
+
+import { LexState, lexVerseLine } from "./verseLexer";
 
 /**
- * The text with every comment replaced by spaces, so offsets still address the
- * original.
+ * The text with every comment, `"` string and char literal replaced by spaces,
+ * so offsets still address the original.
  *
- * Verse has three comment forms and they do not compose the way a reader
- * expects, so the order of the tests below is the whole of this function:
+ * A line that ends inside an open literal is left masked from the point it
+ * opened, rather than re-read with literal tracking off. This reader must fail
+ * towards blanking: its callers match declarations against what it returns, and
+ * text it wrongly offers as code becomes a declaration one of them edits as if
+ * it were real. The import scanner takes the opposite fallback on the same
+ * lines, for the opposite reason; see lexVerseLine.
  *
- * - `<#>` is the INDENTED comment marker, not a block that closes on the `#>`
- *   inside it. The rest of its line is comment text, and so is every line
- *   indented past it, blank lines included. It must therefore be tested before
- *   `<#`, or a declaration commented out this way reads as live code. A `<#`
- *   written inside its body is still a real opener, and outlives the body.
- * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string
- *   really does open a comment there. Both digraphs are consumed whole, so the
- *   `#` of a `<#` cannot also be read as closing one.
- * - `#` runs to the end of the line, but inside a string it is content. This
- *   is the one place string tracking is needed, and the only reason it is
- *   here.
- *
- * ImportScanner encodes the same three rules for its own line scan. The single
- * quote is deliberately not tracked: it opens a char literal and an
- * identifier's quoted suffix alike, and nothing here can tell the two apart.
+ * A quoted segment suffix is left standing, since it is part of an identifier
+ * rather than literal text. Nothing can hide there: the grammar forbids `{`,
+ * `}`, `"` and `\` inside one.
  */
 export function maskCommentsAndStrings(content: string): string {
-    const masked = content.split("");
-    const lines = content.split("\n");
-    let blockDepth = 0;
-    let markerIndent: number | null = null;
-    let lineStart = 0;
-
-    for (const line of lines) {
-        const lineEnd = lineStart + line.length;
-        const indent = indentOf(content, lineStart);
-
-        // The marker's body runs while lines stay indented past it; a blank
-        // line does not end it. The body is still scanned rather than blanked
-        // wholesale, because a block comment opened inside it survives the
-        // body's end and swallows what follows.
-        if (markerIndent !== null) {
-            if (line.trim().length === 0 || indent > markerIndent) {
-                blockDepth = blankCommentRange(masked, content, lineStart, lineEnd, blockDepth);
-                lineStart = lineEnd + 1;
-                continue;
-            }
-            markerIndent = null;
-        }
-
-        let inString = false;
-
-        for (let i = lineStart; i < lineEnd; i++) {
-            if (blockDepth > 0) {
-                if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
-                    blockDepth += content[i] === "<" ? 1 : -1;
-                    blank(masked, content, i);
-                    blank(masked, content, i + 1);
-                    i++;
-                    continue;
-                }
-                blank(masked, content, i);
-                continue;
-            }
-
-            if (content.startsWith("<#>", i)) {
-                markerIndent = indent;
-                blankRange(masked, content, i, lineEnd);
-                break;
-            }
-
-            if (content.startsWith("<#", i)) {
-                blockDepth++;
-                blank(masked, content, i);
-                blank(masked, content, i + 1);
-                i++;
-                continue;
-            }
-
-            if (inString) {
-                if (content[i] === "\\") {
-                    blank(masked, content, i);
-                    i++;
-                    if (i < lineEnd) blank(masked, content, i);
-                    continue;
-                }
-                if (content[i] === '"') {
-                    inString = false;
-                }
-                blank(masked, content, i);
-                continue;
-            }
-
-            if (content[i] === '"') {
-                inString = true;
-                blank(masked, content, i);
-                continue;
-            }
-
-            if (content[i] === "#") {
-                blankRange(masked, content, i, lineEnd);
-                break;
-            }
-        }
-
-        lineStart = lineEnd + 1;
-    }
-
-    return masked.join("");
+    const state: LexState = { depth: 0, markerIndent: null };
+    // Split on "\n" alone so a CRLF line keeps its "\r" and the masked line is
+    // exactly as long as the line it replaces; joining then rebuilds the file
+    // byte for byte.
+    return content
+        .split("\n")
+        .map((line) => {
+            const lexed = lexVerseLine(line, state);
+            state.depth = lexed.depth;
+            state.markerIndent = lexed.markerIndent;
+            return lexed.masked;
+        })
+        .join("\n");
 }
 
 /**
@@ -153,15 +81,23 @@ export function indentOf(content: string, lineStart: number): number {
 }
 
 /**
- * The brace depth after the half-open range, starting from the depth before it.
- * Counted on masked text, so a brace in a comment or a string contributes none.
+ * The brace depth after the half-open range, starting from the depth before it,
+ * with the index where that depth first returned to zero or below.
+ *
+ * Counted on masked text, so a brace in a comment or a literal contributes none.
+ * That is the whole of the rule: a `{` surviving masking is a body's, and the
+ * `'{'` and `'\{'` that used to need a special case here are already gone by the
+ * time this runs. Nothing may call this on raw source.
  *
  * Both module scans delimit a braced body by this depth, and they must agree:
  * one reads it over the gap between two declarations, the other over a single
  * line, so the range is theirs to choose.
+ *
+ * @returns `closedAt` is -1 where the depth never returned to zero in the range.
  */
-export function countBraces(searchable: string, start: number, end: number, depth: number): number {
+export function scanBraces(searchable: string, start: number, end: number, depth: number): { depth: number; closedAt: number } {
     let braceDepth = depth;
+    let closedAt = -1;
 
     for (let i = start; i < end; i++) {
         const character = searchable[i];
@@ -169,49 +105,20 @@ export function countBraces(searchable: string, start: number, end: number, dept
             continue;
         }
 
-        // A single-quoted brace delimits nothing. Masking leaves single quotes
-        // alone because one opens a char literal and an identifier's quoted
-        // suffix alike, but neither reading makes this brace a body's, and
-        // counting one would strand the depth for the rest of the file with
-        // nothing left to recover it.
-        if (searchable[i - 1] === "'" && searchable[i + 1] === "'") {
-            continue;
-        }
-
         braceDepth += character === "{" ? 1 : -1;
-    }
 
-    return braceDepth;
-}
-
-/** Replaces one character with a space, keeping newlines so line numbers still hold. */
-function blank(masked: string[], content: string, index: number): void {
-    if (content[index] !== "\n") {
-        masked[index] = " ";
-    }
-}
-
-/** Blanks a half-open range. */
-function blankRange(masked: string[], content: string, start: number, end: number): void {
-    for (let i = start; i < end; i++) {
-        blank(masked, content, i);
-    }
-}
-
-/** Blanks a half-open range that is comment text, returning the block-comment depth it leaves behind. */
-function blankCommentRange(masked: string[], content: string, start: number, end: number, depth: number): number {
-    let blockDepth = depth;
-
-    for (let i = start; i < end; i++) {
-        if (content.startsWith("<#", i) || content.startsWith("#>", i)) {
-            blockDepth = Math.max(0, blockDepth + (content[i] === "<" ? 1 : -1));
-            blank(masked, content, i);
-            blank(masked, content, i + 1);
-            i++;
-            continue;
+        if (character === "}" && braceDepth <= 0 && closedAt === -1) {
+            closedAt = i;
         }
-        blank(masked, content, i);
     }
 
-    return blockDepth;
+    return { depth: braceDepth, closedAt };
+}
+
+/**
+ * The brace depth after the half-open range, starting from the depth before it.
+ * See {@link scanBraces}, which this reads for callers that need only the depth.
+ */
+export function countBraces(searchable: string, start: number, end: number, depth: number): number {
+    return scanBraces(searchable, start, end, depth).depth;
 }

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -8,7 +8,11 @@
  * scanner reads too. Nothing here re-spells them.
  */
 
-import { LexState, lexVerseLine } from "./verseLexer";
+import { indentOf, LexState, lexVerseLine } from "./verseLexer";
+
+// Re-exported rather than restated: the width model is the lexer's, and a second
+// copy of it here is what ended a `<#>` body on two different lines.
+export { indentOf };
 
 /**
  * The text with every comment, `"` string and char literal replaced by spaces,
@@ -65,29 +69,21 @@ export function popClosedBlocks(openBlockIndents: number[], indent: number): voi
     }
 }
 
-/** Leading whitespace of a line, each tab counted as four spaces so mixed indentation compares. */
-export function indentOf(content: string, lineStart: number): number {
-    let width = 0;
-    for (let i = lineStart; i < content.length; i++) {
-        if (content[i] === " ") {
-            width += 1;
-        } else if (content[i] === "\t") {
-            width += 4;
-        } else {
-            break;
-        }
-    }
-    return width;
-}
-
 /**
  * The brace depth after the half-open range, starting from the depth before it,
  * with the index where that depth first returned to zero or below.
  *
- * Counted on masked text, so a brace in a comment or a literal contributes none.
- * That is the whole of the rule: a `{` surviving masking is a body's, and the
- * `'{'` and `'\{'` that used to need a special case here are already gone by the
- * time this runs. Nothing may call this on raw source.
+ * Give it lexed text, never raw source: a brace this counts is one the lexer
+ * left standing, and a `#`, a `"` or a `'{'` reaching it unlexed strands the
+ * depth for the rest of the file with nothing to recover it. It carries no
+ * special case of its own, and may not grow one - a rule about which braces are
+ * real belongs to the lexer, where every reader gets it.
+ *
+ * `maskCommentsAndStrings` output is brace-balanced. `codeOutsideLiterals` is
+ * not, quite: it consults only the frame open before each character, so a string
+ * interpolation's opening `{` is blanked while its closing `}` survives. Callers
+ * reading a single line accept that, since a clause the imbalance closes early
+ * was already inside a literal.
  *
  * Both module scans delimit a braced body by this depth, and they must agree:
  * one reads it over the gap between two declarations, the other over a single

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -79,11 +79,18 @@ export function popClosedBlocks(openBlockIndents: number[], indent: number): voi
  * special case of its own, and may not grow one - a rule about which braces are
  * real belongs to the lexer, where every reader gets it.
  *
- * `maskCommentsAndStrings` output is brace-balanced. `codeOutsideLiterals` is
- * not, quite: it consults only the frame open before each character, so a string
- * interpolation's opening `{` is blanked while its closing `}` survives. Callers
- * reading a single line accept that, since a clause the imbalance closes early
- * was already inside a literal.
+ * Neither masked form is balanced unconditionally, so do not read a stranded
+ * depth as proof that a brace was missed:
+ *
+ * - `maskCommentsAndStrings` balances every literal it closes, and cannot
+ *   balance one it does not. Each line is masked from the point a literal opened
+ *   to the line's end, so an interpolation spanning lines - `"Score: {` over
+ *   `Points}"` - loses its `{` and keeps its `}`, and nothing downstream can
+ *   recover the pair.
+ * - `codeOutsideLiterals` consults only the frame open before each character, so
+ *   an interpolation's opening `{` is blanked while its closing `}` survives
+ *   even on one line. Callers reading a single line accept that, since a clause
+ *   the imbalance closes early was already inside a literal.
  *
  * Both module scans delimit a braced body by this depth, and they must agree:
  * one reads it over the gap between two declarations, the other over a single


### PR DESCRIPTION
Closes #373

Takes the lexical half of #373: the four separately-implemented readers of Verse comment, string and indent structure become one, consumed by both the import scanner and the `verseText` clients. C-04's missing word boundary comes along, since it is a one-token repair in the same report.

The second half — one declaration-head matcher in place of three — is deferred by agreement and filed as #410.

## What was wrong

Every lexical failure the lane B review found was two of these four disagreeing with each other rather than with Verse:

| | |
|---|---|
| B-01a | a `<#>` in a marker body leaked block-comment depth out of `blankCommentRange`, where `classifyLines` did not |
| B-03 | the masker had no `'` state, so `X := '#'` blanked the rest of the line and `X := '"'` opened a string |
| B-05 | five probe classes diverged, including the interpolation `"a{F("#")}b"`, which the masker read flat |
| B-07 | two indent models ended a marker body on different lines of a mixed tab/space file |
| B-18 | `countBraces`' paired-quote skip missed the escape literal `'\{'`, so brace depth drifted file-wide |
| C-04 | `ProjectPathScanner` omitted `\b` after three keywords, so `Foo := classify_items(X)` recorded a class |

## What changed

**`src/utils/verseLexer.ts` (new).** One line lexer. Given a line and the `{ depth, markerIndent }` the lines above left open, it returns the block-comment depth either side, whether the line is in or opens a `<#>` body, and three views of the text: `codeWithoutComments` (comments deleted so a spliced token rejoins), `codeOutsideLiterals` (literal contents spaced), and `masked` (same length as the input, for offset-preserving callers).

**`src/utils/verseText.ts`.** `maskCommentsAndStrings` becomes a driver over it. `countBraces` **loses its paired-quote heuristic** rather than gaining an `'\{'` case: char literals are blanked upstream, so a rule about which braces are real lives in the lexer where every reader gets it. `scanBraces` is the one brace primitive, reporting the depth after a range and the column where it first returned to zero. `indentOf` moves into the lexer and is re-exported here, so there is one width model with one definition.

**`src/imports/ImportScanner.ts`.** `lexLine`, `scanLine`'s frame types, and `indentWidth` are deleted — 287 lines down to a 4-line driver. `bracedUsingSpan`'s inline brace loop now calls `scanBraces`.

**`src/services/ProjectPathScanner.ts`.** C-04, in both places it lived — see below.

### The rules, and what settles each

Every claim is cited to the compiler's own `VerseGrammar.h`, not read off the readers under repair:

- **A `'` preceded by `[A-Za-z0-9_]` opens a quoted segment suffix; a `'` anywhere else opens a char literal.** `Ident := Alpha {Alnum} !Alnum ["'" … "'"]` (:1954) reaches for the suffix only straight after the alnum run, while `CharLit` is dispatched from prefix position alone (:3497-3501). Both old readers' comments assert this distinction is impossible — `verseText.ts:28-29` and `ImportScanner.ts:261-266`. It is exactly decidable, and that is what lets char literals be masked while `Economy.Shop'Loc'` survives intact.
- **`<#` opens a real block comment at every place; `<#>` advances depth at none.** `Text`'s `case '<'` (:2115-2137) dispatches `BlockCmt()` everywhere including inside a marker body, while `<#>` reaches `IndCmt()` at trivia, code and marker-body place only and is three characters of plain text elsewhere. This is B-01a, and reading the whole clause rather than the one arm fixes two more cases both old readers got wrong *together*: a `<#>` inside a block comment, and a `<#>` inside a string literal — see below.
- **`'\{'` is a real escape literal** — `IsStringBackslashLiteral` (:381) includes `{`.
- **A quoted suffix forbids `{ } " \` and allows a bare `#`** — `IsIdentifierQuotable` (:377). That is why leaving the suffix standing in `masked` costs nothing.
- **Indentation is compared byte-wise against the opener's prefix, and an inconsistent line is error `S89`** (`Line`, :1666-1690). So the two width models agreed on every file that compiles, and unifying on tab-counted-as-four is the whole of B-07.

### One divergence kept, and named

The two readers want **opposite** fallbacks when a line ends inside an open literal, and both are right. The masker must fail towards blanking — text it wrongly offers as code becomes a declaration `moduleDeclarations` edits as if it were real, which `moduleDeclarationsMasking.test.ts:56` pins. The scanner must fail towards keeping — a `using` it misses is read as permission to remove an import, which `ImportScanner.ts` has documented since #272.

So the lexer reports `endedOpen` and each driver chooses, under a doc comment saying why. Accidental divergence stops being representable; this one gets a name.

### A third case the same clause settles

Reading the whole `case '<'` arm turned up one more, found at the review gate: **a `<#>` inside a string literal opened an indented-comment body over every line below it**. `Label := "a<#>b"` followed by an indented `using` returned no paths at all — and an empty answer from `allUsingPaths` is what its caller reads as permission to remove an import.

Pre-existing and identical on `origin/main`, so not a regression, and not a divergence either — both old readers agreed here and were both wrong. It is in scope because the single lexer had cited that clause in its own header and claimed the rule held in every scope while implementing three of its four places. One lexer documenting a rule it three-quarters keeps is worse than four readers that never claimed to agree.

### C-04 had two homes, not one

The ticket cites the class/struct/interface patterns. Adding `\b` there alone made things **worse**: the fall-through backstop was a bare substring test —

```js
if (line.includes(":=") && (line.includes("class") || line.includes("struct") || ...)) continue;
```

— so `Items := classify_items(X)` went from *wrongly recorded as a class* to *dropped entirely*. Both are bounded here, the backstop via a named `DECLARATION_KEYWORD_AFTER_ASSIGN` anchored at the `:=`. This is #373's own thesis in miniature and it is why #410 is worth doing.

## Tests

`src/utils/__tests__/verseLexerCorpus.test.ts` is the shared probe corpus the ticket asks for. Seventeen probes, each run through both entry points, each asserted twice: that the readers **agree**, and that what they agree on is the language's answer. The two teeth are independent — the `<#>`-inside-a-block-comment and `<#>`-inside-a-string probes fail only their correctness half against the old code, because both old readers agreed there and were both wrong.

A further block runs probes through the readers built on those entry points — `allUsingPaths`, `scanModuleImports`, `scanModuleAliases`, `findExplicitModuleDeclarations` and `ProjectPathScanner.extractDeclarations` — since those are where a lexing mistake is finally paid for. One of them pins a contrast worth naming: `allUsingPaths` reads `codeWithoutComments` and so **over**-reports a `using` written inside a string, while `scanModuleImports` reads `codeOutsideLiterals` and reports none. Opposite directions, both deliberate — one decides whether removing an import is safe, the other decides what already counts as imported.

**Proved to detect the defect.** Against `1b6244a`'s readers, 16 of the 37 corpus assertions fail:

```
● a `#` inside a char literal is content › both readers agree on which text is a statement
● a `#` inside a char literal is content › and what they agree on is the language's answer
● a `"` inside a char literal opens no string › (both)
● a `#` inside a string nested in an interpolation is content › (both)
● a `<#>` inside a marker body opens no block comment › (both)
● a `<#>` inside a block comment opens no nested block › and what they agree on is the language's answer
● a `<#` inside a marker body outlives the body › (both)
● a marker body indented with a tab ends where a two-space line meets it › (both)
● a marker body runs through a blank line › (both)
● brace depth › returns to zero across an escaped brace in a char literal
```

and all three C-04 cases fail against the pre-fix `ProjectPathScanner` while its four positive cases still pass. The two `<#>`-in-a-string probes were checked the same way against the lexer before that fix.

That check earned its keep twice. The first version of those two probes **passed** against the defect: the marker sat at column 0 and the line below it was also at column 0, so a wrongly-opened body closed again immediately. Both now indent the lines below.

Also added: `verseText.test.ts` gains direct cases for `maskCommentsAndStrings` and `scanBraces`, which had none — the offset and length contracts `moduleDeclarations` depends on.

No existing test was modified or removed. The diff against `origin/main` is 307 test-file insertions and one deletion, that deletion being an import line.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 45 passed, 45 total
Tests:       1354 passed, 1354 total
Snapshots:   0 total
Time:        8.485 s
Ran all test suites.
```

Baseline on `origin/main` was 44 suites / 1292 tests. All 1292 still pass unmodified; the 62 added are the corpus, the `verseText` contract cases and the C-04 regression.

`npm run format:check`

```
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

`npx jest src/imports/__tests__` — 9 suites, 825 tests, all passing, read in full rather than by summary: a shared lexer that changed a rule surfaces as an unrelated existing case changing shape, not as the failure you predicted.

## Review

Two rounds against a fresh context, at the session model. **Round 1: PASS_WITH_SUGGESTIONS**, no Critical. **Round 2: PASS**, scoped to the delta.

The reviewer verified all eight grammar claims against `VerseGrammar.h` itself rather than taking them, and ran its own differential: on 46 real `.verse` files including the 600 KB `Fortnite.digest.verse`, old and new produce byte-identical output from `maskCommentsAndStrings`, `classifyLines`, `scanModuleImports`, `allUsingPaths` and `scanModuleAliases`. A 200,000-case fuzz over the offset contract found no violation; a 150,000-case fuzz seeded with `<#>` and quote tokens found 976 differences, every one of which contains **both** a marker and a quote — nothing outside the intended fix moved.

Round 1's single `Important` was the `<#>`-in-a-string case, fixed here rather than deferred. Its suggestions taken: one width model with one definition, `LexedLine.indent` dropped as unread, the `scanBraces` doc corrected, incident narration trimmed, and the corpus extended to the derived readers. Round 2 left two comment-accuracy suggestions, both applied — one of them a counterexample to a sentence this PR had added, which is recorded below.

### A pre-existing defect the review surfaced

Not introduced here and not fixed here, but worth stating plainly rather than leaving in a comment: **a `"` interpolation spanning lines leaves `maskCommentsAndStrings` output brace-unbalanced.** Each line is masked from the point a literal opened to the line's end, so `Msg := "Score: {` over `Points}"` loses its `{` and keeps its `}`, and the file-wide depth ends at −1. The fallout is real — on a module whose body contains such a string, `ProjectPathScanner.extractDeclarations` reports the nested declarations at top level, because the stray `}` closed the enclosing body a line early. Byte-identical on `origin/main`.

The `scanBraces` doc now states the limit instead of claiming balance, so the next person to meet a stranded depth is not reassured out of looking.

## Not in this change

- The three declaration-head matchers, beyond C-04 — #410.
- `LineCmt`'s treatment of `#>`. The grammar (:2105-2114) makes a `#>` after a `#` inside a block comment error `S05`, where both readers here close the block. That is over-acceptance on a file that does not compile, so it is neither a divergence nor a defect a user can reach.
