### PR TITLE
fix(imports): keep an added import below the file header

### DIFF
--- a/changelog.d/383.fixed.md
+++ b/changelog.d/383.fixed.md
@@ -1,0 +1,1 @@
+**Import placement**: a new import is written below the file's opening comment header instead of above it, on every configuration.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -666,6 +666,14 @@ export class ImportDocumentEditor {
         const classifications = classifyLines(lines);
         const pinned = pinnedImports(scannedImports);
 
+        // The top of the file for anything written here, in place of line 0:
+        // writing above the header puts it into the middle of the file, which
+        // headerLineCount calls the one place a header must never be. Every
+        // line it covers is comment or blank - it ends at the first code line,
+        // and an import line is code - so no `using` is crossed by starting
+        // below it, and no resolution order changes.
+        const headerEnd = headerLineCount(classifications);
+
         const importBlocks: ImportBlock[] = [];
         for (const imp of rewritableImports(scannedImports)) {
             logger.debug("ImportDocumentEditor", `Found existing import at line ${imp.startLine}: ${imp.path}`);
@@ -825,7 +833,7 @@ export class ImportDocumentEditor {
                 }
 
                 if (unhandledPaths.length > 0) {
-                    const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;
+                    const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
                     for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, pinned, classifications, diagnosticLinesByPath)) {
                         this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, importBlocks.length === 0);
                     }
@@ -883,7 +891,7 @@ export class ImportDocumentEditor {
                         // rewritable import opens or extends a block, so no
                         // block means none of them, which is also why the
                         // trailing comments here are always empty.
-                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, 0, pinned, classifications, diagnosticLinesByPath)) {
+                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, headerEnd, pinned, classifications, diagnosticLinesByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, true);
                         }
                     }
@@ -959,7 +967,7 @@ export class ImportDocumentEditor {
                             this.createBlockReplacementEdit(edit, document, importBlocks[index], pathsByBlock.get(index)!, preferDotSyntax, true, eol);
                         }
 
-                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, 0, pinned, classifications, diagnosticLinesByPath)) {
+                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, headerEnd, pinned, classifications, diagnosticLinesByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), eol, true);
                         }
                     } else {
@@ -983,7 +991,7 @@ export class ImportDocumentEditor {
                         // precede it sits there, which is the one case a file
                         // whose only import is pinned always reaches. That is
                         // what groupByPlacementLine answers, from either start.
-                        const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : 0;
+                        const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
                         const blankLineAfter = importBlocks.length === 0;
 
                         for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, pinned, classifications, diagnosticLinesByPath)) {
@@ -1024,8 +1032,7 @@ export class ImportDocumentEditor {
                 // No blank line after the block: ensureEmptyLinesAfterImports
                 // runs once the edit has been applied and puts the configured
                 // number there.
-                const importsText = formattedImports.join(eol) + eol;
-                edit.insert(document.uri, new vscode.Position(0, 0), importsText);
+                this.insertImportLines(edit, document, headerEnd, formattedImports, eol, false);
             }
 
             for (const [line, paths] of [...newPathsByLine].sort(([a], [b]) => a - b)) {

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -666,12 +666,9 @@ export class ImportDocumentEditor {
         const classifications = classifyLines(lines);
         const pinned = pinnedImports(scannedImports);
 
-        // The top of the file for anything written here, in place of line 0:
-        // writing above the header puts it into the middle of the file, which
-        // headerLineCount calls the one place a header must never be. Every
-        // line it covers is comment or blank - it ends at the first code line,
-        // and an import line is code - so no `using` is crossed by starting
-        // below it, and no resolution order changes.
+        // The top of the file for everything written below, in place of line 0.
+        // See headerLineCount. Every line it covers is comment or blank, so
+        // starting here crosses no `using` and changes no resolution order.
         const headerEnd = headerLineCount(classifications);
 
         const importBlocks: ImportBlock[] = [];
@@ -967,6 +964,11 @@ export class ImportDocumentEditor {
                             this.createBlockReplacementEdit(edit, document, importBlocks[index], pathsByBlock.get(index)!, preferDotSyntax, true, eol);
                         }
 
+                        // headerEnd never decides anything here, and is passed
+                        // so that no site holds a different top of the file: a
+                        // path with unconstrained bounds finds every block
+                        // eligible, so an unblocked one always has a floor or a
+                        // ceiling, and both sit at or below the header's end.
                         for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, headerEnd, pinned, classifications, diagnosticLinesByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), eol, true);
                         }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -991,7 +991,11 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
-    it("adds an import that exists only inside a block comment, above the comment", async () => {
+    // The commented-out copy stays inert and the live one is added anyway. It
+    // goes below the comment rather than above it: the comment opens the file,
+    // so it is the header, which is the same reading buildOrganizedContent
+    // makes of this shape.
+    it("adds an import that exists only inside a block comment, below the comment", async () => {
         const input = ["<#", "using { /Fortnite.com/Devices }", "#>", "", "my_device := class(creative_device):", "    Button : button_device = button_device{}"].join("\n");
 
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
@@ -1000,7 +1004,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const operations = appliedOperations(0);
         expect(operations).toHaveLength(1);
         expect(operations[0].kind).toBe("insert");
-        expect(operations[0].position).toEqual({ line: 0, character: 0 });
+        expect(operations[0].position).toEqual({ line: 4, character: 0 });
         expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n\n");
     });
 
@@ -1508,6 +1512,62 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
 
         expect(operations.some((op) => op.kind === "replace")).toBe(false);
         expect(operations.some((op) => op.kind === "delete")).toBe(false);
+    });
+
+    // The rule that a header stays above the block was held by the organize
+    // path alone, so every add-path branch that writes at the top of a file
+    // wrote at line 0. A file with a header and no import block reaches one of
+    // these on every configuration, and the licence ended up in the middle of
+    // the file.
+    describe("adding to a headered file with no import block", () => {
+        it("preserve + grouping none: writes the new import below the header", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["# Copyright 2026 MyGame", "", "hello := 1"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(2);
+            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\n\n");
+        });
+
+        // Grouping with no block of its own to regroup: the file's only import
+        // is pinned, which is a block to no placement decision.
+        it("preserve + digestFirst: writes below the header when the only import is pinned", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "digestFirst",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["# Copyright 2026 MyGame", "", "using { Economy.Shop } <#> note", "    body", "hello := 1"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(2);
+            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\n\n");
+        });
+
+        it("consolidating: writes the consolidated block below the header", async () => {
+            mockConfig({ "behavior.preserveImportLocations": false });
+            const input = ["# Copyright 2026 MyGame", "", "using { /Verse.org/Simulation }", "", "hello := 1"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(2);
+            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n");
+        });
     });
 
     // An import anchored by a comment marker belongs to no import block, so


### PR DESCRIPTION
Closes #383

## What

`headerLineCount` had exactly one call site, inside `buildOrganizedContent`. Every `addImportsToDocument` branch that writes at the top of a file wrote at line 0, so a file opening with a licence header and holding no import block took the new import above its header — reachable on the default configuration — and with `preserveImportLocations: false` the whole consolidated block landed above it on every add.

The header end is now computed once in `addImportsToDocument` and used as the start line everywhere the add path would otherwise begin at 0, and as the consolidation insert position. Consolidation goes through `insertImportLines` rather than a raw `edit.insert(..., Position(0, 0), ...)`, because inserting at the header end can now target a line past the last one, which VS Code clamps onto the end of the last line and splices.

Two of the five changed sites are provably inert — the `hasGrouping` fallback (that branch already requires two blocks) and the sorted-merge `unblockedPaths` start (an unblocked path always has a floor or a ceiling, and both sit at or below the header's end). They are changed so that no site holds a different idea of where the top of the file is; the reason is pinned in a comment at the second, and both were confirmed byte-identical against `main` under review.

## The Verse rule this relies on

A `using` may legally sit below a leading comment run. Position inside file level is advisory (Book of Verse `docs/16_modules.md:390-393`), and module-scope `using` analysis is deferred FIFO in the compiler (`Deferred_ModuleReferences`), so order matters only between `using` statements, never between a `using` and a definition. The skipped region can hold no `using` at all: `headerLineCount` stops at the first `code` line and the classifier types a `using` line as `code`.

## Behaviour change worth naming

A file opening with a `<# ... #>` block comment now takes an added import below that comment rather than above it. That is the same reading `buildOrganizedContent` already makes of the shape (`leaves a commented-out import in the body instead of resurrecting it`), so the two paths converge on one rule; the pre-existing test pinning line 0 was updated rather than exempted.

## Verification

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./

Test Suites: 46 passed, 46 total
Tests:       1378 passed, 1378 total
Snapshots:   0 total
Time:        12.772 s
Ran all test suites.

> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The three new tests were each shown to fail — writing at line 0 — with the production change stashed.

## Review

One round at opus, fresh context: `PASS_WITH_SUGGESTIONS`, no Critical and no Important. The reviewer ran every changed path A/B against `main` (default config, consolidation, grouped-with-pinned, sorted-merge, `localFirst`, dot syntax, sort off, CRLF, tabs, an indented `using:` pair, a `<#>` marker header, pinned floor and ceiling): every case the fix does not target came back byte-identical. Both suggestions taken — the comment above `headerEnd` was trimmed to the clause that is load-bearing, and the inert site now says why it is inert.

One residual it recorded, left as is: in a file that is a single unterminated `<#` and nothing else, the import is now appended at EOF, inside the open comment, where it is inert. No code line exists in such a file, so no diagnostic can ask for an import there.
