### PR TITLE
fix(imports): read a block comment opened inside a line comment

### DIFF
--- a/changelog.d/374.fixed.md
+++ b/changelog.d/374.fixed.md
@@ -1,0 +1,1 @@
+**Verse file scanning**: a block comment opened with `<#` inside a `#` line comment now reads as commented out to its `#>`, so imports written in that region no longer count as present or get rewritten.

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -954,10 +954,14 @@ describe("scanModuleImports", () => {
         ]);
     });
 
-    it("does not flag an import whose trailing line comment mentions <#", () => {
-        expect(scanModuleImports(["using { /A } # opens with <#", "using { /B }"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# opens with <#" },
-            { path: "/B", startLine: 1, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+    it("flags an import whose trailing line comment opens a block comment", () => {
+        // The line comment ends with its line and the block it opens does not,
+        // so the lines below really are commented out and moving the statement
+        // moves which ones.
+        const lines = ["using { /A } # opens with <#", "using { /Old/Path }", "#>", "using { /B }"];
+        expect(scanModuleImports(lines)).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "# opens with <#" },
+            { path: "/B", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
 
@@ -1036,9 +1040,12 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 2, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
-    it("does not treat a <# inside a line comment as a block opener", () => {
-        const lines = ["# a block comment opens with <#", "using { /Verse.org/Simulation }"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 1, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
+    it("treats a <# inside a line comment as the block opener it is", () => {
+        // A line comment is lexed like any other text, so the block runs from
+        // the `<#` to the `#>` below and the import between them is commented
+        // out. Reading it as live is how a needed using gets suppressed.
+        const lines = ["# a block comment opens with <#", "using { /Old/Path }", "#>", "using { /Verse.org/Simulation }"];
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
     it("returns entries in document order with correct spans across mixed styles", () => {
@@ -1247,8 +1254,12 @@ describe("classifyLines", () => {
         expect(kinds(["<#> the marker is not a block opener", "code()"])).toEqual(["comment", "code"]);
     });
 
-    it("does not mistake a block opener inside a line comment for one", () => {
-        expect(kinds(["# see <# below", "code()"])).toEqual(["comment", "code"]);
+    it("reads a block opener inside a line comment as one", () => {
+        expect(kinds(["# see <# below", "code()", "#>", "code()"])).toEqual(["comment", "comment", "comment", "code"]);
+    });
+
+    it("ends a line comment that opened and closed a block on its own line", () => {
+        expect(kinds(["# see <# aside #> below", "code()"])).toEqual(["comment", "code"]);
     });
 
     it("keeps a # inside a string literal in the line's code", () => {

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -137,6 +137,31 @@ const probes: Probe[] = [
         live: ["L1"],
     },
     {
+        // Both readers held the opposite, that a line comment made its tail
+        // text: `Text`'s `<` arm dispatches BlockCmt at every place, so the
+        // block outlives the line that opened it exactly as one opened in code
+        // does. The lines it swallows were being read as live imports.
+        name: "a `<#` inside a line comment outlives the line",
+        source: "# D1 <# D2\nD3 := 1 #>\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // The line comment ends at its own newline where the block it opened
+        // closed on the line, and the text between the two is trivia either way.
+        name: "a line comment that closes its block still ends with its line",
+        source: "# D1 <# D2 #> D3\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // The `<#>` arm falls to three characters of text at line-comment place,
+        // so this opens neither a block nor a body. It has to be tested before
+        // the `<#` above or the tail reads as an opener that never closes, and
+        // the indented line below is what tells the two mistakes apart.
+        name: "a `<#>` inside a line comment opens nothing over the lines below it",
+        source: "# D1 <#> D2\n    L1 := 1\nL2 := 2\n",
+        live: ["L1", "L2"],
+    },
+    {
         // Two indent models ended the body on different lines: a tab counted as
         // one column in the scanner and four in the masker.
         name: "a marker body indented with a tab ends where a two-space line meets it",

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -154,9 +154,10 @@ const probes: Probe[] = [
     },
     {
         // The `<#>` arm falls to three characters of text at line-comment place,
-        // so this opens neither a block nor a body. It has to be tested before
-        // the `<#` above or the tail reads as an opener that never closes, and
-        // the indented line below is what tells the two mistakes apart.
+        // so this opens neither a block nor a body. The lexer has to test it
+        // before it tests `<#`, or the tail reads as an opener that never
+        // closes; the indented line below is what tells the two mistakes apart,
+        // since only the marker reading leaves the line after it live.
         name: "a `<#>` inside a line comment opens nothing over the lines below it",
         source: "# D1 <#> D2\n    L1 := 1\nL2 := 2\n",
         live: ["L1", "L2"],

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -290,9 +290,10 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         //
         // The tail keeps being lexed rather than consumed here: the comment ends
         // with the line, but a `<#` written in it opens a block that does not.
-        // The `#` itself is taken first, so the `#>` of a `#>` opening the line
-        // cannot also be read as closing a block - at line-comment place that is
-        // error S05 rather than a closer.
+        // The `#` itself is taken first, so a line opening `#>` cannot also be
+        // read as closing a block - `LineCmt := '#' !'>'` (:2016) declines to
+        // open a comment on one at all, and outside a block comment it is error
+        // S05, so there is no depth for it to close.
         if (line[i] === "#" && innermost?.kind !== "literal") {
             insideLineComment = true;
             commentChar();

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -31,7 +31,12 @@
  * - `<# ... #>` nests, and beats a string literal: a `<#` inside a string really
  *   does open a comment there. Both digraphs are consumed whole, so the `#` of a
  *   `<#` cannot also be read as closing one.
- * - `#` runs to the end of the line, but inside a literal it is content.
+ * - `#` runs to the end of the line, but inside a literal it is content. What it
+ *   opens does not have to end there: `LineCmt` is `'#' !'>' {Text} Ending`
+ *   (:2014-2024) over the same `Text` as everywhere else, and `Text`'s `case '<'`
+ *   dispatches `BlockCmt()` at every place, so a `<#` written in a line comment
+ *   opens a block that runs to its `#>` however many lines below. Failing to
+ *   carry that reads the lines the compiler comments out as live imports.
  * - A `"` string interpolates, and `Interp := '{' List '}'` (:2163) makes the
  *   interpolation body ordinary code: a `"` inside one opens a fresh string and
  *   a `#` opens a real comment. So literal state is a stack of frames, and an
@@ -199,6 +204,10 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     let codeOutsideLiterals = "";
     let masked = "";
     let opensIndentedComment = false;
+    // Whether a `#` opened a line comment earlier on this line. Per-line, since
+    // a line comment ends with its line - but what it opened need not, so this
+    // says only that the text left is trivia, never that it holds no opener.
+    let insideLineComment = false;
     let i = 0;
 
     // What is open at this point, innermost last, and empty at code scope. A
@@ -215,11 +224,12 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     };
 
     while (i < line.length) {
-        // Comment text, whether from a block comment opened above or from the
-        // body of a `<#>`. Scanned rather than skipped so a `<#` inside it still
-        // opens a block that outlives the region, which is what the compiler
-        // does at every place (VerseGrammar.h:2115-2137).
-        if (nesting > 0 || insideIndentedComment) {
+        // Comment text, whether from a block comment opened above, from the body
+        // of a `<#>`, or from a `#` earlier on this line. Scanned rather than
+        // skipped so a `<#` inside it still opens a block that outlives the
+        // region, which is what the compiler does at every place
+        // (VerseGrammar.h:2115-2137).
+        if (nesting > 0 || insideIndentedComment || insideLineComment) {
             if (line.startsWith("<#>", i)) {
                 // Already comment text, so this opens nothing. Tested before
                 // `<#` or its first two characters read as a block opener that
@@ -277,11 +287,17 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         // the line as one at the head of it would. A `#` inside any literal is
         // content: a `"` string and a char literal both hold it, and
         // `IsIdentifierQuotable` admits a bare `#` in a quoted suffix.
+        //
+        // The tail keeps being lexed rather than consumed here: the comment ends
+        // with the line, but a `<#` written in it opens a block that does not.
+        // The `#` itself is taken first, so the `#>` of a `#>` opening the line
+        // cannot also be read as closing a block - at line-comment place that is
+        // error S05 rather than a closer.
         if (line[i] === "#" && innermost?.kind !== "literal") {
-            for (; i < line.length; i++) {
-                commentChar();
-            }
-            break;
+            insideLineComment = true;
+            commentChar();
+            i += 1;
+            continue;
         }
 
         if (line.startsWith("<#", i)) {


### PR DESCRIPTION
Closes #374

`LineCmt` runs over the same `Text` as every other place, and `Text`'s `case '<'` dispatches `BlockCmt()` with no place guard (`VerseGrammar.h:2115-2126`), so a `<#` written in a `#` line comment opens a block comment that runs to its `#>` however many lines below. The lexer consumed the comment tail character by character instead, so every line the compiler reads as comment was read here as live code.

## Scope

Most of #374 landed two hours earlier in #413, which replaced the four separate readers with `src/utils/verseLexer.ts`. That took the ticket's three `<#>`-interior cases and the scanner/masker divergence with it. What was left is the half named in the title, and it now lives in one place rather than two.

`anchorsCommentBelow` needed nothing, as the ticket predicted: it re-drives the same lexer over the statement's span, so it inherits the rule.

## What changed

**`src/utils/verseLexer.ts`.** The `#` arm no longer consumes the rest of the line. It takes the `#` itself, sets `insideLineComment`, and lets the existing comment-text branch lex the tail — the same branch a block comment's body and a `<#>` marker's body already go through. That branch tests `<#>` before `<#`, so the three rules fall out of one place:

- a `<#` in the tail opens a block, which outlives the line that opened it
- a `<#>` in the tail stays three characters of text, opening neither a block nor a body
- the opening `#` is consumed before the branch is entered, so a `#>` at the head of a line cannot also read as a closer

Every output is byte-for-byte what it was for a comment tail holding neither digraph, `masked` included, so nothing that indexes into it moves.

## The rules, and what settles each

Read from the compiler source at `Engine/Source/Runtime/VerseCompiler/Public/uLang/Parser/VerseGrammar.h`, not from the readers under repair:

- **A `<#` opens a real block comment at line-comment place.** `LineCmt := '#' !'>' {Text} Ending` (:2014-2024) runs the same `Text`, whose `case '<'` reaches `BlockCmt()` at every place — the `if constexpr` guard on that arm covers only the `<#>` case (:2115-2126).
- **The block spans lines.** `Text<EPlace::BlockCmt>` continues over a newline (:2099-2103).
- **A `<#>` at line-comment place is plain text.** The guard admits `Space`, `Content` and `IndCmt`; everything else falls to `Next(3)` (:2127-2138).
- **A bare `#>` at line-comment place is error S05** (:2105-2113), so nothing legal closes at depth 0 inside a line comment.
- **An unclosed `<#` is a hard S04 at EOF** (`BlockCmt`, :2034-2039) — not comment-to-EOF. A file that writes one does not compile; reading its remainder as comment is what the lexer already did for an unclosed `<#` at code scope, so the two agree.
- **Compile-validated corroboration.** `book-of-verse/Tests/ParametricFunctions.versetest:256` writes `<# type{:int|:string}, i.e. any #>` inside a `#` line comment. Under the old reading its `#>` would be S05, so the file compiles only under the block reading. It is the one artifact in the book that discriminates between the two.

## Tests

Three pins encoded the old belief and now pin the compiler's answer. Each fixture gained a later `#>`, because a fixture without one is a file that fails to parse and so does not exhibit the divergence at all:

- `scanModuleImports` › flags an import whose trailing line comment opens a block comment
- `scanModuleImports` › treats a `<#` inside a line comment as the block opener it is
- `classifyLines` › reads a block opener inside a line comment as one

Three probes were added to the shared lexer corpus, where every entry point is held to the same answer: a `<#` in a line comment outliving the line, a line comment that closes its own block still ending with its line, and a `<#>` in a line comment opening nothing over the indented line below it. Two more `classifyLines` cases guard the same-line and ordering halves.

The four assertions that carry the fix were run against the unfixed lexer and fail there.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
Test Suites: 46 passed, 46 total
Tests:       1382 passed, 1382 total
Snapshots:   0 total
Time:        11.697 s
Ran all test suites.
```

`npm run format:check`

```
Checking formatting...
All matched files use Prettier code style!
```

## Review

One round, fresh context, `PASS_WITH_SUGGESTIONS`, no Critical. The reviewer re-derived R1-R5 from `VerseGrammar.h` rather than from the diff, ran ~40 probes across `lexVerseLine`, `classifyLines`, `scanModuleImports`, `allUsingPaths`, `maskCommentsAndStrings`, `findExplicitModuleDeclarations` and `ProjectPathScanner.extractDeclarations` — same-line close, close many lines below, never closing, `<#>` with an indented line under it, a line-opening `#>`, a `#>` later in the tail, `#` in a string, a char literal, a quoted suffix and an interpolation, a line comment inside a block comment and inside a marker body, nested `<# <# #> #>`, CRLF and tabs — and asserted `masked.length === line.length` on every one, with no violations. It also compiled the pre-fix lexer standalone to confirm the new fixtures fail against it, and confirmed the `<#>`-before-`<#` ordering is load-bearing by removing it (the probe's answer collapses from `["L1","L2"]` to `[]`).

Two Suggestions applied: a misattributed grammar place in the `#` arm's comment, and an ambiguous "above" in a corpus probe comment.

Three Important findings are left unfixed, all outside this ticket rather than defects in it:

1. **The `<#>` marker's own line has the same gap.** `IndCmt()` lexes the marker's tail with `Text<EPlace::LineCmt>` (`VerseGrammar.h:2041-2047`) — the identical place fixed here — so `<#> note <# opener` should open a block and does not. Same rule, sibling path.
2. **A line comment does not resume after its block closes on a later line.** `Text<LineCmt>` continues after `BlockCmt()` returns, so in `#> using { /X }` the `using` is still comment text; it currently reads as live. Pre-existing, not a regression.
3. **`ImportFormatter.commentStartIndex` truncates a path at a `#` inside a quoted segment suffix.** `IsIdentifierQuotable` excludes `#` only before `>`, so `Mod'a#b'` is legal; the entry is marked rewritable, so Organize Imports can rebuild the line from the truncated path. Unrelated to comments-in-lexing, and the higher-impact of the three.

The ticket's structural note — that block-comment depth is an unbounded file-long accumulator — is unaddressed by design: its own prescribed fix carries no bound.
