### PR TITLE
fix(commands): log every failure the commands report to the user

### DIFF
--- a/changelog.d/363.fixed.md
+++ b/changelog.d/363.fixed.md
@@ -1,0 +1,1 @@
+**Commands**: The palette toggles, the two debug-capture commands and Rebuild Path Cache now record their failures in the extension log, so an exported log holds the failure being reported.

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -234,6 +234,11 @@ export class CommandsHandler {
      * Writes the opposite of a setting's current value to global scope, then
      * refreshes the status bar.
      *
+     * Reports its own failures and swallows what it reports, so none of the
+     * five toggle commands built on it rejects. The refresh is inside that
+     * guard too, which means a failure it reports may be one where the setting
+     * was written and only the status bar did not follow.
+     *
      * @param toggleFn How to invert a value that is not a boolean. Omit it and
      *   the current value is negated.
      */

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -238,11 +238,16 @@ export class CommandsHandler {
      *   the current value is negated.
      */
     private async toggleConfig<T>(configKey: string, toggleFn?: (current: T) => T): Promise<void> {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
-        const current = config.get<T>(configKey);
-        const newValue = toggleFn ? toggleFn(current as T) : !current;
-        await config.update(configKey, newValue, vscode.ConfigurationTarget.Global);
-        this.deps.statusBarHandler.updateDisplay();
+        try {
+            const config = vscode.workspace.getConfiguration("verseAutoImports");
+            const current = config.get<T>(configKey);
+            const newValue = toggleFn ? toggleFn(current as T) : !current;
+            await config.update(configKey, newValue, vscode.ConfigurationTarget.Global);
+            this.deps.statusBarHandler.updateDisplay();
+        } catch (error) {
+            logger.error("CommandsHandler", `Failed to toggle ${configKey}`, error);
+            vscode.window.showErrorMessage(`Action failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
     }
 
     async toggleAutoImport(): Promise<void> {
@@ -299,6 +304,7 @@ export class CommandsHandler {
                 }
             }
         } catch (error) {
+            logger.error("CommandsHandler", "Failed to export debug logs", error);
             vscode.window.showErrorMessage(`Failed to export debug logs: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
@@ -351,6 +357,7 @@ export class CommandsHandler {
                 await vscode.commands.executeCommand("vscode.open", target);
             }
         } catch (error) {
+            logger.error("CommandsHandler", "Failed to capture diagnostics corpus", error);
             vscode.window.showErrorMessage(`Failed to capture diagnostics: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
@@ -369,21 +376,26 @@ export class CommandsHandler {
             return;
         }
 
-        logger.info("CommandsHandler", "Rebuilding project path cache");
+        try {
+            logger.info("CommandsHandler", "Rebuilding project path cache");
 
-        await vscode.window.withProgress(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: "Rebuilding project path cache...",
-                cancellable: false,
-            },
-            async () => {
-                await this.deps.projectPathCache!.rebuildCache();
-            },
-        );
+            await vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: "Rebuilding project path cache...",
+                    cancellable: false,
+                },
+                async () => {
+                    await this.deps.projectPathCache!.rebuildCache();
+                },
+            );
 
-        const stats = this.deps.projectPathCache.getStats();
-        vscode.window.showInformationMessage(`Project path cache rebuilt: ${stats.identifiers} identifiers from ${stats.files} files`);
+            const stats = this.deps.projectPathCache.getStats();
+            vscode.window.showInformationMessage(`Project path cache rebuilt: ${stats.identifiers} identifiers from ${stats.files} files`);
+        } catch (error) {
+            logger.error("CommandsHandler", "Failed to rebuild project path cache", error);
+            vscode.window.showErrorMessage(`Failed to rebuild project path cache: ${error instanceof Error ? error.message : String(error)}`);
+        }
     }
 
     /**

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -513,18 +513,25 @@ describe("CommandsHandler failure logging", () => {
     };
 
     let errors: jest.SpyInstance;
+    /** Spied only by the exportDebugLogs case, and restored here for all of them. */
+    let exportedLogs: jest.SpyInstance | undefined;
 
     beforeEach(() => {
         errors = jest.spyOn(logger, "error").mockImplementation(() => {});
     });
 
+    // Every restore belongs here rather than at the end of a test body: a
+    // failing assertion skips the tail of the body, and clearAllMocks leaves a
+    // mockReturnValue in place, so a rejecting configuration or a mocked logger
+    // singleton would survive into every later test.
     afterEach(() => {
         errors.mockRestore();
-        // clearAllMocks leaves a mockReturnValue in place, so a rejecting
-        // configuration would otherwise survive into every later test.
+        exportedLogs?.mockRestore();
+        exportedLogs = undefined;
         (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue(WORKING_CONFIGURATION);
         (vscode.commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
         (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([]);
+        (vscode.window.showInformationMessage as jest.Mock).mockReset();
     });
 
     /** Every palette toggle, each of which writes its setting through toggleConfig. */
@@ -574,7 +581,7 @@ describe("CommandsHandler failure logging", () => {
     // untraced half is what follows it: opening the file it wrote.
     it("exportDebugLogs logs a failure to open the exported file", async () => {
         const uri = vscode.Uri.file("C:\\Temp\\verseAutoImports_debugLogs.log");
-        const exportDebugLogs = jest.spyOn(logger, "exportDebugLogs").mockResolvedValue(uri);
+        exportedLogs = jest.spyOn(logger, "exportDebugLogs").mockResolvedValue(uri);
         (vscode.window.showInformationMessage as jest.Mock).mockResolvedValue("Open File");
         (vscode.commands.executeCommand as jest.Mock).mockRejectedValue(new Error("no editor for this file"));
 
@@ -583,9 +590,6 @@ describe("CommandsHandler failure logging", () => {
         expect(errors).toHaveBeenCalledTimes(1);
         expect(errors.mock.calls[0][0]).toBe("CommandsHandler");
         expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
-
-        exportDebugLogs.mockRestore();
-        (vscode.window.showInformationMessage as jest.Mock).mockReset();
     });
 
     it("captureDiagnosticsCorpus logs the failure it reports", async () => {

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -1,6 +1,9 @@
 import * as vscode from "vscode";
 import { CommandsHandler, CommandsDependencies } from "../CommandsHandler";
+import { logger } from "../../utils";
 import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../../imports";
+import { ProjectPathCache } from "../../services";
+import { StatusBarHandler } from "../../ui";
 
 // Regression for #133: addImportsToDocument and organizeImports return false
 // when applyEdit is rejected - a stale document version, or a read-only file -
@@ -493,5 +496,156 @@ describe("CommandsHandler per-document conversion keying", () => {
             // This is the half that fails when it does.
             expect(new Set(forwarded).size).toBe(2);
         }
+    });
+});
+
+// Regression for #363: a command that reports a failure only through
+// showErrorMessage leaves the extension's own log empty, so the log export the
+// maintainer asks for afterwards omits the failure being reported. Asserted at
+// the command entry points rather than at the catch blocks, since a toggle
+// reaches its write through toggleConfig and only the entry point proves the
+// path a user takes is covered.
+describe("CommandsHandler failure logging", () => {
+    /** The default the suite-wide getConfiguration mock returns, restored after each override. */
+    const WORKING_CONFIGURATION = {
+        get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+        update: jest.fn().mockResolvedValue(undefined),
+    };
+
+    let errors: jest.SpyInstance;
+
+    beforeEach(() => {
+        errors = jest.spyOn(logger, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        errors.mockRestore();
+        // clearAllMocks leaves a mockReturnValue in place, so a rejecting
+        // configuration would otherwise survive into every later test.
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue(WORKING_CONFIGURATION);
+        (vscode.commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
+        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([]);
+    });
+
+    /** Every palette toggle, each of which writes its setting through toggleConfig. */
+    const TOGGLE_COMMANDS: Array<[string, (handler: CommandsHandler) => Promise<void>]> = [
+        ["toggleAutoImport", (handler) => handler.toggleAutoImport()],
+        ["togglePreserveLocations", (handler) => handler.togglePreserveLocations()],
+        ["toggleImportSyntax", (handler) => handler.toggleImportSyntax()],
+        ["toggleDigestFiles", (handler) => handler.toggleDigestFiles()],
+        ["toggleFullPathCodeLens", (handler) => handler.toggleFullPathCodeLens()],
+    ];
+
+    describe("a rejected global settings write", () => {
+        function rejectConfigurationWrites(): void {
+            (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+                get: jest.fn().mockReturnValue(false),
+                update: jest.fn().mockRejectedValue(new Error("EACCES: settings.json is read-only")),
+            });
+        }
+
+        function makeToggleHandler(): CommandsHandler {
+            return new CommandsHandler({
+                statusBarHandler: { updateDisplay: jest.fn() } as unknown as StatusBarHandler,
+            } as unknown as CommandsDependencies);
+        }
+
+        it.each(TOGGLE_COMMANDS)("%s logs the failure and tells the user, rather than throwing", async (_name, run) => {
+            rejectConfigurationWrites();
+
+            await expect(run(makeToggleHandler())).resolves.toBeUndefined();
+
+            expect(errors).toHaveBeenCalledTimes(1);
+            expect(errors.mock.calls[0][0]).toBe("CommandsHandler");
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+            expect((vscode.window.showErrorMessage as jest.Mock).mock.calls[0][0]).toMatch(/Action failed: EACCES/);
+        });
+
+        it("names the setting it could not write", async () => {
+            rejectConfigurationWrites();
+
+            await makeToggleHandler().toggleAutoImport();
+
+            expect(errors.mock.calls[0][1]).toMatch(/general\.autoImport/);
+        });
+    });
+
+    // logger.exportDebugLogs logs the write itself before rethrowing, so the
+    // untraced half is what follows it: opening the file it wrote.
+    it("exportDebugLogs logs a failure to open the exported file", async () => {
+        const uri = vscode.Uri.file("C:\\Temp\\verseAutoImports_debugLogs.log");
+        const exportDebugLogs = jest.spyOn(logger, "exportDebugLogs").mockResolvedValue(uri);
+        (vscode.window.showInformationMessage as jest.Mock).mockResolvedValue("Open File");
+        (vscode.commands.executeCommand as jest.Mock).mockRejectedValue(new Error("no editor for this file"));
+
+        await new CommandsHandler({} as unknown as CommandsDependencies).exportDebugLogs();
+
+        expect(errors).toHaveBeenCalledTimes(1);
+        expect(errors.mock.calls[0][0]).toBe("CommandsHandler");
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+
+        exportDebugLogs.mockRestore();
+        (vscode.window.showInformationMessage as jest.Mock).mockReset();
+    });
+
+    it("captureDiagnosticsCorpus logs the failure it reports", async () => {
+        (vscode.languages.getDiagnostics as jest.Mock).mockImplementation(() => {
+            throw new Error("diagnostics unavailable");
+        });
+
+        await new CommandsHandler({} as unknown as CommandsDependencies).captureDiagnosticsCorpus();
+
+        expect(errors).toHaveBeenCalledTimes(1);
+        expect(errors.mock.calls[0][0]).toBe("CommandsHandler");
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+        expect((vscode.window.showErrorMessage as jest.Mock).mock.calls[0][0]).toMatch(/Failed to capture diagnostics/);
+    });
+
+    describe("rebuildPathCache", () => {
+        function makeCacheHandler(cache: Partial<ProjectPathCache>): CommandsHandler {
+            return new CommandsHandler({ projectPathCache: cache as ProjectPathCache } as unknown as CommandsDependencies);
+        }
+
+        it("logs a rejected rebuild and tells the user, rather than throwing", async () => {
+            const handler = makeCacheHandler({
+                rebuildCache: jest.fn().mockRejectedValue(new Error("workspace scan failed")),
+                getStats: jest.fn(),
+            });
+
+            await expect(handler.rebuildPathCache()).resolves.toBeUndefined();
+
+            expect(errors).toHaveBeenCalledTimes(1);
+            expect(errors.mock.calls[0][0]).toBe("CommandsHandler");
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+            expect((vscode.window.showErrorMessage as jest.Mock).mock.calls[0][0]).toMatch(/Failed to rebuild project path cache: workspace scan failed/);
+        });
+
+        it("logs a throwing getStats, which runs after the progress notification closes", async () => {
+            const handler = makeCacheHandler({
+                rebuildCache: jest.fn().mockResolvedValue(undefined),
+                getStats: jest.fn().mockImplementation(() => {
+                    throw new Error("cache state unreadable");
+                }),
+            });
+
+            await expect(handler.rebuildPathCache()).resolves.toBeUndefined();
+
+            expect(errors).toHaveBeenCalledTimes(1);
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+            expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+        });
+
+        it("still reports the rebuilt counts when nothing fails", async () => {
+            const handler = makeCacheHandler({
+                rebuildCache: jest.fn().mockResolvedValue(undefined),
+                getStats: jest.fn().mockReturnValue({ identifiers: 12, files: 3 }),
+            });
+
+            await handler.rebuildPathCache();
+
+            expect(errors).not.toHaveBeenCalled();
+            expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+            expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("Project path cache rebuilt: 12 identifiers from 3 files");
+        });
     });
 });


### PR DESCRIPTION
Closes #363

## What

Three failure paths in `CommandsHandler` reported to the user without leaving anything in the extension's own log, so the log export a maintainer asks for afterwards omitted the failure being reported.

- `toggleConfig` awaited a Global configuration write with no try/catch anywhere up the chain, and the five palette toggles built on it added none. It now catches, logs, and shows the same `Action failed: ...` message the status menu already uses for a failed action.
- `exportDebugLogs` and `captureDiagnosticsCorpus` caught only to call `showErrorMessage`. Each gained a `logger.error("CommandsHandler", ...)` line before that toast. For `exportDebugLogs` the untraced half was the follow-up `vscode.open` / `revealFileInOS` await, since `logger.exportDebugLogs` already logs its own write failure before rethrowing.
- `rebuildPathCache` had no try/catch at all. It gained one shaped like its neighbour `clearPathCache`. The early "cache is not enabled" guard stays above the try, so that path is unchanged.

Nothing else changed. The blindness landed precisely on the two commands that exist for diagnosing failures, which is why the ticket rated it worth fixing despite the low severity.

## Tests

Eleven regression tests, pinned at the command entry points the issue names rather than at `toggleConfig` beneath them — the five toggles reach their write through that private method, so only the entry point proves the path a user takes is covered. Ten of the eleven were confirmed to fail against the unfixed source; the eleventh is a deliberate happy-path control that passes either way.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 46 passed, 46 total
Tests:       1386 passed, 1386 total
Snapshots:   0 total
Time:        7.922 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round at opus: `PASS_WITH_SUGGESTIONS`, no Critical and no Important findings, with probes across all five toggles, both debug commands, and every branch of `rebuildPathCache`.

Two of its five suggestions are applied in the second commit: `toggleConfig`'s doc comment now states the contract that changed (it swallows what it reports, so no toggle command rejects), and the `exportDebugLogs` test restores its spy from `afterEach` rather than from the tail of the test body.

Three are recorded and deliberately not acted on:

- When `logger.exportDebugLogs` itself rejects, the failure now reaches the log twice — once as `Logger` from `logger.ts` before it rethrows, once as `CommandsHandler`. The ticket flagged this nuance and still prescribed the unconditional line; the user-visible toast stays single.
- Both new try blocks enclose the success side-effect as well as the failing await, so a throwing `updateDisplay` or a throwing success notification is reported under the name of the operation that had already succeeded. Both are host calls that rarely throw, and the alternative is an unhandled rejection. The `toggleConfig` doc comment now says so.
- `error instanceof Error ? error.message : String(error)` now appears six times in the file. The inline form is the file's existing convention and predates this diff; extracting a helper is a change for when it grows again.
