### PR TITLE
fix(digest): keep every module that declares an identifier

### DIFF
--- a/changelog.d/375.fixed.md
+++ b/changelog.d/375.fixed.md
@@ -1,0 +1,1 @@
+**Digest lookup**: an identifier declared by more than one bundled module now offers every module as a quick fix, instead of silently importing whichever one the digests happened to reach first.

--- a/src/data/Fortnite.digest.json
+++ b/src/data/Fortnite.digest.json
@@ -1,11139 +1,14849 @@
 {
-  "version": "1.0.0",
-  "generatedAt": "2026-08-14T12:40:55.229Z",
+  "version": "2.0.0",
+  "generatedAt": "2026-08-15T10:07:02.843Z",
   "sourceFile": "Fortnite.digest.verse",
   "sourceBuild": "++Fortnite+Release-41.30-CL-56430492",
   "entries": {
-    "UI": {
-      "identifier": "UI",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "module",
-      "isPublic": true
-    },
-    "text_button_base": {
-      "identifier": "text_button_base",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "button_loud": {
-      "identifier": "button_loud",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "button_regular": {
-      "identifier": "button_regular",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "button_quiet": {
-      "identifier": "button_quiet",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_hud_controller": {
-      "identifier": "fort_hud_controller",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_all": {
-      "identifier": "creative_hud_identifier_all",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_build_menu": {
-      "identifier": "creative_hud_identifier_build_menu",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_crafting_resources": {
-      "identifier": "creative_hud_identifier_crafting_resources",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_elimination_counter": {
-      "identifier": "creative_hud_identifier_elimination_counter",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_equipped_item": {
-      "identifier": "creative_hud_identifier_equipped_item",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_experience_level": {
-      "identifier": "creative_hud_identifier_experience_level",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_experience_supercharged": {
-      "identifier": "creative_hud_identifier_experience_supercharged",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_experience_ui": {
-      "identifier": "creative_hud_identifier_experience_ui",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_health": {
-      "identifier": "creative_hud_identifier_health",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_health_numbers": {
-      "identifier": "creative_hud_identifier_health_numbers",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_hud_info": {
-      "identifier": "creative_hud_identifier_hud_info",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_interaction_prompts": {
-      "identifier": "creative_hud_identifier_interaction_prompts",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_map_prompts": {
-      "identifier": "creative_hud_identifier_map_prompts",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_mimimap": {
-      "identifier": "creative_hud_identifier_mimimap",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_minimap": {
-      "identifier": "creative_hud_identifier_minimap",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_pickup_stream": {
-      "identifier": "creative_hud_identifier_pickup_stream",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_player_count": {
-      "identifier": "creative_hud_identifier_player_count",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_player_inventory": {
-      "identifier": "creative_hud_identifier_player_inventory",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_round_info": {
-      "identifier": "creative_hud_identifier_round_info",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_round_timer": {
-      "identifier": "creative_hud_identifier_round_timer",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_shield_numbers": {
-      "identifier": "creative_hud_identifier_shield_numbers",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_shileds": {
-      "identifier": "creative_hud_identifier_shileds",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_shields": {
-      "identifier": "creative_hud_identifier_shields",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_storm_notifications": {
-      "identifier": "creative_hud_identifier_storm_notifications",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_storm_timer": {
-      "identifier": "creative_hud_identifier_storm_timer",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_hud_identifier_team_info": {
-      "identifier": "creative_hud_identifier_team_info",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_hud_identifier_all": {
-      "identifier": "player_hud_identifier_all",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_world_resource_wood": {
-      "identifier": "hud_identifier_world_resource_wood",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_world_resource_stone": {
-      "identifier": "hud_identifier_world_resource_stone",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_world_resource_metal": {
-      "identifier": "hud_identifier_world_resource_metal",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_world_resource_permanite": {
-      "identifier": "hud_identifier_world_resource_permanite",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_world_resource_gold_currency": {
-      "identifier": "hud_identifier_world_resource_gold_currency",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_world_resource_ingredient": {
-      "identifier": "hud_identifier_world_resource_ingredient",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_visual_sound_effect_weapons": {
-      "identifier": "hud_identifier_visual_sound_effect_weapons",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_visual_sound_effect_loot": {
-      "identifier": "hud_identifier_visual_sound_effect_loot",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_visual_sound_effect_movement": {
-      "identifier": "hud_identifier_visual_sound_effect_movement",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_visual_sound_effect_vehicle": {
-      "identifier": "hud_identifier_visual_sound_effect_vehicle",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_visual_sound_effect_healing": {
-      "identifier": "hud_identifier_visual_sound_effect_healing",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_identifier_visual_sound_effect_all": {
-      "identifier": "hud_identifier_visual_sound_effect_all",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_element_identifier": {
-      "identifier": "hud_element_identifier",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "slider_regular": {
-      "identifier": "slider_regular",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "text_block": {
-      "identifier": "text_block",
-      "modulePath": "/Fortnite.com/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "Input": {
-      "identifier": "Input",
-      "modulePath": "/Fortnite.com/Input",
-      "type": "module",
-      "isPublic": true
-    },
-    "Character": {
-      "identifier": "Character",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "module",
-      "isPublic": true
-    },
-    "RangedWeaponMapping": {
-      "identifier": "RangedWeaponMapping",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Reload": {
-      "identifier": "Reload",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "WeaponPrimary": {
-      "identifier": "WeaponPrimary",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "WeaponSecondary": {
-      "identifier": "WeaponSecondary",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "TraversalMapping": {
-      "identifier": "TraversalMapping",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Crouch": {
-      "identifier": "Crouch",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Sprint": {
-      "identifier": "Sprint",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Jump": {
-      "identifier": "Jump",
-      "modulePath": "/Fortnite.com/Input/Character",
-      "type": "variable",
-      "isPublic": true
-    },
-    "AI": {
-      "identifier": "AI",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "module",
-      "isPublic": true
-    },
-    "equipped_sidekick_component": {
-      "identifier": "equipped_sidekick_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "spark_mode_component": {
-      "identifier": "spark_mode_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_action_error_type": {
-      "identifier": "ai_action_error_type",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "focus_interface": {
-      "identifier": "focus_interface",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_leashable": {
-      "identifier": "fort_leashable",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "guard_actions_component": {
-      "identifier": "guard_actions_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "guard_awareness_component": {
-      "identifier": "guard_awareness_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "navigation_target": {
-      "identifier": "navigation_target",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeNavigationTarget": {
-      "identifier": "MakeNavigationTarget",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "function",
-      "isPublic": true
-    },
-    "navigation_result": {
-      "identifier": "navigation_result",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "navigation_action_error_type": {
-      "identifier": "navigation_action_error_type",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "navigation_action_success_type": {
-      "identifier": "navigation_action_success_type",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "movement_type": {
-      "identifier": "movement_type",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "movement_types": {
-      "identifier": "movement_types",
-      "modulePath": "/Fortnite.com/AI/movement_types",
-      "type": "module",
-      "isPublic": true
-    },
-    "Walking": {
-      "identifier": "Walking",
-      "modulePath": "/Fortnite.com/AI/movement_types",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Running": {
-      "identifier": "Running",
-      "modulePath": "/Fortnite.com/AI/movement_types",
-      "type": "variable",
-      "isPublic": true
-    },
-    "navigatable": {
-      "identifier": "navigatable",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "npc_actions_component": {
-      "identifier": "npc_actions_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "npc_awareness_component": {
-      "identifier": "npc_awareness_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "npc_behavior": {
-      "identifier": "npc_behavior",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "guard_alert_level": {
-      "identifier": "guard_alert_level",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "npc_target_info": {
-      "identifier": "npc_target_info",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "sidekick_mood": {
-      "identifier": "sidekick_mood",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "sidekick_reaction": {
-      "identifier": "sidekick_reaction",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "sidekick_component": {
-      "identifier": "sidekick_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "npc_sidekick_component": {
-      "identifier": "npc_sidekick_component",
-      "modulePath": "/Fortnite.com/AI",
-      "type": "class",
-      "isPublic": true
-    },
-    "Devices": {
-      "identifier": "Devices",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "module",
-      "isPublic": true
-    },
-    "vfx_spawner_device": {
-      "identifier": "vfx_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "progress_device_state": {
-      "identifier": "progress_device_state",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "progress_based_mesh_device": {
-      "identifier": "progress_based_mesh_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vote_group_device": {
-      "identifier": "vote_group_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vote_option_interface": {
-      "identifier": "vote_option_interface",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vote_option_device": {
-      "identifier": "vote_option_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "bank_vault_interface": {
-      "identifier": "bank_vault_interface",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "animated_mesh_device": {
-      "identifier": "animated_mesh_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "automated_turret_device": {
-      "identifier": "automated_turret_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "carryable_spawner_device": {
-      "identifier": "carryable_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "reboot_van_device": {
-      "identifier": "reboot_van_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "reboot_progress_decay_behavior": {
-      "identifier": "reboot_progress_decay_behavior",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "reboot_card_purchase_options": {
-      "identifier": "reboot_card_purchase_options",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "reboot_van_interface": {
-      "identifier": "reboot_van_interface",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "post_process_device": {
-      "identifier": "post_process_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "analytics_device": {
-      "identifier": "analytics_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "accolades_device": {
-      "identifier": "accolades_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "has_spire_functionality": {
-      "identifier": "has_spire_functionality",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "item_remover_device": {
-      "identifier": "item_remover_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_marker_device": {
-      "identifier": "player_marker_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "prop_mover_device": {
-      "identifier": "prop_mover_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "real_time_clock_device": {
-      "identifier": "real_time_clock_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "switch_device": {
-      "identifier": "switch_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "audio_mixer_device": {
-      "identifier": "audio_mixer_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "audio_player_device": {
-      "identifier": "audio_player_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "elimination_feed_device": {
-      "identifier": "elimination_feed_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "firefly_spawner_device": {
-      "identifier": "firefly_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "end_game_device": {
-      "identifier": "end_game_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "input_trigger_device": {
-      "identifier": "input_trigger_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "item_placer_device": {
-      "identifier": "item_placer_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "changing_booth_device": {
-      "identifier": "changing_booth_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "race_checkpoint_device": {
-      "identifier": "race_checkpoint_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "race_manager_device": {
-      "identifier": "race_manager_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_counter_device": {
-      "identifier": "player_counter_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "customizable_light_device": {
-      "identifier": "customizable_light_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "prop_manipulator_device": {
-      "identifier": "prop_manipulator_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "skydome_device": {
-      "identifier": "skydome_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vfx_creator_device": {
-      "identifier": "vfx_creator_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "campfire_device": {
-      "identifier": "campfire_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "sentry_device": {
-      "identifier": "sentry_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "map_controller_device": {
-      "identifier": "map_controller_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_controls_device": {
-      "identifier": "gameplay_controls_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_controls_side_scroller_device": {
-      "identifier": "gameplay_controls_side_scroller_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_controls_third_person_device": {
-      "identifier": "gameplay_controls_third_person_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "video_player_device": {
-      "identifier": "video_player_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "volume_device": {
-      "identifier": "volume_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_spawner_device": {
-      "identifier": "player_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_reference_device": {
-      "identifier": "player_reference_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "crowd_volume_device": {
-      "identifier": "crowd_volume_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "disguise_device": {
-      "identifier": "disguise_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_checkpoint_device": {
-      "identifier": "player_checkpoint_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "hiding_prop_device": {
-      "identifier": "hiding_prop_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "bouncer_device": {
-      "identifier": "bouncer_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "signal_remote_manager_device": {
-      "identifier": "signal_remote_manager_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "crash_pad_device": {
-      "identifier": "crash_pad_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "fishing_zone_device": {
-      "identifier": "fishing_zone_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "barrier_device": {
-      "identifier": "barrier_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "damage_volume_device": {
-      "identifier": "damage_volume_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "effect_volume_device": {
-      "identifier": "effect_volume_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "fire_volume_device": {
-      "identifier": "fire_volume_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "mutator_zone_device": {
-      "identifier": "mutator_zone_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "skydive_volume_device": {
-      "identifier": "skydive_volume_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "service_station_device": {
-      "identifier": "service_station_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "spire_spike_device": {
-      "identifier": "spire_spike_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "dance_mannequin_device": {
-      "identifier": "dance_mannequin_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creature_manager_device": {
-      "identifier": "creature_manager_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creature_placer_device": {
-      "identifier": "creature_placer_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creature_spawner_device": {
-      "identifier": "creature_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_patrol_path_device": {
-      "identifier": "ai_patrol_path_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "Patchwork": {
-      "identifier": "Patchwork",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "module",
-      "isPublic": true
-    },
-    "patchwork_device": {
-      "identifier": "patchwork_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "drum_sequencer_device": {
-      "identifier": "drum_sequencer_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "lfo_modulator_device": {
-      "identifier": "lfo_modulator_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "cable_splitter_device": {
-      "identifier": "cable_splitter_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "speaker_device": {
-      "identifier": "speaker_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "music_manager_device": {
-      "identifier": "music_manager_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "distortion_effect_device": {
-      "identifier": "distortion_effect_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "instrument_player_device": {
-      "identifier": "instrument_player_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "song_sync_device": {
-      "identifier": "song_sync_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "note_trigger_device": {
-      "identifier": "note_trigger_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "step_modulator_device": {
-      "identifier": "step_modulator_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "omega_synthesizer_device": {
-      "identifier": "omega_synthesizer_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "drum_player_device": {
-      "identifier": "drum_player_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "value_setter_device": {
-      "identifier": "value_setter_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "echo_effect_device": {
-      "identifier": "echo_effect_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "note_progressor_device": {
-      "identifier": "note_progressor_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "note_sequencer_device": {
-      "identifier": "note_sequencer_device",
-      "modulePath": "/Fortnite.com/Devices/Patchwork",
-      "type": "class",
-      "isPublic": true
-    },
-    "skilled_interaction_device": {
-      "identifier": "skilled_interaction_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_camera_device": {
-      "identifier": "gameplay_camera_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_camera_fixed_point_device": {
-      "identifier": "gameplay_camera_fixed_point_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_camera_first_person_device": {
-      "identifier": "gameplay_camera_first_person_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_camera_fixed_angle_device": {
-      "identifier": "gameplay_camera_fixed_angle_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "gameplay_camera_orbit_device": {
-      "identifier": "gameplay_camera_orbit_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "water_device": {
-      "identifier": "water_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "character_device": {
-      "identifier": "character_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "item_shop_device": {
-      "identifier": "item_shop_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "advanced_storm_beacon_device": {
-      "identifier": "advanced_storm_beacon_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "advanced_storm_controller_device": {
-      "identifier": "advanced_storm_controller_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "air_vent_device": {
-      "identifier": "air_vent_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "attribute_evaluator_device": {
-      "identifier": "attribute_evaluator_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "ball_spawner_device": {
-      "identifier": "ball_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "base_item_spawner_device": {
-      "identifier": "base_item_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "basic_storm_controller_device": {
-      "identifier": "basic_storm_controller_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "beacon_device": {
-      "identifier": "beacon_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "billboard_device": {
-      "identifier": "billboard_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "button_device": {
-      "identifier": "button_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "capture_area_device": {
-      "identifier": "capture_area_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "capture_item_spawner_device": {
-      "identifier": "capture_item_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "channel_device": {
-      "identifier": "channel_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "class_and_team_selector_device": {
-      "identifier": "class_and_team_selector_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "class_designer_device": {
-      "identifier": "class_designer_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "collectible_object_device": {
-      "identifier": "collectible_object_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "color_changing_tiles_device": {
-      "identifier": "color_changing_tiles_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "conditional_button_device": {
-      "identifier": "conditional_button_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "damage_amplifier_powerup_device": {
-      "identifier": "damage_amplifier_powerup_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "elimination_manager_device": {
-      "identifier": "elimination_manager_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "experience_settings_device": {
-      "identifier": "experience_settings_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "explosive_device": {
-      "identifier": "explosive_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "fuel_pump_device": {
-      "identifier": "fuel_pump_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "grind_powerup_device": {
-      "identifier": "grind_powerup_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "holoscreen_device": {
-      "identifier": "holoscreen_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_message_device": {
-      "identifier": "hud_message_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "item_granter_device": {
-      "identifier": "item_granter_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "item_spawner_device": {
-      "identifier": "item_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "lock_device": {
-      "identifier": "lock_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "map_indicator_device": {
-      "identifier": "map_indicator_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "matchmaking_portal_device": {
-      "identifier": "matchmaking_portal_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "movement_modulator_device": {
-      "identifier": "movement_modulator_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "objective_device": {
-      "identifier": "objective_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "perception_trigger_device": {
-      "identifier": "perception_trigger_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "pinball_bumper_device": {
-      "identifier": "pinball_bumper_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "pinball_flipper_device": {
-      "identifier": "pinball_flipper_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "powerup_device": {
-      "identifier": "powerup_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "prop_o_matic_manager_device": {
-      "identifier": "prop_o_matic_manager_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "prop_spawner_base_device": {
-      "identifier": "prop_spawner_base_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "pulse_trigger_device": {
-      "identifier": "pulse_trigger_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "radio_device": {
-      "identifier": "radio_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "rng_device": {
-      "identifier": "rng_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "round_settings_device": {
-      "identifier": "round_settings_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "score_manager_device": {
-      "identifier": "score_manager_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "shooting_range_target_device": {
-      "identifier": "shooting_range_target_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "shooting_range_target_track_device": {
-      "identifier": "shooting_range_target_track_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "storm_controller_device": {
-      "identifier": "storm_controller_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "support_a_creator_device": {
-      "identifier": "support_a_creator_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "sword_in_the_stone_device": {
-      "identifier": "sword_in_the_stone_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "team_settings_and_inventory_device": {
-      "identifier": "team_settings_and_inventory_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "teleporter_device": {
-      "identifier": "teleporter_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "timed_objective_device": {
-      "identifier": "timed_objective_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "timer_device": {
-      "identifier": "timer_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "tracker_device": {
-      "identifier": "tracker_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "trick_tile_device": {
-      "identifier": "trick_tile_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "trigger_base_device": {
-      "identifier": "trigger_base_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "trigger_device": {
-      "identifier": "trigger_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vending_machine_device": {
-      "identifier": "vending_machine_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "visual_effect_powerup_device": {
-      "identifier": "visual_effect_powerup_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "chair_device": {
-      "identifier": "chair_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "hud_controller_device": {
-      "identifier": "hud_controller_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_mod_box_spawner_device": {
-      "identifier": "vehicle_mod_box_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_mod_box_settings": {
-      "identifier": "vehicle_mod_box_settings",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_atk_device": {
-      "identifier": "vehicle_spawner_atk_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_baller_device": {
-      "identifier": "vehicle_spawner_baller_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_pickup_truck_device": {
-      "identifier": "vehicle_spawner_pickup_truck_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_biplane_device": {
-      "identifier": "vehicle_spawner_biplane_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_boat_device": {
-      "identifier": "vehicle_spawner_boat_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_cannon_device": {
-      "identifier": "vehicle_spawner_cannon_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_driftboard_device": {
-      "identifier": "vehicle_spawner_driftboard_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_big_rig_device": {
-      "identifier": "vehicle_spawner_big_rig_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_sedan_device": {
-      "identifier": "vehicle_spawner_sedan_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_quadcrasher_device": {
-      "identifier": "vehicle_spawner_quadcrasher_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_shopping_cart_device": {
-      "identifier": "vehicle_spawner_shopping_cart_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_surfboard_device": {
-      "identifier": "vehicle_spawner_surfboard_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_taxi_device": {
-      "identifier": "vehicle_spawner_taxi_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_device": {
-      "identifier": "vehicle_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_sports_car_device": {
-      "identifier": "vehicle_spawner_sports_car_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "boost_pad_rocketracing_device": {
-      "identifier": "boost_pad_rocketracing_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_movement_settings_device": {
-      "identifier": "player_movement_settings_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "class_selector_ui_device": {
-      "identifier": "class_selector_ui_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "popup_dialog_device": {
-      "identifier": "popup_dialog_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "physics_boulder_device": {
-      "identifier": "physics_boulder_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "physics_object_base_device": {
-      "identifier": "physics_object_base_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "physics_tree_device": {
-      "identifier": "physics_tree_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "stat_creator_device": {
-      "identifier": "stat_creator_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "stat_powerup_device": {
-      "identifier": "stat_powerup_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "health_powerup_device": {
-      "identifier": "health_powerup_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "spawn_on_enable_behavior": {
-      "identifier": "spawn_on_enable_behavior",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "roly_poly_spawner_device": {
-      "identifier": "roly_poly_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "roly_poly": {
-      "identifier": "roly_poly",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "nitro_hoop_device": {
-      "identifier": "nitro_hoop_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_octane_device": {
-      "identifier": "vehicle_spawner_octane_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_hammerhead_choppa_device": {
-      "identifier": "vehicle_spawner_hammerhead_choppa_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_helicopter_device": {
-      "identifier": "vehicle_spawner_helicopter_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_heavy_turret_device": {
-      "identifier": "vehicle_spawner_heavy_turret_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_siege_cannon_device": {
-      "identifier": "vehicle_spawner_siege_cannon_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_ufo_device": {
-      "identifier": "vehicle_spawner_ufo_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_tank_device": {
-      "identifier": "vehicle_spawner_tank_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_armored_battle_bus_device": {
-      "identifier": "vehicle_spawner_armored_battle_bus_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_dirtbike_device": {
-      "identifier": "vehicle_spawner_dirtbike_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_nitro_drifter_sedan_device": {
-      "identifier": "vehicle_spawner_nitro_drifter_sedan_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_sportbike_device": {
-      "identifier": "vehicle_spawner_sportbike_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_valet_suv_device": {
-      "identifier": "vehicle_spawner_valet_suv_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "conversation_device": {
-      "identifier": "conversation_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "earth_sprite_device": {
-      "identifier": "earth_sprite_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "guard_spawner_accuracy": {
-      "identifier": "guard_spawner_accuracy",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "guard_spawner_visibility_range_restriction": {
-      "identifier": "guard_spawner_visibility_range_restriction",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "guard_spawner_device": {
-      "identifier": "guard_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "nitro_barrel_spawner_device": {
-      "identifier": "nitro_barrel_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_getaway_device": {
-      "identifier": "vehicle_spawner_getaway_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "wilds_plant_device": {
-      "identifier": "wilds_plant_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "grind_rail_device": {
-      "identifier": "grind_rail_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vine_rail_device": {
-      "identifier": "vine_rail_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "rift_point_volume_device": {
-      "identifier": "rift_point_volume_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_drivable_reboot_van_device": {
-      "identifier": "vehicle_spawner_drivable_reboot_van_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "down_but_not_out_device": {
-      "identifier": "down_but_not_out_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_war_bus_device": {
-      "identifier": "vehicle_spawner_war_bus_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_xwing_device": {
-      "identifier": "vehicle_spawner_xwing_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_tie_fighter_device": {
-      "identifier": "vehicle_spawner_tie_fighter_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_n1_starfighter_device": {
-      "identifier": "vehicle_spawner_n1_starfighter_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_armored_assault_tank_device": {
-      "identifier": "vehicle_spawner_armored_assault_tank_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_turbolaser_device": {
-      "identifier": "vehicle_spawner_turbolaser_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_df9_device": {
-      "identifier": "vehicle_spawner_df9_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "healing_cactus_device": {
-      "identifier": "healing_cactus_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "emp_volume_hazard_rocketracing_device": {
-      "identifier": "emp_volume_hazard_rocketracing_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "npc_spawner_device": {
-      "identifier": "npc_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "scout_spire_device": {
-      "identifier": "scout_spire_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "bank_vault_device": {
-      "identifier": "bank_vault_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "cinematic_sequence_device": {
-      "identifier": "cinematic_sequence_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_rocketracing_device": {
-      "identifier": "vehicle_spawner_rocketracing_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "overlord_spire_device": {
-      "identifier": "overlord_spire_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "wildlife_spawner_device": {
-      "identifier": "wildlife_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "vehicle_spawner_armored_transport_device": {
-      "identifier": "vehicle_spawner_armored_transport_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "hive_stash_style": {
-      "identifier": "hive_stash_style",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "hive_stash_device": {
-      "identifier": "hive_stash_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "hero_chest_rank": {
-      "identifier": "hero_chest_rank",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "hero_chest_device": {
-      "identifier": "hero_chest_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "supply_drop_spawner_device": {
-      "identifier": "supply_drop_spawner_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "CreativeAnimation": {
-      "identifier": "CreativeAnimation",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
-      "type": "module",
-      "isPublic": true
-    },
-    "cubic_bezier_parameters": {
-      "identifier": "cubic_bezier_parameters",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "InterpolationTypes": {
-      "identifier": "InterpolationTypes",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
-      "type": "module",
-      "isPublic": true
-    },
-    "Linear": {
-      "identifier": "Linear",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Ease": {
-      "identifier": "Ease",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
-      "type": "variable",
-      "isPublic": true
-    },
-    "EaseIn": {
-      "identifier": "EaseIn",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
-      "type": "variable",
-      "isPublic": true
-    },
-    "EaseOut": {
-      "identifier": "EaseOut",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
-      "type": "variable",
-      "isPublic": true
-    },
-    "EaseInOut": {
-      "identifier": "EaseInOut",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
-      "type": "variable",
-      "isPublic": true
-    },
-    "keyframe_delta": {
-      "identifier": "keyframe_delta",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "animation_mode": {
-      "identifier": "animation_mode",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "animation_controller_state": {
-      "identifier": "animation_controller_state",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "await_next_keyframe_result": {
-      "identifier": "await_next_keyframe_result",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "animation_controller": {
-      "identifier": "animation_controller",
-      "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_device": {
-      "identifier": "creative_device",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_device_base": {
-      "identifier": "creative_device_base",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_device_asset": {
-      "identifier": "creative_device_asset",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_object": {
-      "identifier": "creative_object",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_object_interface": {
-      "identifier": "creative_object_interface",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_prop": {
-      "identifier": "creative_prop",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "creative_prop_asset": {
-      "identifier": "creative_prop_asset",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "DefaultCreativePropAsset": {
-      "identifier": "DefaultCreativePropAsset",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "variable",
-      "isPublic": true
-    },
-    "spawn_prop_result": {
-      "identifier": "spawn_prop_result",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpawnProp": {
-      "identifier": "SpawnProp",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "function",
-      "isPublic": true
-    },
-    "device_ai_interaction_result": {
-      "identifier": "device_ai_interaction_result",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "carryable_spawner_agent_impact_result": {
-      "identifier": "carryable_spawner_agent_impact_result",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "GetCreativeObjectsWithTag": {
-      "identifier": "GetCreativeObjectsWithTag",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "function",
-      "isPublic": true
-    },
-    "GetCreativeObjectsWithTags": {
-      "identifier": "GetCreativeObjectsWithTags",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "function",
-      "isPublic": true
-    },
-    "move_to_result": {
-      "identifier": "move_to_result",
-      "modulePath": "/Fortnite.com/Devices",
-      "type": "class",
-      "isPublic": true
-    },
-    "Marketplace": {
-      "identifier": "Marketplace",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "module",
-      "isPublic": true
-    },
-    "offer_interactable_component": {
-      "identifier": "offer_interactable_component",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "price_vbucks": {
-      "identifier": "price_vbucks",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakePriceVBucks": {
-      "identifier": "MakePriceVBucks",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "GetPriceVBucks": {
-      "identifier": "GetPriceVBucks",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "price_dimension": {
-      "identifier": "price_dimension",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "entitlement": {
-      "identifier": "entitlement",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "offer": {
-      "identifier": "offer",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "entitlement_offer": {
-      "identifier": "entitlement_offer",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "bundle_offer": {
-      "identifier": "bundle_offer",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "RestrictPaidRandomItems": {
-      "identifier": "RestrictPaidRandomItems",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "RestrictDirectPromptsToPurchase": {
-      "identifier": "RestrictDirectPromptsToPurchase",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "BuyOffer": {
-      "identifier": "BuyOffer",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "GrantEntitlement": {
-      "identifier": "GrantEntitlement",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "GetPurchasedEntitlements": {
-      "identifier": "GetPurchasedEntitlements",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "entitlement_change": {
-      "identifier": "entitlement_change",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "class",
-      "isPublic": true
-    },
-    "GetEntitlementsChangedEvent": {
-      "identifier": "GetEntitlementsChangedEvent",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "ConsumeEntitlement": {
-      "identifier": "ConsumeEntitlement",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "ShowOffersDialog": {
-      "identifier": "ShowOffersDialog",
-      "modulePath": "/Fortnite.com/Marketplace",
-      "type": "function",
-      "isPublic": true
-    },
-    "Armory": {
-      "identifier": "Armory",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "module",
-      "isPublic": true
-    },
-    "fort_multi_trace_weapon_component": {
-      "identifier": "fort_multi_trace_weapon_component",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_range_damage_multiplier": {
-      "identifier": "fort_range_damage_multiplier",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_trace_weapon_component": {
-      "identifier": "fort_trace_weapon_component",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_weapon_component": {
-      "identifier": "fort_weapon_component",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "pistol_mesh": {
-      "identifier": "pistol_mesh",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "pistol_template": {
-      "identifier": "pistol_template",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "assault_rifle_mesh": {
-      "identifier": "assault_rifle_mesh",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "assault_rifle_template": {
-      "identifier": "assault_rifle_template",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "sub_machine_gun_mesh": {
-      "identifier": "sub_machine_gun_mesh",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "sub_machine_gun_template": {
-      "identifier": "sub_machine_gun_template",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "shotgun_mesh": {
-      "identifier": "shotgun_mesh",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "shotgun_template": {
-      "identifier": "shotgun_template",
-      "modulePath": "/Fortnite.com/Armory",
-      "type": "class",
-      "isPublic": true
-    },
-    "Itemization": {
-      "identifier": "Itemization",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "module",
-      "isPublic": true
-    },
-    "fort_inventory_component": {
-      "identifier": "fort_inventory_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_inventory_weapon_hotbar_component": {
-      "identifier": "fort_inventory_weapon_hotbar_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_inventory_build_hotbar_component": {
-      "identifier": "fort_inventory_build_hotbar_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_inventory_harvest_tool_component": {
-      "identifier": "fort_inventory_harvest_tool_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_inventory_trap_component": {
-      "identifier": "fort_inventory_trap_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_inventory_resources_component": {
-      "identifier": "fort_inventory_resources_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_inventory_ammo_component": {
-      "identifier": "fort_inventory_ammo_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_inventory_currencies_component": {
-      "identifier": "fort_inventory_currencies_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "FortniteItemCategories": {
-      "identifier": "FortniteItemCategories",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "module",
-      "isPublic": true
-    },
-    "WorldItem": {
-      "identifier": "WorldItem",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Currency": {
-      "identifier": "Currency",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Trap": {
-      "identifier": "Trap",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Ammo": {
-      "identifier": "Ammo",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Resource": {
-      "identifier": "Resource",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "variable",
-      "isPublic": true
-    },
-    "WeaponMelee": {
-      "identifier": "WeaponMelee",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "variable",
-      "isPublic": true
-    },
-    "WeaponRanged": {
-      "identifier": "WeaponRanged",
-      "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
-      "type": "variable",
-      "isPublic": true
-    },
-    "fort_item_pickup_interactable_component": {
-      "identifier": "fort_item_pickup_interactable_component",
-      "modulePath": "/Fortnite.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "FortniteRarities": {
-      "identifier": "FortniteRarities",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "module",
-      "isPublic": true
-    },
-    "Common": {
-      "identifier": "Common",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Uncommon": {
-      "identifier": "Uncommon",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Rare": {
-      "identifier": "Rare",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Epic": {
-      "identifier": "Epic",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Legendary": {
-      "identifier": "Legendary",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Mythic": {
-      "identifier": "Mythic",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Exotic": {
-      "identifier": "Exotic",
-      "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Animation": {
-      "identifier": "Animation",
-      "modulePath": "/Fortnite.com/Animation",
-      "type": "module",
-      "isPublic": true
-    },
-    "PlayAnimation": {
-      "identifier": "PlayAnimation",
-      "modulePath": "/Fortnite.com/Animation/PlayAnimation",
-      "type": "module",
-      "isPublic": true
-    },
-    "play_animation_result": {
-      "identifier": "play_animation_result",
-      "modulePath": "/Fortnite.com/Animation/PlayAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "play_animation_controller": {
-      "identifier": "play_animation_controller",
-      "modulePath": "/Fortnite.com/Animation/PlayAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "play_animation_instance": {
-      "identifier": "play_animation_instance",
-      "modulePath": "/Fortnite.com/Animation/PlayAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "play_animation_state": {
-      "identifier": "play_animation_state",
-      "modulePath": "/Fortnite.com/Animation/PlayAnimation",
-      "type": "class",
-      "isPublic": true
-    },
-    "Assets": {
-      "identifier": "Assets",
-      "modulePath": "/Fortnite.com/Assets",
-      "type": "module",
-      "isPublic": true
-    },
-    "npc_character_definition": {
-      "identifier": "npc_character_definition",
-      "modulePath": "/Fortnite.com/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "Characters": {
-      "identifier": "Characters",
-      "modulePath": "/Fortnite.com/Characters",
-      "type": "module",
-      "isPublic": true
-    },
-    "fort_character": {
-      "identifier": "fort_character",
-      "modulePath": "/Fortnite.com/Characters",
-      "type": "class",
-      "isPublic": true
-    },
-    "stasis_args": {
-      "identifier": "stasis_args",
-      "modulePath": "/Fortnite.com/Characters",
-      "type": "class",
-      "isPublic": true
-    },
-    "FortPlayerUtilities": {
-      "identifier": "FortPlayerUtilities",
-      "modulePath": "/Fortnite.com/FortPlayerUtilities",
-      "type": "module",
-      "isPublic": true
-    },
-    "Game": {
-      "identifier": "Game",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "module",
-      "isPublic": true
-    },
-    "elimination_result": {
-      "identifier": "elimination_result",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_round_manager": {
-      "identifier": "fort_round_manager",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "positional": {
-      "identifier": "positional",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "healthful": {
-      "identifier": "healthful",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "shieldable": {
-      "identifier": "shieldable",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "damageable": {
-      "identifier": "damageable",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "healable": {
-      "identifier": "healable",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "damage_args": {
-      "identifier": "damage_args",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "damage_result": {
-      "identifier": "damage_result",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "healing_args": {
-      "identifier": "healing_args",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "healing_result": {
-      "identifier": "healing_result",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "game_action_instigator": {
-      "identifier": "game_action_instigator",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "game_action_causer": {
-      "identifier": "game_action_causer",
-      "modulePath": "/Fortnite.com/Game",
-      "type": "class",
-      "isPublic": true
-    },
-    "Playspaces": {
-      "identifier": "Playspaces",
-      "modulePath": "/Fortnite.com/Playspaces",
-      "type": "module",
-      "isPublic": true
-    },
-    "fort_playspace": {
-      "identifier": "fort_playspace",
-      "modulePath": "/Fortnite.com/Playspaces",
-      "type": "class",
-      "isPublic": true
-    },
-    "Teams": {
-      "identifier": "Teams",
-      "modulePath": "/Fortnite.com/Teams",
-      "type": "module",
-      "isPublic": true
-    },
-    "team_attitude": {
-      "identifier": "team_attitude",
-      "modulePath": "/Fortnite.com/Teams",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_team_collection": {
-      "identifier": "fort_team_collection",
-      "modulePath": "/Fortnite.com/Teams",
-      "type": "class",
-      "isPublic": true
-    },
-    "Vehicles": {
-      "identifier": "Vehicles",
-      "modulePath": "/Fortnite.com/Vehicles",
-      "type": "module",
-      "isPublic": true
-    },
-    "fort_vehicle": {
-      "identifier": "fort_vehicle",
-      "modulePath": "/Fortnite.com/Vehicles",
-      "type": "class",
-      "isPublic": true
-    },
-    "fort_vehicle_seat": {
-      "identifier": "fort_vehicle_seat",
-      "modulePath": "/Fortnite.com/Vehicles",
-      "type": "class",
-      "isPublic": true
-    },
-    "Items": {
-      "identifier": "Items",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "module",
-      "isPublic": true
-    },
-    "Acorn_Creative_V1_Common": {
-      "identifier": "Acorn_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ActivePowercell_Creative_V1_Epic": {
-      "identifier": "ActivePowercell_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AdhesiveResin_Creative_V1_Uncommon": {
-      "identifier": "AdhesiveResin_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AirStrike_BR_CH1S9_Legendary": {
-      "identifier": "AirStrike_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AlienNanites_BR_CH2S7_Common": {
-      "identifier": "AlienNanites_BR_CH2S7_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AmmoArrows_BR_CH2S6_Common": {
-      "identifier": "AmmoArrows_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AmmoHeavyBullets_BR_PreSeason_Common": {
-      "identifier": "AmmoHeavyBullets_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AmmoLightBullets_BR_PreSeason_Common": {
-      "identifier": "AmmoLightBullets_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AmmoMediumBullets_BR_PreSeason_Common": {
-      "identifier": "AmmoMediumBullets_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AmmoRockets_BR_PreSeason_Common": {
-      "identifier": "AmmoRockets_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AmmoShells_BR_PreSeason_Common": {
-      "identifier": "AmmoShells_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AnimalBones_BR_CH2S6_Common": {
-      "identifier": "AnimalBones_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Apple_BR_CH1S4_Common": {
-      "identifier": "Apple_BR_CH1S4_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ArmoredWall_BR_CH2S8_Uncommon": {
-      "identifier": "ArmoredWall_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "AuthorityKeycard_BR_CH2S3_Legendary": {
-      "identifier": "AuthorityKeycard_BR_CH2S3_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Bacon_Creative_V1_Common": {
-      "identifier": "Bacon_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Balloons_BR_CH1S6_Rare": {
-      "identifier": "Balloons_BR_CH1S6_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Banana_BR_CH1S8_Common": {
-      "identifier": "Banana_BR_CH1S8_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BananaOfTheGods_BR_CH5S2_Legendary": {
-      "identifier": "BananaOfTheGods_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Bandage_BR_PreSeason_Common": {
-      "identifier": "Bandage_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Bandage_BR_CH5S1_Common": {
-      "identifier": "Bandage_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BandageBazooka_BR_CH2S1_Epic": {
-      "identifier": "BandageBazooka_BR_CH2S1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Batteries_Creative_V1_Common": {
-      "identifier": "Batteries_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BigBushBomb_BR_CH4S1_Rare": {
-      "identifier": "BigBushBomb_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BirthdayPresents_BR_CH1S9_Legendary": {
-      "identifier": "BirthdayPresents_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BlastPowder_Creative_V1_Uncommon": {
-      "identifier": "BlastPowder_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BlizzardGrenade_BR_CH6S1_Rare": {
-      "identifier": "BlizzardGrenade_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoarHair_Creative_V1_Uncommon": {
-      "identifier": "BoarHair_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoogieBomb_BR_CH1S2_Rare": {
-      "identifier": "BoogieBomb_BR_CH1S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoomBox_BR_CH1S7_Epic": {
-      "identifier": "BoomBox_BR_CH1S7_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BottleRockets_BR_CH1S7_Uncommon": {
-      "identifier": "BottleRockets_BR_CH1S7_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Bouncer_BR_CH1S4_Rare": {
-      "identifier": "Bouncer_BR_CH1S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BrickABunker_BR_CH7S2_Common": {
-      "identifier": "BrickABunker_BR_CH7S2_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BubbleShield_Ballistic_V1_Common": {
-      "identifier": "BubbleShield_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Bush_BR_CH1S1_Legendary": {
-      "identifier": "Bush_BR_CH1S1_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BusinessTurret_BR_CH4S4_Epic": {
-      "identifier": "BusinessTurret_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Butter_Creative_V1_Uncommon": {
-      "identifier": "Butter_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Cabbage_BR_CH2S3_Common": {
-      "identifier": "Cabbage_BR_CH2S3_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CandyCorn_BR_CH2S4_Common": {
-      "identifier": "CandyCorn_BR_CH2S4_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CattyCornerKeycard_BR_CH2S3_Legendary": {
-      "identifier": "CattyCornerKeycard_BR_CH2S3_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CeilingZapper_OG_CH1S1_Rare": {
-      "identifier": "CeilingZapper_OG_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CeilingZapper_BR_CH4MS1_Rare": {
-      "identifier": "CeilingZapper_BR_CH4MS1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CeilingZapper_BR_CH1S1_Rare": {
-      "identifier": "CeilingZapper_BR_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChiliChugSplash_BR_CH2S8_Exotic": {
-      "identifier": "ChiliChugSplash_BR_CH2S8_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Chiller_BR_CH1S6_Common": {
-      "identifier": "Chiller_BR_CH1S6_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChillerGrenade_BR_CH1S7_Common": {
-      "identifier": "ChillerGrenade_BR_CH1S7_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChugCannon_BR_CH2S5_Exotic": {
-      "identifier": "ChugCannon_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChugJug_BR_CH1S2_Legendary": {
-      "identifier": "ChugJug_BR_CH1S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "OceansBottomlessChugJug_BR_CH2S3_Mythic": {
-      "identifier": "OceansBottomlessChugJug_BR_CH2S3_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChugJug_BR_CH6S2_Legendary": {
-      "identifier": "ChugJug_BR_CH6S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChugSplash_BR_CH1S9_Rare": {
-      "identifier": "ChugSplash_BR_CH1S9_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Clinger_BR_CH1S3_Uncommon": {
-      "identifier": "Clinger_BR_CH1S3_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CloakGauntlets_BR_CH4S3_Epic": {
-      "identifier": "CloakGauntlets_BR_CH4S3_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WildguardReliksCloakGauntlets_BR_CH4S3_Mythic": {
-      "identifier": "WildguardReliksCloakGauntlets_BR_CH4S3_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ClusterClinger_BR_CH5S1_Uncommon": {
-      "identifier": "ClusterClinger_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Coconut_BR_CH1S8_Common": {
-      "identifier": "Coconut_BR_CH1S8_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CommandCavernKeycard_BR_CH3S2_Legendary": {
-      "identifier": "CommandCavernKeycard_BR_CH3S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Corn_BR_CH2S3_Common": {
-      "identifier": "Corn_BR_CH2S3_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CozyCampfire_BR_CH1S2_Rare": {
-      "identifier": "CozyCampfire_BR_CH1S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CrashPad_BR_CH2S2_Rare": {
-      "identifier": "CrashPad_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CrashPadJr_BR_CH4S4_Uncommon": {
-      "identifier": "CrashPadJr_BR_CH4S4_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CreepinCardboard_BR_CH2S2_Uncommon": {
-      "identifier": "CreepinCardboard_BR_CH2S2_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "QuartzCrystal_Creative_V1_Uncommon": {
-      "identifier": "QuartzCrystal_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RainbowCrystal_Creative_V1_Epic": {
-      "identifier": "RainbowCrystal_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShadowshardCrystal_Creative_V1_Epic": {
-      "identifier": "ShadowshardCrystal_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SunbeamCrystal_Creative_V1_Epic": {
-      "identifier": "SunbeamCrystal_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CuddleFish_BR_CH2S6_Rare": {
-      "identifier": "CuddleFish_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "DamageTrap_BR_CH1S2_Uncommon": {
-      "identifier": "DamageTrap_BR_CH1S2_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Decoy_BR_CH2S2_Rare": {
-      "identifier": "Decoy_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "DialADrop_BR_CH3S4_Epic": {
-      "identifier": "DialADrop_BR_CH3S4_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Diamond_Creative_V1_Epic": {
-      "identifier": "Diamond_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WhiteDinoEgg_Creative_V1_Rare": {
-      "identifier": "WhiteDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BrownDinoEgg_Creative_V1_Rare": {
-      "identifier": "BrownDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GreenDinoEgg_Creative_V1_Rare": {
-      "identifier": "GreenDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WhiteSpeckledDinoEgg_Creative_V1_Rare": {
-      "identifier": "WhiteSpeckledDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BrownSpeckledDinoEgg_Creative_V1_Rare": {
-      "identifier": "BrownSpeckledDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BlueSpeckledDinoEgg_Creative_V1_Rare": {
-      "identifier": "BlueSpeckledDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WhiteMarbledDinoEgg_Creative_V1_Rare": {
-      "identifier": "WhiteMarbledDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PinkMarbledDinoEgg_Creative_V1_Rare": {
-      "identifier": "PinkMarbledDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GreenMarbledDinoEgg_Creative_V1_Rare": {
-      "identifier": "GreenMarbledDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BlueFleckedDinoEgg_Creative_V1_Rare": {
-      "identifier": "BlueFleckedDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedFleckedDinoEgg_Creative_V1_Rare": {
-      "identifier": "RedFleckedDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GreenFleckedDinoEgg_Creative_V1_Rare": {
-      "identifier": "GreenFleckedDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WhiteShimmeringDinoEgg_Creative_V1_Rare": {
-      "identifier": "WhiteShimmeringDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BlueShimmeringDinoEgg_Creative_V1_Rare": {
-      "identifier": "BlueShimmeringDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedShimmeringDinoEgg_Creative_V1_Rare": {
-      "identifier": "RedShimmeringDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrayEruptionDinoEgg_Creative_V1_Rare": {
-      "identifier": "GrayEruptionDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedEruptionDinoEgg_Creative_V1_Rare": {
-      "identifier": "RedEruptionDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "YellowEruptionDinoEgg_Creative_V1_Rare": {
-      "identifier": "YellowEruptionDinoEgg_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "DuctTape_Creative_V1_Uncommon": {
-      "identifier": "DuctTape_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Dynamite_BR_CH1S6_Uncommon": {
-      "identifier": "Dynamite_BR_CH1S6_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedHarpoonGun_BR_CH7S2_Mythic": {
-      "identifier": "EnhancedHarpoonGun_BR_CH7S2_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "EstateVaultKeycard_BR_CH4S4_Legendary": {
-      "identifier": "EstateVaultKeycard_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExoticSlapBerryFizz_BR_CH6S4_Exotic": {
-      "identifier": "ExoticSlapBerryFizz_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FalconScout_BR_CH4S1_Epic": {
-      "identifier": "FalconScout_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FibrousHerbs_Creative_V1_Common": {
-      "identifier": "FibrousHerbs_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FireflyJar_BR_CH2S3_Rare": {
-      "identifier": "FireflyJar_BR_CH2S3_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FireGrenade_Ballistic_V1_Common": {
-      "identifier": "FireGrenade_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FireTrap_BR_CH2S4_Uncommon": {
-      "identifier": "FireTrap_BR_CH2S4_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CreativeFishingRod_Creative_V1_Common": {
-      "identifier": "CreativeFishingRod_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CreativeProFishingRod_Creative_V1_Rare": {
-      "identifier": "CreativeProFishingRod_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Flag_Creative_V1_Rare": {
-      "identifier": "Flag_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Flashbang_Ballistic_V1_Common": {
-      "identifier": "Flashbang_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Flashlight_Creative_V1_Rare": {
-      "identifier": "Flashlight_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Flopper_BR_CH2S1_Uncommon": {
-      "identifier": "Flopper_BR_CH2S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlowBerry_BR_CH5S1_Uncommon": {
-      "identifier": "FlowBerry_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlowBerryFizz_BR_CH5S1_Rare": {
-      "identifier": "FlowBerryFizz_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlowBerryMistGrenade_BR_CH7S1_Epic": {
-      "identifier": "FlowBerryMistGrenade_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlowerPetals_Creative_V1_Common": {
-      "identifier": "FlowerPetals_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FortillaKeycard_BR_CH2S3_Legendary": {
-      "identifier": "FortillaKeycard_BR_CH2S3_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FragGrenade_Ballistic_V1_Common": {
-      "identifier": "FragGrenade_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FriendZoneBubble_BR_CH7S3_Exotic": {
-      "identifier": "FriendZoneBubble_BR_CH7S3_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FrozenIcecreamCone_BR_CH3S3_Common": {
-      "identifier": "FrozenIcecreamCone_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GasCan_BR_CH2S3_Common": {
-      "identifier": "GasCan_BR_CH2S3_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Gliders_BR_CH1S7_Rare": {
-      "identifier": "Gliders_BR_CH1S7_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Gold_BR_CH2S1_Common": {
-      "identifier": "Gold_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GoldSplash_BR_CH6S2_Rare": {
-      "identifier": "GoldSplash_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrappleGlider_BR_CH3S4_Epic": {
-      "identifier": "GrappleGlider_BR_CH3S4_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrappleGlove_BR_CH3S3_Epic": {
-      "identifier": "GrappleGlove_BR_CH3S3_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Grappler_BR_CH1S5_Epic": {
-      "identifier": "Grappler_BR_CH1S5_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Grenade_BR_PreSeason_Common": {
-      "identifier": "Grenade_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Grenade_BR_CH7S1_Common": {
-      "identifier": "Grenade_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Grenade_OG_CH1S1_Common": {
-      "identifier": "Grenade_OG_CH1S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Grenade_BR_CH4MS1_Common": {
-      "identifier": "Grenade_BR_CH4MS1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrottoKeycard_BR_CH2S2_Legendary": {
-      "identifier": "GrottoKeycard_BR_CH2S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Grub_Creative_V1_Common": {
-      "identifier": "Grub_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GuardianShield_BR_CH4S1_Rare": {
-      "identifier": "GuardianShield_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GuzzleJuice_BR_CH3S1_Uncommon": {
-      "identifier": "GuzzleJuice_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "GuzzlingIcecreamCone_BR_CH3S3_Uncommon": {
-      "identifier": "GuzzlingIcecreamCone_BR_CH3S3_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "HarpoonGun_BR_CH2S1_Rare": {
-      "identifier": "HarpoonGun_BR_CH2S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "HealEgg_BR_CH4S2_Uncommon": {
-      "identifier": "HealEgg_BR_CH4S2_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Herb_Creative_V1_Common": {
-      "identifier": "Herb_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "HolidayPresents_BR_CH2S5_Legendary": {
-      "identifier": "HolidayPresents_BR_CH2S5_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Honey_Creative_V1_Rare": {
-      "identifier": "Honey_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "HopDrop_BR_CH2S4_Common": {
-      "identifier": "HopDrop_BR_CH2S4_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "HopEgg_BR_CH4S2_Rare": {
-      "identifier": "HopEgg_BR_CH4S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "HopFlopper_BR_CH2S4_Epic": {
-      "identifier": "HopFlopper_BR_CH2S4_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "IcecreamCone_BR_CH3S3_Common": {
-      "identifier": "IcecreamCone_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "IcyGrappler_BR_CH2S8_Exotic": {
-      "identifier": "IcyGrappler_BR_CH2S8_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ImpulseGrenade_BR_CH1S2_Rare": {
-      "identifier": "ImpulseGrenade_BR_CH1S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ImpulseGrenade_Ballistic_V1_Common": {
-      "identifier": "ImpulseGrenade_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "InflateABull_BR_CH2S7_Rare": {
-      "identifier": "InflateABull_BR_CH2S7_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "JellyBean_BR_CH2S4_Common": {
-      "identifier": "JellyBean_BR_CH2S4_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Jellyfish_BR_CH2S4_Rare": {
-      "identifier": "Jellyfish_BR_CH2S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Jetpack_BR_CH1S4_Legendary": {
-      "identifier": "Jetpack_BR_CH1S4_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Jewel_Creative_V1_Rare": {
-      "identifier": "Jewel_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "JulesGliderGun_BR_CH2S3_Mythic": {
-      "identifier": "JulesGliderGun_BR_CH2S3_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "JunkRift_BR_CH1SX_Epic": {
-      "identifier": "JunkRift_BR_CH1SX_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Key_BR_CH3S4_Rare": {
-      "identifier": "Key_BR_CH3S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LaunchPad_BR_CH3S4_Rare": {
-      "identifier": "LaunchPad_BR_CH3S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuperLaunchPad_Creative_V1_Epic": {
-      "identifier": "SuperLaunchPad_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessRiftLauncher_BR_CH6S2_Exotic": {
-      "identifier": "LawlessRiftLauncher_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessSlapCannon_BR_CH6S2_Exotic": {
-      "identifier": "LawlessSlapCannon_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessSlapJug_BR_CH6S2_Exotic": {
-      "identifier": "LawlessSlapJug_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LemonLime_Creative_V1_Common": {
-      "identifier": "LemonLime_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LilWhipsSpecialServe_BR_CH3S3_Legendary": {
-      "identifier": "LilWhipsSpecialServe_BR_CH3S3_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LimitlessSevenSliders_BR_CH7S3_Mythic": {
-      "identifier": "LimitlessSevenSliders_BR_CH7S3_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LumpOfCoal_BR_CH2S1_Common": {
-      "identifier": "LumpOfCoal_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MapleSyrup_Creative_V1_Uncommon": {
-      "identifier": "MapleSyrup_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Meat_BR_CH2S6_Uncommon": {
-      "identifier": "Meat_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalParts_BR_CH2S6_Common": {
-      "identifier": "MechanicalParts_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RustyMechanicalParts_Creative_V1_Rare": {
-      "identifier": "RustyMechanicalParts_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SimpleMechanicalParts_Creative_V1_Rare": {
-      "identifier": "SimpleMechanicalParts_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SturdyMechanicalParts_Creative_V1_Rare": {
-      "identifier": "SturdyMechanicalParts_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SleekMechanicalParts_Creative_V1_Rare": {
-      "identifier": "SleekMechanicalParts_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "EfficientMechanicalParts_Creative_V1_Rare": {
-      "identifier": "EfficientMechanicalParts_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "VindertechMechanicalParts_Creative_V1_Rare": {
-      "identifier": "VindertechMechanicalParts_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MedMist_BR_CH3S1_Uncommon": {
-      "identifier": "MedMist_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MedMistSmokeGrenade_BR_CH6S2_Rare": {
-      "identifier": "MedMistSmokeGrenade_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MedKit_BR_PreSeason_Uncommon": {
-      "identifier": "MedKit_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MedKit_BR_CH5S1_Uncommon": {
-      "identifier": "MedKit_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Metal_BR_PreSeason_Common": {
-      "identifier": "Metal_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MidasFlopper_BR_CH2S4_Legendary": {
-      "identifier": "MidasFlopper_BR_CH2S4_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Milk_Creative_V1_Uncommon": {
-      "identifier": "Milk_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RoughMineralPowder_Creative_V1_Common": {
-      "identifier": "RoughMineralPowder_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SimpleMineralPowder_Creative_V1_Common": {
-      "identifier": "SimpleMineralPowder_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "FineGrainMineralPowder_Creative_V1_Common": {
-      "identifier": "FineGrainMineralPowder_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CharBlackMineralPowder_Creative_V1_Common": {
-      "identifier": "CharBlackMineralPowder_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "OxidizedMineralPowder_Creative_V1_Common": {
-      "identifier": "OxidizedMineralPowder_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MonsterParts_BR_CH2S8_Common": {
-      "identifier": "MonsterParts_BR_CH2S8_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BlueMushroom_Creative_V1_Uncommon": {
-      "identifier": "BlueMushroom_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PinkMushroom_Creative_V1_Uncommon": {
-      "identifier": "PinkMushroom_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedMushroom_Creative_V1_Uncommon": {
-      "identifier": "RedMushroom_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WhiteMushroom_Creative_V1_Uncommon": {
-      "identifier": "WhiteMushroom_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "YellowMushroom_Creative_V1_Uncommon": {
-      "identifier": "YellowMushroom_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MystForm_BR_CH6S3_Epic": {
-      "identifier": "MystForm_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MythicGoldfish_BR_CH2S1_Mythic": {
-      "identifier": "MythicGoldfish_BR_CH2S1_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "NitroSplash_BR_CH5S3_Rare": {
-      "identifier": "NitroSplash_BR_CH5S3_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "OrangePaintGrenade_BR_CH2S2_Rare": {
-      "identifier": "OrangePaintGrenade_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RoughOre_Creative_V1_Common": {
-      "identifier": "RoughOre_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Coal_Creative_V1_Uncommon": {
-      "identifier": "Coal_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "BrightcoreOre_Creative_V1_Epic": {
-      "identifier": "BrightcoreOre_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CopperOre_Creative_V1_Epic": {
-      "identifier": "CopperOre_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "MalachiteOre_Creative_V1_Epic": {
-      "identifier": "MalachiteOre_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ObsidianOre_Creative_V1_Epic": {
-      "identifier": "ObsidianOre_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SilverOre_Creative_V1_Epic": {
-      "identifier": "SilverOre_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpectroliteOre_Creative_V1_Epic": {
-      "identifier": "SpectroliteOre_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Overdrive_Ballistic_V1_Common": {
-      "identifier": "Overdrive_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "OverdriveGrenade_BR_CH7S2_Rare": {
-      "identifier": "OverdriveGrenade_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PatchworkTool_Creative_V1_Rare": {
-      "identifier": "PatchworkTool_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pepper_BR_CH1S8_Common": {
-      "identifier": "Pepper_BR_CH1S8_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PepperMint_BR_CH2S4_Common": {
-      "identifier": "PepperMint_BR_CH2S4_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PizzaParty_BR_CH3S1_Epic": {
-      "identifier": "PizzaParty_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PizzaSlice_BR_CH3S1_Rare": {
-      "identifier": "PizzaSlice_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Planks_Creative_V1_Common": {
-      "identifier": "Planks_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PoisonDartTrap_BR_CH1S8_Uncommon": {
-      "identifier": "PoisonDartTrap_BR_CH1S8_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PortABunker_BR_CH3S4_Uncommon": {
-      "identifier": "PortABunker_BR_CH3S4_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PortACover_BR_CH6S2_Rare": {
-      "identifier": "PortACover_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PortAFort_BR_CH1S3_Rare": {
-      "identifier": "PortAFort_BR_CH1S3_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PortAFortress_BR_CH1S5_Legendary": {
-      "identifier": "PortAFortress_BR_CH1S5_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrecisionAirStrike_BR_CH6S4_Legendary": {
-      "identifier": "PrecisionAirStrike_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Presents_BR_CH1S7_Legendary": {
-      "identifier": "Presents_BR_CH1S7_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PropOMatic_Creative_V1_Rare": {
-      "identifier": "PropOMatic_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ProximityMine_BR_CH2S2_Rare": {
-      "identifier": "ProximityMine_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ProximityMine_Ballistic_V1_Common": {
-      "identifier": "ProximityMine_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PulseScanner_BR_CH6S2_Epic": {
-      "identifier": "PulseScanner_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pumpkin_Creative_V1_Common": {
-      "identifier": "Pumpkin_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PurplePaintGrenade_BR_CH2S2_Rare": {
-      "identifier": "PurplePaintGrenade_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RaptorEye_Creative_V1_Rare": {
-      "identifier": "RaptorEye_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReconGrenade_Ballistic_V1_Common": {
-      "identifier": "ReconGrenade_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RemoteExplosives_BR_CH1S3_Epic": {
-      "identifier": "RemoteExplosives_BR_CH1S3_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RepairTorch_BR_CH3S2_Rare": {
-      "identifier": "RepairTorch_BR_CH3S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RiftToGo_BR_CH1S5_Epic": {
-      "identifier": "RiftToGo_BR_CH1S5_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RiftFish_BR_CH2S5_Epic": {
-      "identifier": "RiftFish_BR_CH2S5_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RiftPointDevice_Ballistic_V1_Exotic": {
-      "identifier": "RiftPointDevice_Ballistic_V1_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RigKeycard_BR_CH2S2_Legendary": {
-      "identifier": "RigKeycard_BR_CH2S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RoastedChicken_Creative_V1_Uncommon": {
-      "identifier": "RoastedChicken_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RotatingGizmo_Creative_V1_Rare": {
-      "identifier": "RotatingGizmo_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "RustyCan_BR_CH2S1_Common": {
-      "identifier": "RustyCan_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SevenSliders_BR_CH7S3_Epic": {
-      "identifier": "SevenSliders_BR_CH7S3_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShadowBomb_BR_CH1S8_Uncommon": {
-      "identifier": "ShadowBomb_BR_CH1S8_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShadowFlopper_BR_CH2S8_Rare": {
-      "identifier": "ShadowFlopper_BR_CH2S8_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SharkKeycard_BR_CH2S2_Legendary": {
-      "identifier": "SharkKeycard_BR_CH2S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SharkTooth_Creative_V1_Rare": {
-      "identifier": "SharkTooth_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldBreakerEMP_BR_CH4S4_Rare": {
-      "identifier": "ShieldBreakerEMP_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldBubble_BR_CH1SX_Rare": {
-      "identifier": "ShieldBubble_BR_CH1SX_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldBubbleJr_BR_CH5S2_Uncommon": {
-      "identifier": "ShieldBubbleJr_BR_CH5S2_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldFish_BR_CH2S4_Rare": {
-      "identifier": "ShieldFish_BR_CH2S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldKeg_BR_CH3S1_Rare": {
-      "identifier": "ShieldKeg_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldMushroom_BR_CH1S4_Common": {
-      "identifier": "ShieldMushroom_BR_CH1S4_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldPotion_BR_PreSeason_Rare": {
-      "identifier": "ShieldPotion_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShieldPotion_BR_CH5S1_Rare": {
-      "identifier": "ShieldPotion_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShockRock_BR_CH7S3_Epic": {
-      "identifier": "ShockRock_BR_CH7S3_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShockwaveGrenade_BR_CH1S5_Epic": {
-      "identifier": "ShockwaveGrenade_BR_CH1S5_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Shove_Creative_V1_Common": {
-      "identifier": "Shove_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SignalRemote_Creative_V1_Common": {
-      "identifier": "SignalRemote_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SignalRemoteA_Creative_V1_Uncommon": {
-      "identifier": "SignalRemoteA_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SignalRemoteB_Creative_V1_Rare": {
-      "identifier": "SignalRemoteB_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SignalRemoteC_Creative_V1_Epic": {
-      "identifier": "SignalRemoteC_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SignalRemoteD_Creative_V1_Legendary": {
-      "identifier": "SignalRemoteD_Creative_V1_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SkyesGrappler_BR_CH2S2_Mythic": {
-      "identifier": "SkyesGrappler_BR_CH2S2_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SkylineDeployer_BR_CH7S2_Rare": {
-      "identifier": "SkylineDeployer_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlapBerry_BR_CH4S1_Uncommon": {
-      "identifier": "SlapBerry_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlapJuice_BR_CH4S1_Rare": {
-      "identifier": "SlapJuice_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlapperoniPizza_BR_CH7S2_Legendary": {
-      "identifier": "SlapperoniPizza_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlapperoniSlice_BR_CH7S2_Legendary": {
-      "identifier": "SlapperoniSlice_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlapSplash_BR_CH4S3_Rare": {
-      "identifier": "SlapSplash_BR_CH4S3_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuperSlapSplash_BR_CH4S3_Exotic": {
-      "identifier": "SuperSlapSplash_BR_CH4S3_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Slurpfish_BR_CH2S1_Epic": {
-      "identifier": "Slurpfish_BR_CH2S1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlurpJuice_BR_CH1S1_Legendary": {
-      "identifier": "SlurpJuice_BR_CH1S1_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlurpJuice_BR_CH6S4_Epic": {
-      "identifier": "SlurpJuice_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlurpMushroom_BR_CH2S1_Common": {
-      "identifier": "SlurpMushroom_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SmallFry_BR_CH2S1_Common": {
-      "identifier": "SmallFry_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SmallShieldPotion_BR_CH1S2_Uncommon": {
-      "identifier": "SmallShieldPotion_BR_CH1S2_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SmallShieldPotion_BR_CH5S1_Uncommon": {
-      "identifier": "SmallShieldPotion_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SmokeCloud_BR_CH7S3_Common": {
-      "identifier": "SmokeCloud_BR_CH7S3_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SmokeGrenade_BR_CH1S1_Uncommon": {
-      "identifier": "SmokeGrenade_BR_CH1S1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SmokeGrenade_Ballistic_V1_Common": {
-      "identifier": "SmokeGrenade_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SneakySnowman_BR_CH2S1_Rare": {
-      "identifier": "SneakySnowman_BR_CH2S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SneakySnowman_OG_CH1S7_Common": {
-      "identifier": "SneakySnowman_OG_CH1S7_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SnowyFlopper_BR_CH2S5_Uncommon": {
-      "identifier": "SnowyFlopper_BR_CH2S5_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpeedBoostLow_Creative_V1_Uncommon": {
-      "identifier": "SpeedBoostLow_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpeedBoostMedium_Creative_V1_Rare": {
-      "identifier": "SpeedBoostMedium_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpeedBoostHigh_Creative_V1_Epic": {
-      "identifier": "SpeedBoostHigh_Creative_V1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpicyFish_BR_CH2S4_Rare": {
-      "identifier": "SpicyFish_BR_CH2S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpicyIcecreamCone_BR_CH3S3_Common": {
-      "identifier": "SpicyIcecreamCone_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireJumpboots_BR_CH2S6_Mythic": {
-      "identifier": "SpireJumpboots_BR_CH2S6_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "StealthSplash_BR_CH7S1_Rare": {
-      "identifier": "StealthSplash_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "StinkBomb_BR_CH1S4_Rare": {
-      "identifier": "StinkBomb_BR_CH1S4_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "StinkFish_BR_CH2S6_Uncommon": {
-      "identifier": "StinkFish_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "StinkSac_BR_CH2S6_Uncommon": {
-      "identifier": "StinkSac_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Stone_BR_PreSeason_Common": {
-      "identifier": "Stone_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "StormFlip_BR_CH1S9_Epic": {
-      "identifier": "StormFlip_BR_CH1S9_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurfCube_BR_CH6S3_Epic": {
-      "identifier": "SurfCube_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "LightridersSurfCube_BR_CH6S3_Mythic": {
-      "identifier": "LightridersSurfCube_BR_CH6S3_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalFish_BR_CH2S4_Legendary": {
-      "identifier": "ThermalFish_BR_CH2S4_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalTaffy_BR_CH2S4_Common": {
-      "identifier": "ThermalTaffy_BR_CH2S4_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Thermite_BR_CH6S2_Rare": {
-      "identifier": "Thermite_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThunderboltOfZeus_BR_CH5S2_Mythic": {
-      "identifier": "ThunderboltOfZeus_BR_CH5S2_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Torch_Creative_V1_Rare": {
-      "identifier": "Torch_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "TrackingVisor_BR_CH6S3_Rare": {
-      "identifier": "TrackingVisor_BR_CH6S3_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "StringyTwine_Creative_V1_Uncommon": {
-      "identifier": "StringyTwine_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SimpleTwine_Creative_V1_Uncommon": {
-      "identifier": "SimpleTwine_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SturdyTwine_Creative_V1_Uncommon": {
-      "identifier": "SturdyTwine_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "PeakyTwine_Creative_V1_Uncommon": {
-      "identifier": "PeakyTwine_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "CarvedTwine_Creative_V1_Uncommon": {
-      "identifier": "CarvedTwine_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpectralTwine_Creative_V1_Uncommon": {
-      "identifier": "SpectralTwine_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "UnstableBounceGrenade_BR_CH6S3_Exotic": {
-      "identifier": "UnstableBounceGrenade_BR_CH6S3_Exotic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "VehicleModCowCatcher_BR_CH3S2_Common": {
-      "identifier": "VehicleModCowCatcher_BR_CH3S2_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "VehicleModOffRoadTires_BR_CH2S6_Common": {
-      "identifier": "VehicleModOffRoadTires_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "VendettaFlopper_BR_CH2S4_Legendary": {
-      "identifier": "VendettaFlopper_BR_CH2S4_Legendary",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "VoidOniMask_BR_CH6S1_Epic": {
-      "identifier": "VoidOniMask_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "NightRosesVoidOniMask_BR_CH6S1_Mythic": {
-      "identifier": "NightRosesVoidOniMask_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WallDynamo_OG_CH1S1_Rare": {
-      "identifier": "WallDynamo_OG_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WallDynamo_BR_CH4MS1_Rare": {
-      "identifier": "WallDynamo_BR_CH4MS1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WallDynamo_BR_CH1S1_Rare": {
-      "identifier": "WallDynamo_BR_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Wheat_Creative_V1_Common": {
-      "identifier": "Wheat_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WildwaspJar_BR_CH4S3_Rare": {
-      "identifier": "WildwaspJar_BR_CH4S3_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WingsOfIcarus_BR_CH5S2_Epic": {
-      "identifier": "WingsOfIcarus_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Wingsuit_BR_CH7S1_Epic": {
-      "identifier": "Wingsuit_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WitchBroom_BR_CH2S4_Mythic": {
-      "identifier": "WitchBroom_BR_CH2S4_Mythic",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "WolfTooth_Creative_V1_Uncommon": {
-      "identifier": "WolfTooth_Creative_V1_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Wood_BR_PreSeason_Common": {
-      "identifier": "Wood_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ZeroPointFish_BR_CH2S5_Rare": {
-      "identifier": "ZeroPointFish_BR_CH2S5_Rare",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "ZeroPointPretzel_BR_CH2S8_Uncommon": {
-      "identifier": "ZeroPointPretzel_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Items",
-      "type": "class",
-      "isPublic": true
-    },
-    "Weapons": {
-      "identifier": "Weapons",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "module",
-      "isPublic": true
-    },
-    "AnvilRocketLauncher_BR_CH3S2_Rare": {
-      "identifier": "AnvilRocketLauncher_BR_CH3S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AnvilRocketLauncher_BR_CH3S2_Epic": {
-      "identifier": "AnvilRocketLauncher_BR_CH3S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AnvilRocketLauncher_BR_CH3S2_Legendary": {
-      "identifier": "AnvilRocketLauncher_BR_CH3S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ArcLightningGun_BR_CH7S1_Epic": {
-      "identifier": "ArcLightningGun_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ArcLightningGun_BR_CH7S1_Legendary": {
-      "identifier": "ArcLightningGun_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HumanBillsArcLightningGun_BR_CH7S1_Mythic": {
-      "identifier": "HumanBillsArcLightningGun_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AscendedMyst_BR_CH6S3_Legendary": {
-      "identifier": "AscendedMyst_BR_CH6S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_PreSeason_Common": {
-      "identifier": "AssaultRifle_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_PreSeason_Uncommon": {
-      "identifier": "AssaultRifle_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_PreSeason_Rare": {
-      "identifier": "AssaultRifle_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_PreSeason_Epic": {
-      "identifier": "AssaultRifle_BR_PreSeason_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_PreSeason_Legendary": {
-      "identifier": "AssaultRifle_BR_PreSeason_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SkyesAssaultRifle_BR_CH2S2_Mythic": {
-      "identifier": "SkyesAssaultRifle_BR_CH2S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_CH4S1_Common": {
-      "identifier": "AssaultRifle_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_CH4S1_Uncommon": {
-      "identifier": "AssaultRifle_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_CH4S1_Rare": {
-      "identifier": "AssaultRifle_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_CH4S1_Epic": {
-      "identifier": "AssaultRifle_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AssaultRifle_BR_CH4S1_Legendary": {
-      "identifier": "AssaultRifle_BR_CH4S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedAssaultRifle_BR_CH6S4_Mythic": {
-      "identifier": "EnhancedAssaultRifle_BR_CH6S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutomaticSniperRifle_BR_CH1SX_Rare": {
-      "identifier": "AutomaticSniperRifle_BR_CH1SX_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutomaticSniperRifle_BR_CH1SX_Epic": {
-      "identifier": "AutomaticSniperRifle_BR_CH1SX_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutomaticSniperRifle_BR_CH1SX_Legendary": {
-      "identifier": "AutomaticSniperRifle_BR_CH1SX_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutomaticSniperRifle_BR_CH2S5_Uncommon": {
-      "identifier": "AutomaticSniperRifle_BR_CH2S5_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutoShotgun_BR_CH3S1_Common": {
-      "identifier": "AutoShotgun_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutoShotgun_BR_CH3S1_Uncommon": {
-      "identifier": "AutoShotgun_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutoShotgun_BR_CH3S1_Rare": {
-      "identifier": "AutoShotgun_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutoShotgun_BR_CH3S1_Epic": {
-      "identifier": "AutoShotgun_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutoShotgun_BR_CH3S1_Legendary": {
-      "identifier": "AutoShotgun_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AutoShotgun_BR_CH3S1_Mythic": {
-      "identifier": "AutoShotgun_BR_CH3S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BallisticShield_BR_CH5S1_Epic": {
-      "identifier": "BallisticShield_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BankShotPistol_BR_CH7S3_Uncommon": {
-      "identifier": "BankShotPistol_BR_CH7S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BankShotPistol_BR_CH7S3_Rare": {
-      "identifier": "BankShotPistol_BR_CH7S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BankShotPistol_BR_CH7S3_Epic": {
-      "identifier": "BankShotPistol_BR_CH7S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BankShotPistol_BR_CH7S3_Legendary": {
-      "identifier": "BankShotPistol_BR_CH7S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BankShotPistol_BR_CH7S3_Mythic": {
-      "identifier": "BankShotPistol_BR_CH7S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BasicHammer_Creative_V1_Common": {
-      "identifier": "BasicHammer_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BasicSword_Creative_V1_Common": {
-      "identifier": "BasicSword_Creative_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BassBoost_BR_CH6S3_Rare": {
-      "identifier": "BassBoost_BR_CH6S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BassBoost_BR_CH6S3_Epic": {
-      "identifier": "BassBoost_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BassBoost_BR_CH6S3_Mythic": {
-      "identifier": "BassBoost_BR_CH6S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoltActionSniperRifle_BR_PreSeason_Rare": {
-      "identifier": "BoltActionSniperRifle_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoltActionSniperRifle_BR_PreSeason_Epic": {
-      "identifier": "BoltActionSniperRifle_BR_PreSeason_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoltActionSniperRifle_BR_PreSeason_Legendary": {
-      "identifier": "BoltActionSniperRifle_BR_PreSeason_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoltActionSniperRifle_BR_CH2S1_Common": {
-      "identifier": "BoltActionSniperRifle_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoltActionSniperRifle_BR_CH2S1_Uncommon": {
-      "identifier": "BoltActionSniperRifle_BR_CH2S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularBoomBolt_BR_CH5S3_Rare": {
-      "identifier": "ModularBoomBolt_BR_CH5S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularBoomBolt_BR_CH5S3_Epic": {
-      "identifier": "ModularBoomBolt_BR_CH5S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularBoomBolt_BR_CH5S3_Legendary": {
-      "identifier": "ModularBoomBolt_BR_CH5S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RingmastersModularBoomBolt_BR_CH5S3_Mythic": {
-      "identifier": "RingmastersModularBoomBolt_BR_CH5S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoomBow_BR_CH1S8_Legendary": {
-      "identifier": "BoomBow_BR_CH1S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BoomSniperRifle_BR_CH2S5_Exotic": {
-      "identifier": "BoomSniperRifle_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BugBlaster_BR_CH6S4_Rare": {
-      "identifier": "BugBlaster_BR_CH6S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BugBlaster_BR_CH6S4_Epic": {
-      "identifier": "BugBlaster_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BugBlaster_BR_CH6S4_Legendary": {
-      "identifier": "BugBlaster_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAR_Ballistic_V1_Common": {
-      "identifier": "BurstAR_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_PreSeason_Common": {
-      "identifier": "BurstAssaultRifle_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_PreSeason_Uncommon": {
-      "identifier": "BurstAssaultRifle_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_PreSeason_Rare": {
-      "identifier": "BurstAssaultRifle_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_CH1S4_Epic": {
-      "identifier": "BurstAssaultRifle_BR_CH1S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_CH1S4_Legendary": {
-      "identifier": "BurstAssaultRifle_BR_CH1S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OceansBurstAssaultRifle_BR_CH2S3_Mythic": {
-      "identifier": "OceansBurstAssaultRifle_BR_CH2S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlonesBurstAssaultRifle_BR_CH2S8_Mythic": {
-      "identifier": "SlonesBurstAssaultRifle_BR_CH2S8_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_OG_CH1S1_Common": {
-      "identifier": "BurstAssaultRifle_OG_CH1S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_CH4MS1_Common": {
-      "identifier": "BurstAssaultRifle_BR_CH4MS1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_OG_CH1S1_Uncommon": {
-      "identifier": "BurstAssaultRifle_OG_CH1S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_CH4MS1_Uncommon": {
-      "identifier": "BurstAssaultRifle_BR_CH4MS1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_OG_CH1S1_Rare": {
-      "identifier": "BurstAssaultRifle_OG_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_CH4MS1_Rare": {
-      "identifier": "BurstAssaultRifle_BR_CH4MS1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_OG_CH1S1_Epic": {
-      "identifier": "BurstAssaultRifle_OG_CH1S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_CH4MS1_Epic": {
-      "identifier": "BurstAssaultRifle_BR_CH4MS1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_OG_CH1S1_Legendary": {
-      "identifier": "BurstAssaultRifle_OG_CH1S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstAssaultRifle_BR_CH4MS1_Legendary": {
-      "identifier": "BurstAssaultRifle_BR_CH4MS1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstQuadLauncher_BR_CH2S5_Exotic": {
-      "identifier": "BurstQuadLauncher_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstSMG_BR_CH1S9_Common": {
-      "identifier": "BurstSMG_BR_CH1S9_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstSMG_BR_CH1S9_Uncommon": {
-      "identifier": "BurstSMG_BR_CH1S9_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstSMG_BR_CH1S9_Rare": {
-      "identifier": "BurstSMG_BR_CH1S9_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Chainsaw_BR_CH5S4_Epic": {
-      "identifier": "Chainsaw_BR_CH5S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChainsOfHades_BR_CH5S2_Epic": {
-      "identifier": "ChainsOfHades_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosExploderRifle_BR_CH7S3_Common": {
-      "identifier": "ChaosExploderRifle_BR_CH7S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosExploderRifle_BR_CH7S3_Uncommon": {
-      "identifier": "ChaosExploderRifle_BR_CH7S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosExploderRifle_BR_CH7S3_Rare": {
-      "identifier": "ChaosExploderRifle_BR_CH7S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosExploderRifle_BR_CH7S3_Epic": {
-      "identifier": "ChaosExploderRifle_BR_CH7S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosExploderRifle_BR_CH7S3_Legendary": {
-      "identifier": "ChaosExploderRifle_BR_CH7S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosReloaderShotgun_BR_CH7S2_Common": {
-      "identifier": "ChaosReloaderShotgun_BR_CH7S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosReloaderShotgun_BR_CH7S2_Uncommon": {
-      "identifier": "ChaosReloaderShotgun_BR_CH7S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosReloaderShotgun_BR_CH7S2_Rare": {
-      "identifier": "ChaosReloaderShotgun_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosReloaderShotgun_BR_CH7S2_Epic": {
-      "identifier": "ChaosReloaderShotgun_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChaosReloaderShotgun_BR_CH7S2_Legendary": {
-      "identifier": "ChaosReloaderShotgun_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DarkVoyagersObliterator_BR_CH7S2_Mythic": {
-      "identifier": "DarkVoyagersObliterator_BR_CH7S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeShotgun_BR_CH2S3_Common": {
-      "identifier": "ChargeShotgun_BR_CH2S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeShotgun_BR_CH2S3_Uncommon": {
-      "identifier": "ChargeShotgun_BR_CH2S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeShotgun_BR_CH2S3_Rare": {
-      "identifier": "ChargeShotgun_BR_CH2S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeShotgun_BR_CH2S3_Epic": {
-      "identifier": "ChargeShotgun_BR_CH2S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeShotgun_BR_CH2S3_Legendary": {
-      "identifier": "ChargeShotgun_BR_CH2S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KitsChargeShotgun_BR_CH2S3_Mythic": {
-      "identifier": "KitsChargeShotgun_BR_CH2S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeSMG_BR_CH3S3_Common": {
-      "identifier": "ChargeSMG_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeSMG_BR_CH3S3_Uncommon": {
-      "identifier": "ChargeSMG_BR_CH3S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeSMG_BR_CH3S3_Rare": {
-      "identifier": "ChargeSMG_BR_CH3S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeSMG_BR_CH3S3_Epic": {
-      "identifier": "ChargeSMG_BR_CH3S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeSMG_BR_CH3S3_Legendary": {
-      "identifier": "ChargeSMG_BR_CH3S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ChargeSMG_BR_CH3S3_Mythic": {
-      "identifier": "ChargeSMG_BR_CH3S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CobraDMR_BR_CH3S4_Common": {
-      "identifier": "CobraDMR_BR_CH3S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CobraDMR_BR_CH3S4_Uncommon": {
-      "identifier": "CobraDMR_BR_CH3S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CobraDMR_BR_CH3S4_Rare": {
-      "identifier": "CobraDMR_BR_CH3S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CobraDMR_BR_CH3S4_Epic": {
-      "identifier": "CobraDMR_BR_CH3S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CobraDMR_BR_CH3S4_Legendary": {
-      "identifier": "CobraDMR_BR_CH3S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CobraDMR_BR_CH3S4_Mythic": {
-      "identifier": "CobraDMR_BR_CH3S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CollateralDamageAssaultRifle_BR_CH6S2_Common": {
-      "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CollateralDamageAssaultRifle_BR_CH6S2_Uncommon": {
-      "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CollateralDamageAssaultRifle_BR_CH6S2_Rare": {
-      "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CollateralDamageAssaultRifle_BR_CH6S2_Epic": {
-      "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CollateralDamageAssaultRifle_BR_CH6S2_Legendary": {
-      "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedCollateralDamageAR_BR_CH6S2_Mythic": {
-      "identifier": "EnhancedCollateralDamageAR_BR_CH6S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessTrinityAssaultRifle_BR_CH6S2_Exotic": {
-      "identifier": "LawlessTrinityAssaultRifle_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH2S8_Common": {
-      "identifier": "CombatAssaultRifle_BR_CH2S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH2S8_Uncommon": {
-      "identifier": "CombatAssaultRifle_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH2S8_Rare": {
-      "identifier": "CombatAssaultRifle_BR_CH2S8_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH2S8_Epic": {
-      "identifier": "CombatAssaultRifle_BR_CH2S8_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH2S8_Legendary": {
-      "identifier": "CombatAssaultRifle_BR_CH2S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatAssaultRifle_BR_CH5S3_Common": {
-      "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatAssaultRifle_BR_CH5S3_Uncommon": {
-      "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatAssaultRifle_BR_CH5S3_Rare": {
-      "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatAssaultRifle_BR_CH5S3_Epic": {
-      "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatAssaultRifle_BR_CH5S3_Legendary": {
-      "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheMachinistsModularCombatAssaultRifle_BR_CH5S3_Mythic": {
-      "identifier": "TheMachinistsModularCombatAssaultRifle_BR_CH5S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH7S2_Common": {
-      "identifier": "CombatAssaultRifle_BR_CH7S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH7S2_Uncommon": {
-      "identifier": "CombatAssaultRifle_BR_CH7S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH7S2_Rare": {
-      "identifier": "CombatAssaultRifle_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH7S2_Epic": {
-      "identifier": "CombatAssaultRifle_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatAssaultRifle_BR_CH7S2_Legendary": {
-      "identifier": "CombatAssaultRifle_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatPistol_BR_CH2S8_Common": {
-      "identifier": "CombatPistol_BR_CH2S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatPistol_BR_CH2S8_Uncommon": {
-      "identifier": "CombatPistol_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatPistol_BR_CH2S8_Rare": {
-      "identifier": "CombatPistol_BR_CH2S8_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatPistol_BR_CH2S8_Epic": {
-      "identifier": "CombatPistol_BR_CH2S8_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatPistol_BR_CH2S8_Legendary": {
-      "identifier": "CombatPistol_BR_CH2S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatShotgun_BR_CH1S9_Rare": {
-      "identifier": "CombatShotgun_BR_CH1S9_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatShotgun_BR_CH1S9_Epic": {
-      "identifier": "CombatShotgun_BR_CH1S9_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatShotgun_BR_CH1S9_Legendary": {
-      "identifier": "CombatShotgun_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatShotgun_BR_CH2S8_Uncommon": {
-      "identifier": "CombatShotgun_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatShotgun_BR_CH4S2_Common": {
-      "identifier": "CombatShotgun_BR_CH4S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatShotgun_BR_CH5S3_Common": {
-      "identifier": "ModularCombatShotgun_BR_CH5S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatShotgun_BR_CH5S3_Uncommon": {
-      "identifier": "ModularCombatShotgun_BR_CH5S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatShotgun_BR_CH5S3_Rare": {
-      "identifier": "ModularCombatShotgun_BR_CH5S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatShotgun_BR_CH5S3_Epic": {
-      "identifier": "ModularCombatShotgun_BR_CH5S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularCombatShotgun_BR_CH5S3_Legendary": {
-      "identifier": "ModularCombatShotgun_BR_CH5S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MegaloDonsModularCombatShotgun_BR_CH5S3_Mythic": {
-      "identifier": "MegaloDonsModularCombatShotgun_BR_CH5S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatSMG_BR_CH3S2_Common": {
-      "identifier": "CombatSMG_BR_CH3S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatSMG_BR_CH3S2_Uncommon": {
-      "identifier": "CombatSMG_BR_CH3S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatSMG_BR_CH3S2_Rare": {
-      "identifier": "CombatSMG_BR_CH3S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatSMG_BR_CH3S2_Epic": {
-      "identifier": "CombatSMG_BR_CH3S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatSMG_BR_CH3S2_Legendary": {
-      "identifier": "CombatSMG_BR_CH3S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CombatSMG_BR_CH3S2_Mythic": {
-      "identifier": "CombatSMG_BR_CH3S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CompactSMG_BR_CH1S5_Epic": {
-      "identifier": "CompactSMG_BR_CH1S5_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CompactSMG_BR_CH1S5_Legendary": {
-      "identifier": "CompactSMG_BR_CH1S5_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CompactSMG_BR_CH6MS2_Uncommon": {
-      "identifier": "CompactSMG_BR_CH6MS2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CompactSMG_BR_CH6MS2_Rare": {
-      "identifier": "CompactSMG_BR_CH6MS2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedCompactSMG_BR_CH6MS2_Mythic": {
-      "identifier": "EnhancedCompactSMG_BR_CH6MS2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Crossbow_BR_CH1S3_Rare": {
-      "identifier": "Crossbow_BR_CH1S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Crossbow_BR_CH1S3_Epic": {
-      "identifier": "Crossbow_BR_CH1S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CubeRifle_BR_CH7S2_Epic": {
-      "identifier": "CubeRifle_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CubeRifle_BR_CH7S2_Legendary": {
-      "identifier": "CubeRifle_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CubeRifle_BR_CH7S2_Mythic": {
-      "identifier": "CubeRifle_BR_CH7S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CupidsCrossbow_BR_CH1S2_Epic": {
-      "identifier": "CupidsCrossbow_BR_CH1S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EmpoweredCupidsCrossbow_BR_CH7S1_Mythic": {
-      "identifier": "EmpoweredCupidsCrossbow_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DarkVoyagersChaosRifle_BR_CH7S3_Mythic": {
-      "identifier": "DarkVoyagersChaosRifle_BR_CH7S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeAssaultRifle_BR_CH7S1_Common": {
-      "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeAssaultRifle_BR_CH7S1_Uncommon": {
-      "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeAssaultRifle_BR_CH7S1_Rare": {
-      "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeAssaultRifle_BR_CH7S1_Epic": {
-      "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeAssaultRifle_BR_CH7S1_Legendary": {
-      "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HushsDeadeyeAssaultRifle_BR_CH7S1_Mythic": {
-      "identifier": "HushsDeadeyeAssaultRifle_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeDMR_BR_CH6S3_Common": {
-      "identifier": "DeadeyeDMR_BR_CH6S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeDMR_BR_CH6S3_Uncommon": {
-      "identifier": "DeadeyeDMR_BR_CH6S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeDMR_BR_CH6S3_Rare": {
-      "identifier": "DeadeyeDMR_BR_CH6S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeDMR_BR_CH6S3_Epic": {
-      "identifier": "DeadeyeDMR_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DeadeyeDMR_BR_CH6S3_Legendary": {
-      "identifier": "DeadeyeDMR_BR_CH6S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KorsDeadeyeDMR_BR_CH6S3_Mythic": {
-      "identifier": "KorsDeadeyeDMR_BR_CH6S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "UnstableThunderclapDMR_BR_CH6S3_Exotic": {
-      "identifier": "UnstableThunderclapDMR_BR_CH6S3_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DMR_BR_CH3S3_Common": {
-      "identifier": "DMR_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DMR_BR_CH3S3_Uncommon": {
-      "identifier": "DMR_BR_CH3S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DMR_BR_CH3S3_Rare": {
-      "identifier": "DMR_BR_CH3S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DMR_BR_CH3S3_Epic": {
-      "identifier": "DMR_BR_CH3S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DMR_BR_CH3S3_Legendary": {
-      "identifier": "DMR_BR_CH3S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DMR_BR_CH3S3_Mythic": {
-      "identifier": "DMR_BR_CH3S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Double_BR_CH6S4_Exotic": {
-      "identifier": "Double_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DoubleBarrelShotgun_BR_CH1S5_Epic": {
-      "identifier": "DoubleBarrelShotgun_BR_CH1S5_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DoubleBarrelShotgun_BR_CH1S5_Legendary": {
-      "identifier": "DoubleBarrelShotgun_BR_CH1S5_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DragonsBreathShotgun_BR_CH6S2_Epic": {
-      "identifier": "DragonsBreathShotgun_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DragonsBreathShotgun_BR_CH6S2_Legendary": {
-      "identifier": "DragonsBreathShotgun_BR_CH6S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DragonsBreathSniper_BR_CH2S5_Exotic": {
-      "identifier": "DragonsBreathSniper_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DragonsBreathShotgun_BR_CH2S5_Epic": {
-      "identifier": "DragonsBreathShotgun_BR_CH2S5_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DragonsBreathShotgun_BR_CH2S5_Legendary": {
-      "identifier": "DragonsBreathShotgun_BR_CH2S5_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumGun_BR_CH1S4_Uncommon": {
-      "identifier": "DrumGun_BR_CH1S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumGun_BR_CH1S4_Rare": {
-      "identifier": "DrumGun_BR_CH1S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MidasDrumGun_BR_CH2S2_Mythic": {
-      "identifier": "MidasDrumGun_BR_CH2S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "JulesDrumGun_BR_CH2S3_Mythic": {
-      "identifier": "JulesDrumGun_BR_CH2S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShadowMidasDrumGun_BR_CH2S4_Mythic": {
-      "identifier": "ShadowMidasDrumGun_BR_CH2S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularDrumGun_BR_CH5S2_Rare": {
-      "identifier": "ModularDrumGun_BR_CH5S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularDrumGun_BR_CH5S2_Epic": {
-      "identifier": "ModularDrumGun_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularDrumGun_BR_CH5S2_Legendary": {
-      "identifier": "ModularDrumGun_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MidasModularDrumGun_BR_CH5S2_Mythic": {
-      "identifier": "MidasModularDrumGun_BR_CH5S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MidasGildedEyeDrumGun_BR_CH6S2_Mythic": {
-      "identifier": "MidasGildedEyeDrumGun_BR_CH6S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumGun_BR_CH6MS2_Rare": {
-      "identifier": "DrumGun_BR_CH6MS2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumGun_BR_CH6MS2_Epic": {
-      "identifier": "DrumGun_BR_CH6MS2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumGun_BR_CH6MS2_Legendary": {
-      "identifier": "DrumGun_BR_CH6MS2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumGun_Ballistic_V1_Common": {
-      "identifier": "DrumGun_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumShotgun_BR_CH1S9_Common": {
-      "identifier": "DrumShotgun_BR_CH1S9_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumShotgun_BR_CH1S9_Uncommon": {
-      "identifier": "DrumShotgun_BR_CH1S9_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumShotgun_BR_CH1S9_Rare": {
-      "identifier": "DrumShotgun_BR_CH1S9_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumShotgun_BR_CH3S2_Epic": {
-      "identifier": "DrumShotgun_BR_CH3S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DrumShotgun_BR_CH3S2_Legendary": {
-      "identifier": "DrumShotgun_BR_CH3S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedDrumShotgun_BR_CH4S3_Mythic": {
-      "identifier": "EnhancedDrumShotgun_BR_CH4S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualFiendHunters_BR_CH2S8_Common": {
-      "identifier": "DualFiendHunters_BR_CH2S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualFiendHunters_BR_CH2S8_Uncommon": {
-      "identifier": "DualFiendHunters_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualFiendHunters_BR_CH2S8_Rare": {
-      "identifier": "DualFiendHunters_BR_CH2S8_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualFiendHunters_BR_CH2S8_Epic": {
-      "identifier": "DualFiendHunters_BR_CH2S8_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualFiendHunters_BR_CH2S8_Legendary": {
-      "identifier": "DualFiendHunters_BR_CH2S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH5S4_Common": {
-      "identifier": "DualMicroSMGs_BR_CH5S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH5S4_Uncommon": {
-      "identifier": "DualMicroSMGs_BR_CH5S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH5S4_Rare": {
-      "identifier": "DualMicroSMGs_BR_CH5S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH5S4_Epic": {
-      "identifier": "DualMicroSMGs_BR_CH5S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH5S4_Legendary": {
-      "identifier": "DualMicroSMGs_BR_CH5S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH7S1_Common": {
-      "identifier": "DualMicroSMGs_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH7S1_Uncommon": {
-      "identifier": "DualMicroSMGs_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH7S1_Rare": {
-      "identifier": "DualMicroSMGs_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH7S1_Epic": {
-      "identifier": "DualMicroSMGs_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualMicroSMGs_BR_CH7S1_Legendary": {
-      "identifier": "DualMicroSMGs_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualPistols_BR_CH1S4_Rare": {
-      "identifier": "DualPistols_BR_CH1S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualPistols_BR_CH1S4_Epic": {
-      "identifier": "DualPistols_BR_CH1S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualPistols_BR_CH2S6_Common": {
-      "identifier": "DualPistols_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualPistols_BR_CH2S6_Uncommon": {
-      "identifier": "DualPistols_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualPistols_BR_CH2S6_Legendary": {
-      "identifier": "DualPistols_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualSuppressedPistols_BR_CH3S1_Uncommon": {
-      "identifier": "DualSuppressedPistols_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualSuppressedPistols_BR_CH3S1_Rare": {
-      "identifier": "DualSuppressedPistols_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualSuppressedPistols_BR_CH3S1_Epic": {
-      "identifier": "DualSuppressedPistols_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DualSuppressedPistols_BR_CH3S1_Legendary": {
-      "identifier": "DualSuppressedPistols_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EggLauncher_BR_CH1S3_Rare": {
-      "identifier": "EggLauncher_BR_CH1S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EggLauncher_BR_CH1S3_Epic": {
-      "identifier": "EggLauncher_BR_CH1S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EggLauncher_BR_CH1S3_Legendary": {
-      "identifier": "EggLauncher_BR_CH1S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EggLauncher_BR_CH2S6_Uncommon": {
-      "identifier": "EggLauncher_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularEnforcerAR_BR_CH5S1_Common": {
-      "identifier": "ModularEnforcerAR_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularEnforcerAR_BR_CH5S1_Uncommon": {
-      "identifier": "ModularEnforcerAR_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularEnforcerAR_BR_CH5S1_Rare": {
-      "identifier": "ModularEnforcerAR_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularEnforcerAR_BR_CH5S1_Epic": {
-      "identifier": "ModularEnforcerAR_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularEnforcerAR_BR_CH5S1_Legendary": {
-      "identifier": "ModularEnforcerAR_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnforcerAR_BR_CH7S1_Common": {
-      "identifier": "EnforcerAR_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnforcerAR_BR_CH7S1_Uncommon": {
-      "identifier": "EnforcerAR_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnforcerAR_BR_CH7S1_Rare": {
-      "identifier": "EnforcerAR_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnforcerAR_BR_CH7S1_Epic": {
-      "identifier": "EnforcerAR_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnforcerAR_BR_CH7S1_Legendary": {
-      "identifier": "EnforcerAR_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnforcerAR_Ballistic_V1_Common": {
-      "identifier": "EnforcerAR_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeBurstRifle_BR_CH3S4_Common": {
-      "identifier": "EvoChromeBurstRifle_BR_CH3S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeBurstRifle_BR_CH3S4_Uncommon": {
-      "identifier": "EvoChromeBurstRifle_BR_CH3S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeBurstRifle_BR_CH3S4_Rare": {
-      "identifier": "EvoChromeBurstRifle_BR_CH3S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeBurstRifle_BR_CH3S4_Epic": {
-      "identifier": "EvoChromeBurstRifle_BR_CH3S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeBurstRifle_BR_CH3S4_Legendary": {
-      "identifier": "EvoChromeBurstRifle_BR_CH3S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeBurstRifle_BR_CH3S4_Mythic": {
-      "identifier": "EvoChromeBurstRifle_BR_CH3S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeShotgun_BR_CH3S4_Common": {
-      "identifier": "EvoChromeShotgun_BR_CH3S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeShotgun_BR_CH3S4_Uncommon": {
-      "identifier": "EvoChromeShotgun_BR_CH3S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeShotgun_BR_CH3S4_Rare": {
-      "identifier": "EvoChromeShotgun_BR_CH3S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeShotgun_BR_CH3S4_Epic": {
-      "identifier": "EvoChromeShotgun_BR_CH3S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeShotgun_BR_CH3S4_Legendary": {
-      "identifier": "EvoChromeShotgun_BR_CH3S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EvoChromeShotgun_BR_CH3S4_Mythic": {
-      "identifier": "EvoChromeShotgun_BR_CH3S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExCaliberRifle_BR_CH4S1_Common": {
-      "identifier": "ExCaliberRifle_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExCaliberRifle_BR_CH4S1_Uncommon": {
-      "identifier": "ExCaliberRifle_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExCaliberRifle_BR_CH4S1_Rare": {
-      "identifier": "ExCaliberRifle_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExCaliberRifle_BR_CH4S1_Epic": {
-      "identifier": "ExCaliberRifle_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExCaliberRifle_BR_CH4S1_Legendary": {
-      "identifier": "ExCaliberRifle_BR_CH4S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheAgelessChampionsExCaliberRifle_BR_CH4S1_Mythic": {
-      "identifier": "TheAgelessChampionsExCaliberRifle_BR_CH4S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExoticLeapingLightningGun_BR_CH7S2_Exotic": {
-      "identifier": "ExoticLeapingLightningGun_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExplosiveGooGun_BR_CH3S4_Rare": {
-      "identifier": "ExplosiveGooGun_BR_CH3S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExplosiveRepeaterRifle_BR_CH4S3_Common": {
-      "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExplosiveRepeaterRifle_BR_CH4S3_Uncommon": {
-      "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExplosiveRepeaterRifle_BR_CH4S3_Rare": {
-      "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExplosiveRepeaterRifle_BR_CH4S3_Epic": {
-      "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExplosiveRepeaterRifle_BR_CH4S3_Legendary": {
-      "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExplosiveRepeaterRifle_BR_CH4S3_Mythic": {
-      "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExtendingFocusShotgun_BR_CH7S3_Common": {
-      "identifier": "ExtendingFocusShotgun_BR_CH7S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExtendingFocusShotgun_BR_CH7S3_Uncommon": {
-      "identifier": "ExtendingFocusShotgun_BR_CH7S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExtendingFocusShotgun_BR_CH7S3_Rare": {
-      "identifier": "ExtendingFocusShotgun_BR_CH7S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExtendingFocusShotgun_BR_CH7S3_Epic": {
-      "identifier": "ExtendingFocusShotgun_BR_CH7S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExtendingFocusShotgun_BR_CH7S3_Legendary": {
-      "identifier": "ExtendingFocusShotgun_BR_CH7S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FalconEyeSniper_BR_CH6S2_Common": {
-      "identifier": "FalconEyeSniper_BR_CH6S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FalconEyeSniper_BR_CH6S2_Uncommon": {
-      "identifier": "FalconEyeSniper_BR_CH6S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FalconEyeSniper_BR_CH6S2_Rare": {
-      "identifier": "FalconEyeSniper_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FalconEyeSniper_BR_CH6S2_Epic": {
-      "identifier": "FalconEyeSniper_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FalconEyeSniper_BR_CH6S2_Legendary": {
-      "identifier": "FalconEyeSniper_BR_CH6S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedFalconEyeSniper_BR_CH6S2_Mythic": {
-      "identifier": "EnhancedFalconEyeSniper_BR_CH6S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FiendHunterCrossbow_BR_CH1S6_Epic": {
-      "identifier": "FiendHunterCrossbow_BR_CH1S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FireOniMask_BR_CH6S1_Epic": {
-      "identifier": "FireOniMask_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShogunXsFireOniMask_BR_CH6S1_Mythic": {
-      "identifier": "ShogunXsFireOniMask_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FireworkFlareGun_BR_CH3S3_Rare": {
-      "identifier": "FireworkFlareGun_BR_CH3S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlapjackRifle_BR_CH4S3_Common": {
-      "identifier": "FlapjackRifle_BR_CH4S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlapjackRifle_BR_CH4S3_Uncommon": {
-      "identifier": "FlapjackRifle_BR_CH4S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlapjackRifle_BR_CH4S3_Rare": {
-      "identifier": "FlapjackRifle_BR_CH4S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlapjackRifle_BR_CH4S3_Epic": {
-      "identifier": "FlapjackRifle_BR_CH4S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlapjackRifle_BR_CH4S3_Legendary": {
-      "identifier": "FlapjackRifle_BR_CH4S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedFlapJackRifle_BR_CH4S3_Mythic": {
-      "identifier": "EnhancedFlapJackRifle_BR_CH4S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlareGun_BR_CH2S3_Rare": {
-      "identifier": "FlareGun_BR_CH2S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlashlightPistol_Creative_V1_Rare": {
-      "identifier": "FlashlightPistol_Creative_V1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlexSMG_BR_CH7S1_Common": {
-      "identifier": "FlexSMG_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlexSMG_BR_CH7S1_Uncommon": {
-      "identifier": "FlexSMG_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlexSMG_BR_CH7S1_Rare": {
-      "identifier": "FlexSMG_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlexSMG_BR_CH7S1_Epic": {
-      "identifier": "FlexSMG_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlexSMG_BR_CH7S1_Legendary": {
-      "identifier": "FlexSMG_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BigfootsFlexSMG_BR_CH7S1_Mythic": {
-      "identifier": "BigfootsFlexSMG_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlintKnockPistol_BR_CH1S8_Common": {
-      "identifier": "FlintKnockPistol_BR_CH1S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FlintKnockPistol_BR_CH1S8_Uncommon": {
-      "identifier": "FlintKnockPistol_BR_CH1S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularFrenzyAutoShotgun_BR_CH5S1_Common": {
-      "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularFrenzyAutoShotgun_BR_CH5S1_Uncommon": {
-      "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularFrenzyAutoShotgun_BR_CH5S1_Rare": {
-      "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularFrenzyAutoShotgun_BR_CH5S1_Epic": {
-      "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularFrenzyAutoShotgun_BR_CH5S1_Legendary": {
-      "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OscarsModularFrenzyAutoShotgun_BR_CH5S1_Mythic": {
-      "identifier": "OscarsModularFrenzyAutoShotgun_BR_CH5S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FrenzyAutoShotgun_Ballistic_V1_Common": {
-      "identifier": "FrenzyAutoShotgun_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FuryAssaultRifle_BR_CH6S1_Common": {
-      "identifier": "FuryAssaultRifle_BR_CH6S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FuryAssaultRifle_BR_CH6S1_Uncommon": {
-      "identifier": "FuryAssaultRifle_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FuryAssaultRifle_BR_CH6S1_Rare": {
-      "identifier": "FuryAssaultRifle_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FuryAssaultRifle_BR_CH6S1_Epic": {
-      "identifier": "FuryAssaultRifle_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FuryAssaultRifle_BR_CH6S1_Legendary": {
-      "identifier": "FuryAssaultRifle_BR_CH6S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedFuryAssaultRifle_BR_CH6S1_Mythic": {
-      "identifier": "EnhancedFuryAssaultRifle_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EradicatorHopRockFuryAssaultRifle_BR_CH6S4_Exotic": {
-      "identifier": "EradicatorHopRockFuryAssaultRifle_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularGatekeeperShotgun_BR_CH5S2_Common": {
-      "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularGatekeeperShotgun_BR_CH5S2_Uncommon": {
-      "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularGatekeeperShotgun_BR_CH5S2_Rare": {
-      "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularGatekeeperShotgun_BR_CH5S2_Epic": {
-      "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularGatekeeperShotgun_BR_CH5S2_Legendary": {
-      "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "CerberusModularGatekeeperShotgun_BR_CH5S2_Mythic": {
-      "identifier": "CerberusModularGatekeeperShotgun_BR_CH5S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrappleBlade_BR_CH5S1_Epic": {
-      "identifier": "GrappleBlade_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrapplerBow_BR_CH2S6_Exotic": {
-      "identifier": "GrapplerBow_BR_CH2S6_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrenadeLauncher_BR_PreSeason_Rare": {
-      "identifier": "GrenadeLauncher_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrenadeLauncher_BR_PreSeason_Epic": {
-      "identifier": "GrenadeLauncher_BR_PreSeason_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GrenadeLauncher_BR_PreSeason_Legendary": {
-      "identifier": "GrenadeLauncher_BR_PreSeason_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GuidedMissile_OG_CH1S3_Epic": {
-      "identifier": "GuidedMissile_OG_CH1S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GuidedMissile_BR_CH4MS1_Epic": {
-      "identifier": "GuidedMissile_BR_CH4MS1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GuidedMissile_OG_CH1S3_Legendary": {
-      "identifier": "GuidedMissile_OG_CH1S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GuidedMissile_BR_CH4MS1_Legendary": {
-      "identifier": "GuidedMissile_BR_CH4MS1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerAssaultRifle_BR_CH3S3_Common": {
-      "identifier": "HammerAssaultRifle_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerAssaultRifle_BR_CH3S3_Uncommon": {
-      "identifier": "HammerAssaultRifle_BR_CH3S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerAssaultRifle_BR_CH3S3_Rare": {
-      "identifier": "HammerAssaultRifle_BR_CH3S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerAssaultRifle_BR_CH3S3_Epic": {
-      "identifier": "HammerAssaultRifle_BR_CH3S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerAssaultRifle_BR_CH3S3_Legendary": {
-      "identifier": "HammerAssaultRifle_BR_CH3S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerAssaultRifle_BR_CH3S3_Mythic": {
-      "identifier": "HammerAssaultRifle_BR_CH3S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHammerPumpShotgun_BR_CH5S1_Common": {
-      "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHammerPumpShotgun_BR_CH5S1_Uncommon": {
-      "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHammerPumpShotgun_BR_CH5S1_Rare": {
-      "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHammerPumpShotgun_BR_CH5S1_Epic": {
-      "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHammerPumpShotgun_BR_CH5S1_Legendary": {
-      "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerPumpShotgun_Ballistic_V1_Common": {
-      "identifier": "HammerPumpShotgun_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerRevolver_BR_CH7S2_Uncommon": {
-      "identifier": "HammerRevolver_BR_CH7S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerRevolver_BR_CH7S2_Rare": {
-      "identifier": "HammerRevolver_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerRevolver_BR_CH7S2_Epic": {
-      "identifier": "HammerRevolver_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerRevolver_BR_CH7S2_Legendary": {
-      "identifier": "HammerRevolver_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HammerRevolver_BR_CH7S2_Mythic": {
-      "identifier": "HammerRevolver_BR_CH7S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HandCannon_BR_CH1S3_Epic": {
-      "identifier": "HandCannon_BR_CH1S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HandCannon_BR_CH1S3_Legendary": {
-      "identifier": "HandCannon_BR_CH1S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HandCannon_BR_CH2S2_Rare": {
-      "identifier": "HandCannon_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHandCannon_BR_CH5S2_Rare": {
-      "identifier": "ModularHandCannon_BR_CH5S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHandCannon_BR_CH5S2_Epic": {
-      "identifier": "ModularHandCannon_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHandCannon_BR_CH5S2_Legendary": {
-      "identifier": "ModularHandCannon_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularConductorHandCannon_BR_CH5S3_Mythic": {
-      "identifier": "ModularConductorHandCannon_BR_CH5S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HandCannon_Ballistic_V1_Common": {
-      "identifier": "HandCannon_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHarbingerSMG_BR_CH5S2_Common": {
-      "identifier": "ModularHarbingerSMG_BR_CH5S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHarbingerSMG_BR_CH5S2_Uncommon": {
-      "identifier": "ModularHarbingerSMG_BR_CH5S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHarbingerSMG_BR_CH5S2_Rare": {
-      "identifier": "ModularHarbingerSMG_BR_CH5S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHarbingerSMG_BR_CH5S2_Epic": {
-      "identifier": "ModularHarbingerSMG_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHarbingerSMG_BR_CH5S2_Legendary": {
-      "identifier": "ModularHarbingerSMG_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HadesModularHarbingerSMG_BR_CH5S2_Mythic": {
-      "identifier": "HadesModularHarbingerSMG_BR_CH5S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocPumpShotgun_BR_CH4S2_Common": {
-      "identifier": "HavocPumpShotgun_BR_CH4S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocPumpShotgun_BR_CH4S2_Uncommon": {
-      "identifier": "HavocPumpShotgun_BR_CH4S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocPumpShotgun_BR_CH4S2_Rare": {
-      "identifier": "HavocPumpShotgun_BR_CH4S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocPumpShotgun_BR_CH4S2_Epic": {
-      "identifier": "HavocPumpShotgun_BR_CH4S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocPumpShotgun_BR_CH4S2_Legendary": {
-      "identifier": "HavocPumpShotgun_BR_CH4S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedHavocShotgun_BR_CH4S2_Mythic": {
-      "identifier": "EnhancedHavocShotgun_BR_CH4S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocSuppressedAssaultRifle_BR_CH4S2_Common": {
-      "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocSuppressedAssaultRifle_BR_CH4S2_Uncommon": {
-      "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocSuppressedAssaultRifle_BR_CH4S2_Rare": {
-      "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocSuppressedAssaultRifle_BR_CH4S2_Epic": {
-      "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocSuppressedAssaultRifle_BR_CH4S2_Legendary": {
-      "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HavocSuppressedAssaultRifle_BR_CH4S2_Mythic": {
-      "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HighcardsHavocSuppressedRifle_BR_CH4S2_Mythic": {
-      "identifier": "HighcardsHavocSuppressedRifle_BR_CH4S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeartsHavocSuppressedRifle_BR_CH4S4_Mythic": {
-      "identifier": "HeartsHavocSuppressedRifle_BR_CH4S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyAssaultRifle_BR_CH1S6_Rare": {
-      "identifier": "HeavyAssaultRifle_BR_CH1S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyAssaultRifle_BR_CH1S6_Epic": {
-      "identifier": "HeavyAssaultRifle_BR_CH1S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyAssaultRifle_BR_CH1S6_Legendary": {
-      "identifier": "HeavyAssaultRifle_BR_CH1S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyAssaultRifle_BR_CH1S8_Common": {
-      "identifier": "HeavyAssaultRifle_BR_CH1S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyAssaultRifle_BR_CH1S8_Uncommon": {
-      "identifier": "HeavyAssaultRifle_BR_CH1S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyImpactSniperRifle_BR_CH5S3_Rare": {
-      "identifier": "HeavyImpactSniperRifle_BR_CH5S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyImpactSniperRifle_BR_CH5S3_Epic": {
-      "identifier": "HeavyImpactSniperRifle_BR_CH5S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyImpactSniperRifle_BR_CH5S3_Legendary": {
-      "identifier": "HeavyImpactSniperRifle_BR_CH5S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessHeavyImpactTrackingRifle_BR_CH6S2_Exotic": {
-      "identifier": "LawlessHeavyImpactTrackingRifle_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawfulHeavyImpactTrackingRifle_BR_CH7S2_Exotic": {
-      "identifier": "LawfulHeavyImpactTrackingRifle_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyShotgun_BR_CH3S1_Common": {
-      "identifier": "HeavyShotgun_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyShotgun_BR_CH3S1_Uncommon": {
-      "identifier": "HeavyShotgun_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyShotgun_BR_CH3S1_Rare": {
-      "identifier": "HeavyShotgun_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyShotgun_BR_CH3S1_Epic": {
-      "identifier": "HeavyShotgun_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyShotgun_BR_CH3S1_Legendary": {
-      "identifier": "HeavyShotgun_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeistedBreacherShotgun_BR_CH4S1_Exotic": {
-      "identifier": "HeistedBreacherShotgun_BR_CH4S1_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyShotgun_OG_CH1S3_Epic": {
-      "identifier": "HeavyShotgun_OG_CH1S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavyShotgun_OG_CH1S3_Legendary": {
-      "identifier": "HeavyShotgun_OG_CH1S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavySniperRifle_BR_CH1S5_Epic": {
-      "identifier": "HeavySniperRifle_BR_CH1S5_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavySniperRifle_BR_CH1S5_Legendary": {
-      "identifier": "HeavySniperRifle_BR_CH1S5_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeavySniperRifle_BR_CH3S3_Mythic": {
-      "identifier": "HeavySniperRifle_BR_CH3S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloRushSMG_BR_CH7S1_Common": {
-      "identifier": "HoloRushSMG_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloRushSMG_BR_CH7S1_Uncommon": {
-      "identifier": "HoloRushSMG_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloRushSMG_BR_CH7S1_Rare": {
-      "identifier": "HoloRushSMG_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloRushSMG_BR_CH7S1_Epic": {
-      "identifier": "HoloRushSMG_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloRushSMG_BR_CH7S1_Legendary": {
-      "identifier": "HoloRushSMG_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "YuleTroopersHoloRushSMG_BR_CH7S1_Mythic": {
-      "identifier": "YuleTroopersHoloRushSMG_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloTwisterAssaultRifle_BR_CH6S1_Common": {
-      "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloTwisterAssaultRifle_BR_CH6S1_Uncommon": {
-      "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloTwisterAssaultRifle_BR_CH6S1_Rare": {
-      "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloTwisterAssaultRifle_BR_CH6S1_Epic": {
-      "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HoloTwisterAssaultRifle_BR_CH6S1_Legendary": {
-      "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedHoloTwisterAssaultRifle_BR_CH6S1_Mythic": {
-      "identifier": "EnhancedHoloTwisterAssaultRifle_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HopRockDualies_BR_CH2S5_Exotic": {
-      "identifier": "HopRockDualies_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HunterBoltActionSniper_BR_CH3S1_Common": {
-      "identifier": "HunterBoltActionSniper_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HunterBoltActionSniper_BR_CH3S1_Uncommon": {
-      "identifier": "HunterBoltActionSniper_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HunterBoltActionSniper_BR_CH3S1_Rare": {
-      "identifier": "HunterBoltActionSniper_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HunterBoltActionSniper_BR_CH3S1_Epic": {
-      "identifier": "HunterBoltActionSniper_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HunterBoltActionSniper_BR_CH3S1_Legendary": {
-      "identifier": "HunterBoltActionSniper_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntingRifle_BR_CH1S3_Uncommon": {
-      "identifier": "HuntingRifle_BR_CH1S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntingRifle_BR_CH1S3_Rare": {
-      "identifier": "HuntingRifle_BR_CH1S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntingRifle_BR_CH2S3_Epic": {
-      "identifier": "HuntingRifle_BR_CH2S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntingRifle_BR_CH2S3_Legendary": {
-      "identifier": "HuntingRifle_BR_CH2S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntingRifle_BR_CH6S1_Uncommon": {
-      "identifier": "HuntingRifle_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntingRifle_BR_CH6S1_Rare": {
-      "identifier": "HuntingRifle_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntingRifle_BR_CH6S1_Mythic": {
-      "identifier": "HuntingRifle_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessStinkRifle_BR_CH6S2_Exotic": {
-      "identifier": "LawlessStinkRifle_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHuntressDMR_BR_CH5S2_Uncommon": {
-      "identifier": "ModularHuntressDMR_BR_CH5S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHuntressDMR_BR_CH5S2_Rare": {
-      "identifier": "ModularHuntressDMR_BR_CH5S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHuntressDMR_BR_CH5S2_Epic": {
-      "identifier": "ModularHuntressDMR_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHuntressDMR_BR_CH5S2_Legendary": {
-      "identifier": "ModularHuntressDMR_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularZeusHuntressDMR_BR_CH5S2_Mythic": {
-      "identifier": "ModularZeusHuntressDMR_BR_CH5S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HyperburstPistol_BR_CH6S3_Common": {
-      "identifier": "HyperburstPistol_BR_CH6S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HyperburstPistol_BR_CH6S3_Uncommon": {
-      "identifier": "HyperburstPistol_BR_CH6S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HyperburstPistol_BR_CH6S3_Rare": {
-      "identifier": "HyperburstPistol_BR_CH6S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HyperburstPistol_BR_CH6S3_Epic": {
-      "identifier": "HyperburstPistol_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HyperburstPistol_BR_CH6S3_Legendary": {
-      "identifier": "HyperburstPistol_BR_CH6S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedHyperburstPistol_BR_CH6S3_Mythic": {
-      "identifier": "EnhancedHyperburstPistol_BR_CH6S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "UnstableVoltageBurstPistol_BR_CH6S3_Exotic": {
-      "identifier": "UnstableVoltageBurstPistol_BR_CH6S3_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHyperSMG_BR_CH5S1_Common": {
-      "identifier": "ModularHyperSMG_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHyperSMG_BR_CH5S1_Uncommon": {
-      "identifier": "ModularHyperSMG_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHyperSMG_BR_CH5S1_Rare": {
-      "identifier": "ModularHyperSMG_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHyperSMG_BR_CH5S1_Epic": {
-      "identifier": "ModularHyperSMG_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularHyperSMG_BR_CH5S1_Legendary": {
-      "identifier": "ModularHyperSMG_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ValeriasModularHyperSMG_BR_CH5S1_Mythic": {
-      "identifier": "ValeriasModularHyperSMG_BR_CH5S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HyperSMG_Ballistic_V1_Common": {
-      "identifier": "HyperSMG_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "IceKingsGauntlets_BR_CH7S2_Mythic": {
-      "identifier": "IceKingsGauntlets_BR_CH7S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfantryRifle_BR_CH1S7_Common": {
-      "identifier": "InfantryRifle_BR_CH1S7_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfantryRifle_BR_CH1S7_Uncommon": {
-      "identifier": "InfantryRifle_BR_CH1S7_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfantryRifle_BR_CH1S7_Rare": {
-      "identifier": "InfantryRifle_BR_CH1S7_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfantryRifle_BR_CH1S8_Epic": {
-      "identifier": "InfantryRifle_BR_CH1S8_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfantryRifle_BR_CH1S8_Legendary": {
-      "identifier": "InfantryRifle_BR_CH1S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfantryRifle_BR_CH6MS2_Epic": {
-      "identifier": "InfantryRifle_BR_CH6MS2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfantryRifle_BR_CH6MS2_Legendary": {
-      "identifier": "InfantryRifle_BR_CH6MS2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfiltratorPumpShotgun_BR_CH4S4_Common": {
-      "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfiltratorPumpShotgun_BR_CH4S4_Uncommon": {
-      "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfiltratorPumpShotgun_BR_CH4S4_Rare": {
-      "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfiltratorPumpShotgun_BR_CH4S4_Epic": {
-      "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfiltratorPumpShotgun_BR_CH4S4_Legendary": {
-      "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedInfiltratorPumpShotgun_BR_CH4S4_Mythic": {
-      "identifier": "EnhancedInfiltratorPumpShotgun_BR_CH4S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InfinityBlade_BR_CH1S7_Mythic": {
-      "identifier": "InfinityBlade_BR_CH1S7_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "IronPumpShotgun_BR_CH7S1_Common": {
-      "identifier": "IronPumpShotgun_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "IronPumpShotgun_BR_CH7S1_Uncommon": {
-      "identifier": "IronPumpShotgun_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "IronPumpShotgun_BR_CH7S1_Rare": {
-      "identifier": "IronPumpShotgun_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "IronPumpShotgun_BR_CH7S1_Epic": {
-      "identifier": "IronPumpShotgun_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "IronPumpShotgun_BR_CH7S1_Legendary": {
-      "identifier": "IronPumpShotgun_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PinpointIronPumpShotgun_BR_CH7S1_Mythic": {
-      "identifier": "PinpointIronPumpShotgun_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KillswitchsRevolvers_BR_CH6S3_Mythic": {
-      "identifier": "KillswitchsRevolvers_BR_CH6S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KillswitchRevolvers_BR_CH6S3_Rare": {
-      "identifier": "KillswitchRevolvers_BR_CH6S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KillswitchRevolvers_BR_CH6S3_Epic": {
-      "identifier": "KillswitchRevolvers_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KillswitchRevolvers_BR_CH6S3_Legendary": {
-      "identifier": "KillswitchRevolvers_BR_CH6S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KineticBlade_BR_CH4S2_Rare": {
-      "identifier": "KineticBlade_BR_CH4S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KineticBlade_BR_CH4S2_Epic": {
-      "identifier": "KineticBlade_BR_CH4S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThornesVampiricBlade_BR_CH4S4_Mythic": {
-      "identifier": "ThornesVampiricBlade_BR_CH4S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KineticBoomerang_BR_CH4S3_Epic": {
-      "identifier": "KineticBoomerang_BR_CH4S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KymeraRayGun_BR_CH2S7_Rare": {
-      "identifier": "KymeraRayGun_BR_CH2S7_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KymeraRayGun_BR_CH2S7_Epic": {
-      "identifier": "KymeraRayGun_BR_CH2S7_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KymeraRayGun_BR_CH2S7_Legendary": {
-      "identifier": "KymeraRayGun_BR_CH2S7_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ZygAndChoppysRayGun_BR_CH2S7_Mythic": {
-      "identifier": "ZygAndChoppysRayGun_BR_CH2S7_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawfulAccelerantHoloTwisterAR_BR_CH7S2_Exotic": {
-      "identifier": "LawfulAccelerantHoloTwisterAR_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawfulShockwaveRocketLauncher_BR_CH7S2_Exotic": {
-      "identifier": "LawfulShockwaveRocketLauncher_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessAccelerantHoloTwisterAR_BR_CH6S2_Exotic": {
-      "identifier": "LawlessAccelerantHoloTwisterAR_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessFinalMarkRifle_BR_CH6S2_Exotic": {
-      "identifier": "LawlessFinalMarkRifle_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessShockwaveRocketLauncher_BR_CH6S2_Exotic": {
-      "identifier": "LawlessShockwaveRocketLauncher_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Leadspitter3000_BR_CH6S4_Epic": {
-      "identifier": "Leadspitter3000_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Leadspitter3000_BR_CH6S4_Legendary": {
-      "identifier": "Leadspitter3000_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Leadspitter3000_BR_CH6S4_Mythic": {
-      "identifier": "Leadspitter3000_BR_CH6S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionRifle_BR_CH2S5_Uncommon": {
-      "identifier": "LeverActionRifle_BR_CH2S5_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionRifle_BR_CH2S5_Rare": {
-      "identifier": "LeverActionRifle_BR_CH2S5_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionRifle_BR_CH2S5_Epic": {
-      "identifier": "LeverActionRifle_BR_CH2S5_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionRifle_BR_CH2S5_Legendary": {
-      "identifier": "LeverActionRifle_BR_CH2S5_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionShotgun_BR_CH2S5_Common": {
-      "identifier": "LeverActionShotgun_BR_CH2S5_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionShotgun_BR_CH2S5_Uncommon": {
-      "identifier": "LeverActionShotgun_BR_CH2S5_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionShotgun_BR_CH2S5_Rare": {
-      "identifier": "LeverActionShotgun_BR_CH2S5_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionShotgun_BR_CH2S5_Epic": {
-      "identifier": "LeverActionShotgun_BR_CH2S5_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LeverActionShotgun_BR_CH2S5_Legendary": {
-      "identifier": "LeverActionShotgun_BR_CH2S5_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LightMachineGun_BR_CH1S3_Rare": {
-      "identifier": "LightMachineGun_BR_CH1S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LightMachineGun_BR_CH1S3_Epic": {
-      "identifier": "LightMachineGun_BR_CH1S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LightMachineGun_BR_CH3S2_Common": {
-      "identifier": "LightMachineGun_BR_CH3S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LightMachineGun_BR_CH3S2_Uncommon": {
-      "identifier": "LightMachineGun_BR_CH3S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LightMachineGun_BR_CH3S2_Legendary": {
-      "identifier": "LightMachineGun_BR_CH3S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LockOnAssaultRifle_BR_CH7S1_Common": {
-      "identifier": "LockOnAssaultRifle_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LockOnAssaultRifle_BR_CH7S1_Uncommon": {
-      "identifier": "LockOnAssaultRifle_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LockOnAssaultRifle_BR_CH7S1_Rare": {
-      "identifier": "LockOnAssaultRifle_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LockOnAssaultRifle_BR_CH7S1_Epic": {
-      "identifier": "LockOnAssaultRifle_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LockOnAssaultRifle_BR_CH7S1_Legendary": {
-      "identifier": "LockOnAssaultRifle_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LockOnPistol_BR_CH4S2_Rare": {
-      "identifier": "LockOnPistol_BR_CH4S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MachinePistol_Ballistic_V1_Common": {
-      "identifier": "MachinePistol_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MachineSMG_BR_CH3S1_Common": {
-      "identifier": "MachineSMG_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MachineSMG_BR_CH3S1_Uncommon": {
-      "identifier": "MachineSMG_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MachineSMG_BR_CH3S1_Rare": {
-      "identifier": "MachineSMG_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MachineSMG_BR_CH3S1_Epic": {
-      "identifier": "MachineSMG_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MachineSMG_BR_CH3S1_Legendary": {
-      "identifier": "MachineSMG_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftBow_BR_CH2S6_Uncommon": {
-      "identifier": "MakeshiftBow_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftRevolver_BR_CH2S6_Common": {
-      "identifier": "MakeshiftRevolver_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftRevolver_BR_CH2S6_Uncommon": {
-      "identifier": "MakeshiftRevolver_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftRevolver_BR_CH2S6_Rare": {
-      "identifier": "MakeshiftRevolver_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftRifle_BR_CH2S6_Common": {
-      "identifier": "MakeshiftRifle_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftRifle_BR_CH2S6_Uncommon": {
-      "identifier": "MakeshiftRifle_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftRifle_BR_CH2S6_Rare": {
-      "identifier": "MakeshiftRifle_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftShotgun_BR_CH2S6_Common": {
-      "identifier": "MakeshiftShotgun_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftShotgun_BR_CH2S6_Uncommon": {
-      "identifier": "MakeshiftShotgun_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftShotgun_BR_CH2S6_Rare": {
-      "identifier": "MakeshiftShotgun_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftSubmachineGun_BR_CH2S6_Common": {
-      "identifier": "MakeshiftSubmachineGun_BR_CH2S6_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftSubmachineGun_BR_CH2S6_Uncommon": {
-      "identifier": "MakeshiftSubmachineGun_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeshiftSubmachineGun_BR_CH2S6_Rare": {
-      "identifier": "MakeshiftSubmachineGun_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MammothPistol_BR_CH4S3_Common": {
-      "identifier": "MammothPistol_BR_CH4S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MammothPistol_BR_CH4S3_Uncommon": {
-      "identifier": "MammothPistol_BR_CH4S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MammothPistol_BR_CH4S3_Rare": {
-      "identifier": "MammothPistol_BR_CH4S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MammothPistol_BR_CH4S3_Epic": {
-      "identifier": "MammothPistol_BR_CH4S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MammothPistol_BR_CH4S3_Legendary": {
-      "identifier": "MammothPistol_BR_CH4S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BaronsDoubleDownPistol_BR_CH6S2_Mythic": {
-      "identifier": "BaronsDoubleDownPistol_BR_CH6S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessExplosiveMammothPistol_BR_CH6S2_Exotic": {
-      "identifier": "LawlessExplosiveMammothPistol_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawfulExplosiveMammothPistol_BR_CH7S2_Exotic": {
-      "identifier": "LawfulExplosiveMammothPistol_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MarksmanSixShooter_BR_CH2S6_Exotic": {
-      "identifier": "MarksmanSixShooter_BR_CH2S6_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MavenAutoShotgun_BR_CH4S1_Common": {
-      "identifier": "MavenAutoShotgun_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MavenAutoShotgun_BR_CH4S1_Uncommon": {
-      "identifier": "MavenAutoShotgun_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MavenAutoShotgun_BR_CH4S1_Rare": {
-      "identifier": "MavenAutoShotgun_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MavenAutoShotgun_BR_CH4S1_Epic": {
-      "identifier": "MavenAutoShotgun_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MavenAutoShotgun_BR_CH4S1_Legendary": {
-      "identifier": "MavenAutoShotgun_BR_CH4S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeistedAccelerantShotgun_BR_CH4S1_Exotic": {
-      "identifier": "HeistedAccelerantShotgun_BR_CH4S1_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalBow_BR_CH2S6_Rare": {
-      "identifier": "MechanicalBow_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalExplosiveBow_BR_CH2S6_Rare": {
-      "identifier": "MechanicalExplosiveBow_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalExplosiveBow_BR_CH2S6_Epic": {
-      "identifier": "MechanicalExplosiveBow_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalExplosiveBow_BR_CH2S6_Legendary": {
-      "identifier": "MechanicalExplosiveBow_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RazsExplosiveBow_BR_CH2S6_Mythic": {
-      "identifier": "RazsExplosiveBow_BR_CH2S6_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalShockwaveBow_BR_CH2S6_Rare": {
-      "identifier": "MechanicalShockwaveBow_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalShockwaveBow_BR_CH2S6_Epic": {
-      "identifier": "MechanicalShockwaveBow_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MechanicalShockwaveBow_BR_CH2S6_Legendary": {
-      "identifier": "MechanicalShockwaveBow_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MeowsclesPeowPeowRifle_BR_CH2S2_Mythic": {
-      "identifier": "MeowsclesPeowPeowRifle_BR_CH2S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Minigun_BR_CH1S2_Epic": {
-      "identifier": "Minigun_BR_CH1S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Minigun_BR_CH1S2_Legendary": {
-      "identifier": "Minigun_BR_CH1S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BrutusMinigun_BR_CH2S2_Mythic": {
-      "identifier": "BrutusMinigun_BR_CH2S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Minigun_BR_CH5S3_Rare": {
-      "identifier": "Minigun_BR_CH5S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKAlphaAssaultRifle_BR_CH4S2_Common": {
-      "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKAlphaAssaultRifle_BR_CH4S2_Uncommon": {
-      "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKAlphaAssaultRifle_BR_CH4S2_Rare": {
-      "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKAlphaAssaultRifle_BR_CH4S2_Epic": {
-      "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKAlphaAssaultRifle_BR_CH4S2_Legendary": {
-      "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKSevenAssaultRifle_BR_CH3S1_Common": {
-      "identifier": "MKSevenAssaultRifle_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKSevenAssaultRifle_BR_CH3S1_Uncommon": {
-      "identifier": "MKSevenAssaultRifle_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKSevenAssaultRifle_BR_CH3S1_Rare": {
-      "identifier": "MKSevenAssaultRifle_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKSevenAssaultRifle_BR_CH3S1_Epic": {
-      "identifier": "MKSevenAssaultRifle_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MKSevenAssaultRifle_BR_CH3S1_Legendary": {
-      "identifier": "MKSevenAssaultRifle_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReliksMKAlphaAssaultRifle_BR_CH4S2_Mythic": {
-      "identifier": "ReliksMKAlphaAssaultRifle_BR_CH4S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheFoundationsMKSevenAssaultRifle_BR_CH3S1_Mythic": {
-      "identifier": "TheFoundationsMKSevenAssaultRifle_BR_CH3S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularMonarchPistol_BR_CH5S4_Common": {
-      "identifier": "ModularMonarchPistol_BR_CH5S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularMonarchPistol_BR_CH5S4_Uncommon": {
-      "identifier": "ModularMonarchPistol_BR_CH5S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularMonarchPistol_BR_CH5S4_Rare": {
-      "identifier": "ModularMonarchPistol_BR_CH5S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularMonarchPistol_BR_CH5S4_Epic": {
-      "identifier": "ModularMonarchPistol_BR_CH5S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularMonarchPistol_BR_CH5S4_Legendary": {
-      "identifier": "ModularMonarchPistol_BR_CH5S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MystGauntlets_BR_CH6S3_Epic": {
-      "identifier": "MystGauntlets_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularNemesisAR_BR_CH5S1_Common": {
-      "identifier": "ModularNemesisAR_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularNemesisAR_BR_CH5S1_Uncommon": {
-      "identifier": "ModularNemesisAR_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularNemesisAR_BR_CH5S1_Rare": {
-      "identifier": "ModularNemesisAR_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularNemesisAR_BR_CH5S1_Epic": {
-      "identifier": "ModularNemesisAR_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularNemesisAR_BR_CH5S1_Legendary": {
-      "identifier": "ModularNemesisAR_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MontaguesModularNemesisAR_BR_CH5S1_Mythic": {
-      "identifier": "MontaguesModularNemesisAR_BR_CH5S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NemesisAR_BR_CH7S2_Common": {
-      "identifier": "NemesisAR_BR_CH7S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NemesisAR_BR_CH7S2_Uncommon": {
-      "identifier": "NemesisAR_BR_CH7S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NemesisAR_BR_CH7S2_Rare": {
-      "identifier": "NemesisAR_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NemesisAR_BR_CH7S2_Epic": {
-      "identifier": "NemesisAR_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NemesisAR_BR_CH7S2_Legendary": {
-      "identifier": "NemesisAR_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NemesisAR_Ballistic_V1_Common": {
-      "identifier": "NemesisAR_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NightHawk_BR_CH2S5_Exotic": {
-      "identifier": "NightHawk_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NitroFists_BR_CH5S3_Epic": {
-      "identifier": "NitroFists_BR_CH5S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "MegaloDonsNitroFists_BR_CH5S3_Mythic": {
-      "identifier": "MegaloDonsNitroFists_BR_CH5S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OXRRifle_BR_CH6S4_Common": {
-      "identifier": "OXRRifle_BR_CH6S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OXRRifle_BR_CH6S4_Uncommon": {
-      "identifier": "OXRRifle_BR_CH6S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OXRRifle_BR_CH6S4_Rare": {
-      "identifier": "OXRRifle_BR_CH6S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OXRRifle_BR_CH6S4_Epic": {
-      "identifier": "OXRRifle_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OXRRifle_BR_CH6S4_Legendary": {
-      "identifier": "OXRRifle_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OXRRifle_BR_CH6S4_Mythic": {
-      "identifier": "OXRRifle_BR_CH6S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OniShotgun_BR_CH6S1_Common": {
-      "identifier": "OniShotgun_BR_CH6S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OniShotgun_BR_CH6S1_Uncommon": {
-      "identifier": "OniShotgun_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OniShotgun_BR_CH6S1_Rare": {
-      "identifier": "OniShotgun_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OniShotgun_BR_CH6S1_Epic": {
-      "identifier": "OniShotgun_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OniShotgun_BR_CH6S1_Legendary": {
-      "identifier": "OniShotgun_BR_CH6S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedOniShotgun_BR_CH6S1_Mythic": {
-      "identifier": "EnhancedOniShotgun_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OrangePaintLauncher_BR_CH2S2_Rare": {
-      "identifier": "OrangePaintLauncher_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OutlawShotgun_BR_CH6S2_Common": {
-      "identifier": "OutlawShotgun_BR_CH6S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OutlawShotgun_BR_CH6S2_Uncommon": {
-      "identifier": "OutlawShotgun_BR_CH6S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OutlawShotgun_BR_CH6S2_Rare": {
-      "identifier": "OutlawShotgun_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OutlawShotgun_BR_CH6S2_Epic": {
-      "identifier": "OutlawShotgun_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OutlawShotgun_BR_CH6S2_Legendary": {
-      "identifier": "OutlawShotgun_BR_CH6S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedOutlawShotgun_BR_CH6S2_Mythic": {
-      "identifier": "EnhancedOutlawShotgun_BR_CH6S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "UnstableYoinkShotgun_BR_CH6S3_Exotic": {
-      "identifier": "UnstableYoinkShotgun_BR_CH6S3_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EradicatorOXRRifle_BR_CH6S4_Exotic": {
-      "identifier": "EradicatorOXRRifle_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH4MS1_Common": {
-      "identifier": "Pistol_BR_CH4MS1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH4MS1_Uncommon": {
-      "identifier": "Pistol_BR_CH4MS1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH4MS1_Rare": {
-      "identifier": "Pistol_BR_CH4MS1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH7S2_Common": {
-      "identifier": "Pistol_BR_CH7S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH7S2_Uncommon": {
-      "identifier": "Pistol_BR_CH7S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH7S2_Rare": {
-      "identifier": "Pistol_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH7S2_Epic": {
-      "identifier": "Pistol_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Pistol_BR_CH7S2_Legendary": {
-      "identifier": "Pistol_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PlasmaBurstLaser_BR_CH6S2_Epic": {
-      "identifier": "PlasmaBurstLaser_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PlasmaCannon_BR_CH2S7_Legendary": {
-      "identifier": "PlasmaCannon_BR_CH2S7_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalBow_BR_CH2S6_Rare": {
-      "identifier": "PrimalBow_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalFlameBow_BR_CH2S6_Rare": {
-      "identifier": "PrimalFlameBow_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalFlameBow_BR_CH2S6_Epic": {
-      "identifier": "PrimalFlameBow_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalFlameBow_BR_CH2S6_Legendary": {
-      "identifier": "PrimalFlameBow_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalPistol_BR_CH2S6_Uncommon": {
-      "identifier": "PrimalPistol_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalPistol_BR_CH2S6_Rare": {
-      "identifier": "PrimalPistol_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalPistol_BR_CH2S6_Epic": {
-      "identifier": "PrimalPistol_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalPistol_BR_CH2S6_Legendary": {
-      "identifier": "PrimalPistol_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalRifle_BR_CH2S6_Uncommon": {
-      "identifier": "PrimalRifle_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalRifle_BR_CH2S6_Rare": {
-      "identifier": "PrimalRifle_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalRifle_BR_CH2S6_Epic": {
-      "identifier": "PrimalRifle_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalRifle_BR_CH2S6_Legendary": {
-      "identifier": "PrimalRifle_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireGuardiansPrimalAssaultRifle_BR_CH2S6_Mythic": {
-      "identifier": "SpireGuardiansPrimalAssaultRifle_BR_CH2S6_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalShotgun_BR_CH2S6_Uncommon": {
-      "identifier": "PrimalShotgun_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalShotgun_BR_CH2S6_Rare": {
-      "identifier": "PrimalShotgun_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalShotgun_BR_CH2S6_Epic": {
-      "identifier": "PrimalShotgun_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalShotgun_BR_CH2S6_Legendary": {
-      "identifier": "PrimalShotgun_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireAssassinsPrimalShotgun_BR_CH2S6_Mythic": {
-      "identifier": "SpireAssassinsPrimalShotgun_BR_CH2S6_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalSMG_BR_CH2S6_Uncommon": {
-      "identifier": "PrimalSMG_BR_CH2S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalSMG_BR_CH2S6_Rare": {
-      "identifier": "PrimalSMG_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalSMG_BR_CH2S6_Epic": {
-      "identifier": "PrimalSMG_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalSMG_BR_CH2S6_Legendary": {
-      "identifier": "PrimalSMG_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalStinkBow_BR_CH2S6_Rare": {
-      "identifier": "PrimalStinkBow_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalStinkBow_BR_CH2S6_Epic": {
-      "identifier": "PrimalStinkBow_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimalStinkBow_BR_CH2S6_Legendary": {
-      "identifier": "PrimalStinkBow_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimeShotgun_BR_CH3S3_Common": {
-      "identifier": "PrimeShotgun_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimeShotgun_BR_CH3S3_Uncommon": {
-      "identifier": "PrimeShotgun_BR_CH3S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimeShotgun_BR_CH3S3_Rare": {
-      "identifier": "PrimeShotgun_BR_CH3S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimeShotgun_BR_CH3S3_Epic": {
-      "identifier": "PrimeShotgun_BR_CH3S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimeShotgun_BR_CH3S3_Legendary": {
-      "identifier": "PrimeShotgun_BR_CH3S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PrimeShotgun_BR_CH3S3_Mythic": {
-      "identifier": "PrimeShotgun_BR_CH3S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ProximityGrenadeLauncher_BR_CH1S9_Epic": {
-      "identifier": "ProximityGrenadeLauncher_BR_CH1S9_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ProximityGrenadeLauncher_BR_CH1S9_Legendary": {
-      "identifier": "ProximityGrenadeLauncher_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PulseRifle_BR_CH2S7_Rare": {
-      "identifier": "PulseRifle_BR_CH2S7_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PulseRifle_BR_CH2S7_Epic": {
-      "identifier": "PulseRifle_BR_CH2S7_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PulseRifle_BR_CH2S7_Legendary": {
-      "identifier": "PulseRifle_BR_CH2S7_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlonesPulseRifle_BR_CH2S7_Mythic": {
-      "identifier": "SlonesPulseRifle_BR_CH2S7_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BurstPulseRifle_BR_CH2S7_Exotic": {
-      "identifier": "BurstPulseRifle_BR_CH2S7_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OverclockedPulseRifle_BR_CH4S2_Mythic": {
-      "identifier": "OverclockedPulseRifle_BR_CH4S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PulseRifle_BR_CH7S2_Uncommon": {
-      "identifier": "PulseRifle_BR_CH7S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OverdrivePulseRifle_BR_CH7S2_Exotic": {
-      "identifier": "OverdrivePulseRifle_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpDump_BR_CH6S2_Common": {
-      "identifier": "PumpDump_BR_CH6S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpDump_BR_CH6S2_Uncommon": {
-      "identifier": "PumpDump_BR_CH6S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpDump_BR_CH6S2_Rare": {
-      "identifier": "PumpDump_BR_CH6S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpDump_BR_CH6S2_Epic": {
-      "identifier": "PumpDump_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpDump_BR_CH6S2_Legendary": {
-      "identifier": "PumpDump_BR_CH6S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpDump_BR_CH6S2_Mythic": {
-      "identifier": "PumpDump_BR_CH6S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessBlinkPumpDump_BR_CH6S2_Exotic": {
-      "identifier": "LawlessBlinkPumpDump_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpkinLauncher_BR_CH1S1_Rare": {
-      "identifier": "PumpkinLauncher_BR_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpkinLauncher_BR_CH1S1_Epic": {
-      "identifier": "PumpkinLauncher_BR_CH1S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpkinLauncher_BR_CH1S1_Legendary": {
-      "identifier": "PumpkinLauncher_BR_CH1S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpkinLauncher_BR_CH2S1_Uncommon": {
-      "identifier": "PumpkinLauncher_BR_CH2S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpkinLauncher_BR_CH6S4_Rare": {
-      "identifier": "PumpkinLauncher_BR_CH6S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpkinLauncher_BR_CH6S4_Epic": {
-      "identifier": "PumpkinLauncher_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpkinLauncher_BR_CH6S4_Legendary": {
-      "identifier": "PumpkinLauncher_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_PreSeason_Uncommon": {
-      "identifier": "PumpShotgun_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_PreSeason_Rare": {
-      "identifier": "PumpShotgun_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH1S6_Epic": {
-      "identifier": "PumpShotgun_BR_CH1S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH1S6_Legendary": {
-      "identifier": "PumpShotgun_BR_CH1S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH2S1_Common": {
-      "identifier": "PumpShotgun_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_OG_CH1S1_Common": {
-      "identifier": "PumpShotgun_OG_CH1S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH4MS1_Common": {
-      "identifier": "PumpShotgun_BR_CH4MS1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_OG_CH1S1_Uncommon": {
-      "identifier": "PumpShotgun_OG_CH1S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH4MS1_Uncommon": {
-      "identifier": "PumpShotgun_BR_CH4MS1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_OG_CH1S3_Rare": {
-      "identifier": "PumpShotgun_OG_CH1S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH4MS1_Rare": {
-      "identifier": "PumpShotgun_BR_CH4MS1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_OG_CH1S6_Epic": {
-      "identifier": "PumpShotgun_OG_CH1S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH4MS1_Epic": {
-      "identifier": "PumpShotgun_BR_CH4MS1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_OG_CH1S6_Legendary": {
-      "identifier": "PumpShotgun_OG_CH1S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PumpShotgun_BR_CH4MS1_Legendary": {
-      "identifier": "PumpShotgun_BR_CH4MS1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "PurplePaintLauncher_BR_CH2S2_Rare": {
-      "identifier": "PurplePaintLauncher_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "QuadLauncher_BR_CH1S6_Epic": {
-      "identifier": "QuadLauncher_BR_CH1S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "QuadLauncher_BR_CH1S6_Legendary": {
-      "identifier": "QuadLauncher_BR_CH1S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RailGun_BR_CH2S7_Rare": {
-      "identifier": "RailGun_BR_CH2S7_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RailGun_BR_CH2S7_Epic": {
-      "identifier": "RailGun_BR_CH2S7_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RailGun_BR_CH2S7_Legendary": {
-      "identifier": "RailGun_BR_CH2S7_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerAssaultRifle_BR_CH3S1_Common": {
-      "identifier": "RangerAssaultRifle_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerAssaultRifle_BR_CH3S1_Uncommon": {
-      "identifier": "RangerAssaultRifle_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerAssaultRifle_BR_CH3S1_Rare": {
-      "identifier": "RangerAssaultRifle_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerAssaultRifle_BR_CH3S1_Epic": {
-      "identifier": "RangerAssaultRifle_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerAssaultRifle_BR_CH3S1_Legendary": {
-      "identifier": "RangerAssaultRifle_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerAssaultRifle_BR_CH3S1_Mythic": {
-      "identifier": "RangerAssaultRifle_BR_CH3S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularRangerPistol_BR_CH5S1_Common": {
-      "identifier": "ModularRangerPistol_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularRangerPistol_BR_CH5S1_Uncommon": {
-      "identifier": "ModularRangerPistol_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularRangerPistol_BR_CH5S1_Rare": {
-      "identifier": "ModularRangerPistol_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularRangerPistol_BR_CH5S1_Epic": {
-      "identifier": "ModularRangerPistol_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularRangerPistol_BR_CH5S1_Legendary": {
-      "identifier": "ModularRangerPistol_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerPistol_Ballistic_V1_Common": {
-      "identifier": "RangerPistol_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerShotgun_BR_CH3S2_Common": {
-      "identifier": "RangerShotgun_BR_CH3S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerShotgun_BR_CH3S2_Uncommon": {
-      "identifier": "RangerShotgun_BR_CH3S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerShotgun_BR_CH3S2_Rare": {
-      "identifier": "RangerShotgun_BR_CH3S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerShotgun_BR_CH3S2_Epic": {
-      "identifier": "RangerShotgun_BR_CH3S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RangerShotgun_BR_CH3S2_Legendary": {
-      "identifier": "RangerShotgun_BR_CH3S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RapidFireSMG_BR_CH2S2_Uncommon": {
-      "identifier": "RapidFireSMG_BR_CH2S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RapidFireSMG_BR_CH2S2_Rare": {
-      "identifier": "RapidFireSMG_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RapidFireSMG_BR_CH2S3_Common": {
-      "identifier": "RapidFireSMG_BR_CH2S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RapidFireSMG_BR_CH2S3_Epic": {
-      "identifier": "RapidFireSMG_BR_CH2S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RapidFireSMG_BR_CH2S3_Legendary": {
-      "identifier": "RapidFireSMG_BR_CH2S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RapidFireSMG_BR_CH3S4_Mythic": {
-      "identifier": "RapidFireSMG_BR_CH3S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReacherExtendingShotgun_BR_CH7S3_Mythic": {
-      "identifier": "ReacherExtendingShotgun_BR_CH7S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReaperModularSniperRifle_BR_CH5S1_Uncommon": {
-      "identifier": "ReaperModularSniperRifle_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReaperModularSniperRifle_BR_CH5S1_Rare": {
-      "identifier": "ReaperModularSniperRifle_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReaperModularSniperRifle_BR_CH5S1_Epic": {
-      "identifier": "ReaperModularSniperRifle_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReaperModularSniperRifle_BR_CH5S1_Legendary": {
-      "identifier": "ReaperModularSniperRifle_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReaperSniperRifle_Ballistic_V1_Common": {
-      "identifier": "ReaperSniperRifle_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReconBow_BR_CH7S2_Exotic": {
-      "identifier": "ReconBow_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ExoticReconBow_BR_CH7S2_Exotic": {
-      "identifier": "ExoticReconBow_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReconScanner_BR_CH2S7_Rare": {
-      "identifier": "ReconScanner_BR_CH2S7_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Recycler_BR_CH2S6_Rare": {
-      "identifier": "Recycler_BR_CH2S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Recycler_BR_CH2S6_Epic": {
-      "identifier": "Recycler_BR_CH2S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Recycler_BR_CH2S6_Legendary": {
-      "identifier": "Recycler_BR_CH2S6_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireAssassinsRecycler_BR_CH2S6_Mythic": {
-      "identifier": "SpireAssassinsRecycler_BR_CH2S6_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedEyeAssaultRifle_BR_CH4S1_Common": {
-      "identifier": "RedEyeAssaultRifle_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedEyeAssaultRifle_BR_CH4S1_Uncommon": {
-      "identifier": "RedEyeAssaultRifle_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedEyeAssaultRifle_BR_CH4S1_Rare": {
-      "identifier": "RedEyeAssaultRifle_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedEyeAssaultRifle_BR_CH4S1_Epic": {
-      "identifier": "RedEyeAssaultRifle_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RedEyeAssaultRifle_BR_CH4S1_Legendary": {
-      "identifier": "RedEyeAssaultRifle_BR_CH4S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeistedExplosiveAssaultRifle_BR_CH4S1_Exotic": {
-      "identifier": "HeistedExplosiveAssaultRifle_BR_CH4S1_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_PreSeason_Common": {
-      "identifier": "Revolver_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_PreSeason_Uncommon": {
-      "identifier": "Revolver_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_PreSeason_Rare": {
-      "identifier": "Revolver_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_CH1S9_Epic": {
-      "identifier": "Revolver_BR_CH1S9_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_CH1S9_Legendary": {
-      "identifier": "Revolver_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_OG_CH1S1_Common": {
-      "identifier": "Revolver_OG_CH1S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_CH4MS1_Common": {
-      "identifier": "Revolver_BR_CH4MS1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_OG_CH1S1_Uncommon": {
-      "identifier": "Revolver_OG_CH1S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_CH4MS1_Uncommon": {
-      "identifier": "Revolver_BR_CH4MS1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_OG_CH1S1_Rare": {
-      "identifier": "Revolver_OG_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_CH4MS1_Rare": {
-      "identifier": "Revolver_BR_CH4MS1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_OG_CH1S1_Epic": {
-      "identifier": "Revolver_OG_CH1S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_CH4MS1_Epic": {
-      "identifier": "Revolver_BR_CH4MS1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_OG_CH1S1_Legendary": {
-      "identifier": "Revolver_OG_CH1S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Revolver_BR_CH4MS1_Legendary": {
-      "identifier": "Revolver_BR_CH4MS1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RipsawLauncher_BR_CH3S3_Rare": {
-      "identifier": "RipsawLauncher_BR_CH3S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RocketDrill_BR_CH6S2_Epic": {
-      "identifier": "RocketDrill_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RocketLauncher_BR_PreSeason_Rare": {
-      "identifier": "RocketLauncher_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RocketLauncher_BR_PreSeason_Epic": {
-      "identifier": "RocketLauncher_BR_PreSeason_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RocketLauncher_BR_PreSeason_Legendary": {
-      "identifier": "RocketLauncher_BR_PreSeason_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RocketLauncher_BR_CH2S1_Common": {
-      "identifier": "RocketLauncher_BR_CH2S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RocketLauncher_BR_CH2S1_Uncommon": {
-      "identifier": "RocketLauncher_BR_CH2S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "RocketRam_BR_CH4S4_Rare": {
-      "identifier": "RocketRam_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedAssaultRifle_BR_PreSeason_Uncommon": {
-      "identifier": "ScopedAssaultRifle_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedAssaultRifle_BR_PreSeason_Rare": {
-      "identifier": "ScopedAssaultRifle_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedAssaultRifle_BR_CH2S4_Epic": {
-      "identifier": "ScopedAssaultRifle_BR_CH2S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedAssaultRifle_BR_CH2S4_Legendary": {
-      "identifier": "ScopedAssaultRifle_BR_CH2S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedBurstSMG_BR_CH4S4_Common": {
-      "identifier": "ScopedBurstSMG_BR_CH4S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedBurstSMG_BR_CH4S4_Uncommon": {
-      "identifier": "ScopedBurstSMG_BR_CH4S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedBurstSMG_BR_CH4S4_Rare": {
-      "identifier": "ScopedBurstSMG_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedBurstSMG_BR_CH4S4_Epic": {
-      "identifier": "ScopedBurstSMG_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedBurstSMG_BR_CH4S4_Legendary": {
-      "identifier": "ScopedBurstSMG_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThornesScopedBurstSMG_BR_CH4S4_Mythic": {
-      "identifier": "ThornesScopedBurstSMG_BR_CH4S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedRevolver_BR_CH1S7_Epic": {
-      "identifier": "ScopedRevolver_BR_CH1S7_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ScopedRevolver_BR_CH1S7_Legendary": {
-      "identifier": "ScopedRevolver_BR_CH1S7_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoPistol_BR_PreSeason_Common": {
-      "identifier": "SemiAutoPistol_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoPistol_BR_PreSeason_Uncommon": {
-      "identifier": "SemiAutoPistol_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoPistol_BR_PreSeason_Rare": {
-      "identifier": "SemiAutoPistol_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoPistol_BR_CH2S1_Epic": {
-      "identifier": "SemiAutoPistol_BR_CH2S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoPistol_BR_CH2S1_Legendary": {
-      "identifier": "SemiAutoPistol_BR_CH2S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSniperRifle_BR_PreSeason_Uncommon": {
-      "identifier": "SemiAutoSniperRifle_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSniperRifle_BR_PreSeason_Rare": {
-      "identifier": "SemiAutoSniperRifle_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSniperRifle_BR_CH2S2_Epic": {
-      "identifier": "SemiAutoSniperRifle_BR_CH2S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSniperRifle_BR_CH2S2_Legendary": {
-      "identifier": "SemiAutoSniperRifle_BR_CH2S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSuppressedPistol_BR_CH1S2_Rare": {
-      "identifier": "SemiAutoSuppressedPistol_BR_CH1S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSuppressedPistol_BR_CH1S2_Epic": {
-      "identifier": "SemiAutoSuppressedPistol_BR_CH1S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSuppressedPistol_BR_CH3S1_Uncommon": {
-      "identifier": "SemiAutoSuppressedPistol_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SemiAutoSuppressedPistol_BR_CH3S1_Legendary": {
-      "identifier": "SemiAutoSuppressedPistol_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SentinelPumpShotgun_BR_CH6S1_Common": {
-      "identifier": "SentinelPumpShotgun_BR_CH6S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SentinelPumpShotgun_BR_CH6S1_Uncommon": {
-      "identifier": "SentinelPumpShotgun_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SentinelPumpShotgun_BR_CH6S1_Rare": {
-      "identifier": "SentinelPumpShotgun_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SentinelPumpShotgun_BR_CH6S1_Epic": {
-      "identifier": "SentinelPumpShotgun_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SentinelPumpShotgun_BR_CH6S1_Legendary": {
-      "identifier": "SentinelPumpShotgun_BR_CH6S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedSentinelPumpShotgun_BR_CH6S1_Mythic": {
-      "identifier": "EnhancedSentinelPumpShotgun_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SevenClusterCannon_BR_CH7S2_Epic": {
-      "identifier": "SevenClusterCannon_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SevenClusterCannon_BR_CH7S2_Legendary": {
-      "identifier": "SevenClusterCannon_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SevenPowerGloves_BR_CH7S2_Epic": {
-      "identifier": "SevenPowerGloves_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "FoundationsPowerGloves_BR_CH7S2_Mythic": {
-      "identifier": "FoundationsPowerGloves_BR_CH7S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShadowTracker_BR_CH2S5_Exotic": {
-      "identifier": "ShadowTracker_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SharpToothShotgun_BR_CH4S3_Uncommon": {
-      "identifier": "SharpToothShotgun_BR_CH4S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SharpToothShotgun_BR_CH4S3_Rare": {
-      "identifier": "SharpToothShotgun_BR_CH4S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SharpToothShotgun_BR_CH4S3_Epic": {
-      "identifier": "SharpToothShotgun_BR_CH4S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SharpToothShotgun_BR_CH4S3_Legendary": {
-      "identifier": "SharpToothShotgun_BR_CH4S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShockwaveHammer_BR_CH4S1_Epic": {
-      "identifier": "ShockwaveHammer_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheAgelessChampionsShockwaveHammer_BR_CH4S1_Mythic": {
-      "identifier": "TheAgelessChampionsShockwaveHammer_BR_CH4S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "KitsShockwaveLauncher_BR_CH2S3_Mythic": {
-      "identifier": "KitsShockwaveLauncher_BR_CH2S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShockwaveLauncher_BR_CH2S8_Legendary": {
-      "identifier": "ShockwaveLauncher_BR_CH2S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ShockwaveLauncher_BR_CH6S4_Epic": {
-      "identifier": "ShockwaveLauncher_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EradicatorShockNSlowShockwaveLauncher_BR_CH6S4_Exotic": {
-      "identifier": "EradicatorShockNSlowShockwaveLauncher_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidearmPistol_BR_CH3S1_Common": {
-      "identifier": "SidearmPistol_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidearmPistol_BR_CH3S1_Uncommon": {
-      "identifier": "SidearmPistol_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidearmPistol_BR_CH3S1_Rare": {
-      "identifier": "SidearmPistol_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidearmPistol_BR_CH3S1_Epic": {
-      "identifier": "SidearmPistol_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidearmPistol_BR_CH3S1_Legendary": {
-      "identifier": "SidearmPistol_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysMinigun_BR_CH2S8_Common": {
-      "identifier": "SidewaysMinigun_BR_CH2S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysMinigun_BR_CH2S8_Uncommon": {
-      "identifier": "SidewaysMinigun_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysMinigun_BR_CH2S8_Rare": {
-      "identifier": "SidewaysMinigun_BR_CH2S8_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysMinigun_BR_CH2S8_Epic": {
-      "identifier": "SidewaysMinigun_BR_CH2S8_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysMinigun_BR_CH2S8_Legendary": {
-      "identifier": "SidewaysMinigun_BR_CH2S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysMinigun_BR_CH2S8_Mythic": {
-      "identifier": "SidewaysMinigun_BR_CH2S8_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysRifle_BR_CH2S8_Common": {
-      "identifier": "SidewaysRifle_BR_CH2S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysRifle_BR_CH2S8_Uncommon": {
-      "identifier": "SidewaysRifle_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysRifle_BR_CH2S8_Rare": {
-      "identifier": "SidewaysRifle_BR_CH2S8_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysRifle_BR_CH2S8_Epic": {
-      "identifier": "SidewaysRifle_BR_CH2S8_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysRifle_BR_CH2S8_Legendary": {
-      "identifier": "SidewaysRifle_BR_CH2S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysRifle_BR_CH2S8_Mythic": {
-      "identifier": "SidewaysRifle_BR_CH2S8_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysScythe_BR_CH2S8_Common": {
-      "identifier": "SidewaysScythe_BR_CH2S8_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysScythe_BR_CH2S8_Uncommon": {
-      "identifier": "SidewaysScythe_BR_CH2S8_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysScythe_BR_CH2S8_Rare": {
-      "identifier": "SidewaysScythe_BR_CH2S8_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysScythe_BR_CH2S8_Epic": {
-      "identifier": "SidewaysScythe_BR_CH2S8_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysScythe_BR_CH2S8_Legendary": {
-      "identifier": "SidewaysScythe_BR_CH2S8_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SidewaysScythe_BR_CH2S8_Mythic": {
-      "identifier": "SidewaysScythe_BR_CH2S8_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SixShooter_BR_CH1S6_Uncommon": {
-      "identifier": "SixShooter_BR_CH1S6_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SixShooter_BR_CH1S6_Rare": {
-      "identifier": "SixShooter_BR_CH1S6_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SixShooter_BR_CH1S6_Epic": {
-      "identifier": "SixShooter_BR_CH1S6_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SixShooter_BR_CH7S1_Legendary": {
-      "identifier": "SixShooter_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SnowballLauncher_BR_CH1S2_Rare": {
-      "identifier": "SnowballLauncher_BR_CH1S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SnowballLauncher_BR_CH1S2_Epic": {
-      "identifier": "SnowballLauncher_BR_CH1S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SnowballLauncher_BR_CH1S2_Legendary": {
-      "identifier": "SnowballLauncher_BR_CH1S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SnowballLauncher_BR_CH2S1_Uncommon": {
-      "identifier": "SnowballLauncher_BR_CH2S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularSovereignShotgun_BR_CH5S4_Common": {
-      "identifier": "ModularSovereignShotgun_BR_CH5S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularSovereignShotgun_BR_CH5S4_Uncommon": {
-      "identifier": "ModularSovereignShotgun_BR_CH5S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularSovereignShotgun_BR_CH5S4_Rare": {
-      "identifier": "ModularSovereignShotgun_BR_CH5S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularSovereignShotgun_BR_CH5S4_Epic": {
-      "identifier": "ModularSovereignShotgun_BR_CH5S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularSovereignShotgun_BR_CH5S4_Legendary": {
-      "identifier": "ModularSovereignShotgun_BR_CH5S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SovereignShotgun_BR_CH7S1_Common": {
-      "identifier": "SovereignShotgun_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SovereignShotgun_BR_CH7S1_Uncommon": {
-      "identifier": "SovereignShotgun_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SovereignShotgun_BR_CH7S1_Rare": {
-      "identifier": "SovereignShotgun_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SovereignShotgun_BR_CH7S1_Epic": {
-      "identifier": "SovereignShotgun_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SovereignShotgun_BR_CH7S1_Legendary": {
-      "identifier": "SovereignShotgun_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SovereignSniper_Ballistic_V1_Common": {
-      "identifier": "SovereignSniper_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireRifle_BR_CH6S3_Common": {
-      "identifier": "SpireRifle_BR_CH6S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireRifle_BR_CH6S3_Uncommon": {
-      "identifier": "SpireRifle_BR_CH6S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireRifle_BR_CH6S3_Rare": {
-      "identifier": "SpireRifle_BR_CH6S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireRifle_BR_CH6S3_Epic": {
-      "identifier": "SpireRifle_BR_CH6S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpireRifle_BR_CH6S3_Legendary": {
-      "identifier": "SpireRifle_BR_CH6S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedSpireRifle_BR_CH6S3_Mythic": {
-      "identifier": "EnhancedSpireRifle_BR_CH6S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StickyGrenadeLauncher_BR_CH4S4_Epic": {
-      "identifier": "StickyGrenadeLauncher_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StickyGrenadeLauncher_BR_CH4S4_Legendary": {
-      "identifier": "StickyGrenadeLauncher_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StingerSMG_BR_CH3S1_Common": {
-      "identifier": "StingerSMG_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StingerSMG_BR_CH3S1_Uncommon": {
-      "identifier": "StingerSMG_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StingerSMG_BR_CH3S1_Rare": {
-      "identifier": "StingerSMG_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StingerSMG_BR_CH3S1_Epic": {
-      "identifier": "StingerSMG_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StingerSMG_BR_CH3S1_Legendary": {
-      "identifier": "StingerSMG_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "GunnarsStingerSMG_BR_CH3S1_Mythic": {
-      "identifier": "GunnarsStingerSMG_BR_CH3S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StormScout_BR_CH2S5_Exotic": {
-      "identifier": "StormScout_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StormScoutSniperRifle_BR_CH1S9_Epic": {
-      "identifier": "StormScoutSniperRifle_BR_CH1S9_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StormScoutSniperRifle_BR_CH1S9_Legendary": {
-      "identifier": "StormScoutSniperRifle_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerAR_BR_CH5S1_Common": {
-      "identifier": "ModularStrikerAR_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerAR_BR_CH5S1_Uncommon": {
-      "identifier": "ModularStrikerAR_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerAR_BR_CH5S1_Rare": {
-      "identifier": "ModularStrikerAR_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerAR_BR_CH5S1_Epic": {
-      "identifier": "ModularStrikerAR_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerAR_BR_CH5S1_Legendary": {
-      "identifier": "ModularStrikerAR_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NishasModularStrikerAR_BR_CH5S1_Mythic": {
-      "identifier": "NishasModularStrikerAR_BR_CH5S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerAR_BR_CH6MS2_Common": {
-      "identifier": "StrikerAR_BR_CH6MS2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerAR_BR_CH6MS2_Uncommon": {
-      "identifier": "StrikerAR_BR_CH6MS2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerAR_BR_CH6MS2_Rare": {
-      "identifier": "StrikerAR_BR_CH6MS2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerAR_BR_CH6MS2_Epic": {
-      "identifier": "StrikerAR_BR_CH6MS2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerAR_BR_CH6MS2_Legendary": {
-      "identifier": "StrikerAR_BR_CH6MS2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerAR_Ballistic_V1_Common": {
-      "identifier": "StrikerAR_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerBurstRifle_BR_CH3S2_Common": {
-      "identifier": "StrikerBurstRifle_BR_CH3S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerBurstRifle_BR_CH3S2_Uncommon": {
-      "identifier": "StrikerBurstRifle_BR_CH3S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerBurstRifle_BR_CH3S2_Rare": {
-      "identifier": "StrikerBurstRifle_BR_CH3S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerBurstRifle_BR_CH3S2_Epic": {
-      "identifier": "StrikerBurstRifle_BR_CH3S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerBurstRifle_BR_CH3S2_Legendary": {
-      "identifier": "StrikerBurstRifle_BR_CH3S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerBurstRifle_BR_CH3S2_Mythic": {
-      "identifier": "StrikerBurstRifle_BR_CH3S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SlonesStrikerBurstRifle_BR_CH3S2_Mythic": {
-      "identifier": "SlonesStrikerBurstRifle_BR_CH3S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerBurstRifle_BR_CH5S4_Common": {
-      "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerBurstRifle_BR_CH5S4_Uncommon": {
-      "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerBurstRifle_BR_CH5S4_Rare": {
-      "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerBurstRifle_BR_CH5S4_Epic": {
-      "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularStrikerBurstRifle_BR_CH5S4_Legendary": {
-      "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerPumpShotgun_BR_CH3S1_Common": {
-      "identifier": "StrikerPumpShotgun_BR_CH3S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerPumpShotgun_BR_CH3S1_Uncommon": {
-      "identifier": "StrikerPumpShotgun_BR_CH3S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerPumpShotgun_BR_CH3S1_Rare": {
-      "identifier": "StrikerPumpShotgun_BR_CH3S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerPumpShotgun_BR_CH3S1_Epic": {
-      "identifier": "StrikerPumpShotgun_BR_CH3S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerPumpShotgun_BR_CH3S1_Legendary": {
-      "identifier": "StrikerPumpShotgun_BR_CH3S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "StrikerPumpShotgun_BR_CH3S1_Mythic": {
-      "identifier": "StrikerPumpShotgun_BR_CH3S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH1S5_Common": {
-      "identifier": "SubmachineGun_BR_CH1S5_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH1S5_Uncommon": {
-      "identifier": "SubmachineGun_BR_CH1S5_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH1S5_Rare": {
-      "identifier": "SubmachineGun_BR_CH1S5_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH2S1_Epic": {
-      "identifier": "SubmachineGun_BR_CH2S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH2S1_Legendary": {
-      "identifier": "SubmachineGun_BR_CH2S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeistedRunNGunSMG_BR_CH4S1_Exotic": {
-      "identifier": "HeistedRunNGunSMG_BR_CH4S1_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH4S2_Epic": {
-      "identifier": "SubmachineGun_BR_CH4S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH4S2_Legendary": {
-      "identifier": "SubmachineGun_BR_CH4S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_OG_CH1S1_Common": {
-      "identifier": "SubmachineGun_OG_CH1S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH4MS1_Common": {
-      "identifier": "SubmachineGun_BR_CH4MS1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_OG_CH1S1_Uncommon": {
-      "identifier": "SubmachineGun_OG_CH1S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH4MS1_Uncommon": {
-      "identifier": "SubmachineGun_BR_CH4MS1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_OG_CH1S1_Rare": {
-      "identifier": "SubmachineGun_OG_CH1S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SubmachineGun_BR_CH4MS1_Rare": {
-      "identifier": "SubmachineGun_BR_CH4MS1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuperShredder_BR_CH7S2_Rare": {
-      "identifier": "SuperShredder_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuperShredder_BR_CH7S2_Epic": {
-      "identifier": "SuperShredder_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuperShredder_BR_CH7S2_Legendary": {
-      "identifier": "SuperShredder_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedAssaultRifle_BR_CH1S5_Epic": {
-      "identifier": "SuppressedAssaultRifle_BR_CH1S5_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedAssaultRifle_BR_CH1S5_Legendary": {
-      "identifier": "SuppressedAssaultRifle_BR_CH1S5_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedAssaultRifle_BR_CH2S2_Rare": {
-      "identifier": "SuppressedAssaultRifle_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedAssaultRifle_BR_CH6MS2_Common": {
-      "identifier": "SuppressedAssaultRifle_BR_CH6MS2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedAssaultRifle_BR_CH6MS2_Uncommon": {
-      "identifier": "SuppressedAssaultRifle_BR_CH6MS2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedPistol_BR_CH4S4_Common": {
-      "identifier": "SuppressedPistol_BR_CH4S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedPistol_BR_CH4S4_Uncommon": {
-      "identifier": "SuppressedPistol_BR_CH4S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedPistol_BR_CH4S4_Rare": {
-      "identifier": "SuppressedPistol_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedPistol_BR_CH4S4_Epic": {
-      "identifier": "SuppressedPistol_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedPistol_BR_CH4S4_Legendary": {
-      "identifier": "SuppressedPistol_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedPistol_BR_CH6S2_Mythic": {
-      "identifier": "SuppressedPistol_BR_CH6S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSniperRifle_BR_CH1S7_Epic": {
-      "identifier": "SuppressedSniperRifle_BR_CH1S7_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSniperRifle_BR_CH1S7_Legendary": {
-      "identifier": "SuppressedSniperRifle_BR_CH1S7_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSniperRifle_BR_CH2S2_Rare": {
-      "identifier": "SuppressedSniperRifle_BR_CH2S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSubmachineGun_BR_PreSeason_Common": {
-      "identifier": "SuppressedSubmachineGun_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSubmachineGun_BR_PreSeason_Uncommon": {
-      "identifier": "SuppressedSubmachineGun_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSubmachineGun_BR_PreSeason_Rare": {
-      "identifier": "SuppressedSubmachineGun_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSubmachineGun_BR_CH3S4_Epic": {
-      "identifier": "SuppressedSubmachineGun_BR_CH3S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SuppressedSubmachineGun_BR_CH3S4_Legendary": {
-      "identifier": "SuppressedSubmachineGun_BR_CH3S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "InkquisitorsSuppressedSMG_BR_CH3S4_Mythic": {
-      "identifier": "InkquisitorsSuppressedSMG_BR_CH3S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgefireSMG_BR_CH6S1_Common": {
-      "identifier": "SurgefireSMG_BR_CH6S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgefireSMG_BR_CH6S1_Uncommon": {
-      "identifier": "SurgefireSMG_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgefireSMG_BR_CH6S1_Rare": {
-      "identifier": "SurgefireSMG_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgefireSMG_BR_CH6S1_Epic": {
-      "identifier": "SurgefireSMG_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgefireSMG_BR_CH6S1_Legendary": {
-      "identifier": "SurgefireSMG_BR_CH6S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedSurgefireSMG_BR_CH6S1_Mythic": {
-      "identifier": "EnhancedSurgefireSMG_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgicalBurstRifle_BR_CH7S3_Common": {
-      "identifier": "SurgicalBurstRifle_BR_CH7S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VanguardBurstRifle_BR_CH7S3_Common": {
-      "identifier": "VanguardBurstRifle_BR_CH7S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgicalBurstRifle_BR_CH7S3_Uncommon": {
-      "identifier": "SurgicalBurstRifle_BR_CH7S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VanguardBurstRifle_BR_CH7S3_Uncommon": {
-      "identifier": "VanguardBurstRifle_BR_CH7S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgicalBurstRifle_BR_CH7S3_Rare": {
-      "identifier": "SurgicalBurstRifle_BR_CH7S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VanguardBurstRifle_BR_CH7S3_Rare": {
-      "identifier": "VanguardBurstRifle_BR_CH7S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgicalBurstRifle_BR_CH7S3_Epic": {
-      "identifier": "SurgicalBurstRifle_BR_CH7S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VanguardBurstRifle_BR_CH7S3_Epic": {
-      "identifier": "VanguardBurstRifle_BR_CH7S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SurgicalBurstRifle_BR_CH7S3_Legendary": {
-      "identifier": "SurgicalBurstRifle_BR_CH7S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VanguardBurstRifle_BR_CH7S3_Legendary": {
-      "identifier": "VanguardBurstRifle_BR_CH7S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Swarmstrike_BR_CH6S4_Epic": {
-      "identifier": "Swarmstrike_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Swarmstrike_BR_CH6S4_Legendary": {
-      "identifier": "Swarmstrike_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SweeperShotgun_BR_CH6S4_Common": {
-      "identifier": "SweeperShotgun_BR_CH6S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SweeperShotgun_BR_CH6S4_Uncommon": {
-      "identifier": "SweeperShotgun_BR_CH6S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SweeperShotgun_BR_CH6S4_Rare": {
-      "identifier": "SweeperShotgun_BR_CH6S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SweeperShotgun_BR_CH6S4_Epic": {
-      "identifier": "SweeperShotgun_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SweeperShotgun_BR_CH6S4_Legendary": {
-      "identifier": "SweeperShotgun_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "SweeperShotgun_BR_CH6S4_Mythic": {
-      "identifier": "SweeperShotgun_BR_CH6S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH1S9_Rare": {
-      "identifier": "TacticalAssaultRifle_BR_CH1S9_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH1S9_Epic": {
-      "identifier": "TacticalAssaultRifle_BR_CH1S9_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH1S9_Legendary": {
-      "identifier": "TacticalAssaultRifle_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH4S1_Common": {
-      "identifier": "TacticalAssaultRifle_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH4S1_Uncommon": {
-      "identifier": "TacticalAssaultRifle_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularTacticalAssaultRifle_BR_CH5S2_Common": {
-      "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularTacticalAssaultRifle_BR_CH5S2_Uncommon": {
-      "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularTacticalAssaultRifle_BR_CH5S2_Rare": {
-      "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularTacticalAssaultRifle_BR_CH5S2_Epic": {
-      "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularTacticalAssaultRifle_BR_CH5S2_Legendary": {
-      "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH7S1_Common": {
-      "identifier": "TacticalAssaultRifle_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH7S1_Uncommon": {
-      "identifier": "TacticalAssaultRifle_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH7S1_Rare": {
-      "identifier": "TacticalAssaultRifle_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH7S1_Epic": {
-      "identifier": "TacticalAssaultRifle_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalAssaultRifle_BR_CH7S1_Legendary": {
-      "identifier": "TacticalAssaultRifle_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalDMR_BR_CH4S4_Common": {
-      "identifier": "TacticalDMR_BR_CH4S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalDMR_BR_CH4S4_Uncommon": {
-      "identifier": "TacticalDMR_BR_CH4S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalDMR_BR_CH4S4_Rare": {
-      "identifier": "TacticalDMR_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalDMR_BR_CH4S4_Epic": {
-      "identifier": "TacticalDMR_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalDMR_BR_CH4S4_Legendary": {
-      "identifier": "TacticalDMR_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH4S1_Common": {
-      "identifier": "TacticalPistol_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH4S1_Uncommon": {
-      "identifier": "TacticalPistol_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH4S1_Rare": {
-      "identifier": "TacticalPistol_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH4S1_Epic": {
-      "identifier": "TacticalPistol_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH4S1_Legendary": {
-      "identifier": "TacticalPistol_BR_CH4S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH4S1_Mythic": {
-      "identifier": "TacticalPistol_BR_CH4S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH7S1_Common": {
-      "identifier": "TacticalPistol_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH7S1_Uncommon": {
-      "identifier": "TacticalPistol_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH7S1_Rare": {
-      "identifier": "TacticalPistol_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH7S1_Epic": {
-      "identifier": "TacticalPistol_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalPistol_BR_CH7S1_Legendary": {
-      "identifier": "TacticalPistol_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "OverdriveTacticalPistol_BR_CH7S1_Mythic": {
-      "identifier": "OverdriveTacticalPistol_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalShotgun_BR_PreSeason_Common": {
-      "identifier": "TacticalShotgun_BR_PreSeason_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalShotgun_BR_PreSeason_Uncommon": {
-      "identifier": "TacticalShotgun_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalShotgun_BR_PreSeason_Rare": {
-      "identifier": "TacticalShotgun_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalShotgun_BR_CH1S9_Epic": {
-      "identifier": "TacticalShotgun_BR_CH1S9_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalShotgun_BR_CH1S9_Legendary": {
-      "identifier": "TacticalShotgun_BR_CH1S9_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalShotgun_BR_CH6MS2_Epic": {
-      "identifier": "TacticalShotgun_BR_CH6MS2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalShotgun_BR_CH6MS2_Legendary": {
-      "identifier": "TacticalShotgun_BR_CH6MS2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalSubmachineGun_BR_PreSeason_Uncommon": {
-      "identifier": "TacticalSubmachineGun_BR_PreSeason_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalSubmachineGun_BR_PreSeason_Rare": {
-      "identifier": "TacticalSubmachineGun_BR_PreSeason_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalSubmachineGun_BR_PreSeason_Epic": {
-      "identifier": "TacticalSubmachineGun_BR_PreSeason_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TacticalSubmachineGun_BR_CH1SX_Legendary": {
-      "identifier": "TacticalSubmachineGun_BR_CH1SX_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheBigChill_BR_CH2S5_Exotic": {
-      "identifier": "TheBigChill_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheDub_BR_CH2S5_Exotic": {
-      "identifier": "TheDub_BR_CH2S5_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheFoundationsRiftRifle_BR_CH7S2_Exotic": {
-      "identifier": "TheFoundationsRiftRifle_BR_CH7S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheKneecapper_BR_CH6S2_Epic": {
-      "identifier": "TheKneecapper_BR_CH6S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalDMR_BR_CH4S3_Common": {
-      "identifier": "ThermalDMR_BR_CH4S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalDMR_BR_CH4S3_Uncommon": {
-      "identifier": "ThermalDMR_BR_CH4S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalDMR_BR_CH4S3_Rare": {
-      "identifier": "ThermalDMR_BR_CH4S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalDMR_BR_CH4S3_Epic": {
-      "identifier": "ThermalDMR_BR_CH4S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalDMR_BR_CH4S3_Legendary": {
-      "identifier": "ThermalDMR_BR_CH4S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalDMR_BR_CH4S3_Mythic": {
-      "identifier": "ThermalDMR_BR_CH4S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "DiamondsThermalDMR_BR_CH4S4_Mythic": {
-      "identifier": "DiamondsThermalDMR_BR_CH4S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalScopedAssaultRifle_BR_CH1S4_Epic": {
-      "identifier": "ThermalScopedAssaultRifle_BR_CH1S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThermalScopedAssaultRifle_BR_CH1S4_Legendary": {
-      "identifier": "ThermalScopedAssaultRifle_BR_CH1S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HuntmasterSabersThermalRifle_BR_CH3S2_Mythic": {
-      "identifier": "HuntmasterSabersThermalRifle_BR_CH3S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TheVoidbladesBurstRifle_BR_CH7S3_Mythic": {
-      "identifier": "TheVoidbladesBurstRifle_BR_CH7S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularThunderBurstSMG_BR_CH5S1_Common": {
-      "identifier": "ModularThunderBurstSMG_BR_CH5S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularThunderBurstSMG_BR_CH5S1_Uncommon": {
-      "identifier": "ModularThunderBurstSMG_BR_CH5S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularThunderBurstSMG_BR_CH5S1_Rare": {
-      "identifier": "ModularThunderBurstSMG_BR_CH5S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularThunderBurstSMG_BR_CH5S1_Epic": {
-      "identifier": "ModularThunderBurstSMG_BR_CH5S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularThunderBurstSMG_BR_CH5S1_Legendary": {
-      "identifier": "ModularThunderBurstSMG_BR_CH5S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThunderBurstSMG_Ballistic_V1_Common": {
-      "identifier": "ThunderBurstSMG_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThunderShotgun_BR_CH4S1_Common": {
-      "identifier": "ThunderShotgun_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThunderShotgun_BR_CH4S1_Uncommon": {
-      "identifier": "ThunderShotgun_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThunderShotgun_BR_CH4S1_Rare": {
-      "identifier": "ThunderShotgun_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThunderShotgun_BR_CH4S1_Epic": {
-      "identifier": "ThunderShotgun_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ThunderShotgun_BR_CH4S1_Legendary": {
-      "identifier": "ThunderShotgun_BR_CH4S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TNTinasKaBoomBow_BR_CH2S2_Mythic": {
-      "identifier": "TNTinasKaBoomBow_BR_CH2S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TowHookCannon_BR_CH5S3_Rare": {
-      "identifier": "TowHookCannon_BR_CH5S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Trouble_BR_CH6S4_Exotic": {
-      "identifier": "Trouble_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinfireAutoShotgun_BR_CH6S1_Common": {
-      "identifier": "TwinfireAutoShotgun_BR_CH6S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinfireAutoShotgun_BR_CH6S1_Uncommon": {
-      "identifier": "TwinfireAutoShotgun_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinfireAutoShotgun_BR_CH6S1_Rare": {
-      "identifier": "TwinfireAutoShotgun_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinfireAutoShotgun_BR_CH6S1_Epic": {
-      "identifier": "TwinfireAutoShotgun_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinfireAutoShotgun_BR_CH6S1_Legendary": {
-      "identifier": "TwinfireAutoShotgun_BR_CH6S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedTwinfireAutoShotgun_BR_CH6S1_Mythic": {
-      "identifier": "EnhancedTwinfireAutoShotgun_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "LawlessTwinfireSlapShotgun_BR_CH6S2_Exotic": {
-      "identifier": "LawlessTwinfireSlapShotgun_BR_CH6S2_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinHammerShotguns_BR_CH7S1_Common": {
-      "identifier": "TwinHammerShotguns_BR_CH7S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinHammerShotguns_BR_CH7S1_Uncommon": {
-      "identifier": "TwinHammerShotguns_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinHammerShotguns_BR_CH7S1_Rare": {
-      "identifier": "TwinHammerShotguns_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinHammerShotguns_BR_CH7S1_Epic": {
-      "identifier": "TwinHammerShotguns_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinHammerShotguns_BR_CH7S1_Legendary": {
-      "identifier": "TwinHammerShotguns_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "BrutusTwinHammerShotguns_BR_CH7S1_Mythic": {
-      "identifier": "BrutusTwinHammerShotguns_BR_CH7S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagAssaultRifle_BR_CH4S4_Common": {
-      "identifier": "TwinMagAssaultRifle_BR_CH4S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagAssaultRifle_BR_CH4S4_Uncommon": {
-      "identifier": "TwinMagAssaultRifle_BR_CH4S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagAssaultRifle_BR_CH4S4_Rare": {
-      "identifier": "TwinMagAssaultRifle_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagAssaultRifle_BR_CH4S4_Epic": {
-      "identifier": "TwinMagAssaultRifle_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagAssaultRifle_BR_CH4S4_Legendary": {
-      "identifier": "TwinMagAssaultRifle_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagSMG_BR_CH4S1_Common": {
-      "identifier": "TwinMagSMG_BR_CH4S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagSMG_BR_CH4S1_Uncommon": {
-      "identifier": "TwinMagSMG_BR_CH4S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagSMG_BR_CH4S1_Rare": {
-      "identifier": "TwinMagSMG_BR_CH4S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagSMG_BR_CH4S1_Epic": {
-      "identifier": "TwinMagSMG_BR_CH4S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwinMagSMG_BR_CH4S1_Legendary": {
-      "identifier": "TwinMagSMG_BR_CH4S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HeistedBlinkMagSMG_BR_CH4S1_Exotic": {
-      "identifier": "HeistedBlinkMagSMG_BR_CH4S1_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwoShotShotgun_BR_CH3S3_Common": {
-      "identifier": "TwoShotShotgun_BR_CH3S3_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwoShotShotgun_BR_CH3S3_Uncommon": {
-      "identifier": "TwoShotShotgun_BR_CH3S3_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwoShotShotgun_BR_CH3S3_Rare": {
-      "identifier": "TwoShotShotgun_BR_CH3S3_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwoShotShotgun_BR_CH3S3_Epic": {
-      "identifier": "TwoShotShotgun_BR_CH3S3_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwoShotShotgun_BR_CH3S3_Legendary": {
-      "identifier": "TwoShotShotgun_BR_CH3S3_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TwoShotShotgun_BR_CH3S3_Mythic": {
-      "identifier": "TwoShotShotgun_BR_CH3S3_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TyphoonBlade_BR_CH6S1_Epic": {
-      "identifier": "TyphoonBlade_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "TyphoonBlade_BR_CH6S1_Mythic": {
-      "identifier": "TyphoonBlade_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "UnstableBow_BR_CH2S6_Exotic": {
-      "identifier": "UnstableBow_BR_CH2S6_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "UnstableFrostfireShotgun_BR_CH6S3_Exotic": {
-      "identifier": "UnstableFrostfireShotgun_BR_CH6S3_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Vector7DMR_BR_CH7S2_Rare": {
-      "identifier": "Vector7DMR_BR_CH7S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Vector7DMR_BR_CH7S2_Epic": {
-      "identifier": "Vector7DMR_BR_CH7S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Vector7DMR_BR_CH7S2_Legendary": {
-      "identifier": "Vector7DMR_BR_CH7S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VeiledPrecisionSMG_BR_CH6S1_Common": {
-      "identifier": "VeiledPrecisionSMG_BR_CH6S1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VeiledPrecisionSMG_BR_CH6S1_Uncommon": {
-      "identifier": "VeiledPrecisionSMG_BR_CH6S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VeiledPrecisionSMG_BR_CH6S1_Rare": {
-      "identifier": "VeiledPrecisionSMG_BR_CH6S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VeiledPrecisionSMG_BR_CH6S1_Epic": {
-      "identifier": "VeiledPrecisionSMG_BR_CH6S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VeiledPrecisionSMG_BR_CH6S1_Legendary": {
-      "identifier": "VeiledPrecisionSMG_BR_CH6S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "NightRoseVeiledPrecisionSMG_BR_CH6S1_Mythic": {
-      "identifier": "NightRoseVeiledPrecisionSMG_BR_CH6S1_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EradicatorShadowPrecisionSMG_BR_CH6S4_Exotic": {
-      "identifier": "EradicatorShadowPrecisionSMG_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VeiledPrecisionSMG_Ballistic_V1_Common": {
-      "identifier": "VeiledPrecisionSMG_Ballistic_V1_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VengefulSniperRifle_BR_CH7S1_Uncommon": {
-      "identifier": "VengefulSniperRifle_BR_CH7S1_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VengefulSniperRifle_BR_CH7S1_Rare": {
-      "identifier": "VengefulSniperRifle_BR_CH7S1_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VengefulSniperRifle_BR_CH7S1_Epic": {
-      "identifier": "VengefulSniperRifle_BR_CH7S1_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "VengefulSniperRifle_BR_CH7S1_Legendary": {
-      "identifier": "VengefulSniperRifle_BR_CH7S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularWarforgedAssaultRifle_BR_CH5S2_Common": {
-      "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularWarforgedAssaultRifle_BR_CH5S2_Uncommon": {
-      "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularWarforgedAssaultRifle_BR_CH5S2_Rare": {
-      "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularWarforgedAssaultRifle_BR_CH5S2_Epic": {
-      "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "ModularWarforgedAssaultRifle_BR_CH5S2_Legendary": {
-      "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "AresModularWarforgedAssaultRifle_BR_CH5S2_Mythic": {
-      "identifier": "AresModularWarforgedAssaultRifle_BR_CH5S2_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WoodStakeShotgun_BR_CH4S4_Rare": {
-      "identifier": "WoodStakeShotgun_BR_CH4S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WoodStakeShotgun_BR_CH4S4_Epic": {
-      "identifier": "WoodStakeShotgun_BR_CH4S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WoodStakeShotgun_BR_CH4S4_Legendary": {
-      "identifier": "WoodStakeShotgun_BR_CH4S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "HighStakesShotgun_BR_CH4S4_Mythic": {
-      "identifier": "HighStakesShotgun_BR_CH4S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WreckerRevolver_BR_CH6S4_Common": {
-      "identifier": "WreckerRevolver_BR_CH6S4_Common",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WreckerRevolver_BR_CH6S4_Uncommon": {
-      "identifier": "WreckerRevolver_BR_CH6S4_Uncommon",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WreckerRevolver_BR_CH6S4_Rare": {
-      "identifier": "WreckerRevolver_BR_CH6S4_Rare",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WreckerRevolver_BR_CH6S4_Epic": {
-      "identifier": "WreckerRevolver_BR_CH6S4_Epic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "WreckerRevolver_BR_CH6S4_Legendary": {
-      "identifier": "WreckerRevolver_BR_CH6S4_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EnhancedWreckerRevolver_BR_CH6S4_Mythic": {
-      "identifier": "EnhancedWreckerRevolver_BR_CH6S4_Mythic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "EradicatorMarksmanWreckerRevolver_BR_CH6S4_Exotic": {
-      "identifier": "EradicatorMarksmanWreckerRevolver_BR_CH6S4_Exotic",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Zapotron_OG_CH1S2_Legendary": {
-      "identifier": "Zapotron_OG_CH1S2_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    },
-    "Zapotron_OG_CH1S1_Legendary": {
-      "identifier": "Zapotron_OG_CH1S1_Legendary",
-      "modulePath": "/Fortnite.com/Weapons",
-      "type": "class",
-      "isPublic": true
-    }
+    "UI": [
+      {
+        "identifier": "UI",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "text_button_base": [
+      {
+        "identifier": "text_button_base",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "button_loud": [
+      {
+        "identifier": "button_loud",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "button_regular": [
+      {
+        "identifier": "button_regular",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "button_quiet": [
+      {
+        "identifier": "button_quiet",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_hud_controller": [
+      {
+        "identifier": "fort_hud_controller",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_all": [
+      {
+        "identifier": "creative_hud_identifier_all",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_build_menu": [
+      {
+        "identifier": "creative_hud_identifier_build_menu",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_crafting_resources": [
+      {
+        "identifier": "creative_hud_identifier_crafting_resources",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_elimination_counter": [
+      {
+        "identifier": "creative_hud_identifier_elimination_counter",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_equipped_item": [
+      {
+        "identifier": "creative_hud_identifier_equipped_item",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_experience_level": [
+      {
+        "identifier": "creative_hud_identifier_experience_level",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_experience_supercharged": [
+      {
+        "identifier": "creative_hud_identifier_experience_supercharged",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_experience_ui": [
+      {
+        "identifier": "creative_hud_identifier_experience_ui",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_health": [
+      {
+        "identifier": "creative_hud_identifier_health",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_health_numbers": [
+      {
+        "identifier": "creative_hud_identifier_health_numbers",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_hud_info": [
+      {
+        "identifier": "creative_hud_identifier_hud_info",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_interaction_prompts": [
+      {
+        "identifier": "creative_hud_identifier_interaction_prompts",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_map_prompts": [
+      {
+        "identifier": "creative_hud_identifier_map_prompts",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_mimimap": [
+      {
+        "identifier": "creative_hud_identifier_mimimap",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_minimap": [
+      {
+        "identifier": "creative_hud_identifier_minimap",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_pickup_stream": [
+      {
+        "identifier": "creative_hud_identifier_pickup_stream",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_player_count": [
+      {
+        "identifier": "creative_hud_identifier_player_count",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_player_inventory": [
+      {
+        "identifier": "creative_hud_identifier_player_inventory",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_round_info": [
+      {
+        "identifier": "creative_hud_identifier_round_info",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_round_timer": [
+      {
+        "identifier": "creative_hud_identifier_round_timer",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_shield_numbers": [
+      {
+        "identifier": "creative_hud_identifier_shield_numbers",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_shileds": [
+      {
+        "identifier": "creative_hud_identifier_shileds",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_shields": [
+      {
+        "identifier": "creative_hud_identifier_shields",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_storm_notifications": [
+      {
+        "identifier": "creative_hud_identifier_storm_notifications",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_storm_timer": [
+      {
+        "identifier": "creative_hud_identifier_storm_timer",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_hud_identifier_team_info": [
+      {
+        "identifier": "creative_hud_identifier_team_info",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_hud_identifier_all": [
+      {
+        "identifier": "player_hud_identifier_all",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_world_resource_wood": [
+      {
+        "identifier": "hud_identifier_world_resource_wood",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_world_resource_stone": [
+      {
+        "identifier": "hud_identifier_world_resource_stone",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_world_resource_metal": [
+      {
+        "identifier": "hud_identifier_world_resource_metal",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_world_resource_permanite": [
+      {
+        "identifier": "hud_identifier_world_resource_permanite",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_world_resource_gold_currency": [
+      {
+        "identifier": "hud_identifier_world_resource_gold_currency",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_world_resource_ingredient": [
+      {
+        "identifier": "hud_identifier_world_resource_ingredient",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_visual_sound_effect_weapons": [
+      {
+        "identifier": "hud_identifier_visual_sound_effect_weapons",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_visual_sound_effect_loot": [
+      {
+        "identifier": "hud_identifier_visual_sound_effect_loot",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_visual_sound_effect_movement": [
+      {
+        "identifier": "hud_identifier_visual_sound_effect_movement",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_visual_sound_effect_vehicle": [
+      {
+        "identifier": "hud_identifier_visual_sound_effect_vehicle",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_visual_sound_effect_healing": [
+      {
+        "identifier": "hud_identifier_visual_sound_effect_healing",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_identifier_visual_sound_effect_all": [
+      {
+        "identifier": "hud_identifier_visual_sound_effect_all",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_element_identifier": [
+      {
+        "identifier": "hud_element_identifier",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "slider_regular": [
+      {
+        "identifier": "slider_regular",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "text_block": [
+      {
+        "identifier": "text_block",
+        "modulePath": "/Fortnite.com/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Input": [
+      {
+        "identifier": "Input",
+        "modulePath": "/Fortnite.com/Input",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Character": [
+      {
+        "identifier": "Character",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "RangedWeaponMapping": [
+      {
+        "identifier": "RangedWeaponMapping",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Reload": [
+      {
+        "identifier": "Reload",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "WeaponPrimary": [
+      {
+        "identifier": "WeaponPrimary",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "WeaponSecondary": [
+      {
+        "identifier": "WeaponSecondary",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "TraversalMapping": [
+      {
+        "identifier": "TraversalMapping",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Crouch": [
+      {
+        "identifier": "Crouch",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Sprint": [
+      {
+        "identifier": "Sprint",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Jump": [
+      {
+        "identifier": "Jump",
+        "modulePath": "/Fortnite.com/Input/Character",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "AI": [
+      {
+        "identifier": "AI",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "equipped_sidekick_component": [
+      {
+        "identifier": "equipped_sidekick_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "spark_mode_component": [
+      {
+        "identifier": "spark_mode_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_action_error_type": [
+      {
+        "identifier": "ai_action_error_type",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "focus_interface": [
+      {
+        "identifier": "focus_interface",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_leashable": [
+      {
+        "identifier": "fort_leashable",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "guard_actions_component": [
+      {
+        "identifier": "guard_actions_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "guard_awareness_component": [
+      {
+        "identifier": "guard_awareness_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "navigation_target": [
+      {
+        "identifier": "navigation_target",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeNavigationTarget": [
+      {
+        "identifier": "MakeNavigationTarget",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "navigation_result": [
+      {
+        "identifier": "navigation_result",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "navigation_action_error_type": [
+      {
+        "identifier": "navigation_action_error_type",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "navigation_action_success_type": [
+      {
+        "identifier": "navigation_action_success_type",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "movement_type": [
+      {
+        "identifier": "movement_type",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "movement_types": [
+      {
+        "identifier": "movement_types",
+        "modulePath": "/Fortnite.com/AI/movement_types",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Walking": [
+      {
+        "identifier": "Walking",
+        "modulePath": "/Fortnite.com/AI/movement_types",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Running": [
+      {
+        "identifier": "Running",
+        "modulePath": "/Fortnite.com/AI/movement_types",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "navigatable": [
+      {
+        "identifier": "navigatable",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "npc_actions_component": [
+      {
+        "identifier": "npc_actions_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "npc_awareness_component": [
+      {
+        "identifier": "npc_awareness_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "npc_behavior": [
+      {
+        "identifier": "npc_behavior",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "guard_alert_level": [
+      {
+        "identifier": "guard_alert_level",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "npc_target_info": [
+      {
+        "identifier": "npc_target_info",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sidekick_mood": [
+      {
+        "identifier": "sidekick_mood",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sidekick_reaction": [
+      {
+        "identifier": "sidekick_reaction",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sidekick_component": [
+      {
+        "identifier": "sidekick_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "npc_sidekick_component": [
+      {
+        "identifier": "npc_sidekick_component",
+        "modulePath": "/Fortnite.com/AI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Devices": [
+      {
+        "identifier": "Devices",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "vfx_spawner_device": [
+      {
+        "identifier": "vfx_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "progress_device_state": [
+      {
+        "identifier": "progress_device_state",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "progress_based_mesh_device": [
+      {
+        "identifier": "progress_based_mesh_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vote_group_device": [
+      {
+        "identifier": "vote_group_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vote_option_interface": [
+      {
+        "identifier": "vote_option_interface",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vote_option_device": [
+      {
+        "identifier": "vote_option_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "bank_vault_interface": [
+      {
+        "identifier": "bank_vault_interface",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "animated_mesh_device": [
+      {
+        "identifier": "animated_mesh_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "automated_turret_device": [
+      {
+        "identifier": "automated_turret_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "carryable_spawner_device": [
+      {
+        "identifier": "carryable_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "reboot_van_device": [
+      {
+        "identifier": "reboot_van_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "reboot_progress_decay_behavior": [
+      {
+        "identifier": "reboot_progress_decay_behavior",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "reboot_card_purchase_options": [
+      {
+        "identifier": "reboot_card_purchase_options",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "reboot_van_interface": [
+      {
+        "identifier": "reboot_van_interface",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "post_process_device": [
+      {
+        "identifier": "post_process_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "analytics_device": [
+      {
+        "identifier": "analytics_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "accolades_device": [
+      {
+        "identifier": "accolades_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "has_spire_functionality": [
+      {
+        "identifier": "has_spire_functionality",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "item_remover_device": [
+      {
+        "identifier": "item_remover_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_marker_device": [
+      {
+        "identifier": "player_marker_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "prop_mover_device": [
+      {
+        "identifier": "prop_mover_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "real_time_clock_device": [
+      {
+        "identifier": "real_time_clock_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "switch_device": [
+      {
+        "identifier": "switch_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "audio_mixer_device": [
+      {
+        "identifier": "audio_mixer_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "audio_player_device": [
+      {
+        "identifier": "audio_player_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "elimination_feed_device": [
+      {
+        "identifier": "elimination_feed_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "firefly_spawner_device": [
+      {
+        "identifier": "firefly_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "end_game_device": [
+      {
+        "identifier": "end_game_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "input_trigger_device": [
+      {
+        "identifier": "input_trigger_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "item_placer_device": [
+      {
+        "identifier": "item_placer_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "changing_booth_device": [
+      {
+        "identifier": "changing_booth_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "race_checkpoint_device": [
+      {
+        "identifier": "race_checkpoint_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "race_manager_device": [
+      {
+        "identifier": "race_manager_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_counter_device": [
+      {
+        "identifier": "player_counter_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "customizable_light_device": [
+      {
+        "identifier": "customizable_light_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "prop_manipulator_device": [
+      {
+        "identifier": "prop_manipulator_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "skydome_device": [
+      {
+        "identifier": "skydome_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vfx_creator_device": [
+      {
+        "identifier": "vfx_creator_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "campfire_device": [
+      {
+        "identifier": "campfire_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sentry_device": [
+      {
+        "identifier": "sentry_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "map_controller_device": [
+      {
+        "identifier": "map_controller_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_controls_device": [
+      {
+        "identifier": "gameplay_controls_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_controls_side_scroller_device": [
+      {
+        "identifier": "gameplay_controls_side_scroller_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_controls_third_person_device": [
+      {
+        "identifier": "gameplay_controls_third_person_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "video_player_device": [
+      {
+        "identifier": "video_player_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "volume_device": [
+      {
+        "identifier": "volume_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_spawner_device": [
+      {
+        "identifier": "player_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_reference_device": [
+      {
+        "identifier": "player_reference_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "crowd_volume_device": [
+      {
+        "identifier": "crowd_volume_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "disguise_device": [
+      {
+        "identifier": "disguise_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_checkpoint_device": [
+      {
+        "identifier": "player_checkpoint_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hiding_prop_device": [
+      {
+        "identifier": "hiding_prop_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "bouncer_device": [
+      {
+        "identifier": "bouncer_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "signal_remote_manager_device": [
+      {
+        "identifier": "signal_remote_manager_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "crash_pad_device": [
+      {
+        "identifier": "crash_pad_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fishing_zone_device": [
+      {
+        "identifier": "fishing_zone_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "barrier_device": [
+      {
+        "identifier": "barrier_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "damage_volume_device": [
+      {
+        "identifier": "damage_volume_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "effect_volume_device": [
+      {
+        "identifier": "effect_volume_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fire_volume_device": [
+      {
+        "identifier": "fire_volume_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "mutator_zone_device": [
+      {
+        "identifier": "mutator_zone_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "skydive_volume_device": [
+      {
+        "identifier": "skydive_volume_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "service_station_device": [
+      {
+        "identifier": "service_station_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "spire_spike_device": [
+      {
+        "identifier": "spire_spike_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "dance_mannequin_device": [
+      {
+        "identifier": "dance_mannequin_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creature_manager_device": [
+      {
+        "identifier": "creature_manager_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creature_placer_device": [
+      {
+        "identifier": "creature_placer_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creature_spawner_device": [
+      {
+        "identifier": "creature_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_patrol_path_device": [
+      {
+        "identifier": "ai_patrol_path_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Patchwork": [
+      {
+        "identifier": "Patchwork",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "patchwork_device": [
+      {
+        "identifier": "patchwork_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "drum_sequencer_device": [
+      {
+        "identifier": "drum_sequencer_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "lfo_modulator_device": [
+      {
+        "identifier": "lfo_modulator_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "cable_splitter_device": [
+      {
+        "identifier": "cable_splitter_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "speaker_device": [
+      {
+        "identifier": "speaker_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "music_manager_device": [
+      {
+        "identifier": "music_manager_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "distortion_effect_device": [
+      {
+        "identifier": "distortion_effect_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "instrument_player_device": [
+      {
+        "identifier": "instrument_player_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "song_sync_device": [
+      {
+        "identifier": "song_sync_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "note_trigger_device": [
+      {
+        "identifier": "note_trigger_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "step_modulator_device": [
+      {
+        "identifier": "step_modulator_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "omega_synthesizer_device": [
+      {
+        "identifier": "omega_synthesizer_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "drum_player_device": [
+      {
+        "identifier": "drum_player_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "value_setter_device": [
+      {
+        "identifier": "value_setter_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "echo_effect_device": [
+      {
+        "identifier": "echo_effect_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "note_progressor_device": [
+      {
+        "identifier": "note_progressor_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "note_sequencer_device": [
+      {
+        "identifier": "note_sequencer_device",
+        "modulePath": "/Fortnite.com/Devices/Patchwork",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "skilled_interaction_device": [
+      {
+        "identifier": "skilled_interaction_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_camera_device": [
+      {
+        "identifier": "gameplay_camera_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_camera_fixed_point_device": [
+      {
+        "identifier": "gameplay_camera_fixed_point_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_camera_first_person_device": [
+      {
+        "identifier": "gameplay_camera_first_person_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_camera_fixed_angle_device": [
+      {
+        "identifier": "gameplay_camera_fixed_angle_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "gameplay_camera_orbit_device": [
+      {
+        "identifier": "gameplay_camera_orbit_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "water_device": [
+      {
+        "identifier": "water_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "character_device": [
+      {
+        "identifier": "character_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "item_shop_device": [
+      {
+        "identifier": "item_shop_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "advanced_storm_beacon_device": [
+      {
+        "identifier": "advanced_storm_beacon_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "advanced_storm_controller_device": [
+      {
+        "identifier": "advanced_storm_controller_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "air_vent_device": [
+      {
+        "identifier": "air_vent_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "attribute_evaluator_device": [
+      {
+        "identifier": "attribute_evaluator_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ball_spawner_device": [
+      {
+        "identifier": "ball_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "base_item_spawner_device": [
+      {
+        "identifier": "base_item_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "basic_storm_controller_device": [
+      {
+        "identifier": "basic_storm_controller_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "beacon_device": [
+      {
+        "identifier": "beacon_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "billboard_device": [
+      {
+        "identifier": "billboard_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "button_device": [
+      {
+        "identifier": "button_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "capture_area_device": [
+      {
+        "identifier": "capture_area_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "capture_item_spawner_device": [
+      {
+        "identifier": "capture_item_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "channel_device": [
+      {
+        "identifier": "channel_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "class_and_team_selector_device": [
+      {
+        "identifier": "class_and_team_selector_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "class_designer_device": [
+      {
+        "identifier": "class_designer_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collectible_object_device": [
+      {
+        "identifier": "collectible_object_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "color_changing_tiles_device": [
+      {
+        "identifier": "color_changing_tiles_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "conditional_button_device": [
+      {
+        "identifier": "conditional_button_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "damage_amplifier_powerup_device": [
+      {
+        "identifier": "damage_amplifier_powerup_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "elimination_manager_device": [
+      {
+        "identifier": "elimination_manager_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "experience_settings_device": [
+      {
+        "identifier": "experience_settings_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "explosive_device": [
+      {
+        "identifier": "explosive_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fuel_pump_device": [
+      {
+        "identifier": "fuel_pump_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "grind_powerup_device": [
+      {
+        "identifier": "grind_powerup_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "holoscreen_device": [
+      {
+        "identifier": "holoscreen_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_message_device": [
+      {
+        "identifier": "hud_message_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "item_granter_device": [
+      {
+        "identifier": "item_granter_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "item_spawner_device": [
+      {
+        "identifier": "item_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "lock_device": [
+      {
+        "identifier": "lock_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "map_indicator_device": [
+      {
+        "identifier": "map_indicator_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "matchmaking_portal_device": [
+      {
+        "identifier": "matchmaking_portal_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "movement_modulator_device": [
+      {
+        "identifier": "movement_modulator_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "objective_device": [
+      {
+        "identifier": "objective_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "perception_trigger_device": [
+      {
+        "identifier": "perception_trigger_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "pinball_bumper_device": [
+      {
+        "identifier": "pinball_bumper_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "pinball_flipper_device": [
+      {
+        "identifier": "pinball_flipper_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "powerup_device": [
+      {
+        "identifier": "powerup_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "prop_o_matic_manager_device": [
+      {
+        "identifier": "prop_o_matic_manager_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "prop_spawner_base_device": [
+      {
+        "identifier": "prop_spawner_base_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "pulse_trigger_device": [
+      {
+        "identifier": "pulse_trigger_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "radio_device": [
+      {
+        "identifier": "radio_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "rng_device": [
+      {
+        "identifier": "rng_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "round_settings_device": [
+      {
+        "identifier": "round_settings_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "score_manager_device": [
+      {
+        "identifier": "score_manager_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "shooting_range_target_device": [
+      {
+        "identifier": "shooting_range_target_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "shooting_range_target_track_device": [
+      {
+        "identifier": "shooting_range_target_track_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "storm_controller_device": [
+      {
+        "identifier": "storm_controller_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "support_a_creator_device": [
+      {
+        "identifier": "support_a_creator_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sword_in_the_stone_device": [
+      {
+        "identifier": "sword_in_the_stone_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "team_settings_and_inventory_device": [
+      {
+        "identifier": "team_settings_and_inventory_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "teleporter_device": [
+      {
+        "identifier": "teleporter_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "timed_objective_device": [
+      {
+        "identifier": "timed_objective_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "timer_device": [
+      {
+        "identifier": "timer_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tracker_device": [
+      {
+        "identifier": "tracker_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "trick_tile_device": [
+      {
+        "identifier": "trick_tile_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "trigger_base_device": [
+      {
+        "identifier": "trigger_base_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "trigger_device": [
+      {
+        "identifier": "trigger_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vending_machine_device": [
+      {
+        "identifier": "vending_machine_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "visual_effect_powerup_device": [
+      {
+        "identifier": "visual_effect_powerup_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "chair_device": [
+      {
+        "identifier": "chair_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hud_controller_device": [
+      {
+        "identifier": "hud_controller_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_mod_box_spawner_device": [
+      {
+        "identifier": "vehicle_mod_box_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_mod_box_settings": [
+      {
+        "identifier": "vehicle_mod_box_settings",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_atk_device": [
+      {
+        "identifier": "vehicle_spawner_atk_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_baller_device": [
+      {
+        "identifier": "vehicle_spawner_baller_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_pickup_truck_device": [
+      {
+        "identifier": "vehicle_spawner_pickup_truck_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_biplane_device": [
+      {
+        "identifier": "vehicle_spawner_biplane_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_boat_device": [
+      {
+        "identifier": "vehicle_spawner_boat_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_cannon_device": [
+      {
+        "identifier": "vehicle_spawner_cannon_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_driftboard_device": [
+      {
+        "identifier": "vehicle_spawner_driftboard_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_big_rig_device": [
+      {
+        "identifier": "vehicle_spawner_big_rig_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_sedan_device": [
+      {
+        "identifier": "vehicle_spawner_sedan_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_quadcrasher_device": [
+      {
+        "identifier": "vehicle_spawner_quadcrasher_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_shopping_cart_device": [
+      {
+        "identifier": "vehicle_spawner_shopping_cart_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_surfboard_device": [
+      {
+        "identifier": "vehicle_spawner_surfboard_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_taxi_device": [
+      {
+        "identifier": "vehicle_spawner_taxi_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_device": [
+      {
+        "identifier": "vehicle_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_sports_car_device": [
+      {
+        "identifier": "vehicle_spawner_sports_car_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "boost_pad_rocketracing_device": [
+      {
+        "identifier": "boost_pad_rocketracing_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_movement_settings_device": [
+      {
+        "identifier": "player_movement_settings_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "class_selector_ui_device": [
+      {
+        "identifier": "class_selector_ui_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "popup_dialog_device": [
+      {
+        "identifier": "popup_dialog_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "physics_boulder_device": [
+      {
+        "identifier": "physics_boulder_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "physics_object_base_device": [
+      {
+        "identifier": "physics_object_base_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "physics_tree_device": [
+      {
+        "identifier": "physics_tree_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "stat_creator_device": [
+      {
+        "identifier": "stat_creator_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "stat_powerup_device": [
+      {
+        "identifier": "stat_powerup_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "health_powerup_device": [
+      {
+        "identifier": "health_powerup_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "spawn_on_enable_behavior": [
+      {
+        "identifier": "spawn_on_enable_behavior",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "roly_poly_spawner_device": [
+      {
+        "identifier": "roly_poly_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "roly_poly": [
+      {
+        "identifier": "roly_poly",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "nitro_hoop_device": [
+      {
+        "identifier": "nitro_hoop_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_octane_device": [
+      {
+        "identifier": "vehicle_spawner_octane_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_hammerhead_choppa_device": [
+      {
+        "identifier": "vehicle_spawner_hammerhead_choppa_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_helicopter_device": [
+      {
+        "identifier": "vehicle_spawner_helicopter_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_heavy_turret_device": [
+      {
+        "identifier": "vehicle_spawner_heavy_turret_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_siege_cannon_device": [
+      {
+        "identifier": "vehicle_spawner_siege_cannon_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_ufo_device": [
+      {
+        "identifier": "vehicle_spawner_ufo_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_tank_device": [
+      {
+        "identifier": "vehicle_spawner_tank_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_armored_battle_bus_device": [
+      {
+        "identifier": "vehicle_spawner_armored_battle_bus_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_dirtbike_device": [
+      {
+        "identifier": "vehicle_spawner_dirtbike_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_nitro_drifter_sedan_device": [
+      {
+        "identifier": "vehicle_spawner_nitro_drifter_sedan_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_sportbike_device": [
+      {
+        "identifier": "vehicle_spawner_sportbike_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_valet_suv_device": [
+      {
+        "identifier": "vehicle_spawner_valet_suv_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "conversation_device": [
+      {
+        "identifier": "conversation_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "earth_sprite_device": [
+      {
+        "identifier": "earth_sprite_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "guard_spawner_accuracy": [
+      {
+        "identifier": "guard_spawner_accuracy",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "guard_spawner_visibility_range_restriction": [
+      {
+        "identifier": "guard_spawner_visibility_range_restriction",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "guard_spawner_device": [
+      {
+        "identifier": "guard_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "nitro_barrel_spawner_device": [
+      {
+        "identifier": "nitro_barrel_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_getaway_device": [
+      {
+        "identifier": "vehicle_spawner_getaway_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "wilds_plant_device": [
+      {
+        "identifier": "wilds_plant_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "grind_rail_device": [
+      {
+        "identifier": "grind_rail_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vine_rail_device": [
+      {
+        "identifier": "vine_rail_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "rift_point_volume_device": [
+      {
+        "identifier": "rift_point_volume_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_drivable_reboot_van_device": [
+      {
+        "identifier": "vehicle_spawner_drivable_reboot_van_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "down_but_not_out_device": [
+      {
+        "identifier": "down_but_not_out_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_war_bus_device": [
+      {
+        "identifier": "vehicle_spawner_war_bus_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_xwing_device": [
+      {
+        "identifier": "vehicle_spawner_xwing_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_tie_fighter_device": [
+      {
+        "identifier": "vehicle_spawner_tie_fighter_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_n1_starfighter_device": [
+      {
+        "identifier": "vehicle_spawner_n1_starfighter_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_armored_assault_tank_device": [
+      {
+        "identifier": "vehicle_spawner_armored_assault_tank_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_turbolaser_device": [
+      {
+        "identifier": "vehicle_spawner_turbolaser_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_df9_device": [
+      {
+        "identifier": "vehicle_spawner_df9_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "healing_cactus_device": [
+      {
+        "identifier": "healing_cactus_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "emp_volume_hazard_rocketracing_device": [
+      {
+        "identifier": "emp_volume_hazard_rocketracing_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "npc_spawner_device": [
+      {
+        "identifier": "npc_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "scout_spire_device": [
+      {
+        "identifier": "scout_spire_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "bank_vault_device": [
+      {
+        "identifier": "bank_vault_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "cinematic_sequence_device": [
+      {
+        "identifier": "cinematic_sequence_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_rocketracing_device": [
+      {
+        "identifier": "vehicle_spawner_rocketracing_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "overlord_spire_device": [
+      {
+        "identifier": "overlord_spire_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "wildlife_spawner_device": [
+      {
+        "identifier": "wildlife_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vehicle_spawner_armored_transport_device": [
+      {
+        "identifier": "vehicle_spawner_armored_transport_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hive_stash_style": [
+      {
+        "identifier": "hive_stash_style",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hive_stash_device": [
+      {
+        "identifier": "hive_stash_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hero_chest_rank": [
+      {
+        "identifier": "hero_chest_rank",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hero_chest_device": [
+      {
+        "identifier": "hero_chest_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "supply_drop_spawner_device": [
+      {
+        "identifier": "supply_drop_spawner_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CreativeAnimation": [
+      {
+        "identifier": "CreativeAnimation",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "cubic_bezier_parameters": [
+      {
+        "identifier": "cubic_bezier_parameters",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InterpolationTypes": [
+      {
+        "identifier": "InterpolationTypes",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Linear": [
+      {
+        "identifier": "Linear",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Ease": [
+      {
+        "identifier": "Ease",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "EaseIn": [
+      {
+        "identifier": "EaseIn",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "EaseOut": [
+      {
+        "identifier": "EaseOut",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "EaseInOut": [
+      {
+        "identifier": "EaseInOut",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "keyframe_delta": [
+      {
+        "identifier": "keyframe_delta",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "animation_mode": [
+      {
+        "identifier": "animation_mode",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "animation_controller_state": [
+      {
+        "identifier": "animation_controller_state",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "await_next_keyframe_result": [
+      {
+        "identifier": "await_next_keyframe_result",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "animation_controller": [
+      {
+        "identifier": "animation_controller",
+        "modulePath": "/Fortnite.com/Devices/CreativeAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_device": [
+      {
+        "identifier": "creative_device",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_device_base": [
+      {
+        "identifier": "creative_device_base",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_device_asset": [
+      {
+        "identifier": "creative_device_asset",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_object": [
+      {
+        "identifier": "creative_object",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_object_interface": [
+      {
+        "identifier": "creative_object_interface",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_prop": [
+      {
+        "identifier": "creative_prop",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "creative_prop_asset": [
+      {
+        "identifier": "creative_prop_asset",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DefaultCreativePropAsset": [
+      {
+        "identifier": "DefaultCreativePropAsset",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "spawn_prop_result": [
+      {
+        "identifier": "spawn_prop_result",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpawnProp": [
+      {
+        "identifier": "SpawnProp",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "device_ai_interaction_result": [
+      {
+        "identifier": "device_ai_interaction_result",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "carryable_spawner_agent_impact_result": [
+      {
+        "identifier": "carryable_spawner_agent_impact_result",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GetCreativeObjectsWithTag": [
+      {
+        "identifier": "GetCreativeObjectsWithTag",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "GetCreativeObjectsWithTags": [
+      {
+        "identifier": "GetCreativeObjectsWithTags",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "move_to_result": [
+      {
+        "identifier": "move_to_result",
+        "modulePath": "/Fortnite.com/Devices",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Marketplace": [
+      {
+        "identifier": "Marketplace",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "offer_interactable_component": [
+      {
+        "identifier": "offer_interactable_component",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "price_vbucks": [
+      {
+        "identifier": "price_vbucks",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakePriceVBucks": [
+      {
+        "identifier": "MakePriceVBucks",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "GetPriceVBucks": [
+      {
+        "identifier": "GetPriceVBucks",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "price_dimension": [
+      {
+        "identifier": "price_dimension",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "entitlement": [
+      {
+        "identifier": "entitlement",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "offer": [
+      {
+        "identifier": "offer",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "entitlement_offer": [
+      {
+        "identifier": "entitlement_offer",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "bundle_offer": [
+      {
+        "identifier": "bundle_offer",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RestrictPaidRandomItems": [
+      {
+        "identifier": "RestrictPaidRandomItems",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "RestrictDirectPromptsToPurchase": [
+      {
+        "identifier": "RestrictDirectPromptsToPurchase",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "BuyOffer": [
+      {
+        "identifier": "BuyOffer",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "GrantEntitlement": [
+      {
+        "identifier": "GrantEntitlement",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "GetPurchasedEntitlements": [
+      {
+        "identifier": "GetPurchasedEntitlements",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "entitlement_change": [
+      {
+        "identifier": "entitlement_change",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GetEntitlementsChangedEvent": [
+      {
+        "identifier": "GetEntitlementsChangedEvent",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ConsumeEntitlement": [
+      {
+        "identifier": "ConsumeEntitlement",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ShowOffersDialog": [
+      {
+        "identifier": "ShowOffersDialog",
+        "modulePath": "/Fortnite.com/Marketplace",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Armory": [
+      {
+        "identifier": "Armory",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "fort_multi_trace_weapon_component": [
+      {
+        "identifier": "fort_multi_trace_weapon_component",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_range_damage_multiplier": [
+      {
+        "identifier": "fort_range_damage_multiplier",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_trace_weapon_component": [
+      {
+        "identifier": "fort_trace_weapon_component",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_weapon_component": [
+      {
+        "identifier": "fort_weapon_component",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "pistol_mesh": [
+      {
+        "identifier": "pistol_mesh",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "pistol_template": [
+      {
+        "identifier": "pistol_template",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "assault_rifle_mesh": [
+      {
+        "identifier": "assault_rifle_mesh",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "assault_rifle_template": [
+      {
+        "identifier": "assault_rifle_template",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sub_machine_gun_mesh": [
+      {
+        "identifier": "sub_machine_gun_mesh",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sub_machine_gun_template": [
+      {
+        "identifier": "sub_machine_gun_template",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "shotgun_mesh": [
+      {
+        "identifier": "shotgun_mesh",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "shotgun_template": [
+      {
+        "identifier": "shotgun_template",
+        "modulePath": "/Fortnite.com/Armory",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Itemization": [
+      {
+        "identifier": "Itemization",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_component": [
+      {
+        "identifier": "fort_inventory_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_weapon_hotbar_component": [
+      {
+        "identifier": "fort_inventory_weapon_hotbar_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_build_hotbar_component": [
+      {
+        "identifier": "fort_inventory_build_hotbar_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_harvest_tool_component": [
+      {
+        "identifier": "fort_inventory_harvest_tool_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_trap_component": [
+      {
+        "identifier": "fort_inventory_trap_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_resources_component": [
+      {
+        "identifier": "fort_inventory_resources_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_ammo_component": [
+      {
+        "identifier": "fort_inventory_ammo_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_inventory_currencies_component": [
+      {
+        "identifier": "fort_inventory_currencies_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FortniteItemCategories": [
+      {
+        "identifier": "FortniteItemCategories",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "WorldItem": [
+      {
+        "identifier": "WorldItem",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Currency": [
+      {
+        "identifier": "Currency",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Trap": [
+      {
+        "identifier": "Trap",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Ammo": [
+      {
+        "identifier": "Ammo",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Resource": [
+      {
+        "identifier": "Resource",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "WeaponMelee": [
+      {
+        "identifier": "WeaponMelee",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "WeaponRanged": [
+      {
+        "identifier": "WeaponRanged",
+        "modulePath": "/Fortnite.com/Itemization/FortniteItemCategories",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "fort_item_pickup_interactable_component": [
+      {
+        "identifier": "fort_item_pickup_interactable_component",
+        "modulePath": "/Fortnite.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FortniteRarities": [
+      {
+        "identifier": "FortniteRarities",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Common": [
+      {
+        "identifier": "Common",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Uncommon": [
+      {
+        "identifier": "Uncommon",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Rare": [
+      {
+        "identifier": "Rare",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Epic": [
+      {
+        "identifier": "Epic",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Legendary": [
+      {
+        "identifier": "Legendary",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Mythic": [
+      {
+        "identifier": "Mythic",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Exotic": [
+      {
+        "identifier": "Exotic",
+        "modulePath": "/Fortnite.com/Itemization/FortniteRarities",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Animation": [
+      {
+        "identifier": "Animation",
+        "modulePath": "/Fortnite.com/Animation",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "PlayAnimation": [
+      {
+        "identifier": "PlayAnimation",
+        "modulePath": "/Fortnite.com/Animation/PlayAnimation",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "play_animation_result": [
+      {
+        "identifier": "play_animation_result",
+        "modulePath": "/Fortnite.com/Animation/PlayAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "play_animation_controller": [
+      {
+        "identifier": "play_animation_controller",
+        "modulePath": "/Fortnite.com/Animation/PlayAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "play_animation_instance": [
+      {
+        "identifier": "play_animation_instance",
+        "modulePath": "/Fortnite.com/Animation/PlayAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "play_animation_state": [
+      {
+        "identifier": "play_animation_state",
+        "modulePath": "/Fortnite.com/Animation/PlayAnimation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Assets": [
+      {
+        "identifier": "Assets",
+        "modulePath": "/Fortnite.com/Assets",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "npc_character_definition": [
+      {
+        "identifier": "npc_character_definition",
+        "modulePath": "/Fortnite.com/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Characters": [
+      {
+        "identifier": "Characters",
+        "modulePath": "/Fortnite.com/Characters",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "fort_character": [
+      {
+        "identifier": "fort_character",
+        "modulePath": "/Fortnite.com/Characters",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "stasis_args": [
+      {
+        "identifier": "stasis_args",
+        "modulePath": "/Fortnite.com/Characters",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FortPlayerUtilities": [
+      {
+        "identifier": "FortPlayerUtilities",
+        "modulePath": "/Fortnite.com/FortPlayerUtilities",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Game": [
+      {
+        "identifier": "Game",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "elimination_result": [
+      {
+        "identifier": "elimination_result",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_round_manager": [
+      {
+        "identifier": "fort_round_manager",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "positional": [
+      {
+        "identifier": "positional",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "healthful": [
+      {
+        "identifier": "healthful",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "shieldable": [
+      {
+        "identifier": "shieldable",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "damageable": [
+      {
+        "identifier": "damageable",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "healable": [
+      {
+        "identifier": "healable",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "damage_args": [
+      {
+        "identifier": "damage_args",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "damage_result": [
+      {
+        "identifier": "damage_result",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "healing_args": [
+      {
+        "identifier": "healing_args",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "healing_result": [
+      {
+        "identifier": "healing_result",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "game_action_instigator": [
+      {
+        "identifier": "game_action_instigator",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "game_action_causer": [
+      {
+        "identifier": "game_action_causer",
+        "modulePath": "/Fortnite.com/Game",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Playspaces": [
+      {
+        "identifier": "Playspaces",
+        "modulePath": "/Fortnite.com/Playspaces",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "fort_playspace": [
+      {
+        "identifier": "fort_playspace",
+        "modulePath": "/Fortnite.com/Playspaces",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Teams": [
+      {
+        "identifier": "Teams",
+        "modulePath": "/Fortnite.com/Teams",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "team_attitude": [
+      {
+        "identifier": "team_attitude",
+        "modulePath": "/Fortnite.com/Teams",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_team_collection": [
+      {
+        "identifier": "fort_team_collection",
+        "modulePath": "/Fortnite.com/Teams",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Vehicles": [
+      {
+        "identifier": "Vehicles",
+        "modulePath": "/Fortnite.com/Vehicles",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "fort_vehicle": [
+      {
+        "identifier": "fort_vehicle",
+        "modulePath": "/Fortnite.com/Vehicles",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fort_vehicle_seat": [
+      {
+        "identifier": "fort_vehicle_seat",
+        "modulePath": "/Fortnite.com/Vehicles",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Items": [
+      {
+        "identifier": "Items",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Acorn_Creative_V1_Common": [
+      {
+        "identifier": "Acorn_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ActivePowercell_Creative_V1_Epic": [
+      {
+        "identifier": "ActivePowercell_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AdhesiveResin_Creative_V1_Uncommon": [
+      {
+        "identifier": "AdhesiveResin_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AirStrike_BR_CH1S9_Legendary": [
+      {
+        "identifier": "AirStrike_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AlienNanites_BR_CH2S7_Common": [
+      {
+        "identifier": "AlienNanites_BR_CH2S7_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AmmoArrows_BR_CH2S6_Common": [
+      {
+        "identifier": "AmmoArrows_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AmmoHeavyBullets_BR_PreSeason_Common": [
+      {
+        "identifier": "AmmoHeavyBullets_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AmmoLightBullets_BR_PreSeason_Common": [
+      {
+        "identifier": "AmmoLightBullets_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AmmoMediumBullets_BR_PreSeason_Common": [
+      {
+        "identifier": "AmmoMediumBullets_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AmmoRockets_BR_PreSeason_Common": [
+      {
+        "identifier": "AmmoRockets_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AmmoShells_BR_PreSeason_Common": [
+      {
+        "identifier": "AmmoShells_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AnimalBones_BR_CH2S6_Common": [
+      {
+        "identifier": "AnimalBones_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Apple_BR_CH1S4_Common": [
+      {
+        "identifier": "Apple_BR_CH1S4_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ArmoredWall_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "ArmoredWall_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AuthorityKeycard_BR_CH2S3_Legendary": [
+      {
+        "identifier": "AuthorityKeycard_BR_CH2S3_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Bacon_Creative_V1_Common": [
+      {
+        "identifier": "Bacon_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Balloons_BR_CH1S6_Rare": [
+      {
+        "identifier": "Balloons_BR_CH1S6_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Banana_BR_CH1S8_Common": [
+      {
+        "identifier": "Banana_BR_CH1S8_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BananaOfTheGods_BR_CH5S2_Legendary": [
+      {
+        "identifier": "BananaOfTheGods_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Bandage_BR_PreSeason_Common": [
+      {
+        "identifier": "Bandage_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Bandage_BR_CH5S1_Common": [
+      {
+        "identifier": "Bandage_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BandageBazooka_BR_CH2S1_Epic": [
+      {
+        "identifier": "BandageBazooka_BR_CH2S1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Batteries_Creative_V1_Common": [
+      {
+        "identifier": "Batteries_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BigBushBomb_BR_CH4S1_Rare": [
+      {
+        "identifier": "BigBushBomb_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BirthdayPresents_BR_CH1S9_Legendary": [
+      {
+        "identifier": "BirthdayPresents_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BlastPowder_Creative_V1_Uncommon": [
+      {
+        "identifier": "BlastPowder_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BlizzardGrenade_BR_CH6S1_Rare": [
+      {
+        "identifier": "BlizzardGrenade_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoarHair_Creative_V1_Uncommon": [
+      {
+        "identifier": "BoarHair_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoogieBomb_BR_CH1S2_Rare": [
+      {
+        "identifier": "BoogieBomb_BR_CH1S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoomBox_BR_CH1S7_Epic": [
+      {
+        "identifier": "BoomBox_BR_CH1S7_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BottleRockets_BR_CH1S7_Uncommon": [
+      {
+        "identifier": "BottleRockets_BR_CH1S7_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Bouncer_BR_CH1S4_Rare": [
+      {
+        "identifier": "Bouncer_BR_CH1S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BrickABunker_BR_CH7S2_Common": [
+      {
+        "identifier": "BrickABunker_BR_CH7S2_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BubbleShield_Ballistic_V1_Common": [
+      {
+        "identifier": "BubbleShield_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Bush_BR_CH1S1_Legendary": [
+      {
+        "identifier": "Bush_BR_CH1S1_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BusinessTurret_BR_CH4S4_Epic": [
+      {
+        "identifier": "BusinessTurret_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Butter_Creative_V1_Uncommon": [
+      {
+        "identifier": "Butter_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Cabbage_BR_CH2S3_Common": [
+      {
+        "identifier": "Cabbage_BR_CH2S3_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CandyCorn_BR_CH2S4_Common": [
+      {
+        "identifier": "CandyCorn_BR_CH2S4_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CattyCornerKeycard_BR_CH2S3_Legendary": [
+      {
+        "identifier": "CattyCornerKeycard_BR_CH2S3_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CeilingZapper_OG_CH1S1_Rare": [
+      {
+        "identifier": "CeilingZapper_OG_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CeilingZapper_BR_CH4MS1_Rare": [
+      {
+        "identifier": "CeilingZapper_BR_CH4MS1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CeilingZapper_BR_CH1S1_Rare": [
+      {
+        "identifier": "CeilingZapper_BR_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChiliChugSplash_BR_CH2S8_Exotic": [
+      {
+        "identifier": "ChiliChugSplash_BR_CH2S8_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Chiller_BR_CH1S6_Common": [
+      {
+        "identifier": "Chiller_BR_CH1S6_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChillerGrenade_BR_CH1S7_Common": [
+      {
+        "identifier": "ChillerGrenade_BR_CH1S7_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChugCannon_BR_CH2S5_Exotic": [
+      {
+        "identifier": "ChugCannon_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChugJug_BR_CH1S2_Legendary": [
+      {
+        "identifier": "ChugJug_BR_CH1S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OceansBottomlessChugJug_BR_CH2S3_Mythic": [
+      {
+        "identifier": "OceansBottomlessChugJug_BR_CH2S3_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChugJug_BR_CH6S2_Legendary": [
+      {
+        "identifier": "ChugJug_BR_CH6S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChugSplash_BR_CH1S9_Rare": [
+      {
+        "identifier": "ChugSplash_BR_CH1S9_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Clinger_BR_CH1S3_Uncommon": [
+      {
+        "identifier": "Clinger_BR_CH1S3_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CloakGauntlets_BR_CH4S3_Epic": [
+      {
+        "identifier": "CloakGauntlets_BR_CH4S3_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WildguardReliksCloakGauntlets_BR_CH4S3_Mythic": [
+      {
+        "identifier": "WildguardReliksCloakGauntlets_BR_CH4S3_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ClusterClinger_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ClusterClinger_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Coconut_BR_CH1S8_Common": [
+      {
+        "identifier": "Coconut_BR_CH1S8_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CommandCavernKeycard_BR_CH3S2_Legendary": [
+      {
+        "identifier": "CommandCavernKeycard_BR_CH3S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Corn_BR_CH2S3_Common": [
+      {
+        "identifier": "Corn_BR_CH2S3_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CozyCampfire_BR_CH1S2_Rare": [
+      {
+        "identifier": "CozyCampfire_BR_CH1S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CrashPad_BR_CH2S2_Rare": [
+      {
+        "identifier": "CrashPad_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CrashPadJr_BR_CH4S4_Uncommon": [
+      {
+        "identifier": "CrashPadJr_BR_CH4S4_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CreepinCardboard_BR_CH2S2_Uncommon": [
+      {
+        "identifier": "CreepinCardboard_BR_CH2S2_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "QuartzCrystal_Creative_V1_Uncommon": [
+      {
+        "identifier": "QuartzCrystal_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RainbowCrystal_Creative_V1_Epic": [
+      {
+        "identifier": "RainbowCrystal_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShadowshardCrystal_Creative_V1_Epic": [
+      {
+        "identifier": "ShadowshardCrystal_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SunbeamCrystal_Creative_V1_Epic": [
+      {
+        "identifier": "SunbeamCrystal_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CuddleFish_BR_CH2S6_Rare": [
+      {
+        "identifier": "CuddleFish_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DamageTrap_BR_CH1S2_Uncommon": [
+      {
+        "identifier": "DamageTrap_BR_CH1S2_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Decoy_BR_CH2S2_Rare": [
+      {
+        "identifier": "Decoy_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DialADrop_BR_CH3S4_Epic": [
+      {
+        "identifier": "DialADrop_BR_CH3S4_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Diamond_Creative_V1_Epic": [
+      {
+        "identifier": "Diamond_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WhiteDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "WhiteDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BrownDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "BrownDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GreenDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "GreenDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WhiteSpeckledDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "WhiteSpeckledDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BrownSpeckledDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "BrownSpeckledDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BlueSpeckledDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "BlueSpeckledDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WhiteMarbledDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "WhiteMarbledDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PinkMarbledDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "PinkMarbledDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GreenMarbledDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "GreenMarbledDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BlueFleckedDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "BlueFleckedDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedFleckedDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "RedFleckedDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GreenFleckedDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "GreenFleckedDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WhiteShimmeringDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "WhiteShimmeringDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BlueShimmeringDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "BlueShimmeringDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedShimmeringDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "RedShimmeringDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrayEruptionDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "GrayEruptionDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedEruptionDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "RedEruptionDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "YellowEruptionDinoEgg_Creative_V1_Rare": [
+      {
+        "identifier": "YellowEruptionDinoEgg_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DuctTape_Creative_V1_Uncommon": [
+      {
+        "identifier": "DuctTape_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Dynamite_BR_CH1S6_Uncommon": [
+      {
+        "identifier": "Dynamite_BR_CH1S6_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedHarpoonGun_BR_CH7S2_Mythic": [
+      {
+        "identifier": "EnhancedHarpoonGun_BR_CH7S2_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EstateVaultKeycard_BR_CH4S4_Legendary": [
+      {
+        "identifier": "EstateVaultKeycard_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExoticSlapBerryFizz_BR_CH6S4_Exotic": [
+      {
+        "identifier": "ExoticSlapBerryFizz_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FalconScout_BR_CH4S1_Epic": [
+      {
+        "identifier": "FalconScout_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FibrousHerbs_Creative_V1_Common": [
+      {
+        "identifier": "FibrousHerbs_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FireflyJar_BR_CH2S3_Rare": [
+      {
+        "identifier": "FireflyJar_BR_CH2S3_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FireGrenade_Ballistic_V1_Common": [
+      {
+        "identifier": "FireGrenade_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FireTrap_BR_CH2S4_Uncommon": [
+      {
+        "identifier": "FireTrap_BR_CH2S4_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CreativeFishingRod_Creative_V1_Common": [
+      {
+        "identifier": "CreativeFishingRod_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CreativeProFishingRod_Creative_V1_Rare": [
+      {
+        "identifier": "CreativeProFishingRod_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Flag_Creative_V1_Rare": [
+      {
+        "identifier": "Flag_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Flashbang_Ballistic_V1_Common": [
+      {
+        "identifier": "Flashbang_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Flashlight_Creative_V1_Rare": [
+      {
+        "identifier": "Flashlight_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Flopper_BR_CH2S1_Uncommon": [
+      {
+        "identifier": "Flopper_BR_CH2S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlowBerry_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "FlowBerry_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlowBerryFizz_BR_CH5S1_Rare": [
+      {
+        "identifier": "FlowBerryFizz_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlowBerryMistGrenade_BR_CH7S1_Epic": [
+      {
+        "identifier": "FlowBerryMistGrenade_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlowerPetals_Creative_V1_Common": [
+      {
+        "identifier": "FlowerPetals_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FortillaKeycard_BR_CH2S3_Legendary": [
+      {
+        "identifier": "FortillaKeycard_BR_CH2S3_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FragGrenade_Ballistic_V1_Common": [
+      {
+        "identifier": "FragGrenade_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FriendZoneBubble_BR_CH7S3_Exotic": [
+      {
+        "identifier": "FriendZoneBubble_BR_CH7S3_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FrozenIcecreamCone_BR_CH3S3_Common": [
+      {
+        "identifier": "FrozenIcecreamCone_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GasCan_BR_CH2S3_Common": [
+      {
+        "identifier": "GasCan_BR_CH2S3_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Gliders_BR_CH1S7_Rare": [
+      {
+        "identifier": "Gliders_BR_CH1S7_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Gold_BR_CH2S1_Common": [
+      {
+        "identifier": "Gold_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GoldSplash_BR_CH6S2_Rare": [
+      {
+        "identifier": "GoldSplash_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrappleGlider_BR_CH3S4_Epic": [
+      {
+        "identifier": "GrappleGlider_BR_CH3S4_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrappleGlove_BR_CH3S3_Epic": [
+      {
+        "identifier": "GrappleGlove_BR_CH3S3_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Grappler_BR_CH1S5_Epic": [
+      {
+        "identifier": "Grappler_BR_CH1S5_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Grenade_BR_PreSeason_Common": [
+      {
+        "identifier": "Grenade_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Grenade_BR_CH7S1_Common": [
+      {
+        "identifier": "Grenade_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Grenade_OG_CH1S1_Common": [
+      {
+        "identifier": "Grenade_OG_CH1S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Grenade_BR_CH4MS1_Common": [
+      {
+        "identifier": "Grenade_BR_CH4MS1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrottoKeycard_BR_CH2S2_Legendary": [
+      {
+        "identifier": "GrottoKeycard_BR_CH2S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Grub_Creative_V1_Common": [
+      {
+        "identifier": "Grub_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GuardianShield_BR_CH4S1_Rare": [
+      {
+        "identifier": "GuardianShield_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GuzzleJuice_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "GuzzleJuice_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GuzzlingIcecreamCone_BR_CH3S3_Uncommon": [
+      {
+        "identifier": "GuzzlingIcecreamCone_BR_CH3S3_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HarpoonGun_BR_CH2S1_Rare": [
+      {
+        "identifier": "HarpoonGun_BR_CH2S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HealEgg_BR_CH4S2_Uncommon": [
+      {
+        "identifier": "HealEgg_BR_CH4S2_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Herb_Creative_V1_Common": [
+      {
+        "identifier": "Herb_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HolidayPresents_BR_CH2S5_Legendary": [
+      {
+        "identifier": "HolidayPresents_BR_CH2S5_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Honey_Creative_V1_Rare": [
+      {
+        "identifier": "Honey_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HopDrop_BR_CH2S4_Common": [
+      {
+        "identifier": "HopDrop_BR_CH2S4_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HopEgg_BR_CH4S2_Rare": [
+      {
+        "identifier": "HopEgg_BR_CH4S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HopFlopper_BR_CH2S4_Epic": [
+      {
+        "identifier": "HopFlopper_BR_CH2S4_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IcecreamCone_BR_CH3S3_Common": [
+      {
+        "identifier": "IcecreamCone_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IcyGrappler_BR_CH2S8_Exotic": [
+      {
+        "identifier": "IcyGrappler_BR_CH2S8_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ImpulseGrenade_BR_CH1S2_Rare": [
+      {
+        "identifier": "ImpulseGrenade_BR_CH1S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ImpulseGrenade_Ballistic_V1_Common": [
+      {
+        "identifier": "ImpulseGrenade_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InflateABull_BR_CH2S7_Rare": [
+      {
+        "identifier": "InflateABull_BR_CH2S7_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "JellyBean_BR_CH2S4_Common": [
+      {
+        "identifier": "JellyBean_BR_CH2S4_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Jellyfish_BR_CH2S4_Rare": [
+      {
+        "identifier": "Jellyfish_BR_CH2S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Jetpack_BR_CH1S4_Legendary": [
+      {
+        "identifier": "Jetpack_BR_CH1S4_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Jewel_Creative_V1_Rare": [
+      {
+        "identifier": "Jewel_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "JulesGliderGun_BR_CH2S3_Mythic": [
+      {
+        "identifier": "JulesGliderGun_BR_CH2S3_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "JunkRift_BR_CH1SX_Epic": [
+      {
+        "identifier": "JunkRift_BR_CH1SX_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Key_BR_CH3S4_Rare": [
+      {
+        "identifier": "Key_BR_CH3S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LaunchPad_BR_CH3S4_Rare": [
+      {
+        "identifier": "LaunchPad_BR_CH3S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuperLaunchPad_Creative_V1_Epic": [
+      {
+        "identifier": "SuperLaunchPad_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessRiftLauncher_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessRiftLauncher_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessSlapCannon_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessSlapCannon_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessSlapJug_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessSlapJug_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LemonLime_Creative_V1_Common": [
+      {
+        "identifier": "LemonLime_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LilWhipsSpecialServe_BR_CH3S3_Legendary": [
+      {
+        "identifier": "LilWhipsSpecialServe_BR_CH3S3_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LimitlessSevenSliders_BR_CH7S3_Mythic": [
+      {
+        "identifier": "LimitlessSevenSliders_BR_CH7S3_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LumpOfCoal_BR_CH2S1_Common": [
+      {
+        "identifier": "LumpOfCoal_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MapleSyrup_Creative_V1_Uncommon": [
+      {
+        "identifier": "MapleSyrup_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Meat_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "Meat_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalParts_BR_CH2S6_Common": [
+      {
+        "identifier": "MechanicalParts_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RustyMechanicalParts_Creative_V1_Rare": [
+      {
+        "identifier": "RustyMechanicalParts_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SimpleMechanicalParts_Creative_V1_Rare": [
+      {
+        "identifier": "SimpleMechanicalParts_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SturdyMechanicalParts_Creative_V1_Rare": [
+      {
+        "identifier": "SturdyMechanicalParts_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SleekMechanicalParts_Creative_V1_Rare": [
+      {
+        "identifier": "SleekMechanicalParts_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EfficientMechanicalParts_Creative_V1_Rare": [
+      {
+        "identifier": "EfficientMechanicalParts_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VindertechMechanicalParts_Creative_V1_Rare": [
+      {
+        "identifier": "VindertechMechanicalParts_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MedMist_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "MedMist_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MedMistSmokeGrenade_BR_CH6S2_Rare": [
+      {
+        "identifier": "MedMistSmokeGrenade_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MedKit_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "MedKit_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MedKit_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "MedKit_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Metal_BR_PreSeason_Common": [
+      {
+        "identifier": "Metal_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MidasFlopper_BR_CH2S4_Legendary": [
+      {
+        "identifier": "MidasFlopper_BR_CH2S4_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Milk_Creative_V1_Uncommon": [
+      {
+        "identifier": "Milk_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RoughMineralPowder_Creative_V1_Common": [
+      {
+        "identifier": "RoughMineralPowder_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SimpleMineralPowder_Creative_V1_Common": [
+      {
+        "identifier": "SimpleMineralPowder_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FineGrainMineralPowder_Creative_V1_Common": [
+      {
+        "identifier": "FineGrainMineralPowder_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CharBlackMineralPowder_Creative_V1_Common": [
+      {
+        "identifier": "CharBlackMineralPowder_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OxidizedMineralPowder_Creative_V1_Common": [
+      {
+        "identifier": "OxidizedMineralPowder_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MonsterParts_BR_CH2S8_Common": [
+      {
+        "identifier": "MonsterParts_BR_CH2S8_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BlueMushroom_Creative_V1_Uncommon": [
+      {
+        "identifier": "BlueMushroom_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PinkMushroom_Creative_V1_Uncommon": [
+      {
+        "identifier": "PinkMushroom_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedMushroom_Creative_V1_Uncommon": [
+      {
+        "identifier": "RedMushroom_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WhiteMushroom_Creative_V1_Uncommon": [
+      {
+        "identifier": "WhiteMushroom_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "YellowMushroom_Creative_V1_Uncommon": [
+      {
+        "identifier": "YellowMushroom_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MystForm_BR_CH6S3_Epic": [
+      {
+        "identifier": "MystForm_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MythicGoldfish_BR_CH2S1_Mythic": [
+      {
+        "identifier": "MythicGoldfish_BR_CH2S1_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NitroSplash_BR_CH5S3_Rare": [
+      {
+        "identifier": "NitroSplash_BR_CH5S3_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OrangePaintGrenade_BR_CH2S2_Rare": [
+      {
+        "identifier": "OrangePaintGrenade_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RoughOre_Creative_V1_Common": [
+      {
+        "identifier": "RoughOre_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Coal_Creative_V1_Uncommon": [
+      {
+        "identifier": "Coal_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BrightcoreOre_Creative_V1_Epic": [
+      {
+        "identifier": "BrightcoreOre_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CopperOre_Creative_V1_Epic": [
+      {
+        "identifier": "CopperOre_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MalachiteOre_Creative_V1_Epic": [
+      {
+        "identifier": "MalachiteOre_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ObsidianOre_Creative_V1_Epic": [
+      {
+        "identifier": "ObsidianOre_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SilverOre_Creative_V1_Epic": [
+      {
+        "identifier": "SilverOre_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpectroliteOre_Creative_V1_Epic": [
+      {
+        "identifier": "SpectroliteOre_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Overdrive_Ballistic_V1_Common": [
+      {
+        "identifier": "Overdrive_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OverdriveGrenade_BR_CH7S2_Rare": [
+      {
+        "identifier": "OverdriveGrenade_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PatchworkTool_Creative_V1_Rare": [
+      {
+        "identifier": "PatchworkTool_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pepper_BR_CH1S8_Common": [
+      {
+        "identifier": "Pepper_BR_CH1S8_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PepperMint_BR_CH2S4_Common": [
+      {
+        "identifier": "PepperMint_BR_CH2S4_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PizzaParty_BR_CH3S1_Epic": [
+      {
+        "identifier": "PizzaParty_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PizzaSlice_BR_CH3S1_Rare": [
+      {
+        "identifier": "PizzaSlice_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Planks_Creative_V1_Common": [
+      {
+        "identifier": "Planks_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PoisonDartTrap_BR_CH1S8_Uncommon": [
+      {
+        "identifier": "PoisonDartTrap_BR_CH1S8_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PortABunker_BR_CH3S4_Uncommon": [
+      {
+        "identifier": "PortABunker_BR_CH3S4_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PortACover_BR_CH6S2_Rare": [
+      {
+        "identifier": "PortACover_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PortAFort_BR_CH1S3_Rare": [
+      {
+        "identifier": "PortAFort_BR_CH1S3_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PortAFortress_BR_CH1S5_Legendary": [
+      {
+        "identifier": "PortAFortress_BR_CH1S5_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrecisionAirStrike_BR_CH6S4_Legendary": [
+      {
+        "identifier": "PrecisionAirStrike_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Presents_BR_CH1S7_Legendary": [
+      {
+        "identifier": "Presents_BR_CH1S7_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PropOMatic_Creative_V1_Rare": [
+      {
+        "identifier": "PropOMatic_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ProximityMine_BR_CH2S2_Rare": [
+      {
+        "identifier": "ProximityMine_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ProximityMine_Ballistic_V1_Common": [
+      {
+        "identifier": "ProximityMine_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PulseScanner_BR_CH6S2_Epic": [
+      {
+        "identifier": "PulseScanner_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pumpkin_Creative_V1_Common": [
+      {
+        "identifier": "Pumpkin_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PurplePaintGrenade_BR_CH2S2_Rare": [
+      {
+        "identifier": "PurplePaintGrenade_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RaptorEye_Creative_V1_Rare": [
+      {
+        "identifier": "RaptorEye_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReconGrenade_Ballistic_V1_Common": [
+      {
+        "identifier": "ReconGrenade_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RemoteExplosives_BR_CH1S3_Epic": [
+      {
+        "identifier": "RemoteExplosives_BR_CH1S3_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RepairTorch_BR_CH3S2_Rare": [
+      {
+        "identifier": "RepairTorch_BR_CH3S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RiftToGo_BR_CH1S5_Epic": [
+      {
+        "identifier": "RiftToGo_BR_CH1S5_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RiftFish_BR_CH2S5_Epic": [
+      {
+        "identifier": "RiftFish_BR_CH2S5_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RiftPointDevice_Ballistic_V1_Exotic": [
+      {
+        "identifier": "RiftPointDevice_Ballistic_V1_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RigKeycard_BR_CH2S2_Legendary": [
+      {
+        "identifier": "RigKeycard_BR_CH2S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RoastedChicken_Creative_V1_Uncommon": [
+      {
+        "identifier": "RoastedChicken_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RotatingGizmo_Creative_V1_Rare": [
+      {
+        "identifier": "RotatingGizmo_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RustyCan_BR_CH2S1_Common": [
+      {
+        "identifier": "RustyCan_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SevenSliders_BR_CH7S3_Epic": [
+      {
+        "identifier": "SevenSliders_BR_CH7S3_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShadowBomb_BR_CH1S8_Uncommon": [
+      {
+        "identifier": "ShadowBomb_BR_CH1S8_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShadowFlopper_BR_CH2S8_Rare": [
+      {
+        "identifier": "ShadowFlopper_BR_CH2S8_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SharkKeycard_BR_CH2S2_Legendary": [
+      {
+        "identifier": "SharkKeycard_BR_CH2S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SharkTooth_Creative_V1_Rare": [
+      {
+        "identifier": "SharkTooth_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldBreakerEMP_BR_CH4S4_Rare": [
+      {
+        "identifier": "ShieldBreakerEMP_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldBubble_BR_CH1SX_Rare": [
+      {
+        "identifier": "ShieldBubble_BR_CH1SX_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldBubbleJr_BR_CH5S2_Uncommon": [
+      {
+        "identifier": "ShieldBubbleJr_BR_CH5S2_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldFish_BR_CH2S4_Rare": [
+      {
+        "identifier": "ShieldFish_BR_CH2S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldKeg_BR_CH3S1_Rare": [
+      {
+        "identifier": "ShieldKeg_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldMushroom_BR_CH1S4_Common": [
+      {
+        "identifier": "ShieldMushroom_BR_CH1S4_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldPotion_BR_PreSeason_Rare": [
+      {
+        "identifier": "ShieldPotion_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShieldPotion_BR_CH5S1_Rare": [
+      {
+        "identifier": "ShieldPotion_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShockRock_BR_CH7S3_Epic": [
+      {
+        "identifier": "ShockRock_BR_CH7S3_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShockwaveGrenade_BR_CH1S5_Epic": [
+      {
+        "identifier": "ShockwaveGrenade_BR_CH1S5_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Shove_Creative_V1_Common": [
+      {
+        "identifier": "Shove_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SignalRemote_Creative_V1_Common": [
+      {
+        "identifier": "SignalRemote_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SignalRemoteA_Creative_V1_Uncommon": [
+      {
+        "identifier": "SignalRemoteA_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SignalRemoteB_Creative_V1_Rare": [
+      {
+        "identifier": "SignalRemoteB_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SignalRemoteC_Creative_V1_Epic": [
+      {
+        "identifier": "SignalRemoteC_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SignalRemoteD_Creative_V1_Legendary": [
+      {
+        "identifier": "SignalRemoteD_Creative_V1_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SkyesGrappler_BR_CH2S2_Mythic": [
+      {
+        "identifier": "SkyesGrappler_BR_CH2S2_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SkylineDeployer_BR_CH7S2_Rare": [
+      {
+        "identifier": "SkylineDeployer_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlapBerry_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "SlapBerry_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlapJuice_BR_CH4S1_Rare": [
+      {
+        "identifier": "SlapJuice_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlapperoniPizza_BR_CH7S2_Legendary": [
+      {
+        "identifier": "SlapperoniPizza_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlapperoniSlice_BR_CH7S2_Legendary": [
+      {
+        "identifier": "SlapperoniSlice_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlapSplash_BR_CH4S3_Rare": [
+      {
+        "identifier": "SlapSplash_BR_CH4S3_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuperSlapSplash_BR_CH4S3_Exotic": [
+      {
+        "identifier": "SuperSlapSplash_BR_CH4S3_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Slurpfish_BR_CH2S1_Epic": [
+      {
+        "identifier": "Slurpfish_BR_CH2S1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlurpJuice_BR_CH1S1_Legendary": [
+      {
+        "identifier": "SlurpJuice_BR_CH1S1_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlurpJuice_BR_CH6S4_Epic": [
+      {
+        "identifier": "SlurpJuice_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlurpMushroom_BR_CH2S1_Common": [
+      {
+        "identifier": "SlurpMushroom_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SmallFry_BR_CH2S1_Common": [
+      {
+        "identifier": "SmallFry_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SmallShieldPotion_BR_CH1S2_Uncommon": [
+      {
+        "identifier": "SmallShieldPotion_BR_CH1S2_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SmallShieldPotion_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "SmallShieldPotion_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SmokeCloud_BR_CH7S3_Common": [
+      {
+        "identifier": "SmokeCloud_BR_CH7S3_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SmokeGrenade_BR_CH1S1_Uncommon": [
+      {
+        "identifier": "SmokeGrenade_BR_CH1S1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SmokeGrenade_Ballistic_V1_Common": [
+      {
+        "identifier": "SmokeGrenade_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SneakySnowman_BR_CH2S1_Rare": [
+      {
+        "identifier": "SneakySnowman_BR_CH2S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SneakySnowman_OG_CH1S7_Common": [
+      {
+        "identifier": "SneakySnowman_OG_CH1S7_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SnowyFlopper_BR_CH2S5_Uncommon": [
+      {
+        "identifier": "SnowyFlopper_BR_CH2S5_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpeedBoostLow_Creative_V1_Uncommon": [
+      {
+        "identifier": "SpeedBoostLow_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpeedBoostMedium_Creative_V1_Rare": [
+      {
+        "identifier": "SpeedBoostMedium_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpeedBoostHigh_Creative_V1_Epic": [
+      {
+        "identifier": "SpeedBoostHigh_Creative_V1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpicyFish_BR_CH2S4_Rare": [
+      {
+        "identifier": "SpicyFish_BR_CH2S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpicyIcecreamCone_BR_CH3S3_Common": [
+      {
+        "identifier": "SpicyIcecreamCone_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireJumpboots_BR_CH2S6_Mythic": [
+      {
+        "identifier": "SpireJumpboots_BR_CH2S6_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StealthSplash_BR_CH7S1_Rare": [
+      {
+        "identifier": "StealthSplash_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StinkBomb_BR_CH1S4_Rare": [
+      {
+        "identifier": "StinkBomb_BR_CH1S4_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StinkFish_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "StinkFish_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StinkSac_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "StinkSac_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Stone_BR_PreSeason_Common": [
+      {
+        "identifier": "Stone_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StormFlip_BR_CH1S9_Epic": [
+      {
+        "identifier": "StormFlip_BR_CH1S9_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurfCube_BR_CH6S3_Epic": [
+      {
+        "identifier": "SurfCube_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LightridersSurfCube_BR_CH6S3_Mythic": [
+      {
+        "identifier": "LightridersSurfCube_BR_CH6S3_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalFish_BR_CH2S4_Legendary": [
+      {
+        "identifier": "ThermalFish_BR_CH2S4_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalTaffy_BR_CH2S4_Common": [
+      {
+        "identifier": "ThermalTaffy_BR_CH2S4_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Thermite_BR_CH6S2_Rare": [
+      {
+        "identifier": "Thermite_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThunderboltOfZeus_BR_CH5S2_Mythic": [
+      {
+        "identifier": "ThunderboltOfZeus_BR_CH5S2_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Torch_Creative_V1_Rare": [
+      {
+        "identifier": "Torch_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TrackingVisor_BR_CH6S3_Rare": [
+      {
+        "identifier": "TrackingVisor_BR_CH6S3_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StringyTwine_Creative_V1_Uncommon": [
+      {
+        "identifier": "StringyTwine_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SimpleTwine_Creative_V1_Uncommon": [
+      {
+        "identifier": "SimpleTwine_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SturdyTwine_Creative_V1_Uncommon": [
+      {
+        "identifier": "SturdyTwine_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PeakyTwine_Creative_V1_Uncommon": [
+      {
+        "identifier": "PeakyTwine_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CarvedTwine_Creative_V1_Uncommon": [
+      {
+        "identifier": "CarvedTwine_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpectralTwine_Creative_V1_Uncommon": [
+      {
+        "identifier": "SpectralTwine_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "UnstableBounceGrenade_BR_CH6S3_Exotic": [
+      {
+        "identifier": "UnstableBounceGrenade_BR_CH6S3_Exotic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VehicleModCowCatcher_BR_CH3S2_Common": [
+      {
+        "identifier": "VehicleModCowCatcher_BR_CH3S2_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VehicleModOffRoadTires_BR_CH2S6_Common": [
+      {
+        "identifier": "VehicleModOffRoadTires_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VendettaFlopper_BR_CH2S4_Legendary": [
+      {
+        "identifier": "VendettaFlopper_BR_CH2S4_Legendary",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VoidOniMask_BR_CH6S1_Epic": [
+      {
+        "identifier": "VoidOniMask_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NightRosesVoidOniMask_BR_CH6S1_Mythic": [
+      {
+        "identifier": "NightRosesVoidOniMask_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WallDynamo_OG_CH1S1_Rare": [
+      {
+        "identifier": "WallDynamo_OG_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WallDynamo_BR_CH4MS1_Rare": [
+      {
+        "identifier": "WallDynamo_BR_CH4MS1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WallDynamo_BR_CH1S1_Rare": [
+      {
+        "identifier": "WallDynamo_BR_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Wheat_Creative_V1_Common": [
+      {
+        "identifier": "Wheat_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WildwaspJar_BR_CH4S3_Rare": [
+      {
+        "identifier": "WildwaspJar_BR_CH4S3_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WingsOfIcarus_BR_CH5S2_Epic": [
+      {
+        "identifier": "WingsOfIcarus_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Wingsuit_BR_CH7S1_Epic": [
+      {
+        "identifier": "Wingsuit_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WitchBroom_BR_CH2S4_Mythic": [
+      {
+        "identifier": "WitchBroom_BR_CH2S4_Mythic",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WolfTooth_Creative_V1_Uncommon": [
+      {
+        "identifier": "WolfTooth_Creative_V1_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Wood_BR_PreSeason_Common": [
+      {
+        "identifier": "Wood_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ZeroPointFish_BR_CH2S5_Rare": [
+      {
+        "identifier": "ZeroPointFish_BR_CH2S5_Rare",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ZeroPointPretzel_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "ZeroPointPretzel_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Items",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Weapons": [
+      {
+        "identifier": "Weapons",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "AnvilRocketLauncher_BR_CH3S2_Rare": [
+      {
+        "identifier": "AnvilRocketLauncher_BR_CH3S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AnvilRocketLauncher_BR_CH3S2_Epic": [
+      {
+        "identifier": "AnvilRocketLauncher_BR_CH3S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AnvilRocketLauncher_BR_CH3S2_Legendary": [
+      {
+        "identifier": "AnvilRocketLauncher_BR_CH3S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ArcLightningGun_BR_CH7S1_Epic": [
+      {
+        "identifier": "ArcLightningGun_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ArcLightningGun_BR_CH7S1_Legendary": [
+      {
+        "identifier": "ArcLightningGun_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HumanBillsArcLightningGun_BR_CH7S1_Mythic": [
+      {
+        "identifier": "HumanBillsArcLightningGun_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AscendedMyst_BR_CH6S3_Legendary": [
+      {
+        "identifier": "AscendedMyst_BR_CH6S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_PreSeason_Common": [
+      {
+        "identifier": "AssaultRifle_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "AssaultRifle_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_PreSeason_Rare": [
+      {
+        "identifier": "AssaultRifle_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_PreSeason_Epic": [
+      {
+        "identifier": "AssaultRifle_BR_PreSeason_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_PreSeason_Legendary": [
+      {
+        "identifier": "AssaultRifle_BR_PreSeason_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SkyesAssaultRifle_BR_CH2S2_Mythic": [
+      {
+        "identifier": "SkyesAssaultRifle_BR_CH2S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_CH4S1_Common": [
+      {
+        "identifier": "AssaultRifle_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "AssaultRifle_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_CH4S1_Rare": [
+      {
+        "identifier": "AssaultRifle_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_CH4S1_Epic": [
+      {
+        "identifier": "AssaultRifle_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AssaultRifle_BR_CH4S1_Legendary": [
+      {
+        "identifier": "AssaultRifle_BR_CH4S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedAssaultRifle_BR_CH6S4_Mythic": [
+      {
+        "identifier": "EnhancedAssaultRifle_BR_CH6S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutomaticSniperRifle_BR_CH1SX_Rare": [
+      {
+        "identifier": "AutomaticSniperRifle_BR_CH1SX_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutomaticSniperRifle_BR_CH1SX_Epic": [
+      {
+        "identifier": "AutomaticSniperRifle_BR_CH1SX_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutomaticSniperRifle_BR_CH1SX_Legendary": [
+      {
+        "identifier": "AutomaticSniperRifle_BR_CH1SX_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutomaticSniperRifle_BR_CH2S5_Uncommon": [
+      {
+        "identifier": "AutomaticSniperRifle_BR_CH2S5_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutoShotgun_BR_CH3S1_Common": [
+      {
+        "identifier": "AutoShotgun_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutoShotgun_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "AutoShotgun_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutoShotgun_BR_CH3S1_Rare": [
+      {
+        "identifier": "AutoShotgun_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutoShotgun_BR_CH3S1_Epic": [
+      {
+        "identifier": "AutoShotgun_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutoShotgun_BR_CH3S1_Legendary": [
+      {
+        "identifier": "AutoShotgun_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AutoShotgun_BR_CH3S1_Mythic": [
+      {
+        "identifier": "AutoShotgun_BR_CH3S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BallisticShield_BR_CH5S1_Epic": [
+      {
+        "identifier": "BallisticShield_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BankShotPistol_BR_CH7S3_Uncommon": [
+      {
+        "identifier": "BankShotPistol_BR_CH7S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BankShotPistol_BR_CH7S3_Rare": [
+      {
+        "identifier": "BankShotPistol_BR_CH7S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BankShotPistol_BR_CH7S3_Epic": [
+      {
+        "identifier": "BankShotPistol_BR_CH7S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BankShotPistol_BR_CH7S3_Legendary": [
+      {
+        "identifier": "BankShotPistol_BR_CH7S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BankShotPistol_BR_CH7S3_Mythic": [
+      {
+        "identifier": "BankShotPistol_BR_CH7S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BasicHammer_Creative_V1_Common": [
+      {
+        "identifier": "BasicHammer_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BasicSword_Creative_V1_Common": [
+      {
+        "identifier": "BasicSword_Creative_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BassBoost_BR_CH6S3_Rare": [
+      {
+        "identifier": "BassBoost_BR_CH6S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BassBoost_BR_CH6S3_Epic": [
+      {
+        "identifier": "BassBoost_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BassBoost_BR_CH6S3_Mythic": [
+      {
+        "identifier": "BassBoost_BR_CH6S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoltActionSniperRifle_BR_PreSeason_Rare": [
+      {
+        "identifier": "BoltActionSniperRifle_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoltActionSniperRifle_BR_PreSeason_Epic": [
+      {
+        "identifier": "BoltActionSniperRifle_BR_PreSeason_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoltActionSniperRifle_BR_PreSeason_Legendary": [
+      {
+        "identifier": "BoltActionSniperRifle_BR_PreSeason_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoltActionSniperRifle_BR_CH2S1_Common": [
+      {
+        "identifier": "BoltActionSniperRifle_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoltActionSniperRifle_BR_CH2S1_Uncommon": [
+      {
+        "identifier": "BoltActionSniperRifle_BR_CH2S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularBoomBolt_BR_CH5S3_Rare": [
+      {
+        "identifier": "ModularBoomBolt_BR_CH5S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularBoomBolt_BR_CH5S3_Epic": [
+      {
+        "identifier": "ModularBoomBolt_BR_CH5S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularBoomBolt_BR_CH5S3_Legendary": [
+      {
+        "identifier": "ModularBoomBolt_BR_CH5S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RingmastersModularBoomBolt_BR_CH5S3_Mythic": [
+      {
+        "identifier": "RingmastersModularBoomBolt_BR_CH5S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoomBow_BR_CH1S8_Legendary": [
+      {
+        "identifier": "BoomBow_BR_CH1S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BoomSniperRifle_BR_CH2S5_Exotic": [
+      {
+        "identifier": "BoomSniperRifle_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BugBlaster_BR_CH6S4_Rare": [
+      {
+        "identifier": "BugBlaster_BR_CH6S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BugBlaster_BR_CH6S4_Epic": [
+      {
+        "identifier": "BugBlaster_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BugBlaster_BR_CH6S4_Legendary": [
+      {
+        "identifier": "BugBlaster_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAR_Ballistic_V1_Common": [
+      {
+        "identifier": "BurstAR_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_PreSeason_Common": [
+      {
+        "identifier": "BurstAssaultRifle_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "BurstAssaultRifle_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_PreSeason_Rare": [
+      {
+        "identifier": "BurstAssaultRifle_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_CH1S4_Epic": [
+      {
+        "identifier": "BurstAssaultRifle_BR_CH1S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_CH1S4_Legendary": [
+      {
+        "identifier": "BurstAssaultRifle_BR_CH1S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OceansBurstAssaultRifle_BR_CH2S3_Mythic": [
+      {
+        "identifier": "OceansBurstAssaultRifle_BR_CH2S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlonesBurstAssaultRifle_BR_CH2S8_Mythic": [
+      {
+        "identifier": "SlonesBurstAssaultRifle_BR_CH2S8_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_OG_CH1S1_Common": [
+      {
+        "identifier": "BurstAssaultRifle_OG_CH1S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_CH4MS1_Common": [
+      {
+        "identifier": "BurstAssaultRifle_BR_CH4MS1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_OG_CH1S1_Uncommon": [
+      {
+        "identifier": "BurstAssaultRifle_OG_CH1S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_CH4MS1_Uncommon": [
+      {
+        "identifier": "BurstAssaultRifle_BR_CH4MS1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_OG_CH1S1_Rare": [
+      {
+        "identifier": "BurstAssaultRifle_OG_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_CH4MS1_Rare": [
+      {
+        "identifier": "BurstAssaultRifle_BR_CH4MS1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_OG_CH1S1_Epic": [
+      {
+        "identifier": "BurstAssaultRifle_OG_CH1S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_CH4MS1_Epic": [
+      {
+        "identifier": "BurstAssaultRifle_BR_CH4MS1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_OG_CH1S1_Legendary": [
+      {
+        "identifier": "BurstAssaultRifle_OG_CH1S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstAssaultRifle_BR_CH4MS1_Legendary": [
+      {
+        "identifier": "BurstAssaultRifle_BR_CH4MS1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstQuadLauncher_BR_CH2S5_Exotic": [
+      {
+        "identifier": "BurstQuadLauncher_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstSMG_BR_CH1S9_Common": [
+      {
+        "identifier": "BurstSMG_BR_CH1S9_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstSMG_BR_CH1S9_Uncommon": [
+      {
+        "identifier": "BurstSMG_BR_CH1S9_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstSMG_BR_CH1S9_Rare": [
+      {
+        "identifier": "BurstSMG_BR_CH1S9_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Chainsaw_BR_CH5S4_Epic": [
+      {
+        "identifier": "Chainsaw_BR_CH5S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChainsOfHades_BR_CH5S2_Epic": [
+      {
+        "identifier": "ChainsOfHades_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosExploderRifle_BR_CH7S3_Common": [
+      {
+        "identifier": "ChaosExploderRifle_BR_CH7S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosExploderRifle_BR_CH7S3_Uncommon": [
+      {
+        "identifier": "ChaosExploderRifle_BR_CH7S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosExploderRifle_BR_CH7S3_Rare": [
+      {
+        "identifier": "ChaosExploderRifle_BR_CH7S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosExploderRifle_BR_CH7S3_Epic": [
+      {
+        "identifier": "ChaosExploderRifle_BR_CH7S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosExploderRifle_BR_CH7S3_Legendary": [
+      {
+        "identifier": "ChaosExploderRifle_BR_CH7S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosReloaderShotgun_BR_CH7S2_Common": [
+      {
+        "identifier": "ChaosReloaderShotgun_BR_CH7S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosReloaderShotgun_BR_CH7S2_Uncommon": [
+      {
+        "identifier": "ChaosReloaderShotgun_BR_CH7S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosReloaderShotgun_BR_CH7S2_Rare": [
+      {
+        "identifier": "ChaosReloaderShotgun_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosReloaderShotgun_BR_CH7S2_Epic": [
+      {
+        "identifier": "ChaosReloaderShotgun_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChaosReloaderShotgun_BR_CH7S2_Legendary": [
+      {
+        "identifier": "ChaosReloaderShotgun_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DarkVoyagersObliterator_BR_CH7S2_Mythic": [
+      {
+        "identifier": "DarkVoyagersObliterator_BR_CH7S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeShotgun_BR_CH2S3_Common": [
+      {
+        "identifier": "ChargeShotgun_BR_CH2S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeShotgun_BR_CH2S3_Uncommon": [
+      {
+        "identifier": "ChargeShotgun_BR_CH2S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeShotgun_BR_CH2S3_Rare": [
+      {
+        "identifier": "ChargeShotgun_BR_CH2S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeShotgun_BR_CH2S3_Epic": [
+      {
+        "identifier": "ChargeShotgun_BR_CH2S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeShotgun_BR_CH2S3_Legendary": [
+      {
+        "identifier": "ChargeShotgun_BR_CH2S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KitsChargeShotgun_BR_CH2S3_Mythic": [
+      {
+        "identifier": "KitsChargeShotgun_BR_CH2S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeSMG_BR_CH3S3_Common": [
+      {
+        "identifier": "ChargeSMG_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeSMG_BR_CH3S3_Uncommon": [
+      {
+        "identifier": "ChargeSMG_BR_CH3S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeSMG_BR_CH3S3_Rare": [
+      {
+        "identifier": "ChargeSMG_BR_CH3S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeSMG_BR_CH3S3_Epic": [
+      {
+        "identifier": "ChargeSMG_BR_CH3S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeSMG_BR_CH3S3_Legendary": [
+      {
+        "identifier": "ChargeSMG_BR_CH3S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ChargeSMG_BR_CH3S3_Mythic": [
+      {
+        "identifier": "ChargeSMG_BR_CH3S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CobraDMR_BR_CH3S4_Common": [
+      {
+        "identifier": "CobraDMR_BR_CH3S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CobraDMR_BR_CH3S4_Uncommon": [
+      {
+        "identifier": "CobraDMR_BR_CH3S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CobraDMR_BR_CH3S4_Rare": [
+      {
+        "identifier": "CobraDMR_BR_CH3S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CobraDMR_BR_CH3S4_Epic": [
+      {
+        "identifier": "CobraDMR_BR_CH3S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CobraDMR_BR_CH3S4_Legendary": [
+      {
+        "identifier": "CobraDMR_BR_CH3S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CobraDMR_BR_CH3S4_Mythic": [
+      {
+        "identifier": "CobraDMR_BR_CH3S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CollateralDamageAssaultRifle_BR_CH6S2_Common": [
+      {
+        "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CollateralDamageAssaultRifle_BR_CH6S2_Uncommon": [
+      {
+        "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CollateralDamageAssaultRifle_BR_CH6S2_Rare": [
+      {
+        "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CollateralDamageAssaultRifle_BR_CH6S2_Epic": [
+      {
+        "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CollateralDamageAssaultRifle_BR_CH6S2_Legendary": [
+      {
+        "identifier": "CollateralDamageAssaultRifle_BR_CH6S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedCollateralDamageAR_BR_CH6S2_Mythic": [
+      {
+        "identifier": "EnhancedCollateralDamageAR_BR_CH6S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessTrinityAssaultRifle_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessTrinityAssaultRifle_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH2S8_Common": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH2S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH2S8_Rare": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH2S8_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH2S8_Epic": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH2S8_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH2S8_Legendary": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH2S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatAssaultRifle_BR_CH5S3_Common": [
+      {
+        "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatAssaultRifle_BR_CH5S3_Uncommon": [
+      {
+        "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatAssaultRifle_BR_CH5S3_Rare": [
+      {
+        "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatAssaultRifle_BR_CH5S3_Epic": [
+      {
+        "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatAssaultRifle_BR_CH5S3_Legendary": [
+      {
+        "identifier": "ModularCombatAssaultRifle_BR_CH5S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheMachinistsModularCombatAssaultRifle_BR_CH5S3_Mythic": [
+      {
+        "identifier": "TheMachinistsModularCombatAssaultRifle_BR_CH5S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH7S2_Common": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH7S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH7S2_Uncommon": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH7S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH7S2_Rare": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH7S2_Epic": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatAssaultRifle_BR_CH7S2_Legendary": [
+      {
+        "identifier": "CombatAssaultRifle_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatPistol_BR_CH2S8_Common": [
+      {
+        "identifier": "CombatPistol_BR_CH2S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatPistol_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "CombatPistol_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatPistol_BR_CH2S8_Rare": [
+      {
+        "identifier": "CombatPistol_BR_CH2S8_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatPistol_BR_CH2S8_Epic": [
+      {
+        "identifier": "CombatPistol_BR_CH2S8_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatPistol_BR_CH2S8_Legendary": [
+      {
+        "identifier": "CombatPistol_BR_CH2S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatShotgun_BR_CH1S9_Rare": [
+      {
+        "identifier": "CombatShotgun_BR_CH1S9_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatShotgun_BR_CH1S9_Epic": [
+      {
+        "identifier": "CombatShotgun_BR_CH1S9_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatShotgun_BR_CH1S9_Legendary": [
+      {
+        "identifier": "CombatShotgun_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatShotgun_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "CombatShotgun_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatShotgun_BR_CH4S2_Common": [
+      {
+        "identifier": "CombatShotgun_BR_CH4S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatShotgun_BR_CH5S3_Common": [
+      {
+        "identifier": "ModularCombatShotgun_BR_CH5S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatShotgun_BR_CH5S3_Uncommon": [
+      {
+        "identifier": "ModularCombatShotgun_BR_CH5S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatShotgun_BR_CH5S3_Rare": [
+      {
+        "identifier": "ModularCombatShotgun_BR_CH5S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatShotgun_BR_CH5S3_Epic": [
+      {
+        "identifier": "ModularCombatShotgun_BR_CH5S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularCombatShotgun_BR_CH5S3_Legendary": [
+      {
+        "identifier": "ModularCombatShotgun_BR_CH5S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MegaloDonsModularCombatShotgun_BR_CH5S3_Mythic": [
+      {
+        "identifier": "MegaloDonsModularCombatShotgun_BR_CH5S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatSMG_BR_CH3S2_Common": [
+      {
+        "identifier": "CombatSMG_BR_CH3S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatSMG_BR_CH3S2_Uncommon": [
+      {
+        "identifier": "CombatSMG_BR_CH3S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatSMG_BR_CH3S2_Rare": [
+      {
+        "identifier": "CombatSMG_BR_CH3S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatSMG_BR_CH3S2_Epic": [
+      {
+        "identifier": "CombatSMG_BR_CH3S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatSMG_BR_CH3S2_Legendary": [
+      {
+        "identifier": "CombatSMG_BR_CH3S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CombatSMG_BR_CH3S2_Mythic": [
+      {
+        "identifier": "CombatSMG_BR_CH3S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CompactSMG_BR_CH1S5_Epic": [
+      {
+        "identifier": "CompactSMG_BR_CH1S5_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CompactSMG_BR_CH1S5_Legendary": [
+      {
+        "identifier": "CompactSMG_BR_CH1S5_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CompactSMG_BR_CH6MS2_Uncommon": [
+      {
+        "identifier": "CompactSMG_BR_CH6MS2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CompactSMG_BR_CH6MS2_Rare": [
+      {
+        "identifier": "CompactSMG_BR_CH6MS2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedCompactSMG_BR_CH6MS2_Mythic": [
+      {
+        "identifier": "EnhancedCompactSMG_BR_CH6MS2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Crossbow_BR_CH1S3_Rare": [
+      {
+        "identifier": "Crossbow_BR_CH1S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Crossbow_BR_CH1S3_Epic": [
+      {
+        "identifier": "Crossbow_BR_CH1S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CubeRifle_BR_CH7S2_Epic": [
+      {
+        "identifier": "CubeRifle_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CubeRifle_BR_CH7S2_Legendary": [
+      {
+        "identifier": "CubeRifle_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CubeRifle_BR_CH7S2_Mythic": [
+      {
+        "identifier": "CubeRifle_BR_CH7S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CupidsCrossbow_BR_CH1S2_Epic": [
+      {
+        "identifier": "CupidsCrossbow_BR_CH1S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EmpoweredCupidsCrossbow_BR_CH7S1_Mythic": [
+      {
+        "identifier": "EmpoweredCupidsCrossbow_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DarkVoyagersChaosRifle_BR_CH7S3_Mythic": [
+      {
+        "identifier": "DarkVoyagersChaosRifle_BR_CH7S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeAssaultRifle_BR_CH7S1_Common": [
+      {
+        "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeAssaultRifle_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeAssaultRifle_BR_CH7S1_Rare": [
+      {
+        "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeAssaultRifle_BR_CH7S1_Epic": [
+      {
+        "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeAssaultRifle_BR_CH7S1_Legendary": [
+      {
+        "identifier": "DeadeyeAssaultRifle_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HushsDeadeyeAssaultRifle_BR_CH7S1_Mythic": [
+      {
+        "identifier": "HushsDeadeyeAssaultRifle_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeDMR_BR_CH6S3_Common": [
+      {
+        "identifier": "DeadeyeDMR_BR_CH6S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeDMR_BR_CH6S3_Uncommon": [
+      {
+        "identifier": "DeadeyeDMR_BR_CH6S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeDMR_BR_CH6S3_Rare": [
+      {
+        "identifier": "DeadeyeDMR_BR_CH6S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeDMR_BR_CH6S3_Epic": [
+      {
+        "identifier": "DeadeyeDMR_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DeadeyeDMR_BR_CH6S3_Legendary": [
+      {
+        "identifier": "DeadeyeDMR_BR_CH6S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KorsDeadeyeDMR_BR_CH6S3_Mythic": [
+      {
+        "identifier": "KorsDeadeyeDMR_BR_CH6S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "UnstableThunderclapDMR_BR_CH6S3_Exotic": [
+      {
+        "identifier": "UnstableThunderclapDMR_BR_CH6S3_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DMR_BR_CH3S3_Common": [
+      {
+        "identifier": "DMR_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DMR_BR_CH3S3_Uncommon": [
+      {
+        "identifier": "DMR_BR_CH3S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DMR_BR_CH3S3_Rare": [
+      {
+        "identifier": "DMR_BR_CH3S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DMR_BR_CH3S3_Epic": [
+      {
+        "identifier": "DMR_BR_CH3S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DMR_BR_CH3S3_Legendary": [
+      {
+        "identifier": "DMR_BR_CH3S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DMR_BR_CH3S3_Mythic": [
+      {
+        "identifier": "DMR_BR_CH3S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Double_BR_CH6S4_Exotic": [
+      {
+        "identifier": "Double_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DoubleBarrelShotgun_BR_CH1S5_Epic": [
+      {
+        "identifier": "DoubleBarrelShotgun_BR_CH1S5_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DoubleBarrelShotgun_BR_CH1S5_Legendary": [
+      {
+        "identifier": "DoubleBarrelShotgun_BR_CH1S5_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DragonsBreathShotgun_BR_CH6S2_Epic": [
+      {
+        "identifier": "DragonsBreathShotgun_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DragonsBreathShotgun_BR_CH6S2_Legendary": [
+      {
+        "identifier": "DragonsBreathShotgun_BR_CH6S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DragonsBreathSniper_BR_CH2S5_Exotic": [
+      {
+        "identifier": "DragonsBreathSniper_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DragonsBreathShotgun_BR_CH2S5_Epic": [
+      {
+        "identifier": "DragonsBreathShotgun_BR_CH2S5_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DragonsBreathShotgun_BR_CH2S5_Legendary": [
+      {
+        "identifier": "DragonsBreathShotgun_BR_CH2S5_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumGun_BR_CH1S4_Uncommon": [
+      {
+        "identifier": "DrumGun_BR_CH1S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumGun_BR_CH1S4_Rare": [
+      {
+        "identifier": "DrumGun_BR_CH1S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MidasDrumGun_BR_CH2S2_Mythic": [
+      {
+        "identifier": "MidasDrumGun_BR_CH2S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "JulesDrumGun_BR_CH2S3_Mythic": [
+      {
+        "identifier": "JulesDrumGun_BR_CH2S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShadowMidasDrumGun_BR_CH2S4_Mythic": [
+      {
+        "identifier": "ShadowMidasDrumGun_BR_CH2S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularDrumGun_BR_CH5S2_Rare": [
+      {
+        "identifier": "ModularDrumGun_BR_CH5S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularDrumGun_BR_CH5S2_Epic": [
+      {
+        "identifier": "ModularDrumGun_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularDrumGun_BR_CH5S2_Legendary": [
+      {
+        "identifier": "ModularDrumGun_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MidasModularDrumGun_BR_CH5S2_Mythic": [
+      {
+        "identifier": "MidasModularDrumGun_BR_CH5S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MidasGildedEyeDrumGun_BR_CH6S2_Mythic": [
+      {
+        "identifier": "MidasGildedEyeDrumGun_BR_CH6S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumGun_BR_CH6MS2_Rare": [
+      {
+        "identifier": "DrumGun_BR_CH6MS2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumGun_BR_CH6MS2_Epic": [
+      {
+        "identifier": "DrumGun_BR_CH6MS2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumGun_BR_CH6MS2_Legendary": [
+      {
+        "identifier": "DrumGun_BR_CH6MS2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumGun_Ballistic_V1_Common": [
+      {
+        "identifier": "DrumGun_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumShotgun_BR_CH1S9_Common": [
+      {
+        "identifier": "DrumShotgun_BR_CH1S9_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumShotgun_BR_CH1S9_Uncommon": [
+      {
+        "identifier": "DrumShotgun_BR_CH1S9_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumShotgun_BR_CH1S9_Rare": [
+      {
+        "identifier": "DrumShotgun_BR_CH1S9_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumShotgun_BR_CH3S2_Epic": [
+      {
+        "identifier": "DrumShotgun_BR_CH3S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DrumShotgun_BR_CH3S2_Legendary": [
+      {
+        "identifier": "DrumShotgun_BR_CH3S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedDrumShotgun_BR_CH4S3_Mythic": [
+      {
+        "identifier": "EnhancedDrumShotgun_BR_CH4S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualFiendHunters_BR_CH2S8_Common": [
+      {
+        "identifier": "DualFiendHunters_BR_CH2S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualFiendHunters_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "DualFiendHunters_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualFiendHunters_BR_CH2S8_Rare": [
+      {
+        "identifier": "DualFiendHunters_BR_CH2S8_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualFiendHunters_BR_CH2S8_Epic": [
+      {
+        "identifier": "DualFiendHunters_BR_CH2S8_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualFiendHunters_BR_CH2S8_Legendary": [
+      {
+        "identifier": "DualFiendHunters_BR_CH2S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH5S4_Common": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH5S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH5S4_Uncommon": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH5S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH5S4_Rare": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH5S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH5S4_Epic": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH5S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH5S4_Legendary": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH5S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH7S1_Common": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH7S1_Rare": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH7S1_Epic": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualMicroSMGs_BR_CH7S1_Legendary": [
+      {
+        "identifier": "DualMicroSMGs_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualPistols_BR_CH1S4_Rare": [
+      {
+        "identifier": "DualPistols_BR_CH1S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualPistols_BR_CH1S4_Epic": [
+      {
+        "identifier": "DualPistols_BR_CH1S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualPistols_BR_CH2S6_Common": [
+      {
+        "identifier": "DualPistols_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualPistols_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "DualPistols_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualPistols_BR_CH2S6_Legendary": [
+      {
+        "identifier": "DualPistols_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualSuppressedPistols_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "DualSuppressedPistols_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualSuppressedPistols_BR_CH3S1_Rare": [
+      {
+        "identifier": "DualSuppressedPistols_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualSuppressedPistols_BR_CH3S1_Epic": [
+      {
+        "identifier": "DualSuppressedPistols_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DualSuppressedPistols_BR_CH3S1_Legendary": [
+      {
+        "identifier": "DualSuppressedPistols_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EggLauncher_BR_CH1S3_Rare": [
+      {
+        "identifier": "EggLauncher_BR_CH1S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EggLauncher_BR_CH1S3_Epic": [
+      {
+        "identifier": "EggLauncher_BR_CH1S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EggLauncher_BR_CH1S3_Legendary": [
+      {
+        "identifier": "EggLauncher_BR_CH1S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EggLauncher_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "EggLauncher_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularEnforcerAR_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularEnforcerAR_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularEnforcerAR_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularEnforcerAR_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularEnforcerAR_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularEnforcerAR_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularEnforcerAR_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularEnforcerAR_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularEnforcerAR_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularEnforcerAR_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnforcerAR_BR_CH7S1_Common": [
+      {
+        "identifier": "EnforcerAR_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnforcerAR_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "EnforcerAR_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnforcerAR_BR_CH7S1_Rare": [
+      {
+        "identifier": "EnforcerAR_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnforcerAR_BR_CH7S1_Epic": [
+      {
+        "identifier": "EnforcerAR_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnforcerAR_BR_CH7S1_Legendary": [
+      {
+        "identifier": "EnforcerAR_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnforcerAR_Ballistic_V1_Common": [
+      {
+        "identifier": "EnforcerAR_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeBurstRifle_BR_CH3S4_Common": [
+      {
+        "identifier": "EvoChromeBurstRifle_BR_CH3S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeBurstRifle_BR_CH3S4_Uncommon": [
+      {
+        "identifier": "EvoChromeBurstRifle_BR_CH3S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeBurstRifle_BR_CH3S4_Rare": [
+      {
+        "identifier": "EvoChromeBurstRifle_BR_CH3S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeBurstRifle_BR_CH3S4_Epic": [
+      {
+        "identifier": "EvoChromeBurstRifle_BR_CH3S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeBurstRifle_BR_CH3S4_Legendary": [
+      {
+        "identifier": "EvoChromeBurstRifle_BR_CH3S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeBurstRifle_BR_CH3S4_Mythic": [
+      {
+        "identifier": "EvoChromeBurstRifle_BR_CH3S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeShotgun_BR_CH3S4_Common": [
+      {
+        "identifier": "EvoChromeShotgun_BR_CH3S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeShotgun_BR_CH3S4_Uncommon": [
+      {
+        "identifier": "EvoChromeShotgun_BR_CH3S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeShotgun_BR_CH3S4_Rare": [
+      {
+        "identifier": "EvoChromeShotgun_BR_CH3S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeShotgun_BR_CH3S4_Epic": [
+      {
+        "identifier": "EvoChromeShotgun_BR_CH3S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeShotgun_BR_CH3S4_Legendary": [
+      {
+        "identifier": "EvoChromeShotgun_BR_CH3S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EvoChromeShotgun_BR_CH3S4_Mythic": [
+      {
+        "identifier": "EvoChromeShotgun_BR_CH3S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExCaliberRifle_BR_CH4S1_Common": [
+      {
+        "identifier": "ExCaliberRifle_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExCaliberRifle_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "ExCaliberRifle_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExCaliberRifle_BR_CH4S1_Rare": [
+      {
+        "identifier": "ExCaliberRifle_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExCaliberRifle_BR_CH4S1_Epic": [
+      {
+        "identifier": "ExCaliberRifle_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExCaliberRifle_BR_CH4S1_Legendary": [
+      {
+        "identifier": "ExCaliberRifle_BR_CH4S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheAgelessChampionsExCaliberRifle_BR_CH4S1_Mythic": [
+      {
+        "identifier": "TheAgelessChampionsExCaliberRifle_BR_CH4S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExoticLeapingLightningGun_BR_CH7S2_Exotic": [
+      {
+        "identifier": "ExoticLeapingLightningGun_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExplosiveGooGun_BR_CH3S4_Rare": [
+      {
+        "identifier": "ExplosiveGooGun_BR_CH3S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExplosiveRepeaterRifle_BR_CH4S3_Common": [
+      {
+        "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExplosiveRepeaterRifle_BR_CH4S3_Uncommon": [
+      {
+        "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExplosiveRepeaterRifle_BR_CH4S3_Rare": [
+      {
+        "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExplosiveRepeaterRifle_BR_CH4S3_Epic": [
+      {
+        "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExplosiveRepeaterRifle_BR_CH4S3_Legendary": [
+      {
+        "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExplosiveRepeaterRifle_BR_CH4S3_Mythic": [
+      {
+        "identifier": "ExplosiveRepeaterRifle_BR_CH4S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExtendingFocusShotgun_BR_CH7S3_Common": [
+      {
+        "identifier": "ExtendingFocusShotgun_BR_CH7S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExtendingFocusShotgun_BR_CH7S3_Uncommon": [
+      {
+        "identifier": "ExtendingFocusShotgun_BR_CH7S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExtendingFocusShotgun_BR_CH7S3_Rare": [
+      {
+        "identifier": "ExtendingFocusShotgun_BR_CH7S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExtendingFocusShotgun_BR_CH7S3_Epic": [
+      {
+        "identifier": "ExtendingFocusShotgun_BR_CH7S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExtendingFocusShotgun_BR_CH7S3_Legendary": [
+      {
+        "identifier": "ExtendingFocusShotgun_BR_CH7S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FalconEyeSniper_BR_CH6S2_Common": [
+      {
+        "identifier": "FalconEyeSniper_BR_CH6S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FalconEyeSniper_BR_CH6S2_Uncommon": [
+      {
+        "identifier": "FalconEyeSniper_BR_CH6S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FalconEyeSniper_BR_CH6S2_Rare": [
+      {
+        "identifier": "FalconEyeSniper_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FalconEyeSniper_BR_CH6S2_Epic": [
+      {
+        "identifier": "FalconEyeSniper_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FalconEyeSniper_BR_CH6S2_Legendary": [
+      {
+        "identifier": "FalconEyeSniper_BR_CH6S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedFalconEyeSniper_BR_CH6S2_Mythic": [
+      {
+        "identifier": "EnhancedFalconEyeSniper_BR_CH6S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FiendHunterCrossbow_BR_CH1S6_Epic": [
+      {
+        "identifier": "FiendHunterCrossbow_BR_CH1S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FireOniMask_BR_CH6S1_Epic": [
+      {
+        "identifier": "FireOniMask_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShogunXsFireOniMask_BR_CH6S1_Mythic": [
+      {
+        "identifier": "ShogunXsFireOniMask_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FireworkFlareGun_BR_CH3S3_Rare": [
+      {
+        "identifier": "FireworkFlareGun_BR_CH3S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlapjackRifle_BR_CH4S3_Common": [
+      {
+        "identifier": "FlapjackRifle_BR_CH4S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlapjackRifle_BR_CH4S3_Uncommon": [
+      {
+        "identifier": "FlapjackRifle_BR_CH4S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlapjackRifle_BR_CH4S3_Rare": [
+      {
+        "identifier": "FlapjackRifle_BR_CH4S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlapjackRifle_BR_CH4S3_Epic": [
+      {
+        "identifier": "FlapjackRifle_BR_CH4S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlapjackRifle_BR_CH4S3_Legendary": [
+      {
+        "identifier": "FlapjackRifle_BR_CH4S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedFlapJackRifle_BR_CH4S3_Mythic": [
+      {
+        "identifier": "EnhancedFlapJackRifle_BR_CH4S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlareGun_BR_CH2S3_Rare": [
+      {
+        "identifier": "FlareGun_BR_CH2S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlashlightPistol_Creative_V1_Rare": [
+      {
+        "identifier": "FlashlightPistol_Creative_V1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlexSMG_BR_CH7S1_Common": [
+      {
+        "identifier": "FlexSMG_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlexSMG_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "FlexSMG_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlexSMG_BR_CH7S1_Rare": [
+      {
+        "identifier": "FlexSMG_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlexSMG_BR_CH7S1_Epic": [
+      {
+        "identifier": "FlexSMG_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlexSMG_BR_CH7S1_Legendary": [
+      {
+        "identifier": "FlexSMG_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BigfootsFlexSMG_BR_CH7S1_Mythic": [
+      {
+        "identifier": "BigfootsFlexSMG_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlintKnockPistol_BR_CH1S8_Common": [
+      {
+        "identifier": "FlintKnockPistol_BR_CH1S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FlintKnockPistol_BR_CH1S8_Uncommon": [
+      {
+        "identifier": "FlintKnockPistol_BR_CH1S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularFrenzyAutoShotgun_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularFrenzyAutoShotgun_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularFrenzyAutoShotgun_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularFrenzyAutoShotgun_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularFrenzyAutoShotgun_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularFrenzyAutoShotgun_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OscarsModularFrenzyAutoShotgun_BR_CH5S1_Mythic": [
+      {
+        "identifier": "OscarsModularFrenzyAutoShotgun_BR_CH5S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FrenzyAutoShotgun_Ballistic_V1_Common": [
+      {
+        "identifier": "FrenzyAutoShotgun_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FuryAssaultRifle_BR_CH6S1_Common": [
+      {
+        "identifier": "FuryAssaultRifle_BR_CH6S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FuryAssaultRifle_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "FuryAssaultRifle_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FuryAssaultRifle_BR_CH6S1_Rare": [
+      {
+        "identifier": "FuryAssaultRifle_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FuryAssaultRifle_BR_CH6S1_Epic": [
+      {
+        "identifier": "FuryAssaultRifle_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FuryAssaultRifle_BR_CH6S1_Legendary": [
+      {
+        "identifier": "FuryAssaultRifle_BR_CH6S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedFuryAssaultRifle_BR_CH6S1_Mythic": [
+      {
+        "identifier": "EnhancedFuryAssaultRifle_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EradicatorHopRockFuryAssaultRifle_BR_CH6S4_Exotic": [
+      {
+        "identifier": "EradicatorHopRockFuryAssaultRifle_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularGatekeeperShotgun_BR_CH5S2_Common": [
+      {
+        "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularGatekeeperShotgun_BR_CH5S2_Uncommon": [
+      {
+        "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularGatekeeperShotgun_BR_CH5S2_Rare": [
+      {
+        "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularGatekeeperShotgun_BR_CH5S2_Epic": [
+      {
+        "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularGatekeeperShotgun_BR_CH5S2_Legendary": [
+      {
+        "identifier": "ModularGatekeeperShotgun_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CerberusModularGatekeeperShotgun_BR_CH5S2_Mythic": [
+      {
+        "identifier": "CerberusModularGatekeeperShotgun_BR_CH5S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrappleBlade_BR_CH5S1_Epic": [
+      {
+        "identifier": "GrappleBlade_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrapplerBow_BR_CH2S6_Exotic": [
+      {
+        "identifier": "GrapplerBow_BR_CH2S6_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrenadeLauncher_BR_PreSeason_Rare": [
+      {
+        "identifier": "GrenadeLauncher_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrenadeLauncher_BR_PreSeason_Epic": [
+      {
+        "identifier": "GrenadeLauncher_BR_PreSeason_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GrenadeLauncher_BR_PreSeason_Legendary": [
+      {
+        "identifier": "GrenadeLauncher_BR_PreSeason_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GuidedMissile_OG_CH1S3_Epic": [
+      {
+        "identifier": "GuidedMissile_OG_CH1S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GuidedMissile_BR_CH4MS1_Epic": [
+      {
+        "identifier": "GuidedMissile_BR_CH4MS1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GuidedMissile_OG_CH1S3_Legendary": [
+      {
+        "identifier": "GuidedMissile_OG_CH1S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GuidedMissile_BR_CH4MS1_Legendary": [
+      {
+        "identifier": "GuidedMissile_BR_CH4MS1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerAssaultRifle_BR_CH3S3_Common": [
+      {
+        "identifier": "HammerAssaultRifle_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerAssaultRifle_BR_CH3S3_Uncommon": [
+      {
+        "identifier": "HammerAssaultRifle_BR_CH3S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerAssaultRifle_BR_CH3S3_Rare": [
+      {
+        "identifier": "HammerAssaultRifle_BR_CH3S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerAssaultRifle_BR_CH3S3_Epic": [
+      {
+        "identifier": "HammerAssaultRifle_BR_CH3S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerAssaultRifle_BR_CH3S3_Legendary": [
+      {
+        "identifier": "HammerAssaultRifle_BR_CH3S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerAssaultRifle_BR_CH3S3_Mythic": [
+      {
+        "identifier": "HammerAssaultRifle_BR_CH3S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHammerPumpShotgun_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHammerPumpShotgun_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHammerPumpShotgun_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHammerPumpShotgun_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHammerPumpShotgun_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularHammerPumpShotgun_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerPumpShotgun_Ballistic_V1_Common": [
+      {
+        "identifier": "HammerPumpShotgun_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerRevolver_BR_CH7S2_Uncommon": [
+      {
+        "identifier": "HammerRevolver_BR_CH7S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerRevolver_BR_CH7S2_Rare": [
+      {
+        "identifier": "HammerRevolver_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerRevolver_BR_CH7S2_Epic": [
+      {
+        "identifier": "HammerRevolver_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerRevolver_BR_CH7S2_Legendary": [
+      {
+        "identifier": "HammerRevolver_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HammerRevolver_BR_CH7S2_Mythic": [
+      {
+        "identifier": "HammerRevolver_BR_CH7S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HandCannon_BR_CH1S3_Epic": [
+      {
+        "identifier": "HandCannon_BR_CH1S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HandCannon_BR_CH1S3_Legendary": [
+      {
+        "identifier": "HandCannon_BR_CH1S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HandCannon_BR_CH2S2_Rare": [
+      {
+        "identifier": "HandCannon_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHandCannon_BR_CH5S2_Rare": [
+      {
+        "identifier": "ModularHandCannon_BR_CH5S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHandCannon_BR_CH5S2_Epic": [
+      {
+        "identifier": "ModularHandCannon_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHandCannon_BR_CH5S2_Legendary": [
+      {
+        "identifier": "ModularHandCannon_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularConductorHandCannon_BR_CH5S3_Mythic": [
+      {
+        "identifier": "ModularConductorHandCannon_BR_CH5S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HandCannon_Ballistic_V1_Common": [
+      {
+        "identifier": "HandCannon_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHarbingerSMG_BR_CH5S2_Common": [
+      {
+        "identifier": "ModularHarbingerSMG_BR_CH5S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHarbingerSMG_BR_CH5S2_Uncommon": [
+      {
+        "identifier": "ModularHarbingerSMG_BR_CH5S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHarbingerSMG_BR_CH5S2_Rare": [
+      {
+        "identifier": "ModularHarbingerSMG_BR_CH5S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHarbingerSMG_BR_CH5S2_Epic": [
+      {
+        "identifier": "ModularHarbingerSMG_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHarbingerSMG_BR_CH5S2_Legendary": [
+      {
+        "identifier": "ModularHarbingerSMG_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HadesModularHarbingerSMG_BR_CH5S2_Mythic": [
+      {
+        "identifier": "HadesModularHarbingerSMG_BR_CH5S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocPumpShotgun_BR_CH4S2_Common": [
+      {
+        "identifier": "HavocPumpShotgun_BR_CH4S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocPumpShotgun_BR_CH4S2_Uncommon": [
+      {
+        "identifier": "HavocPumpShotgun_BR_CH4S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocPumpShotgun_BR_CH4S2_Rare": [
+      {
+        "identifier": "HavocPumpShotgun_BR_CH4S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocPumpShotgun_BR_CH4S2_Epic": [
+      {
+        "identifier": "HavocPumpShotgun_BR_CH4S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocPumpShotgun_BR_CH4S2_Legendary": [
+      {
+        "identifier": "HavocPumpShotgun_BR_CH4S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedHavocShotgun_BR_CH4S2_Mythic": [
+      {
+        "identifier": "EnhancedHavocShotgun_BR_CH4S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocSuppressedAssaultRifle_BR_CH4S2_Common": [
+      {
+        "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocSuppressedAssaultRifle_BR_CH4S2_Uncommon": [
+      {
+        "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocSuppressedAssaultRifle_BR_CH4S2_Rare": [
+      {
+        "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocSuppressedAssaultRifle_BR_CH4S2_Epic": [
+      {
+        "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocSuppressedAssaultRifle_BR_CH4S2_Legendary": [
+      {
+        "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HavocSuppressedAssaultRifle_BR_CH4S2_Mythic": [
+      {
+        "identifier": "HavocSuppressedAssaultRifle_BR_CH4S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HighcardsHavocSuppressedRifle_BR_CH4S2_Mythic": [
+      {
+        "identifier": "HighcardsHavocSuppressedRifle_BR_CH4S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeartsHavocSuppressedRifle_BR_CH4S4_Mythic": [
+      {
+        "identifier": "HeartsHavocSuppressedRifle_BR_CH4S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyAssaultRifle_BR_CH1S6_Rare": [
+      {
+        "identifier": "HeavyAssaultRifle_BR_CH1S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyAssaultRifle_BR_CH1S6_Epic": [
+      {
+        "identifier": "HeavyAssaultRifle_BR_CH1S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyAssaultRifle_BR_CH1S6_Legendary": [
+      {
+        "identifier": "HeavyAssaultRifle_BR_CH1S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyAssaultRifle_BR_CH1S8_Common": [
+      {
+        "identifier": "HeavyAssaultRifle_BR_CH1S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyAssaultRifle_BR_CH1S8_Uncommon": [
+      {
+        "identifier": "HeavyAssaultRifle_BR_CH1S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyImpactSniperRifle_BR_CH5S3_Rare": [
+      {
+        "identifier": "HeavyImpactSniperRifle_BR_CH5S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyImpactSniperRifle_BR_CH5S3_Epic": [
+      {
+        "identifier": "HeavyImpactSniperRifle_BR_CH5S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyImpactSniperRifle_BR_CH5S3_Legendary": [
+      {
+        "identifier": "HeavyImpactSniperRifle_BR_CH5S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessHeavyImpactTrackingRifle_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessHeavyImpactTrackingRifle_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawfulHeavyImpactTrackingRifle_BR_CH7S2_Exotic": [
+      {
+        "identifier": "LawfulHeavyImpactTrackingRifle_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyShotgun_BR_CH3S1_Common": [
+      {
+        "identifier": "HeavyShotgun_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyShotgun_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "HeavyShotgun_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyShotgun_BR_CH3S1_Rare": [
+      {
+        "identifier": "HeavyShotgun_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyShotgun_BR_CH3S1_Epic": [
+      {
+        "identifier": "HeavyShotgun_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyShotgun_BR_CH3S1_Legendary": [
+      {
+        "identifier": "HeavyShotgun_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeistedBreacherShotgun_BR_CH4S1_Exotic": [
+      {
+        "identifier": "HeistedBreacherShotgun_BR_CH4S1_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyShotgun_OG_CH1S3_Epic": [
+      {
+        "identifier": "HeavyShotgun_OG_CH1S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavyShotgun_OG_CH1S3_Legendary": [
+      {
+        "identifier": "HeavyShotgun_OG_CH1S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavySniperRifle_BR_CH1S5_Epic": [
+      {
+        "identifier": "HeavySniperRifle_BR_CH1S5_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavySniperRifle_BR_CH1S5_Legendary": [
+      {
+        "identifier": "HeavySniperRifle_BR_CH1S5_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeavySniperRifle_BR_CH3S3_Mythic": [
+      {
+        "identifier": "HeavySniperRifle_BR_CH3S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloRushSMG_BR_CH7S1_Common": [
+      {
+        "identifier": "HoloRushSMG_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloRushSMG_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "HoloRushSMG_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloRushSMG_BR_CH7S1_Rare": [
+      {
+        "identifier": "HoloRushSMG_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloRushSMG_BR_CH7S1_Epic": [
+      {
+        "identifier": "HoloRushSMG_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloRushSMG_BR_CH7S1_Legendary": [
+      {
+        "identifier": "HoloRushSMG_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "YuleTroopersHoloRushSMG_BR_CH7S1_Mythic": [
+      {
+        "identifier": "YuleTroopersHoloRushSMG_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloTwisterAssaultRifle_BR_CH6S1_Common": [
+      {
+        "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloTwisterAssaultRifle_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloTwisterAssaultRifle_BR_CH6S1_Rare": [
+      {
+        "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloTwisterAssaultRifle_BR_CH6S1_Epic": [
+      {
+        "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HoloTwisterAssaultRifle_BR_CH6S1_Legendary": [
+      {
+        "identifier": "HoloTwisterAssaultRifle_BR_CH6S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedHoloTwisterAssaultRifle_BR_CH6S1_Mythic": [
+      {
+        "identifier": "EnhancedHoloTwisterAssaultRifle_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HopRockDualies_BR_CH2S5_Exotic": [
+      {
+        "identifier": "HopRockDualies_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HunterBoltActionSniper_BR_CH3S1_Common": [
+      {
+        "identifier": "HunterBoltActionSniper_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HunterBoltActionSniper_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "HunterBoltActionSniper_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HunterBoltActionSniper_BR_CH3S1_Rare": [
+      {
+        "identifier": "HunterBoltActionSniper_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HunterBoltActionSniper_BR_CH3S1_Epic": [
+      {
+        "identifier": "HunterBoltActionSniper_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HunterBoltActionSniper_BR_CH3S1_Legendary": [
+      {
+        "identifier": "HunterBoltActionSniper_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntingRifle_BR_CH1S3_Uncommon": [
+      {
+        "identifier": "HuntingRifle_BR_CH1S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntingRifle_BR_CH1S3_Rare": [
+      {
+        "identifier": "HuntingRifle_BR_CH1S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntingRifle_BR_CH2S3_Epic": [
+      {
+        "identifier": "HuntingRifle_BR_CH2S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntingRifle_BR_CH2S3_Legendary": [
+      {
+        "identifier": "HuntingRifle_BR_CH2S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntingRifle_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "HuntingRifle_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntingRifle_BR_CH6S1_Rare": [
+      {
+        "identifier": "HuntingRifle_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntingRifle_BR_CH6S1_Mythic": [
+      {
+        "identifier": "HuntingRifle_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessStinkRifle_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessStinkRifle_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHuntressDMR_BR_CH5S2_Uncommon": [
+      {
+        "identifier": "ModularHuntressDMR_BR_CH5S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHuntressDMR_BR_CH5S2_Rare": [
+      {
+        "identifier": "ModularHuntressDMR_BR_CH5S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHuntressDMR_BR_CH5S2_Epic": [
+      {
+        "identifier": "ModularHuntressDMR_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHuntressDMR_BR_CH5S2_Legendary": [
+      {
+        "identifier": "ModularHuntressDMR_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularZeusHuntressDMR_BR_CH5S2_Mythic": [
+      {
+        "identifier": "ModularZeusHuntressDMR_BR_CH5S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HyperburstPistol_BR_CH6S3_Common": [
+      {
+        "identifier": "HyperburstPistol_BR_CH6S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HyperburstPistol_BR_CH6S3_Uncommon": [
+      {
+        "identifier": "HyperburstPistol_BR_CH6S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HyperburstPistol_BR_CH6S3_Rare": [
+      {
+        "identifier": "HyperburstPistol_BR_CH6S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HyperburstPistol_BR_CH6S3_Epic": [
+      {
+        "identifier": "HyperburstPistol_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HyperburstPistol_BR_CH6S3_Legendary": [
+      {
+        "identifier": "HyperburstPistol_BR_CH6S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedHyperburstPistol_BR_CH6S3_Mythic": [
+      {
+        "identifier": "EnhancedHyperburstPistol_BR_CH6S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "UnstableVoltageBurstPistol_BR_CH6S3_Exotic": [
+      {
+        "identifier": "UnstableVoltageBurstPistol_BR_CH6S3_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHyperSMG_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularHyperSMG_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHyperSMG_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularHyperSMG_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHyperSMG_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularHyperSMG_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHyperSMG_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularHyperSMG_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularHyperSMG_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularHyperSMG_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ValeriasModularHyperSMG_BR_CH5S1_Mythic": [
+      {
+        "identifier": "ValeriasModularHyperSMG_BR_CH5S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HyperSMG_Ballistic_V1_Common": [
+      {
+        "identifier": "HyperSMG_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IceKingsGauntlets_BR_CH7S2_Mythic": [
+      {
+        "identifier": "IceKingsGauntlets_BR_CH7S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfantryRifle_BR_CH1S7_Common": [
+      {
+        "identifier": "InfantryRifle_BR_CH1S7_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfantryRifle_BR_CH1S7_Uncommon": [
+      {
+        "identifier": "InfantryRifle_BR_CH1S7_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfantryRifle_BR_CH1S7_Rare": [
+      {
+        "identifier": "InfantryRifle_BR_CH1S7_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfantryRifle_BR_CH1S8_Epic": [
+      {
+        "identifier": "InfantryRifle_BR_CH1S8_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfantryRifle_BR_CH1S8_Legendary": [
+      {
+        "identifier": "InfantryRifle_BR_CH1S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfantryRifle_BR_CH6MS2_Epic": [
+      {
+        "identifier": "InfantryRifle_BR_CH6MS2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfantryRifle_BR_CH6MS2_Legendary": [
+      {
+        "identifier": "InfantryRifle_BR_CH6MS2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfiltratorPumpShotgun_BR_CH4S4_Common": [
+      {
+        "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfiltratorPumpShotgun_BR_CH4S4_Uncommon": [
+      {
+        "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfiltratorPumpShotgun_BR_CH4S4_Rare": [
+      {
+        "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfiltratorPumpShotgun_BR_CH4S4_Epic": [
+      {
+        "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfiltratorPumpShotgun_BR_CH4S4_Legendary": [
+      {
+        "identifier": "InfiltratorPumpShotgun_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedInfiltratorPumpShotgun_BR_CH4S4_Mythic": [
+      {
+        "identifier": "EnhancedInfiltratorPumpShotgun_BR_CH4S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InfinityBlade_BR_CH1S7_Mythic": [
+      {
+        "identifier": "InfinityBlade_BR_CH1S7_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IronPumpShotgun_BR_CH7S1_Common": [
+      {
+        "identifier": "IronPumpShotgun_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IronPumpShotgun_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "IronPumpShotgun_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IronPumpShotgun_BR_CH7S1_Rare": [
+      {
+        "identifier": "IronPumpShotgun_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IronPumpShotgun_BR_CH7S1_Epic": [
+      {
+        "identifier": "IronPumpShotgun_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "IronPumpShotgun_BR_CH7S1_Legendary": [
+      {
+        "identifier": "IronPumpShotgun_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PinpointIronPumpShotgun_BR_CH7S1_Mythic": [
+      {
+        "identifier": "PinpointIronPumpShotgun_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KillswitchsRevolvers_BR_CH6S3_Mythic": [
+      {
+        "identifier": "KillswitchsRevolvers_BR_CH6S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KillswitchRevolvers_BR_CH6S3_Rare": [
+      {
+        "identifier": "KillswitchRevolvers_BR_CH6S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KillswitchRevolvers_BR_CH6S3_Epic": [
+      {
+        "identifier": "KillswitchRevolvers_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KillswitchRevolvers_BR_CH6S3_Legendary": [
+      {
+        "identifier": "KillswitchRevolvers_BR_CH6S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KineticBlade_BR_CH4S2_Rare": [
+      {
+        "identifier": "KineticBlade_BR_CH4S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KineticBlade_BR_CH4S2_Epic": [
+      {
+        "identifier": "KineticBlade_BR_CH4S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThornesVampiricBlade_BR_CH4S4_Mythic": [
+      {
+        "identifier": "ThornesVampiricBlade_BR_CH4S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KineticBoomerang_BR_CH4S3_Epic": [
+      {
+        "identifier": "KineticBoomerang_BR_CH4S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KymeraRayGun_BR_CH2S7_Rare": [
+      {
+        "identifier": "KymeraRayGun_BR_CH2S7_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KymeraRayGun_BR_CH2S7_Epic": [
+      {
+        "identifier": "KymeraRayGun_BR_CH2S7_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KymeraRayGun_BR_CH2S7_Legendary": [
+      {
+        "identifier": "KymeraRayGun_BR_CH2S7_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ZygAndChoppysRayGun_BR_CH2S7_Mythic": [
+      {
+        "identifier": "ZygAndChoppysRayGun_BR_CH2S7_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawfulAccelerantHoloTwisterAR_BR_CH7S2_Exotic": [
+      {
+        "identifier": "LawfulAccelerantHoloTwisterAR_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawfulShockwaveRocketLauncher_BR_CH7S2_Exotic": [
+      {
+        "identifier": "LawfulShockwaveRocketLauncher_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessAccelerantHoloTwisterAR_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessAccelerantHoloTwisterAR_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessFinalMarkRifle_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessFinalMarkRifle_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessShockwaveRocketLauncher_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessShockwaveRocketLauncher_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Leadspitter3000_BR_CH6S4_Epic": [
+      {
+        "identifier": "Leadspitter3000_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Leadspitter3000_BR_CH6S4_Legendary": [
+      {
+        "identifier": "Leadspitter3000_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Leadspitter3000_BR_CH6S4_Mythic": [
+      {
+        "identifier": "Leadspitter3000_BR_CH6S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionRifle_BR_CH2S5_Uncommon": [
+      {
+        "identifier": "LeverActionRifle_BR_CH2S5_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionRifle_BR_CH2S5_Rare": [
+      {
+        "identifier": "LeverActionRifle_BR_CH2S5_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionRifle_BR_CH2S5_Epic": [
+      {
+        "identifier": "LeverActionRifle_BR_CH2S5_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionRifle_BR_CH2S5_Legendary": [
+      {
+        "identifier": "LeverActionRifle_BR_CH2S5_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionShotgun_BR_CH2S5_Common": [
+      {
+        "identifier": "LeverActionShotgun_BR_CH2S5_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionShotgun_BR_CH2S5_Uncommon": [
+      {
+        "identifier": "LeverActionShotgun_BR_CH2S5_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionShotgun_BR_CH2S5_Rare": [
+      {
+        "identifier": "LeverActionShotgun_BR_CH2S5_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionShotgun_BR_CH2S5_Epic": [
+      {
+        "identifier": "LeverActionShotgun_BR_CH2S5_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LeverActionShotgun_BR_CH2S5_Legendary": [
+      {
+        "identifier": "LeverActionShotgun_BR_CH2S5_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LightMachineGun_BR_CH1S3_Rare": [
+      {
+        "identifier": "LightMachineGun_BR_CH1S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LightMachineGun_BR_CH1S3_Epic": [
+      {
+        "identifier": "LightMachineGun_BR_CH1S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LightMachineGun_BR_CH3S2_Common": [
+      {
+        "identifier": "LightMachineGun_BR_CH3S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LightMachineGun_BR_CH3S2_Uncommon": [
+      {
+        "identifier": "LightMachineGun_BR_CH3S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LightMachineGun_BR_CH3S2_Legendary": [
+      {
+        "identifier": "LightMachineGun_BR_CH3S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LockOnAssaultRifle_BR_CH7S1_Common": [
+      {
+        "identifier": "LockOnAssaultRifle_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LockOnAssaultRifle_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "LockOnAssaultRifle_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LockOnAssaultRifle_BR_CH7S1_Rare": [
+      {
+        "identifier": "LockOnAssaultRifle_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LockOnAssaultRifle_BR_CH7S1_Epic": [
+      {
+        "identifier": "LockOnAssaultRifle_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LockOnAssaultRifle_BR_CH7S1_Legendary": [
+      {
+        "identifier": "LockOnAssaultRifle_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LockOnPistol_BR_CH4S2_Rare": [
+      {
+        "identifier": "LockOnPistol_BR_CH4S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MachinePistol_Ballistic_V1_Common": [
+      {
+        "identifier": "MachinePistol_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MachineSMG_BR_CH3S1_Common": [
+      {
+        "identifier": "MachineSMG_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MachineSMG_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "MachineSMG_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MachineSMG_BR_CH3S1_Rare": [
+      {
+        "identifier": "MachineSMG_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MachineSMG_BR_CH3S1_Epic": [
+      {
+        "identifier": "MachineSMG_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MachineSMG_BR_CH3S1_Legendary": [
+      {
+        "identifier": "MachineSMG_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftBow_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "MakeshiftBow_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftRevolver_BR_CH2S6_Common": [
+      {
+        "identifier": "MakeshiftRevolver_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftRevolver_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "MakeshiftRevolver_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftRevolver_BR_CH2S6_Rare": [
+      {
+        "identifier": "MakeshiftRevolver_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftRifle_BR_CH2S6_Common": [
+      {
+        "identifier": "MakeshiftRifle_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftRifle_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "MakeshiftRifle_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftRifle_BR_CH2S6_Rare": [
+      {
+        "identifier": "MakeshiftRifle_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftShotgun_BR_CH2S6_Common": [
+      {
+        "identifier": "MakeshiftShotgun_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftShotgun_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "MakeshiftShotgun_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftShotgun_BR_CH2S6_Rare": [
+      {
+        "identifier": "MakeshiftShotgun_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftSubmachineGun_BR_CH2S6_Common": [
+      {
+        "identifier": "MakeshiftSubmachineGun_BR_CH2S6_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftSubmachineGun_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "MakeshiftSubmachineGun_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeshiftSubmachineGun_BR_CH2S6_Rare": [
+      {
+        "identifier": "MakeshiftSubmachineGun_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MammothPistol_BR_CH4S3_Common": [
+      {
+        "identifier": "MammothPistol_BR_CH4S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MammothPistol_BR_CH4S3_Uncommon": [
+      {
+        "identifier": "MammothPistol_BR_CH4S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MammothPistol_BR_CH4S3_Rare": [
+      {
+        "identifier": "MammothPistol_BR_CH4S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MammothPistol_BR_CH4S3_Epic": [
+      {
+        "identifier": "MammothPistol_BR_CH4S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MammothPistol_BR_CH4S3_Legendary": [
+      {
+        "identifier": "MammothPistol_BR_CH4S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BaronsDoubleDownPistol_BR_CH6S2_Mythic": [
+      {
+        "identifier": "BaronsDoubleDownPistol_BR_CH6S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessExplosiveMammothPistol_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessExplosiveMammothPistol_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawfulExplosiveMammothPistol_BR_CH7S2_Exotic": [
+      {
+        "identifier": "LawfulExplosiveMammothPistol_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MarksmanSixShooter_BR_CH2S6_Exotic": [
+      {
+        "identifier": "MarksmanSixShooter_BR_CH2S6_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MavenAutoShotgun_BR_CH4S1_Common": [
+      {
+        "identifier": "MavenAutoShotgun_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MavenAutoShotgun_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "MavenAutoShotgun_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MavenAutoShotgun_BR_CH4S1_Rare": [
+      {
+        "identifier": "MavenAutoShotgun_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MavenAutoShotgun_BR_CH4S1_Epic": [
+      {
+        "identifier": "MavenAutoShotgun_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MavenAutoShotgun_BR_CH4S1_Legendary": [
+      {
+        "identifier": "MavenAutoShotgun_BR_CH4S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeistedAccelerantShotgun_BR_CH4S1_Exotic": [
+      {
+        "identifier": "HeistedAccelerantShotgun_BR_CH4S1_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalBow_BR_CH2S6_Rare": [
+      {
+        "identifier": "MechanicalBow_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalExplosiveBow_BR_CH2S6_Rare": [
+      {
+        "identifier": "MechanicalExplosiveBow_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalExplosiveBow_BR_CH2S6_Epic": [
+      {
+        "identifier": "MechanicalExplosiveBow_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalExplosiveBow_BR_CH2S6_Legendary": [
+      {
+        "identifier": "MechanicalExplosiveBow_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RazsExplosiveBow_BR_CH2S6_Mythic": [
+      {
+        "identifier": "RazsExplosiveBow_BR_CH2S6_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalShockwaveBow_BR_CH2S6_Rare": [
+      {
+        "identifier": "MechanicalShockwaveBow_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalShockwaveBow_BR_CH2S6_Epic": [
+      {
+        "identifier": "MechanicalShockwaveBow_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MechanicalShockwaveBow_BR_CH2S6_Legendary": [
+      {
+        "identifier": "MechanicalShockwaveBow_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MeowsclesPeowPeowRifle_BR_CH2S2_Mythic": [
+      {
+        "identifier": "MeowsclesPeowPeowRifle_BR_CH2S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Minigun_BR_CH1S2_Epic": [
+      {
+        "identifier": "Minigun_BR_CH1S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Minigun_BR_CH1S2_Legendary": [
+      {
+        "identifier": "Minigun_BR_CH1S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BrutusMinigun_BR_CH2S2_Mythic": [
+      {
+        "identifier": "BrutusMinigun_BR_CH2S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Minigun_BR_CH5S3_Rare": [
+      {
+        "identifier": "Minigun_BR_CH5S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKAlphaAssaultRifle_BR_CH4S2_Common": [
+      {
+        "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKAlphaAssaultRifle_BR_CH4S2_Uncommon": [
+      {
+        "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKAlphaAssaultRifle_BR_CH4S2_Rare": [
+      {
+        "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKAlphaAssaultRifle_BR_CH4S2_Epic": [
+      {
+        "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKAlphaAssaultRifle_BR_CH4S2_Legendary": [
+      {
+        "identifier": "MKAlphaAssaultRifle_BR_CH4S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKSevenAssaultRifle_BR_CH3S1_Common": [
+      {
+        "identifier": "MKSevenAssaultRifle_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKSevenAssaultRifle_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "MKSevenAssaultRifle_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKSevenAssaultRifle_BR_CH3S1_Rare": [
+      {
+        "identifier": "MKSevenAssaultRifle_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKSevenAssaultRifle_BR_CH3S1_Epic": [
+      {
+        "identifier": "MKSevenAssaultRifle_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MKSevenAssaultRifle_BR_CH3S1_Legendary": [
+      {
+        "identifier": "MKSevenAssaultRifle_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReliksMKAlphaAssaultRifle_BR_CH4S2_Mythic": [
+      {
+        "identifier": "ReliksMKAlphaAssaultRifle_BR_CH4S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheFoundationsMKSevenAssaultRifle_BR_CH3S1_Mythic": [
+      {
+        "identifier": "TheFoundationsMKSevenAssaultRifle_BR_CH3S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularMonarchPistol_BR_CH5S4_Common": [
+      {
+        "identifier": "ModularMonarchPistol_BR_CH5S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularMonarchPistol_BR_CH5S4_Uncommon": [
+      {
+        "identifier": "ModularMonarchPistol_BR_CH5S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularMonarchPistol_BR_CH5S4_Rare": [
+      {
+        "identifier": "ModularMonarchPistol_BR_CH5S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularMonarchPistol_BR_CH5S4_Epic": [
+      {
+        "identifier": "ModularMonarchPistol_BR_CH5S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularMonarchPistol_BR_CH5S4_Legendary": [
+      {
+        "identifier": "ModularMonarchPistol_BR_CH5S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MystGauntlets_BR_CH6S3_Epic": [
+      {
+        "identifier": "MystGauntlets_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularNemesisAR_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularNemesisAR_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularNemesisAR_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularNemesisAR_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularNemesisAR_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularNemesisAR_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularNemesisAR_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularNemesisAR_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularNemesisAR_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularNemesisAR_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MontaguesModularNemesisAR_BR_CH5S1_Mythic": [
+      {
+        "identifier": "MontaguesModularNemesisAR_BR_CH5S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NemesisAR_BR_CH7S2_Common": [
+      {
+        "identifier": "NemesisAR_BR_CH7S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NemesisAR_BR_CH7S2_Uncommon": [
+      {
+        "identifier": "NemesisAR_BR_CH7S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NemesisAR_BR_CH7S2_Rare": [
+      {
+        "identifier": "NemesisAR_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NemesisAR_BR_CH7S2_Epic": [
+      {
+        "identifier": "NemesisAR_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NemesisAR_BR_CH7S2_Legendary": [
+      {
+        "identifier": "NemesisAR_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NemesisAR_Ballistic_V1_Common": [
+      {
+        "identifier": "NemesisAR_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NightHawk_BR_CH2S5_Exotic": [
+      {
+        "identifier": "NightHawk_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NitroFists_BR_CH5S3_Epic": [
+      {
+        "identifier": "NitroFists_BR_CH5S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MegaloDonsNitroFists_BR_CH5S3_Mythic": [
+      {
+        "identifier": "MegaloDonsNitroFists_BR_CH5S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OXRRifle_BR_CH6S4_Common": [
+      {
+        "identifier": "OXRRifle_BR_CH6S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OXRRifle_BR_CH6S4_Uncommon": [
+      {
+        "identifier": "OXRRifle_BR_CH6S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OXRRifle_BR_CH6S4_Rare": [
+      {
+        "identifier": "OXRRifle_BR_CH6S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OXRRifle_BR_CH6S4_Epic": [
+      {
+        "identifier": "OXRRifle_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OXRRifle_BR_CH6S4_Legendary": [
+      {
+        "identifier": "OXRRifle_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OXRRifle_BR_CH6S4_Mythic": [
+      {
+        "identifier": "OXRRifle_BR_CH6S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OniShotgun_BR_CH6S1_Common": [
+      {
+        "identifier": "OniShotgun_BR_CH6S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OniShotgun_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "OniShotgun_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OniShotgun_BR_CH6S1_Rare": [
+      {
+        "identifier": "OniShotgun_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OniShotgun_BR_CH6S1_Epic": [
+      {
+        "identifier": "OniShotgun_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OniShotgun_BR_CH6S1_Legendary": [
+      {
+        "identifier": "OniShotgun_BR_CH6S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedOniShotgun_BR_CH6S1_Mythic": [
+      {
+        "identifier": "EnhancedOniShotgun_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OrangePaintLauncher_BR_CH2S2_Rare": [
+      {
+        "identifier": "OrangePaintLauncher_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OutlawShotgun_BR_CH6S2_Common": [
+      {
+        "identifier": "OutlawShotgun_BR_CH6S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OutlawShotgun_BR_CH6S2_Uncommon": [
+      {
+        "identifier": "OutlawShotgun_BR_CH6S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OutlawShotgun_BR_CH6S2_Rare": [
+      {
+        "identifier": "OutlawShotgun_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OutlawShotgun_BR_CH6S2_Epic": [
+      {
+        "identifier": "OutlawShotgun_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OutlawShotgun_BR_CH6S2_Legendary": [
+      {
+        "identifier": "OutlawShotgun_BR_CH6S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedOutlawShotgun_BR_CH6S2_Mythic": [
+      {
+        "identifier": "EnhancedOutlawShotgun_BR_CH6S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "UnstableYoinkShotgun_BR_CH6S3_Exotic": [
+      {
+        "identifier": "UnstableYoinkShotgun_BR_CH6S3_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EradicatorOXRRifle_BR_CH6S4_Exotic": [
+      {
+        "identifier": "EradicatorOXRRifle_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH4MS1_Common": [
+      {
+        "identifier": "Pistol_BR_CH4MS1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH4MS1_Uncommon": [
+      {
+        "identifier": "Pistol_BR_CH4MS1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH4MS1_Rare": [
+      {
+        "identifier": "Pistol_BR_CH4MS1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH7S2_Common": [
+      {
+        "identifier": "Pistol_BR_CH7S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH7S2_Uncommon": [
+      {
+        "identifier": "Pistol_BR_CH7S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH7S2_Rare": [
+      {
+        "identifier": "Pistol_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH7S2_Epic": [
+      {
+        "identifier": "Pistol_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Pistol_BR_CH7S2_Legendary": [
+      {
+        "identifier": "Pistol_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PlasmaBurstLaser_BR_CH6S2_Epic": [
+      {
+        "identifier": "PlasmaBurstLaser_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PlasmaCannon_BR_CH2S7_Legendary": [
+      {
+        "identifier": "PlasmaCannon_BR_CH2S7_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalBow_BR_CH2S6_Rare": [
+      {
+        "identifier": "PrimalBow_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalFlameBow_BR_CH2S6_Rare": [
+      {
+        "identifier": "PrimalFlameBow_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalFlameBow_BR_CH2S6_Epic": [
+      {
+        "identifier": "PrimalFlameBow_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalFlameBow_BR_CH2S6_Legendary": [
+      {
+        "identifier": "PrimalFlameBow_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalPistol_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "PrimalPistol_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalPistol_BR_CH2S6_Rare": [
+      {
+        "identifier": "PrimalPistol_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalPistol_BR_CH2S6_Epic": [
+      {
+        "identifier": "PrimalPistol_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalPistol_BR_CH2S6_Legendary": [
+      {
+        "identifier": "PrimalPistol_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalRifle_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "PrimalRifle_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalRifle_BR_CH2S6_Rare": [
+      {
+        "identifier": "PrimalRifle_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalRifle_BR_CH2S6_Epic": [
+      {
+        "identifier": "PrimalRifle_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalRifle_BR_CH2S6_Legendary": [
+      {
+        "identifier": "PrimalRifle_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireGuardiansPrimalAssaultRifle_BR_CH2S6_Mythic": [
+      {
+        "identifier": "SpireGuardiansPrimalAssaultRifle_BR_CH2S6_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalShotgun_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "PrimalShotgun_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalShotgun_BR_CH2S6_Rare": [
+      {
+        "identifier": "PrimalShotgun_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalShotgun_BR_CH2S6_Epic": [
+      {
+        "identifier": "PrimalShotgun_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalShotgun_BR_CH2S6_Legendary": [
+      {
+        "identifier": "PrimalShotgun_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireAssassinsPrimalShotgun_BR_CH2S6_Mythic": [
+      {
+        "identifier": "SpireAssassinsPrimalShotgun_BR_CH2S6_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalSMG_BR_CH2S6_Uncommon": [
+      {
+        "identifier": "PrimalSMG_BR_CH2S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalSMG_BR_CH2S6_Rare": [
+      {
+        "identifier": "PrimalSMG_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalSMG_BR_CH2S6_Epic": [
+      {
+        "identifier": "PrimalSMG_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalSMG_BR_CH2S6_Legendary": [
+      {
+        "identifier": "PrimalSMG_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalStinkBow_BR_CH2S6_Rare": [
+      {
+        "identifier": "PrimalStinkBow_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalStinkBow_BR_CH2S6_Epic": [
+      {
+        "identifier": "PrimalStinkBow_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimalStinkBow_BR_CH2S6_Legendary": [
+      {
+        "identifier": "PrimalStinkBow_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimeShotgun_BR_CH3S3_Common": [
+      {
+        "identifier": "PrimeShotgun_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimeShotgun_BR_CH3S3_Uncommon": [
+      {
+        "identifier": "PrimeShotgun_BR_CH3S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimeShotgun_BR_CH3S3_Rare": [
+      {
+        "identifier": "PrimeShotgun_BR_CH3S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimeShotgun_BR_CH3S3_Epic": [
+      {
+        "identifier": "PrimeShotgun_BR_CH3S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimeShotgun_BR_CH3S3_Legendary": [
+      {
+        "identifier": "PrimeShotgun_BR_CH3S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PrimeShotgun_BR_CH3S3_Mythic": [
+      {
+        "identifier": "PrimeShotgun_BR_CH3S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ProximityGrenadeLauncher_BR_CH1S9_Epic": [
+      {
+        "identifier": "ProximityGrenadeLauncher_BR_CH1S9_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ProximityGrenadeLauncher_BR_CH1S9_Legendary": [
+      {
+        "identifier": "ProximityGrenadeLauncher_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PulseRifle_BR_CH2S7_Rare": [
+      {
+        "identifier": "PulseRifle_BR_CH2S7_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PulseRifle_BR_CH2S7_Epic": [
+      {
+        "identifier": "PulseRifle_BR_CH2S7_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PulseRifle_BR_CH2S7_Legendary": [
+      {
+        "identifier": "PulseRifle_BR_CH2S7_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlonesPulseRifle_BR_CH2S7_Mythic": [
+      {
+        "identifier": "SlonesPulseRifle_BR_CH2S7_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BurstPulseRifle_BR_CH2S7_Exotic": [
+      {
+        "identifier": "BurstPulseRifle_BR_CH2S7_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OverclockedPulseRifle_BR_CH4S2_Mythic": [
+      {
+        "identifier": "OverclockedPulseRifle_BR_CH4S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PulseRifle_BR_CH7S2_Uncommon": [
+      {
+        "identifier": "PulseRifle_BR_CH7S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OverdrivePulseRifle_BR_CH7S2_Exotic": [
+      {
+        "identifier": "OverdrivePulseRifle_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpDump_BR_CH6S2_Common": [
+      {
+        "identifier": "PumpDump_BR_CH6S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpDump_BR_CH6S2_Uncommon": [
+      {
+        "identifier": "PumpDump_BR_CH6S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpDump_BR_CH6S2_Rare": [
+      {
+        "identifier": "PumpDump_BR_CH6S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpDump_BR_CH6S2_Epic": [
+      {
+        "identifier": "PumpDump_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpDump_BR_CH6S2_Legendary": [
+      {
+        "identifier": "PumpDump_BR_CH6S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpDump_BR_CH6S2_Mythic": [
+      {
+        "identifier": "PumpDump_BR_CH6S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessBlinkPumpDump_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessBlinkPumpDump_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpkinLauncher_BR_CH1S1_Rare": [
+      {
+        "identifier": "PumpkinLauncher_BR_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpkinLauncher_BR_CH1S1_Epic": [
+      {
+        "identifier": "PumpkinLauncher_BR_CH1S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpkinLauncher_BR_CH1S1_Legendary": [
+      {
+        "identifier": "PumpkinLauncher_BR_CH1S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpkinLauncher_BR_CH2S1_Uncommon": [
+      {
+        "identifier": "PumpkinLauncher_BR_CH2S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpkinLauncher_BR_CH6S4_Rare": [
+      {
+        "identifier": "PumpkinLauncher_BR_CH6S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpkinLauncher_BR_CH6S4_Epic": [
+      {
+        "identifier": "PumpkinLauncher_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpkinLauncher_BR_CH6S4_Legendary": [
+      {
+        "identifier": "PumpkinLauncher_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "PumpShotgun_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_PreSeason_Rare": [
+      {
+        "identifier": "PumpShotgun_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH1S6_Epic": [
+      {
+        "identifier": "PumpShotgun_BR_CH1S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH1S6_Legendary": [
+      {
+        "identifier": "PumpShotgun_BR_CH1S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH2S1_Common": [
+      {
+        "identifier": "PumpShotgun_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_OG_CH1S1_Common": [
+      {
+        "identifier": "PumpShotgun_OG_CH1S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH4MS1_Common": [
+      {
+        "identifier": "PumpShotgun_BR_CH4MS1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_OG_CH1S1_Uncommon": [
+      {
+        "identifier": "PumpShotgun_OG_CH1S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH4MS1_Uncommon": [
+      {
+        "identifier": "PumpShotgun_BR_CH4MS1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_OG_CH1S3_Rare": [
+      {
+        "identifier": "PumpShotgun_OG_CH1S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH4MS1_Rare": [
+      {
+        "identifier": "PumpShotgun_BR_CH4MS1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_OG_CH1S6_Epic": [
+      {
+        "identifier": "PumpShotgun_OG_CH1S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH4MS1_Epic": [
+      {
+        "identifier": "PumpShotgun_BR_CH4MS1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_OG_CH1S6_Legendary": [
+      {
+        "identifier": "PumpShotgun_OG_CH1S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PumpShotgun_BR_CH4MS1_Legendary": [
+      {
+        "identifier": "PumpShotgun_BR_CH4MS1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "PurplePaintLauncher_BR_CH2S2_Rare": [
+      {
+        "identifier": "PurplePaintLauncher_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "QuadLauncher_BR_CH1S6_Epic": [
+      {
+        "identifier": "QuadLauncher_BR_CH1S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "QuadLauncher_BR_CH1S6_Legendary": [
+      {
+        "identifier": "QuadLauncher_BR_CH1S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RailGun_BR_CH2S7_Rare": [
+      {
+        "identifier": "RailGun_BR_CH2S7_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RailGun_BR_CH2S7_Epic": [
+      {
+        "identifier": "RailGun_BR_CH2S7_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RailGun_BR_CH2S7_Legendary": [
+      {
+        "identifier": "RailGun_BR_CH2S7_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerAssaultRifle_BR_CH3S1_Common": [
+      {
+        "identifier": "RangerAssaultRifle_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerAssaultRifle_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "RangerAssaultRifle_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerAssaultRifle_BR_CH3S1_Rare": [
+      {
+        "identifier": "RangerAssaultRifle_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerAssaultRifle_BR_CH3S1_Epic": [
+      {
+        "identifier": "RangerAssaultRifle_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerAssaultRifle_BR_CH3S1_Legendary": [
+      {
+        "identifier": "RangerAssaultRifle_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerAssaultRifle_BR_CH3S1_Mythic": [
+      {
+        "identifier": "RangerAssaultRifle_BR_CH3S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularRangerPistol_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularRangerPistol_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularRangerPistol_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularRangerPistol_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularRangerPistol_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularRangerPistol_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularRangerPistol_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularRangerPistol_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularRangerPistol_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularRangerPistol_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerPistol_Ballistic_V1_Common": [
+      {
+        "identifier": "RangerPistol_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerShotgun_BR_CH3S2_Common": [
+      {
+        "identifier": "RangerShotgun_BR_CH3S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerShotgun_BR_CH3S2_Uncommon": [
+      {
+        "identifier": "RangerShotgun_BR_CH3S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerShotgun_BR_CH3S2_Rare": [
+      {
+        "identifier": "RangerShotgun_BR_CH3S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerShotgun_BR_CH3S2_Epic": [
+      {
+        "identifier": "RangerShotgun_BR_CH3S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RangerShotgun_BR_CH3S2_Legendary": [
+      {
+        "identifier": "RangerShotgun_BR_CH3S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RapidFireSMG_BR_CH2S2_Uncommon": [
+      {
+        "identifier": "RapidFireSMG_BR_CH2S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RapidFireSMG_BR_CH2S2_Rare": [
+      {
+        "identifier": "RapidFireSMG_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RapidFireSMG_BR_CH2S3_Common": [
+      {
+        "identifier": "RapidFireSMG_BR_CH2S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RapidFireSMG_BR_CH2S3_Epic": [
+      {
+        "identifier": "RapidFireSMG_BR_CH2S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RapidFireSMG_BR_CH2S3_Legendary": [
+      {
+        "identifier": "RapidFireSMG_BR_CH2S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RapidFireSMG_BR_CH3S4_Mythic": [
+      {
+        "identifier": "RapidFireSMG_BR_CH3S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReacherExtendingShotgun_BR_CH7S3_Mythic": [
+      {
+        "identifier": "ReacherExtendingShotgun_BR_CH7S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReaperModularSniperRifle_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ReaperModularSniperRifle_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReaperModularSniperRifle_BR_CH5S1_Rare": [
+      {
+        "identifier": "ReaperModularSniperRifle_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReaperModularSniperRifle_BR_CH5S1_Epic": [
+      {
+        "identifier": "ReaperModularSniperRifle_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReaperModularSniperRifle_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ReaperModularSniperRifle_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReaperSniperRifle_Ballistic_V1_Common": [
+      {
+        "identifier": "ReaperSniperRifle_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReconBow_BR_CH7S2_Exotic": [
+      {
+        "identifier": "ReconBow_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ExoticReconBow_BR_CH7S2_Exotic": [
+      {
+        "identifier": "ExoticReconBow_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReconScanner_BR_CH2S7_Rare": [
+      {
+        "identifier": "ReconScanner_BR_CH2S7_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Recycler_BR_CH2S6_Rare": [
+      {
+        "identifier": "Recycler_BR_CH2S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Recycler_BR_CH2S6_Epic": [
+      {
+        "identifier": "Recycler_BR_CH2S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Recycler_BR_CH2S6_Legendary": [
+      {
+        "identifier": "Recycler_BR_CH2S6_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireAssassinsRecycler_BR_CH2S6_Mythic": [
+      {
+        "identifier": "SpireAssassinsRecycler_BR_CH2S6_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedEyeAssaultRifle_BR_CH4S1_Common": [
+      {
+        "identifier": "RedEyeAssaultRifle_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedEyeAssaultRifle_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "RedEyeAssaultRifle_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedEyeAssaultRifle_BR_CH4S1_Rare": [
+      {
+        "identifier": "RedEyeAssaultRifle_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedEyeAssaultRifle_BR_CH4S1_Epic": [
+      {
+        "identifier": "RedEyeAssaultRifle_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RedEyeAssaultRifle_BR_CH4S1_Legendary": [
+      {
+        "identifier": "RedEyeAssaultRifle_BR_CH4S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeistedExplosiveAssaultRifle_BR_CH4S1_Exotic": [
+      {
+        "identifier": "HeistedExplosiveAssaultRifle_BR_CH4S1_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_PreSeason_Common": [
+      {
+        "identifier": "Revolver_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "Revolver_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_PreSeason_Rare": [
+      {
+        "identifier": "Revolver_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_CH1S9_Epic": [
+      {
+        "identifier": "Revolver_BR_CH1S9_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_CH1S9_Legendary": [
+      {
+        "identifier": "Revolver_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_OG_CH1S1_Common": [
+      {
+        "identifier": "Revolver_OG_CH1S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_CH4MS1_Common": [
+      {
+        "identifier": "Revolver_BR_CH4MS1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_OG_CH1S1_Uncommon": [
+      {
+        "identifier": "Revolver_OG_CH1S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_CH4MS1_Uncommon": [
+      {
+        "identifier": "Revolver_BR_CH4MS1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_OG_CH1S1_Rare": [
+      {
+        "identifier": "Revolver_OG_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_CH4MS1_Rare": [
+      {
+        "identifier": "Revolver_BR_CH4MS1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_OG_CH1S1_Epic": [
+      {
+        "identifier": "Revolver_OG_CH1S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_CH4MS1_Epic": [
+      {
+        "identifier": "Revolver_BR_CH4MS1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_OG_CH1S1_Legendary": [
+      {
+        "identifier": "Revolver_OG_CH1S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Revolver_BR_CH4MS1_Legendary": [
+      {
+        "identifier": "Revolver_BR_CH4MS1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RipsawLauncher_BR_CH3S3_Rare": [
+      {
+        "identifier": "RipsawLauncher_BR_CH3S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RocketDrill_BR_CH6S2_Epic": [
+      {
+        "identifier": "RocketDrill_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RocketLauncher_BR_PreSeason_Rare": [
+      {
+        "identifier": "RocketLauncher_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RocketLauncher_BR_PreSeason_Epic": [
+      {
+        "identifier": "RocketLauncher_BR_PreSeason_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RocketLauncher_BR_PreSeason_Legendary": [
+      {
+        "identifier": "RocketLauncher_BR_PreSeason_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RocketLauncher_BR_CH2S1_Common": [
+      {
+        "identifier": "RocketLauncher_BR_CH2S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RocketLauncher_BR_CH2S1_Uncommon": [
+      {
+        "identifier": "RocketLauncher_BR_CH2S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "RocketRam_BR_CH4S4_Rare": [
+      {
+        "identifier": "RocketRam_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedAssaultRifle_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "ScopedAssaultRifle_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedAssaultRifle_BR_PreSeason_Rare": [
+      {
+        "identifier": "ScopedAssaultRifle_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedAssaultRifle_BR_CH2S4_Epic": [
+      {
+        "identifier": "ScopedAssaultRifle_BR_CH2S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedAssaultRifle_BR_CH2S4_Legendary": [
+      {
+        "identifier": "ScopedAssaultRifle_BR_CH2S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedBurstSMG_BR_CH4S4_Common": [
+      {
+        "identifier": "ScopedBurstSMG_BR_CH4S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedBurstSMG_BR_CH4S4_Uncommon": [
+      {
+        "identifier": "ScopedBurstSMG_BR_CH4S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedBurstSMG_BR_CH4S4_Rare": [
+      {
+        "identifier": "ScopedBurstSMG_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedBurstSMG_BR_CH4S4_Epic": [
+      {
+        "identifier": "ScopedBurstSMG_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedBurstSMG_BR_CH4S4_Legendary": [
+      {
+        "identifier": "ScopedBurstSMG_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThornesScopedBurstSMG_BR_CH4S4_Mythic": [
+      {
+        "identifier": "ThornesScopedBurstSMG_BR_CH4S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedRevolver_BR_CH1S7_Epic": [
+      {
+        "identifier": "ScopedRevolver_BR_CH1S7_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ScopedRevolver_BR_CH1S7_Legendary": [
+      {
+        "identifier": "ScopedRevolver_BR_CH1S7_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoPistol_BR_PreSeason_Common": [
+      {
+        "identifier": "SemiAutoPistol_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoPistol_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "SemiAutoPistol_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoPistol_BR_PreSeason_Rare": [
+      {
+        "identifier": "SemiAutoPistol_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoPistol_BR_CH2S1_Epic": [
+      {
+        "identifier": "SemiAutoPistol_BR_CH2S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoPistol_BR_CH2S1_Legendary": [
+      {
+        "identifier": "SemiAutoPistol_BR_CH2S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSniperRifle_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "SemiAutoSniperRifle_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSniperRifle_BR_PreSeason_Rare": [
+      {
+        "identifier": "SemiAutoSniperRifle_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSniperRifle_BR_CH2S2_Epic": [
+      {
+        "identifier": "SemiAutoSniperRifle_BR_CH2S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSniperRifle_BR_CH2S2_Legendary": [
+      {
+        "identifier": "SemiAutoSniperRifle_BR_CH2S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSuppressedPistol_BR_CH1S2_Rare": [
+      {
+        "identifier": "SemiAutoSuppressedPistol_BR_CH1S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSuppressedPistol_BR_CH1S2_Epic": [
+      {
+        "identifier": "SemiAutoSuppressedPistol_BR_CH1S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSuppressedPistol_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "SemiAutoSuppressedPistol_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SemiAutoSuppressedPistol_BR_CH3S1_Legendary": [
+      {
+        "identifier": "SemiAutoSuppressedPistol_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SentinelPumpShotgun_BR_CH6S1_Common": [
+      {
+        "identifier": "SentinelPumpShotgun_BR_CH6S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SentinelPumpShotgun_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "SentinelPumpShotgun_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SentinelPumpShotgun_BR_CH6S1_Rare": [
+      {
+        "identifier": "SentinelPumpShotgun_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SentinelPumpShotgun_BR_CH6S1_Epic": [
+      {
+        "identifier": "SentinelPumpShotgun_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SentinelPumpShotgun_BR_CH6S1_Legendary": [
+      {
+        "identifier": "SentinelPumpShotgun_BR_CH6S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedSentinelPumpShotgun_BR_CH6S1_Mythic": [
+      {
+        "identifier": "EnhancedSentinelPumpShotgun_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SevenClusterCannon_BR_CH7S2_Epic": [
+      {
+        "identifier": "SevenClusterCannon_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SevenClusterCannon_BR_CH7S2_Legendary": [
+      {
+        "identifier": "SevenClusterCannon_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SevenPowerGloves_BR_CH7S2_Epic": [
+      {
+        "identifier": "SevenPowerGloves_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "FoundationsPowerGloves_BR_CH7S2_Mythic": [
+      {
+        "identifier": "FoundationsPowerGloves_BR_CH7S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShadowTracker_BR_CH2S5_Exotic": [
+      {
+        "identifier": "ShadowTracker_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SharpToothShotgun_BR_CH4S3_Uncommon": [
+      {
+        "identifier": "SharpToothShotgun_BR_CH4S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SharpToothShotgun_BR_CH4S3_Rare": [
+      {
+        "identifier": "SharpToothShotgun_BR_CH4S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SharpToothShotgun_BR_CH4S3_Epic": [
+      {
+        "identifier": "SharpToothShotgun_BR_CH4S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SharpToothShotgun_BR_CH4S3_Legendary": [
+      {
+        "identifier": "SharpToothShotgun_BR_CH4S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShockwaveHammer_BR_CH4S1_Epic": [
+      {
+        "identifier": "ShockwaveHammer_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheAgelessChampionsShockwaveHammer_BR_CH4S1_Mythic": [
+      {
+        "identifier": "TheAgelessChampionsShockwaveHammer_BR_CH4S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KitsShockwaveLauncher_BR_CH2S3_Mythic": [
+      {
+        "identifier": "KitsShockwaveLauncher_BR_CH2S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShockwaveLauncher_BR_CH2S8_Legendary": [
+      {
+        "identifier": "ShockwaveLauncher_BR_CH2S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ShockwaveLauncher_BR_CH6S4_Epic": [
+      {
+        "identifier": "ShockwaveLauncher_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EradicatorShockNSlowShockwaveLauncher_BR_CH6S4_Exotic": [
+      {
+        "identifier": "EradicatorShockNSlowShockwaveLauncher_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidearmPistol_BR_CH3S1_Common": [
+      {
+        "identifier": "SidearmPistol_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidearmPistol_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "SidearmPistol_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidearmPistol_BR_CH3S1_Rare": [
+      {
+        "identifier": "SidearmPistol_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidearmPistol_BR_CH3S1_Epic": [
+      {
+        "identifier": "SidearmPistol_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidearmPistol_BR_CH3S1_Legendary": [
+      {
+        "identifier": "SidearmPistol_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysMinigun_BR_CH2S8_Common": [
+      {
+        "identifier": "SidewaysMinigun_BR_CH2S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysMinigun_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "SidewaysMinigun_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysMinigun_BR_CH2S8_Rare": [
+      {
+        "identifier": "SidewaysMinigun_BR_CH2S8_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysMinigun_BR_CH2S8_Epic": [
+      {
+        "identifier": "SidewaysMinigun_BR_CH2S8_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysMinigun_BR_CH2S8_Legendary": [
+      {
+        "identifier": "SidewaysMinigun_BR_CH2S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysMinigun_BR_CH2S8_Mythic": [
+      {
+        "identifier": "SidewaysMinigun_BR_CH2S8_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysRifle_BR_CH2S8_Common": [
+      {
+        "identifier": "SidewaysRifle_BR_CH2S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysRifle_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "SidewaysRifle_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysRifle_BR_CH2S8_Rare": [
+      {
+        "identifier": "SidewaysRifle_BR_CH2S8_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysRifle_BR_CH2S8_Epic": [
+      {
+        "identifier": "SidewaysRifle_BR_CH2S8_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysRifle_BR_CH2S8_Legendary": [
+      {
+        "identifier": "SidewaysRifle_BR_CH2S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysRifle_BR_CH2S8_Mythic": [
+      {
+        "identifier": "SidewaysRifle_BR_CH2S8_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysScythe_BR_CH2S8_Common": [
+      {
+        "identifier": "SidewaysScythe_BR_CH2S8_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysScythe_BR_CH2S8_Uncommon": [
+      {
+        "identifier": "SidewaysScythe_BR_CH2S8_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysScythe_BR_CH2S8_Rare": [
+      {
+        "identifier": "SidewaysScythe_BR_CH2S8_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysScythe_BR_CH2S8_Epic": [
+      {
+        "identifier": "SidewaysScythe_BR_CH2S8_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysScythe_BR_CH2S8_Legendary": [
+      {
+        "identifier": "SidewaysScythe_BR_CH2S8_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SidewaysScythe_BR_CH2S8_Mythic": [
+      {
+        "identifier": "SidewaysScythe_BR_CH2S8_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SixShooter_BR_CH1S6_Uncommon": [
+      {
+        "identifier": "SixShooter_BR_CH1S6_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SixShooter_BR_CH1S6_Rare": [
+      {
+        "identifier": "SixShooter_BR_CH1S6_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SixShooter_BR_CH1S6_Epic": [
+      {
+        "identifier": "SixShooter_BR_CH1S6_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SixShooter_BR_CH7S1_Legendary": [
+      {
+        "identifier": "SixShooter_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SnowballLauncher_BR_CH1S2_Rare": [
+      {
+        "identifier": "SnowballLauncher_BR_CH1S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SnowballLauncher_BR_CH1S2_Epic": [
+      {
+        "identifier": "SnowballLauncher_BR_CH1S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SnowballLauncher_BR_CH1S2_Legendary": [
+      {
+        "identifier": "SnowballLauncher_BR_CH1S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SnowballLauncher_BR_CH2S1_Uncommon": [
+      {
+        "identifier": "SnowballLauncher_BR_CH2S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularSovereignShotgun_BR_CH5S4_Common": [
+      {
+        "identifier": "ModularSovereignShotgun_BR_CH5S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularSovereignShotgun_BR_CH5S4_Uncommon": [
+      {
+        "identifier": "ModularSovereignShotgun_BR_CH5S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularSovereignShotgun_BR_CH5S4_Rare": [
+      {
+        "identifier": "ModularSovereignShotgun_BR_CH5S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularSovereignShotgun_BR_CH5S4_Epic": [
+      {
+        "identifier": "ModularSovereignShotgun_BR_CH5S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularSovereignShotgun_BR_CH5S4_Legendary": [
+      {
+        "identifier": "ModularSovereignShotgun_BR_CH5S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SovereignShotgun_BR_CH7S1_Common": [
+      {
+        "identifier": "SovereignShotgun_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SovereignShotgun_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "SovereignShotgun_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SovereignShotgun_BR_CH7S1_Rare": [
+      {
+        "identifier": "SovereignShotgun_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SovereignShotgun_BR_CH7S1_Epic": [
+      {
+        "identifier": "SovereignShotgun_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SovereignShotgun_BR_CH7S1_Legendary": [
+      {
+        "identifier": "SovereignShotgun_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SovereignSniper_Ballistic_V1_Common": [
+      {
+        "identifier": "SovereignSniper_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireRifle_BR_CH6S3_Common": [
+      {
+        "identifier": "SpireRifle_BR_CH6S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireRifle_BR_CH6S3_Uncommon": [
+      {
+        "identifier": "SpireRifle_BR_CH6S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireRifle_BR_CH6S3_Rare": [
+      {
+        "identifier": "SpireRifle_BR_CH6S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireRifle_BR_CH6S3_Epic": [
+      {
+        "identifier": "SpireRifle_BR_CH6S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpireRifle_BR_CH6S3_Legendary": [
+      {
+        "identifier": "SpireRifle_BR_CH6S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedSpireRifle_BR_CH6S3_Mythic": [
+      {
+        "identifier": "EnhancedSpireRifle_BR_CH6S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StickyGrenadeLauncher_BR_CH4S4_Epic": [
+      {
+        "identifier": "StickyGrenadeLauncher_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StickyGrenadeLauncher_BR_CH4S4_Legendary": [
+      {
+        "identifier": "StickyGrenadeLauncher_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StingerSMG_BR_CH3S1_Common": [
+      {
+        "identifier": "StingerSMG_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StingerSMG_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "StingerSMG_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StingerSMG_BR_CH3S1_Rare": [
+      {
+        "identifier": "StingerSMG_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StingerSMG_BR_CH3S1_Epic": [
+      {
+        "identifier": "StingerSMG_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StingerSMG_BR_CH3S1_Legendary": [
+      {
+        "identifier": "StingerSMG_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GunnarsStingerSMG_BR_CH3S1_Mythic": [
+      {
+        "identifier": "GunnarsStingerSMG_BR_CH3S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StormScout_BR_CH2S5_Exotic": [
+      {
+        "identifier": "StormScout_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StormScoutSniperRifle_BR_CH1S9_Epic": [
+      {
+        "identifier": "StormScoutSniperRifle_BR_CH1S9_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StormScoutSniperRifle_BR_CH1S9_Legendary": [
+      {
+        "identifier": "StormScoutSniperRifle_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerAR_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularStrikerAR_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerAR_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularStrikerAR_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerAR_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularStrikerAR_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerAR_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularStrikerAR_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerAR_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularStrikerAR_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NishasModularStrikerAR_BR_CH5S1_Mythic": [
+      {
+        "identifier": "NishasModularStrikerAR_BR_CH5S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerAR_BR_CH6MS2_Common": [
+      {
+        "identifier": "StrikerAR_BR_CH6MS2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerAR_BR_CH6MS2_Uncommon": [
+      {
+        "identifier": "StrikerAR_BR_CH6MS2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerAR_BR_CH6MS2_Rare": [
+      {
+        "identifier": "StrikerAR_BR_CH6MS2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerAR_BR_CH6MS2_Epic": [
+      {
+        "identifier": "StrikerAR_BR_CH6MS2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerAR_BR_CH6MS2_Legendary": [
+      {
+        "identifier": "StrikerAR_BR_CH6MS2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerAR_Ballistic_V1_Common": [
+      {
+        "identifier": "StrikerAR_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerBurstRifle_BR_CH3S2_Common": [
+      {
+        "identifier": "StrikerBurstRifle_BR_CH3S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerBurstRifle_BR_CH3S2_Uncommon": [
+      {
+        "identifier": "StrikerBurstRifle_BR_CH3S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerBurstRifle_BR_CH3S2_Rare": [
+      {
+        "identifier": "StrikerBurstRifle_BR_CH3S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerBurstRifle_BR_CH3S2_Epic": [
+      {
+        "identifier": "StrikerBurstRifle_BR_CH3S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerBurstRifle_BR_CH3S2_Legendary": [
+      {
+        "identifier": "StrikerBurstRifle_BR_CH3S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerBurstRifle_BR_CH3S2_Mythic": [
+      {
+        "identifier": "StrikerBurstRifle_BR_CH3S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SlonesStrikerBurstRifle_BR_CH3S2_Mythic": [
+      {
+        "identifier": "SlonesStrikerBurstRifle_BR_CH3S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerBurstRifle_BR_CH5S4_Common": [
+      {
+        "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerBurstRifle_BR_CH5S4_Uncommon": [
+      {
+        "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerBurstRifle_BR_CH5S4_Rare": [
+      {
+        "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerBurstRifle_BR_CH5S4_Epic": [
+      {
+        "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularStrikerBurstRifle_BR_CH5S4_Legendary": [
+      {
+        "identifier": "ModularStrikerBurstRifle_BR_CH5S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerPumpShotgun_BR_CH3S1_Common": [
+      {
+        "identifier": "StrikerPumpShotgun_BR_CH3S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerPumpShotgun_BR_CH3S1_Uncommon": [
+      {
+        "identifier": "StrikerPumpShotgun_BR_CH3S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerPumpShotgun_BR_CH3S1_Rare": [
+      {
+        "identifier": "StrikerPumpShotgun_BR_CH3S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerPumpShotgun_BR_CH3S1_Epic": [
+      {
+        "identifier": "StrikerPumpShotgun_BR_CH3S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerPumpShotgun_BR_CH3S1_Legendary": [
+      {
+        "identifier": "StrikerPumpShotgun_BR_CH3S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "StrikerPumpShotgun_BR_CH3S1_Mythic": [
+      {
+        "identifier": "StrikerPumpShotgun_BR_CH3S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH1S5_Common": [
+      {
+        "identifier": "SubmachineGun_BR_CH1S5_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH1S5_Uncommon": [
+      {
+        "identifier": "SubmachineGun_BR_CH1S5_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH1S5_Rare": [
+      {
+        "identifier": "SubmachineGun_BR_CH1S5_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH2S1_Epic": [
+      {
+        "identifier": "SubmachineGun_BR_CH2S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH2S1_Legendary": [
+      {
+        "identifier": "SubmachineGun_BR_CH2S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeistedRunNGunSMG_BR_CH4S1_Exotic": [
+      {
+        "identifier": "HeistedRunNGunSMG_BR_CH4S1_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH4S2_Epic": [
+      {
+        "identifier": "SubmachineGun_BR_CH4S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH4S2_Legendary": [
+      {
+        "identifier": "SubmachineGun_BR_CH4S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_OG_CH1S1_Common": [
+      {
+        "identifier": "SubmachineGun_OG_CH1S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH4MS1_Common": [
+      {
+        "identifier": "SubmachineGun_BR_CH4MS1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_OG_CH1S1_Uncommon": [
+      {
+        "identifier": "SubmachineGun_OG_CH1S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH4MS1_Uncommon": [
+      {
+        "identifier": "SubmachineGun_BR_CH4MS1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_OG_CH1S1_Rare": [
+      {
+        "identifier": "SubmachineGun_OG_CH1S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SubmachineGun_BR_CH4MS1_Rare": [
+      {
+        "identifier": "SubmachineGun_BR_CH4MS1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuperShredder_BR_CH7S2_Rare": [
+      {
+        "identifier": "SuperShredder_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuperShredder_BR_CH7S2_Epic": [
+      {
+        "identifier": "SuperShredder_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuperShredder_BR_CH7S2_Legendary": [
+      {
+        "identifier": "SuperShredder_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedAssaultRifle_BR_CH1S5_Epic": [
+      {
+        "identifier": "SuppressedAssaultRifle_BR_CH1S5_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedAssaultRifle_BR_CH1S5_Legendary": [
+      {
+        "identifier": "SuppressedAssaultRifle_BR_CH1S5_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedAssaultRifle_BR_CH2S2_Rare": [
+      {
+        "identifier": "SuppressedAssaultRifle_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedAssaultRifle_BR_CH6MS2_Common": [
+      {
+        "identifier": "SuppressedAssaultRifle_BR_CH6MS2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedAssaultRifle_BR_CH6MS2_Uncommon": [
+      {
+        "identifier": "SuppressedAssaultRifle_BR_CH6MS2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedPistol_BR_CH4S4_Common": [
+      {
+        "identifier": "SuppressedPistol_BR_CH4S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedPistol_BR_CH4S4_Uncommon": [
+      {
+        "identifier": "SuppressedPistol_BR_CH4S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedPistol_BR_CH4S4_Rare": [
+      {
+        "identifier": "SuppressedPistol_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedPistol_BR_CH4S4_Epic": [
+      {
+        "identifier": "SuppressedPistol_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedPistol_BR_CH4S4_Legendary": [
+      {
+        "identifier": "SuppressedPistol_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedPistol_BR_CH6S2_Mythic": [
+      {
+        "identifier": "SuppressedPistol_BR_CH6S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSniperRifle_BR_CH1S7_Epic": [
+      {
+        "identifier": "SuppressedSniperRifle_BR_CH1S7_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSniperRifle_BR_CH1S7_Legendary": [
+      {
+        "identifier": "SuppressedSniperRifle_BR_CH1S7_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSniperRifle_BR_CH2S2_Rare": [
+      {
+        "identifier": "SuppressedSniperRifle_BR_CH2S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSubmachineGun_BR_PreSeason_Common": [
+      {
+        "identifier": "SuppressedSubmachineGun_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSubmachineGun_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "SuppressedSubmachineGun_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSubmachineGun_BR_PreSeason_Rare": [
+      {
+        "identifier": "SuppressedSubmachineGun_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSubmachineGun_BR_CH3S4_Epic": [
+      {
+        "identifier": "SuppressedSubmachineGun_BR_CH3S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SuppressedSubmachineGun_BR_CH3S4_Legendary": [
+      {
+        "identifier": "SuppressedSubmachineGun_BR_CH3S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "InkquisitorsSuppressedSMG_BR_CH3S4_Mythic": [
+      {
+        "identifier": "InkquisitorsSuppressedSMG_BR_CH3S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgefireSMG_BR_CH6S1_Common": [
+      {
+        "identifier": "SurgefireSMG_BR_CH6S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgefireSMG_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "SurgefireSMG_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgefireSMG_BR_CH6S1_Rare": [
+      {
+        "identifier": "SurgefireSMG_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgefireSMG_BR_CH6S1_Epic": [
+      {
+        "identifier": "SurgefireSMG_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgefireSMG_BR_CH6S1_Legendary": [
+      {
+        "identifier": "SurgefireSMG_BR_CH6S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedSurgefireSMG_BR_CH6S1_Mythic": [
+      {
+        "identifier": "EnhancedSurgefireSMG_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgicalBurstRifle_BR_CH7S3_Common": [
+      {
+        "identifier": "SurgicalBurstRifle_BR_CH7S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VanguardBurstRifle_BR_CH7S3_Common": [
+      {
+        "identifier": "VanguardBurstRifle_BR_CH7S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgicalBurstRifle_BR_CH7S3_Uncommon": [
+      {
+        "identifier": "SurgicalBurstRifle_BR_CH7S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VanguardBurstRifle_BR_CH7S3_Uncommon": [
+      {
+        "identifier": "VanguardBurstRifle_BR_CH7S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgicalBurstRifle_BR_CH7S3_Rare": [
+      {
+        "identifier": "SurgicalBurstRifle_BR_CH7S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VanguardBurstRifle_BR_CH7S3_Rare": [
+      {
+        "identifier": "VanguardBurstRifle_BR_CH7S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgicalBurstRifle_BR_CH7S3_Epic": [
+      {
+        "identifier": "SurgicalBurstRifle_BR_CH7S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VanguardBurstRifle_BR_CH7S3_Epic": [
+      {
+        "identifier": "VanguardBurstRifle_BR_CH7S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SurgicalBurstRifle_BR_CH7S3_Legendary": [
+      {
+        "identifier": "SurgicalBurstRifle_BR_CH7S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VanguardBurstRifle_BR_CH7S3_Legendary": [
+      {
+        "identifier": "VanguardBurstRifle_BR_CH7S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Swarmstrike_BR_CH6S4_Epic": [
+      {
+        "identifier": "Swarmstrike_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Swarmstrike_BR_CH6S4_Legendary": [
+      {
+        "identifier": "Swarmstrike_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SweeperShotgun_BR_CH6S4_Common": [
+      {
+        "identifier": "SweeperShotgun_BR_CH6S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SweeperShotgun_BR_CH6S4_Uncommon": [
+      {
+        "identifier": "SweeperShotgun_BR_CH6S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SweeperShotgun_BR_CH6S4_Rare": [
+      {
+        "identifier": "SweeperShotgun_BR_CH6S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SweeperShotgun_BR_CH6S4_Epic": [
+      {
+        "identifier": "SweeperShotgun_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SweeperShotgun_BR_CH6S4_Legendary": [
+      {
+        "identifier": "SweeperShotgun_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SweeperShotgun_BR_CH6S4_Mythic": [
+      {
+        "identifier": "SweeperShotgun_BR_CH6S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH1S9_Rare": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH1S9_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH1S9_Epic": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH1S9_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH1S9_Legendary": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH4S1_Common": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularTacticalAssaultRifle_BR_CH5S2_Common": [
+      {
+        "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularTacticalAssaultRifle_BR_CH5S2_Uncommon": [
+      {
+        "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularTacticalAssaultRifle_BR_CH5S2_Rare": [
+      {
+        "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularTacticalAssaultRifle_BR_CH5S2_Epic": [
+      {
+        "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularTacticalAssaultRifle_BR_CH5S2_Legendary": [
+      {
+        "identifier": "ModularTacticalAssaultRifle_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH7S1_Common": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH7S1_Rare": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH7S1_Epic": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalAssaultRifle_BR_CH7S1_Legendary": [
+      {
+        "identifier": "TacticalAssaultRifle_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalDMR_BR_CH4S4_Common": [
+      {
+        "identifier": "TacticalDMR_BR_CH4S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalDMR_BR_CH4S4_Uncommon": [
+      {
+        "identifier": "TacticalDMR_BR_CH4S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalDMR_BR_CH4S4_Rare": [
+      {
+        "identifier": "TacticalDMR_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalDMR_BR_CH4S4_Epic": [
+      {
+        "identifier": "TacticalDMR_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalDMR_BR_CH4S4_Legendary": [
+      {
+        "identifier": "TacticalDMR_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH4S1_Common": [
+      {
+        "identifier": "TacticalPistol_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "TacticalPistol_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH4S1_Rare": [
+      {
+        "identifier": "TacticalPistol_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH4S1_Epic": [
+      {
+        "identifier": "TacticalPistol_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH4S1_Legendary": [
+      {
+        "identifier": "TacticalPistol_BR_CH4S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH4S1_Mythic": [
+      {
+        "identifier": "TacticalPistol_BR_CH4S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH7S1_Common": [
+      {
+        "identifier": "TacticalPistol_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "TacticalPistol_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH7S1_Rare": [
+      {
+        "identifier": "TacticalPistol_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH7S1_Epic": [
+      {
+        "identifier": "TacticalPistol_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalPistol_BR_CH7S1_Legendary": [
+      {
+        "identifier": "TacticalPistol_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "OverdriveTacticalPistol_BR_CH7S1_Mythic": [
+      {
+        "identifier": "OverdriveTacticalPistol_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalShotgun_BR_PreSeason_Common": [
+      {
+        "identifier": "TacticalShotgun_BR_PreSeason_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalShotgun_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "TacticalShotgun_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalShotgun_BR_PreSeason_Rare": [
+      {
+        "identifier": "TacticalShotgun_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalShotgun_BR_CH1S9_Epic": [
+      {
+        "identifier": "TacticalShotgun_BR_CH1S9_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalShotgun_BR_CH1S9_Legendary": [
+      {
+        "identifier": "TacticalShotgun_BR_CH1S9_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalShotgun_BR_CH6MS2_Epic": [
+      {
+        "identifier": "TacticalShotgun_BR_CH6MS2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalShotgun_BR_CH6MS2_Legendary": [
+      {
+        "identifier": "TacticalShotgun_BR_CH6MS2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalSubmachineGun_BR_PreSeason_Uncommon": [
+      {
+        "identifier": "TacticalSubmachineGun_BR_PreSeason_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalSubmachineGun_BR_PreSeason_Rare": [
+      {
+        "identifier": "TacticalSubmachineGun_BR_PreSeason_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalSubmachineGun_BR_PreSeason_Epic": [
+      {
+        "identifier": "TacticalSubmachineGun_BR_PreSeason_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TacticalSubmachineGun_BR_CH1SX_Legendary": [
+      {
+        "identifier": "TacticalSubmachineGun_BR_CH1SX_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheBigChill_BR_CH2S5_Exotic": [
+      {
+        "identifier": "TheBigChill_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheDub_BR_CH2S5_Exotic": [
+      {
+        "identifier": "TheDub_BR_CH2S5_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheFoundationsRiftRifle_BR_CH7S2_Exotic": [
+      {
+        "identifier": "TheFoundationsRiftRifle_BR_CH7S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheKneecapper_BR_CH6S2_Epic": [
+      {
+        "identifier": "TheKneecapper_BR_CH6S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalDMR_BR_CH4S3_Common": [
+      {
+        "identifier": "ThermalDMR_BR_CH4S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalDMR_BR_CH4S3_Uncommon": [
+      {
+        "identifier": "ThermalDMR_BR_CH4S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalDMR_BR_CH4S3_Rare": [
+      {
+        "identifier": "ThermalDMR_BR_CH4S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalDMR_BR_CH4S3_Epic": [
+      {
+        "identifier": "ThermalDMR_BR_CH4S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalDMR_BR_CH4S3_Legendary": [
+      {
+        "identifier": "ThermalDMR_BR_CH4S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalDMR_BR_CH4S3_Mythic": [
+      {
+        "identifier": "ThermalDMR_BR_CH4S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "DiamondsThermalDMR_BR_CH4S4_Mythic": [
+      {
+        "identifier": "DiamondsThermalDMR_BR_CH4S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalScopedAssaultRifle_BR_CH1S4_Epic": [
+      {
+        "identifier": "ThermalScopedAssaultRifle_BR_CH1S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThermalScopedAssaultRifle_BR_CH1S4_Legendary": [
+      {
+        "identifier": "ThermalScopedAssaultRifle_BR_CH1S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HuntmasterSabersThermalRifle_BR_CH3S2_Mythic": [
+      {
+        "identifier": "HuntmasterSabersThermalRifle_BR_CH3S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TheVoidbladesBurstRifle_BR_CH7S3_Mythic": [
+      {
+        "identifier": "TheVoidbladesBurstRifle_BR_CH7S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularThunderBurstSMG_BR_CH5S1_Common": [
+      {
+        "identifier": "ModularThunderBurstSMG_BR_CH5S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularThunderBurstSMG_BR_CH5S1_Uncommon": [
+      {
+        "identifier": "ModularThunderBurstSMG_BR_CH5S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularThunderBurstSMG_BR_CH5S1_Rare": [
+      {
+        "identifier": "ModularThunderBurstSMG_BR_CH5S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularThunderBurstSMG_BR_CH5S1_Epic": [
+      {
+        "identifier": "ModularThunderBurstSMG_BR_CH5S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularThunderBurstSMG_BR_CH5S1_Legendary": [
+      {
+        "identifier": "ModularThunderBurstSMG_BR_CH5S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThunderBurstSMG_Ballistic_V1_Common": [
+      {
+        "identifier": "ThunderBurstSMG_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThunderShotgun_BR_CH4S1_Common": [
+      {
+        "identifier": "ThunderShotgun_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThunderShotgun_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "ThunderShotgun_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThunderShotgun_BR_CH4S1_Rare": [
+      {
+        "identifier": "ThunderShotgun_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThunderShotgun_BR_CH4S1_Epic": [
+      {
+        "identifier": "ThunderShotgun_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ThunderShotgun_BR_CH4S1_Legendary": [
+      {
+        "identifier": "ThunderShotgun_BR_CH4S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TNTinasKaBoomBow_BR_CH2S2_Mythic": [
+      {
+        "identifier": "TNTinasKaBoomBow_BR_CH2S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TowHookCannon_BR_CH5S3_Rare": [
+      {
+        "identifier": "TowHookCannon_BR_CH5S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Trouble_BR_CH6S4_Exotic": [
+      {
+        "identifier": "Trouble_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinfireAutoShotgun_BR_CH6S1_Common": [
+      {
+        "identifier": "TwinfireAutoShotgun_BR_CH6S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinfireAutoShotgun_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "TwinfireAutoShotgun_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinfireAutoShotgun_BR_CH6S1_Rare": [
+      {
+        "identifier": "TwinfireAutoShotgun_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinfireAutoShotgun_BR_CH6S1_Epic": [
+      {
+        "identifier": "TwinfireAutoShotgun_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinfireAutoShotgun_BR_CH6S1_Legendary": [
+      {
+        "identifier": "TwinfireAutoShotgun_BR_CH6S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedTwinfireAutoShotgun_BR_CH6S1_Mythic": [
+      {
+        "identifier": "EnhancedTwinfireAutoShotgun_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "LawlessTwinfireSlapShotgun_BR_CH6S2_Exotic": [
+      {
+        "identifier": "LawlessTwinfireSlapShotgun_BR_CH6S2_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinHammerShotguns_BR_CH7S1_Common": [
+      {
+        "identifier": "TwinHammerShotguns_BR_CH7S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinHammerShotguns_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "TwinHammerShotguns_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinHammerShotguns_BR_CH7S1_Rare": [
+      {
+        "identifier": "TwinHammerShotguns_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinHammerShotguns_BR_CH7S1_Epic": [
+      {
+        "identifier": "TwinHammerShotguns_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinHammerShotguns_BR_CH7S1_Legendary": [
+      {
+        "identifier": "TwinHammerShotguns_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BrutusTwinHammerShotguns_BR_CH7S1_Mythic": [
+      {
+        "identifier": "BrutusTwinHammerShotguns_BR_CH7S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagAssaultRifle_BR_CH4S4_Common": [
+      {
+        "identifier": "TwinMagAssaultRifle_BR_CH4S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagAssaultRifle_BR_CH4S4_Uncommon": [
+      {
+        "identifier": "TwinMagAssaultRifle_BR_CH4S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagAssaultRifle_BR_CH4S4_Rare": [
+      {
+        "identifier": "TwinMagAssaultRifle_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagAssaultRifle_BR_CH4S4_Epic": [
+      {
+        "identifier": "TwinMagAssaultRifle_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagAssaultRifle_BR_CH4S4_Legendary": [
+      {
+        "identifier": "TwinMagAssaultRifle_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagSMG_BR_CH4S1_Common": [
+      {
+        "identifier": "TwinMagSMG_BR_CH4S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagSMG_BR_CH4S1_Uncommon": [
+      {
+        "identifier": "TwinMagSMG_BR_CH4S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagSMG_BR_CH4S1_Rare": [
+      {
+        "identifier": "TwinMagSMG_BR_CH4S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagSMG_BR_CH4S1_Epic": [
+      {
+        "identifier": "TwinMagSMG_BR_CH4S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwinMagSMG_BR_CH4S1_Legendary": [
+      {
+        "identifier": "TwinMagSMG_BR_CH4S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HeistedBlinkMagSMG_BR_CH4S1_Exotic": [
+      {
+        "identifier": "HeistedBlinkMagSMG_BR_CH4S1_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwoShotShotgun_BR_CH3S3_Common": [
+      {
+        "identifier": "TwoShotShotgun_BR_CH3S3_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwoShotShotgun_BR_CH3S3_Uncommon": [
+      {
+        "identifier": "TwoShotShotgun_BR_CH3S3_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwoShotShotgun_BR_CH3S3_Rare": [
+      {
+        "identifier": "TwoShotShotgun_BR_CH3S3_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwoShotShotgun_BR_CH3S3_Epic": [
+      {
+        "identifier": "TwoShotShotgun_BR_CH3S3_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwoShotShotgun_BR_CH3S3_Legendary": [
+      {
+        "identifier": "TwoShotShotgun_BR_CH3S3_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TwoShotShotgun_BR_CH3S3_Mythic": [
+      {
+        "identifier": "TwoShotShotgun_BR_CH3S3_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TyphoonBlade_BR_CH6S1_Epic": [
+      {
+        "identifier": "TyphoonBlade_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TyphoonBlade_BR_CH6S1_Mythic": [
+      {
+        "identifier": "TyphoonBlade_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "UnstableBow_BR_CH2S6_Exotic": [
+      {
+        "identifier": "UnstableBow_BR_CH2S6_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "UnstableFrostfireShotgun_BR_CH6S3_Exotic": [
+      {
+        "identifier": "UnstableFrostfireShotgun_BR_CH6S3_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Vector7DMR_BR_CH7S2_Rare": [
+      {
+        "identifier": "Vector7DMR_BR_CH7S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Vector7DMR_BR_CH7S2_Epic": [
+      {
+        "identifier": "Vector7DMR_BR_CH7S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Vector7DMR_BR_CH7S2_Legendary": [
+      {
+        "identifier": "Vector7DMR_BR_CH7S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VeiledPrecisionSMG_BR_CH6S1_Common": [
+      {
+        "identifier": "VeiledPrecisionSMG_BR_CH6S1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VeiledPrecisionSMG_BR_CH6S1_Uncommon": [
+      {
+        "identifier": "VeiledPrecisionSMG_BR_CH6S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VeiledPrecisionSMG_BR_CH6S1_Rare": [
+      {
+        "identifier": "VeiledPrecisionSMG_BR_CH6S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VeiledPrecisionSMG_BR_CH6S1_Epic": [
+      {
+        "identifier": "VeiledPrecisionSMG_BR_CH6S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VeiledPrecisionSMG_BR_CH6S1_Legendary": [
+      {
+        "identifier": "VeiledPrecisionSMG_BR_CH6S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "NightRoseVeiledPrecisionSMG_BR_CH6S1_Mythic": [
+      {
+        "identifier": "NightRoseVeiledPrecisionSMG_BR_CH6S1_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EradicatorShadowPrecisionSMG_BR_CH6S4_Exotic": [
+      {
+        "identifier": "EradicatorShadowPrecisionSMG_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VeiledPrecisionSMG_Ballistic_V1_Common": [
+      {
+        "identifier": "VeiledPrecisionSMG_Ballistic_V1_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VengefulSniperRifle_BR_CH7S1_Uncommon": [
+      {
+        "identifier": "VengefulSniperRifle_BR_CH7S1_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VengefulSniperRifle_BR_CH7S1_Rare": [
+      {
+        "identifier": "VengefulSniperRifle_BR_CH7S1_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VengefulSniperRifle_BR_CH7S1_Epic": [
+      {
+        "identifier": "VengefulSniperRifle_BR_CH7S1_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "VengefulSniperRifle_BR_CH7S1_Legendary": [
+      {
+        "identifier": "VengefulSniperRifle_BR_CH7S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularWarforgedAssaultRifle_BR_CH5S2_Common": [
+      {
+        "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularWarforgedAssaultRifle_BR_CH5S2_Uncommon": [
+      {
+        "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularWarforgedAssaultRifle_BR_CH5S2_Rare": [
+      {
+        "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularWarforgedAssaultRifle_BR_CH5S2_Epic": [
+      {
+        "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ModularWarforgedAssaultRifle_BR_CH5S2_Legendary": [
+      {
+        "identifier": "ModularWarforgedAssaultRifle_BR_CH5S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "AresModularWarforgedAssaultRifle_BR_CH5S2_Mythic": [
+      {
+        "identifier": "AresModularWarforgedAssaultRifle_BR_CH5S2_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WoodStakeShotgun_BR_CH4S4_Rare": [
+      {
+        "identifier": "WoodStakeShotgun_BR_CH4S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WoodStakeShotgun_BR_CH4S4_Epic": [
+      {
+        "identifier": "WoodStakeShotgun_BR_CH4S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WoodStakeShotgun_BR_CH4S4_Legendary": [
+      {
+        "identifier": "WoodStakeShotgun_BR_CH4S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "HighStakesShotgun_BR_CH4S4_Mythic": [
+      {
+        "identifier": "HighStakesShotgun_BR_CH4S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WreckerRevolver_BR_CH6S4_Common": [
+      {
+        "identifier": "WreckerRevolver_BR_CH6S4_Common",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WreckerRevolver_BR_CH6S4_Uncommon": [
+      {
+        "identifier": "WreckerRevolver_BR_CH6S4_Uncommon",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WreckerRevolver_BR_CH6S4_Rare": [
+      {
+        "identifier": "WreckerRevolver_BR_CH6S4_Rare",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WreckerRevolver_BR_CH6S4_Epic": [
+      {
+        "identifier": "WreckerRevolver_BR_CH6S4_Epic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WreckerRevolver_BR_CH6S4_Legendary": [
+      {
+        "identifier": "WreckerRevolver_BR_CH6S4_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EnhancedWreckerRevolver_BR_CH6S4_Mythic": [
+      {
+        "identifier": "EnhancedWreckerRevolver_BR_CH6S4_Mythic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "EradicatorMarksmanWreckerRevolver_BR_CH6S4_Exotic": [
+      {
+        "identifier": "EradicatorMarksmanWreckerRevolver_BR_CH6S4_Exotic",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Zapotron_OG_CH1S2_Legendary": [
+      {
+        "identifier": "Zapotron_OG_CH1S2_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Zapotron_OG_CH1S1_Legendary": [
+      {
+        "identifier": "Zapotron_OG_CH1S1_Legendary",
+        "modulePath": "/Fortnite.com/Weapons",
+        "type": "class",
+        "isPublic": true
+      }
+    ]
   },
   "moduleIndex": {
     "/Fortnite.com/UI": [

--- a/src/data/UnrealEngine.digest.json
+++ b/src/data/UnrealEngine.digest.json
@@ -1,1029 +1,1369 @@
 {
-  "version": "1.0.0",
-  "generatedAt": "2026-08-14T12:40:55.268Z",
+  "version": "2.0.0",
+  "generatedAt": "2026-08-15T10:07:02.849Z",
   "sourceFile": "UnrealEngine.digest.verse",
   "sourceBuild": "++Fortnite+Release-41.30-CL-56430492",
   "entries": {
-    "Conversations": {
-      "identifier": "Conversations",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "module",
-      "isPublic": true
-    },
-    "ai_error": {
-      "identifier": "ai_error",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_timeout_error": {
-      "identifier": "ai_timeout_error",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_throttled_error": {
-      "identifier": "ai_throttled_error",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_moderated_error": {
-      "identifier": "ai_moderated_error",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_character_limit_error": {
-      "identifier": "ai_character_limit_error",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "prompt_binding_definition": {
-      "identifier": "prompt_binding_definition",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_session": {
-      "identifier": "ai_session",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "persona_interruption_rule": {
-      "identifier": "persona_interruption_rule",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "persona_component": {
-      "identifier": "persona_component",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "voice_model": {
-      "identifier": "voice_model",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "brite_bomber_voice": {
-      "identifier": "brite_bomber_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "elmira_voice": {
-      "identifier": "elmira_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "helsie_midnight_voice": {
-      "identifier": "helsie_midnight_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "mancake_voice": {
-      "identifier": "mancake_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "munitions_master_voice": {
-      "identifier": "munitions_master_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "peely_voice": {
-      "identifier": "peely_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "terns_voice": {
-      "identifier": "terns_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "lexa_hexbringer_voice": {
-      "identifier": "lexa_hexbringer_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "battle_gamer_mae_voice": {
-      "identifier": "battle_gamer_mae_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "halley_voice": {
-      "identifier": "halley_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "aura_voice": {
-      "identifier": "aura_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "brute_gunner_voice": {
-      "identifier": "brute_gunner_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "field_commander_voice": {
-      "identifier": "field_commander_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ziggy_voice": {
-      "identifier": "ziggy_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "haylee_skye_voice": {
-      "identifier": "haylee_skye_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "orin_voice": {
-      "identifier": "orin_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "moxie_voice": {
-      "identifier": "moxie_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "kor_voice": {
-      "identifier": "kor_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "clover_swift_voice": {
-      "identifier": "clover_swift_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "chase_voice": {
-      "identifier": "chase_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "fishstick_voice": {
-      "identifier": "fishstick_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "guild_voice": {
-      "identifier": "guild_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "sunspot_voice": {
-      "identifier": "sunspot_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "the_imagined_voice": {
-      "identifier": "the_imagined_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "red_ruin_joni_voice": {
-      "identifier": "red_ruin_joni_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "nezumi_voice": {
-      "identifier": "nezumi_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "magnus_voice": {
-      "identifier": "magnus_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "revolt_voice": {
-      "identifier": "revolt_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "tomatohead_voice": {
-      "identifier": "tomatohead_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "raven_voice": {
-      "identifier": "raven_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "cuddle_team_leader_voice": {
-      "identifier": "cuddle_team_leader_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "midas_voice": {
-      "identifier": "midas_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "mecha_team_leader_voice": {
-      "identifier": "mecha_team_leader_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "jonesy_voice": {
-      "identifier": "jonesy_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "hope_voice": {
-      "identifier": "hope_voice",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_description_attribute": {
-      "identifier": "ai_description_attribute",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "class",
-      "isPublic": true
-    },
-    "ai_description": {
-      "identifier": "ai_description",
-      "modulePath": "/UnrealEngine.com/Conversations",
-      "type": "function",
-      "isPublic": true
-    },
-    "Progression": {
-      "identifier": "Progression",
-      "modulePath": "/UnrealEngine.com/Progression",
-      "type": "module",
-      "isPublic": true
-    },
-    "entitlement_quest_reward": {
-      "identifier": "entitlement_quest_reward",
-      "modulePath": "/UnrealEngine.com/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "progress_quest_objective": {
-      "identifier": "progress_quest_objective",
-      "modulePath": "/UnrealEngine.com/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "basic_quest": {
-      "identifier": "basic_quest",
-      "modulePath": "/UnrealEngine.com/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "quest_objective": {
-      "identifier": "quest_objective",
-      "modulePath": "/UnrealEngine.com/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "grant_quest_reward_error": {
-      "identifier": "grant_quest_reward_error",
-      "modulePath": "/UnrealEngine.com/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "quest_reward": {
-      "identifier": "quest_reward",
-      "modulePath": "/UnrealEngine.com/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "Itemization": {
-      "identifier": "Itemization",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "module",
-      "isPublic": true
-    },
-    "add_item_result": {
-      "identifier": "add_item_result",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "remove_item_result": {
-      "identifier": "remove_item_result",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "equip_item_result": {
-      "identifier": "equip_item_result",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "unequip_item_result": {
-      "identifier": "unequip_item_result",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "find_inventory_event": {
-      "identifier": "find_inventory_event",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "add_item_error": {
-      "identifier": "add_item_error",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "add_item_query_event": {
-      "identifier": "add_item_query_event",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "remove_item_error": {
-      "identifier": "remove_item_error",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "remove_item_query_event": {
-      "identifier": "remove_item_query_event",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "inventory_component": {
-      "identifier": "inventory_component",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "item_category": {
-      "identifier": "item_category",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "change_equipped_result": {
-      "identifier": "change_equipped_result",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "change_inventory_result": {
-      "identifier": "change_inventory_result",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "equip_item_error": {
-      "identifier": "equip_item_error",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "equip_item_query_event": {
-      "identifier": "equip_item_query_event",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "unequip_item_error": {
-      "identifier": "unequip_item_error",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "unequip_item_query_event": {
-      "identifier": "unequip_item_query_event",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "item_component": {
-      "identifier": "item_component",
-      "modulePath": "/UnrealEngine.com/Itemization",
-      "type": "class",
-      "isPublic": true
-    },
-    "WebAPI": {
-      "identifier": "WebAPI",
-      "modulePath": "/UnrealEngine.com/WebAPI",
-      "type": "module",
-      "isPublic": true
-    },
-    "client_id": {
-      "identifier": "client_id",
-      "modulePath": "/UnrealEngine.com/WebAPI",
-      "type": "class",
-      "isPublic": true
-    },
-    "client": {
-      "identifier": "client",
-      "modulePath": "/UnrealEngine.com/WebAPI",
-      "type": "class",
-      "isPublic": true
-    },
-    "response": {
-      "identifier": "response",
-      "modulePath": "/UnrealEngine.com/WebAPI",
-      "type": "class",
-      "isPublic": true
-    },
-    "body_response": {
-      "identifier": "body_response",
-      "modulePath": "/UnrealEngine.com/WebAPI",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeClient": {
-      "identifier": "MakeClient",
-      "modulePath": "/UnrealEngine.com/WebAPI",
-      "type": "function",
-      "isPublic": true
-    },
-    "Temporary": {
-      "identifier": "Temporary",
-      "modulePath": "/UnrealEngine.com/Temporary",
-      "type": "module",
-      "isPublic": true
-    },
-    "UI": {
-      "identifier": "UI",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "module",
-      "isPublic": true
-    },
-    "GetPlayerUI": {
-      "identifier": "GetPlayerUI",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "function",
-      "isPublic": true
-    },
-    "player_ui": {
-      "identifier": "player_ui",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "widget": {
-      "identifier": "widget",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_ui_slot": {
-      "identifier": "player_ui_slot",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "ui_input_mode": {
-      "identifier": "ui_input_mode",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "widget_message": {
-      "identifier": "widget_message",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "widget_visibility": {
-      "identifier": "widget_visibility",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "orientation": {
-      "identifier": "orientation",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "horizontal_alignment": {
-      "identifier": "horizontal_alignment",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "vertical_alignment": {
-      "identifier": "vertical_alignment",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "anchors": {
-      "identifier": "anchors",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "margin": {
-      "identifier": "margin",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "button": {
-      "identifier": "button",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "button_slot": {
-      "identifier": "button_slot",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "canvas": {
-      "identifier": "canvas",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "canvas_slot": {
-      "identifier": "canvas_slot",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeCanvasSlot": {
-      "identifier": "MakeCanvasSlot",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "function",
-      "isPublic": true
-    },
-    "color_block": {
-      "identifier": "color_block",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "image_tiling": {
-      "identifier": "image_tiling",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "texture_block": {
-      "identifier": "texture_block",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "material_block": {
-      "identifier": "material_block",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "overlay": {
-      "identifier": "overlay",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "overlay_slot": {
-      "identifier": "overlay_slot",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "stack_box": {
-      "identifier": "stack_box",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "stack_box_slot": {
-      "identifier": "stack_box_slot",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "text_justification": {
-      "identifier": "text_justification",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "text_overflow_policy": {
-      "identifier": "text_overflow_policy",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "text_wrapping_policy": {
-      "identifier": "text_wrapping_policy",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "text_base": {
-      "identifier": "text_base",
-      "modulePath": "/UnrealEngine.com/Temporary/UI",
-      "type": "class",
-      "isPublic": true
-    },
-    "Curves": {
-      "identifier": "Curves",
-      "modulePath": "/UnrealEngine.com/Temporary/Curves",
-      "type": "module",
-      "isPublic": true
-    },
-    "editable_curve": {
-      "identifier": "editable_curve",
-      "modulePath": "/UnrealEngine.com/Temporary/Curves",
-      "type": "class",
-      "isPublic": true
-    },
-    "Diagnostics": {
-      "identifier": "Diagnostics",
-      "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
-      "type": "module",
-      "isPublic": true
-    },
-    "debug_draw_duration_policy": {
-      "identifier": "debug_draw_duration_policy",
-      "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
-      "type": "class",
-      "isPublic": true
-    },
-    "debug_draw_channel": {
-      "identifier": "debug_draw_channel",
-      "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
-      "type": "class",
-      "isPublic": true
-    },
-    "debug_draw": {
-      "identifier": "debug_draw",
-      "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
-      "type": "class",
-      "isPublic": true
-    },
-    "log_level": {
-      "identifier": "log_level",
-      "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
-      "type": "class",
-      "isPublic": true
-    },
-    "log_channel": {
-      "identifier": "log_channel",
-      "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
-      "type": "class",
-      "isPublic": true
-    },
-    "log": {
-      "identifier": "log",
-      "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
-      "type": "class",
-      "isPublic": true
-    },
-    "SpatialMath": {
-      "identifier": "SpatialMath",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "module",
-      "isPublic": true
-    },
-    "rotation": {
-      "identifier": "rotation",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeRotation": {
-      "identifier": "MakeRotation",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeRotationFromYawPitchRollDegrees": {
-      "identifier": "MakeRotationFromYawPitchRollDegrees",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "IdentityRotation": {
-      "identifier": "IdentityRotation",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "Distance": {
-      "identifier": "Distance",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "AngularDistance": {
-      "identifier": "AngularDistance",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeShortestRotationBetween": {
-      "identifier": "MakeShortestRotationBetween",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeComponentWiseDeltaRotation": {
-      "identifier": "MakeComponentWiseDeltaRotation",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "Slerp": {
-      "identifier": "Slerp",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "ToString": {
-      "identifier": "ToString",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DegreesToRadians": {
-      "identifier": "DegreesToRadians",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "RadiansToDegrees": {
-      "identifier": "RadiansToDegrees",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "FromVector3": {
-      "identifier": "FromVector3",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "FromScalarVector3": {
-      "identifier": "FromScalarVector3",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "FromRotation": {
-      "identifier": "FromRotation",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "FromTransform": {
-      "identifier": "FromTransform",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "transform": {
-      "identifier": "transform",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "TransformVector": {
-      "identifier": "TransformVector",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "TransformVectorNoScale": {
-      "identifier": "TransformVectorNoScale",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "vector2": {
-      "identifier": "vector2",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReflectVector": {
-      "identifier": "ReflectVector",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DotProduct": {
-      "identifier": "DotProduct",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DistanceSquared": {
-      "identifier": "DistanceSquared",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "Lerp": {
-      "identifier": "Lerp",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "ToVector2": {
-      "identifier": "ToVector2",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "IsAlmostEqual": {
-      "identifier": "IsAlmostEqual",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "vector2i": {
-      "identifier": "vector2i",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "Equals": {
-      "identifier": "Equals",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "ToVector2i": {
-      "identifier": "ToVector2i",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "vector3": {
-      "identifier": "vector3",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "CrossProduct": {
-      "identifier": "CrossProduct",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DistanceXY": {
-      "identifier": "DistanceXY",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DistanceSquaredXY": {
-      "identifier": "DistanceSquaredXY",
-      "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "SortBy": {
-      "identifier": "SortBy",
-      "modulePath": "/UnrealEngine.com/Temporary",
-      "type": "function",
-      "isPublic": true
-    },
-    "JSON": {
-      "identifier": "JSON",
-      "modulePath": "/UnrealEngine.com/JSON",
-      "type": "module",
-      "isPublic": true
-    },
-    "value": {
-      "identifier": "value",
-      "modulePath": "/UnrealEngine.com/JSON",
-      "type": "class",
-      "isPublic": true
-    },
-    "Parse": {
-      "identifier": "Parse",
-      "modulePath": "/UnrealEngine.com/JSON",
-      "type": "function",
-      "isPublic": true
-    },
-    "ControlInput": {
-      "identifier": "ControlInput",
-      "modulePath": "/UnrealEngine.com/ControlInput",
-      "type": "module",
-      "isPublic": true
-    },
-    "input_events": {
-      "identifier": "input_events",
-      "modulePath": "/UnrealEngine.com/ControlInput",
-      "type": "class",
-      "isPublic": true
-    },
-    "GetPlayerInput": {
-      "identifier": "GetPlayerInput",
-      "modulePath": "/UnrealEngine.com/ControlInput",
-      "type": "function",
-      "isPublic": true
-    },
-    "player_input": {
-      "identifier": "player_input",
-      "modulePath": "/UnrealEngine.com/ControlInput",
-      "type": "class",
-      "isPublic": true
-    },
-    "BasicShapes": {
-      "identifier": "BasicShapes",
-      "modulePath": "/UnrealEngine.com/BasicShapes",
-      "type": "module",
-      "isPublic": true
-    },
-    "cube": {
-      "identifier": "cube",
-      "modulePath": "/UnrealEngine.com/BasicShapes",
-      "type": "class",
-      "isPublic": true
-    },
-    "sphere": {
-      "identifier": "sphere",
-      "modulePath": "/UnrealEngine.com/BasicShapes",
-      "type": "class",
-      "isPublic": true
-    },
-    "plane": {
-      "identifier": "plane",
-      "modulePath": "/UnrealEngine.com/BasicShapes",
-      "type": "class",
-      "isPublic": true
-    },
-    "cone": {
-      "identifier": "cone",
-      "modulePath": "/UnrealEngine.com/BasicShapes",
-      "type": "class",
-      "isPublic": true
-    },
-    "cylinder": {
-      "identifier": "cylinder",
-      "modulePath": "/UnrealEngine.com/BasicShapes",
-      "type": "class",
-      "isPublic": true
-    },
-    "Assets": {
-      "identifier": "Assets",
-      "modulePath": "/UnrealEngine.com/Assets",
-      "type": "module",
-      "isPublic": true
-    },
-    "SpawnParticleSystem": {
-      "identifier": "SpawnParticleSystem",
-      "modulePath": "/UnrealEngine.com/Assets",
-      "type": "function",
-      "isPublic": true
-    }
+    "Conversations": [
+      {
+        "identifier": "Conversations",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "ai_error": [
+      {
+        "identifier": "ai_error",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_timeout_error": [
+      {
+        "identifier": "ai_timeout_error",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_throttled_error": [
+      {
+        "identifier": "ai_throttled_error",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_moderated_error": [
+      {
+        "identifier": "ai_moderated_error",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_character_limit_error": [
+      {
+        "identifier": "ai_character_limit_error",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "prompt_binding_definition": [
+      {
+        "identifier": "prompt_binding_definition",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_session": [
+      {
+        "identifier": "ai_session",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "persona_interruption_rule": [
+      {
+        "identifier": "persona_interruption_rule",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "persona_component": [
+      {
+        "identifier": "persona_component",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "voice_model": [
+      {
+        "identifier": "voice_model",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "brite_bomber_voice": [
+      {
+        "identifier": "brite_bomber_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "elmira_voice": [
+      {
+        "identifier": "elmira_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "helsie_midnight_voice": [
+      {
+        "identifier": "helsie_midnight_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "mancake_voice": [
+      {
+        "identifier": "mancake_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "munitions_master_voice": [
+      {
+        "identifier": "munitions_master_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "peely_voice": [
+      {
+        "identifier": "peely_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "terns_voice": [
+      {
+        "identifier": "terns_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "lexa_hexbringer_voice": [
+      {
+        "identifier": "lexa_hexbringer_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "battle_gamer_mae_voice": [
+      {
+        "identifier": "battle_gamer_mae_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "halley_voice": [
+      {
+        "identifier": "halley_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "aura_voice": [
+      {
+        "identifier": "aura_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "brute_gunner_voice": [
+      {
+        "identifier": "brute_gunner_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "field_commander_voice": [
+      {
+        "identifier": "field_commander_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ziggy_voice": [
+      {
+        "identifier": "ziggy_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "haylee_skye_voice": [
+      {
+        "identifier": "haylee_skye_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "orin_voice": [
+      {
+        "identifier": "orin_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "moxie_voice": [
+      {
+        "identifier": "moxie_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "kor_voice": [
+      {
+        "identifier": "kor_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "clover_swift_voice": [
+      {
+        "identifier": "clover_swift_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "chase_voice": [
+      {
+        "identifier": "chase_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "fishstick_voice": [
+      {
+        "identifier": "fishstick_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "guild_voice": [
+      {
+        "identifier": "guild_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sunspot_voice": [
+      {
+        "identifier": "sunspot_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "the_imagined_voice": [
+      {
+        "identifier": "the_imagined_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "red_ruin_joni_voice": [
+      {
+        "identifier": "red_ruin_joni_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "nezumi_voice": [
+      {
+        "identifier": "nezumi_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "magnus_voice": [
+      {
+        "identifier": "magnus_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "revolt_voice": [
+      {
+        "identifier": "revolt_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tomatohead_voice": [
+      {
+        "identifier": "tomatohead_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "raven_voice": [
+      {
+        "identifier": "raven_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "cuddle_team_leader_voice": [
+      {
+        "identifier": "cuddle_team_leader_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "midas_voice": [
+      {
+        "identifier": "midas_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "mecha_team_leader_voice": [
+      {
+        "identifier": "mecha_team_leader_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "jonesy_voice": [
+      {
+        "identifier": "jonesy_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "hope_voice": [
+      {
+        "identifier": "hope_voice",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_description_attribute": [
+      {
+        "identifier": "ai_description_attribute",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ai_description": [
+      {
+        "identifier": "ai_description",
+        "modulePath": "/UnrealEngine.com/Conversations",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Progression": [
+      {
+        "identifier": "Progression",
+        "modulePath": "/UnrealEngine.com/Progression",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "entitlement_quest_reward": [
+      {
+        "identifier": "entitlement_quest_reward",
+        "modulePath": "/UnrealEngine.com/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "progress_quest_objective": [
+      {
+        "identifier": "progress_quest_objective",
+        "modulePath": "/UnrealEngine.com/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "basic_quest": [
+      {
+        "identifier": "basic_quest",
+        "modulePath": "/UnrealEngine.com/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "quest_objective": [
+      {
+        "identifier": "quest_objective",
+        "modulePath": "/UnrealEngine.com/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "grant_quest_reward_error": [
+      {
+        "identifier": "grant_quest_reward_error",
+        "modulePath": "/UnrealEngine.com/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "quest_reward": [
+      {
+        "identifier": "quest_reward",
+        "modulePath": "/UnrealEngine.com/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Itemization": [
+      {
+        "identifier": "Itemization",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "add_item_result": [
+      {
+        "identifier": "add_item_result",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "remove_item_result": [
+      {
+        "identifier": "remove_item_result",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "equip_item_result": [
+      {
+        "identifier": "equip_item_result",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "unequip_item_result": [
+      {
+        "identifier": "unequip_item_result",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "find_inventory_event": [
+      {
+        "identifier": "find_inventory_event",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "add_item_error": [
+      {
+        "identifier": "add_item_error",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "add_item_query_event": [
+      {
+        "identifier": "add_item_query_event",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "remove_item_error": [
+      {
+        "identifier": "remove_item_error",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "remove_item_query_event": [
+      {
+        "identifier": "remove_item_query_event",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "inventory_component": [
+      {
+        "identifier": "inventory_component",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "item_category": [
+      {
+        "identifier": "item_category",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "change_equipped_result": [
+      {
+        "identifier": "change_equipped_result",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "change_inventory_result": [
+      {
+        "identifier": "change_inventory_result",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "equip_item_error": [
+      {
+        "identifier": "equip_item_error",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "equip_item_query_event": [
+      {
+        "identifier": "equip_item_query_event",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "unequip_item_error": [
+      {
+        "identifier": "unequip_item_error",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "unequip_item_query_event": [
+      {
+        "identifier": "unequip_item_query_event",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "item_component": [
+      {
+        "identifier": "item_component",
+        "modulePath": "/UnrealEngine.com/Itemization",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "WebAPI": [
+      {
+        "identifier": "WebAPI",
+        "modulePath": "/UnrealEngine.com/WebAPI",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "client_id": [
+      {
+        "identifier": "client_id",
+        "modulePath": "/UnrealEngine.com/WebAPI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "client": [
+      {
+        "identifier": "client",
+        "modulePath": "/UnrealEngine.com/WebAPI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "response": [
+      {
+        "identifier": "response",
+        "modulePath": "/UnrealEngine.com/WebAPI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "body_response": [
+      {
+        "identifier": "body_response",
+        "modulePath": "/UnrealEngine.com/WebAPI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeClient": [
+      {
+        "identifier": "MakeClient",
+        "modulePath": "/UnrealEngine.com/WebAPI",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Temporary": [
+      {
+        "identifier": "Temporary",
+        "modulePath": "/UnrealEngine.com/Temporary",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "UI": [
+      {
+        "identifier": "UI",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "GetPlayerUI": [
+      {
+        "identifier": "GetPlayerUI",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "player_ui": [
+      {
+        "identifier": "player_ui",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "widget": [
+      {
+        "identifier": "widget",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_ui_slot": [
+      {
+        "identifier": "player_ui_slot",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ui_input_mode": [
+      {
+        "identifier": "ui_input_mode",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "widget_message": [
+      {
+        "identifier": "widget_message",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "widget_visibility": [
+      {
+        "identifier": "widget_visibility",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "orientation": [
+      {
+        "identifier": "orientation",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "horizontal_alignment": [
+      {
+        "identifier": "horizontal_alignment",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vertical_alignment": [
+      {
+        "identifier": "vertical_alignment",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "anchors": [
+      {
+        "identifier": "anchors",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "margin": [
+      {
+        "identifier": "margin",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "button": [
+      {
+        "identifier": "button",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "button_slot": [
+      {
+        "identifier": "button_slot",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "canvas": [
+      {
+        "identifier": "canvas",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "canvas_slot": [
+      {
+        "identifier": "canvas_slot",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeCanvasSlot": [
+      {
+        "identifier": "MakeCanvasSlot",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "color_block": [
+      {
+        "identifier": "color_block",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "image_tiling": [
+      {
+        "identifier": "image_tiling",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "texture_block": [
+      {
+        "identifier": "texture_block",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "material_block": [
+      {
+        "identifier": "material_block",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "overlay": [
+      {
+        "identifier": "overlay",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "overlay_slot": [
+      {
+        "identifier": "overlay_slot",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "stack_box": [
+      {
+        "identifier": "stack_box",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "stack_box_slot": [
+      {
+        "identifier": "stack_box_slot",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "text_justification": [
+      {
+        "identifier": "text_justification",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "text_overflow_policy": [
+      {
+        "identifier": "text_overflow_policy",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "text_wrapping_policy": [
+      {
+        "identifier": "text_wrapping_policy",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "text_base": [
+      {
+        "identifier": "text_base",
+        "modulePath": "/UnrealEngine.com/Temporary/UI",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Curves": [
+      {
+        "identifier": "Curves",
+        "modulePath": "/UnrealEngine.com/Temporary/Curves",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "editable_curve": [
+      {
+        "identifier": "editable_curve",
+        "modulePath": "/UnrealEngine.com/Temporary/Curves",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Diagnostics": [
+      {
+        "identifier": "Diagnostics",
+        "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "debug_draw_duration_policy": [
+      {
+        "identifier": "debug_draw_duration_policy",
+        "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "debug_draw_channel": [
+      {
+        "identifier": "debug_draw_channel",
+        "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "debug_draw": [
+      {
+        "identifier": "debug_draw",
+        "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "log_level": [
+      {
+        "identifier": "log_level",
+        "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "log_channel": [
+      {
+        "identifier": "log_channel",
+        "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "log": [
+      {
+        "identifier": "log",
+        "modulePath": "/UnrealEngine.com/Temporary/Diagnostics",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SpatialMath": [
+      {
+        "identifier": "SpatialMath",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "rotation": [
+      {
+        "identifier": "rotation",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeRotation": [
+      {
+        "identifier": "MakeRotation",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeRotationFromYawPitchRollDegrees": [
+      {
+        "identifier": "MakeRotationFromYawPitchRollDegrees",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "IdentityRotation": [
+      {
+        "identifier": "IdentityRotation",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Distance": [
+      {
+        "identifier": "Distance",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "AngularDistance": [
+      {
+        "identifier": "AngularDistance",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeShortestRotationBetween": [
+      {
+        "identifier": "MakeShortestRotationBetween",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeComponentWiseDeltaRotation": [
+      {
+        "identifier": "MakeComponentWiseDeltaRotation",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Slerp": [
+      {
+        "identifier": "Slerp",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ToString": [
+      {
+        "identifier": "ToString",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DegreesToRadians": [
+      {
+        "identifier": "DegreesToRadians",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "RadiansToDegrees": [
+      {
+        "identifier": "RadiansToDegrees",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "FromVector3": [
+      {
+        "identifier": "FromVector3",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "FromScalarVector3": [
+      {
+        "identifier": "FromScalarVector3",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "FromRotation": [
+      {
+        "identifier": "FromRotation",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "FromTransform": [
+      {
+        "identifier": "FromTransform",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "transform": [
+      {
+        "identifier": "transform",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "TransformVector": [
+      {
+        "identifier": "TransformVector",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "TransformVectorNoScale": [
+      {
+        "identifier": "TransformVectorNoScale",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "vector2": [
+      {
+        "identifier": "vector2",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReflectVector": [
+      {
+        "identifier": "ReflectVector",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DotProduct": [
+      {
+        "identifier": "DotProduct",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DistanceSquared": [
+      {
+        "identifier": "DistanceSquared",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Lerp": [
+      {
+        "identifier": "Lerp",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ToVector2": [
+      {
+        "identifier": "ToVector2",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "IsAlmostEqual": [
+      {
+        "identifier": "IsAlmostEqual",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "vector2i": [
+      {
+        "identifier": "vector2i",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Equals": [
+      {
+        "identifier": "Equals",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ToVector2i": [
+      {
+        "identifier": "ToVector2i",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "vector3": [
+      {
+        "identifier": "vector3",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CrossProduct": [
+      {
+        "identifier": "CrossProduct",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DistanceXY": [
+      {
+        "identifier": "DistanceXY",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DistanceSquaredXY": [
+      {
+        "identifier": "DistanceSquaredXY",
+        "modulePath": "/UnrealEngine.com/Temporary/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "SortBy": [
+      {
+        "identifier": "SortBy",
+        "modulePath": "/UnrealEngine.com/Temporary",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "JSON": [
+      {
+        "identifier": "JSON",
+        "modulePath": "/UnrealEngine.com/JSON",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "value": [
+      {
+        "identifier": "value",
+        "modulePath": "/UnrealEngine.com/JSON",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Parse": [
+      {
+        "identifier": "Parse",
+        "modulePath": "/UnrealEngine.com/JSON",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ControlInput": [
+      {
+        "identifier": "ControlInput",
+        "modulePath": "/UnrealEngine.com/ControlInput",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "input_events": [
+      {
+        "identifier": "input_events",
+        "modulePath": "/UnrealEngine.com/ControlInput",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GetPlayerInput": [
+      {
+        "identifier": "GetPlayerInput",
+        "modulePath": "/UnrealEngine.com/ControlInput",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "player_input": [
+      {
+        "identifier": "player_input",
+        "modulePath": "/UnrealEngine.com/ControlInput",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "BasicShapes": [
+      {
+        "identifier": "BasicShapes",
+        "modulePath": "/UnrealEngine.com/BasicShapes",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "cube": [
+      {
+        "identifier": "cube",
+        "modulePath": "/UnrealEngine.com/BasicShapes",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sphere": [
+      {
+        "identifier": "sphere",
+        "modulePath": "/UnrealEngine.com/BasicShapes",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "plane": [
+      {
+        "identifier": "plane",
+        "modulePath": "/UnrealEngine.com/BasicShapes",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "cone": [
+      {
+        "identifier": "cone",
+        "modulePath": "/UnrealEngine.com/BasicShapes",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "cylinder": [
+      {
+        "identifier": "cylinder",
+        "modulePath": "/UnrealEngine.com/BasicShapes",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Assets": [
+      {
+        "identifier": "Assets",
+        "modulePath": "/UnrealEngine.com/Assets",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "SpawnParticleSystem": [
+      {
+        "identifier": "SpawnParticleSystem",
+        "modulePath": "/UnrealEngine.com/Assets",
+        "type": "function",
+        "isPublic": true
+      }
+    ]
   },
   "moduleIndex": {
     "/UnrealEngine.com/Conversations": [

--- a/src/data/Verse.digest.json
+++ b/src/data/Verse.digest.json
@@ -1,2775 +1,3721 @@
 {
-  "version": "1.0.0",
-  "generatedAt": "2026-08-14T12:40:55.458Z",
+  "version": "2.0.0",
+  "generatedAt": "2026-08-15T10:07:02.853Z",
   "sourceFile": "Verse.digest.verse",
   "sourceBuild": "++Fortnite+Release-41.30-CL-56430492",
   "entries": {
-    "Chat": {
-      "identifier": "Chat",
-      "modulePath": "/Verse.org/Chat",
-      "type": "module",
-      "isPublic": true
-    },
-    "chat_channel": {
-      "identifier": "chat_channel",
-      "modulePath": "/Verse.org/Chat",
-      "type": "class",
-      "isPublic": true
-    },
-    "has_voice_member_info": {
-      "identifier": "has_voice_member_info",
-      "modulePath": "/Verse.org/Chat",
-      "type": "class",
-      "isPublic": true
-    },
-    "voice_channel": {
-      "identifier": "voice_channel",
-      "modulePath": "/Verse.org/Chat",
-      "type": "class",
-      "isPublic": true
-    },
-    "add_channel_error": {
-      "identifier": "add_channel_error",
-      "modulePath": "/Verse.org/Chat",
-      "type": "class",
-      "isPublic": true
-    },
-    "remove_channel_error": {
-      "identifier": "remove_channel_error",
-      "modulePath": "/Verse.org/Chat",
-      "type": "class",
-      "isPublic": true
-    },
-    "SceneGraph": {
-      "identifier": "SceneGraph",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "module",
-      "isPublic": true
-    },
-    "basic_interactable_component": {
-      "identifier": "basic_interactable_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "interactable_component": {
-      "identifier": "interactable_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "interactable_cooldown": {
-      "identifier": "interactable_cooldown",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "interactable_cooldown_per_agent": {
-      "identifier": "interactable_cooldown_per_agent",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "interactable_duration": {
-      "identifier": "interactable_duration",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "interactable_success_limit": {
-      "identifier": "interactable_success_limit",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_body": {
-      "identifier": "camera_body",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_component": {
-      "identifier": "camera_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "GlobalModifierPosition": {
-      "identifier": "GlobalModifierPosition",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "variable",
-      "isPublic": true
-    },
-    "VisualModifierPosition": {
-      "identifier": "VisualModifierPosition",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "variable",
-      "isPublic": true
-    },
-    "camera_director_component": {
-      "identifier": "camera_director_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_lens": {
-      "identifier": "camera_lens",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_modifier_stack": {
-      "identifier": "camera_modifier_stack",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "has_camera_modifier": {
-      "identifier": "has_camera_modifier",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_modifier": {
-      "identifier": "camera_modifier",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_projection_mode": {
-      "identifier": "camera_projection_mode",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_state": {
-      "identifier": "camera_state",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_transition_initial_orientation": {
-      "identifier": "camera_transition_initial_orientation",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_transition": {
-      "identifier": "camera_transition",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_mode_blend": {
-      "identifier": "camera_mode_blend",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_mode_blend_pop": {
-      "identifier": "camera_mode_blend_pop",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_mode_blend_linear": {
-      "identifier": "camera_mode_blend_linear",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_mode_blend_smoothstep": {
-      "identifier": "camera_mode_blend_smoothstep",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_mode_blend_smootherstep": {
-      "identifier": "camera_mode_blend_smootherstep",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera_mode_blend_orbit": {
-      "identifier": "camera_mode_blend_orbit",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "orthographic_camera_component": {
-      "identifier": "orthographic_camera_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "perspective_camera_component": {
-      "identifier": "perspective_camera_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "physical_camera_component": {
-      "identifier": "physical_camera_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "skeletal_animation": {
-      "identifier": "skeletal_animation",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "play_skeletal_animation_result": {
-      "identifier": "play_skeletal_animation_result",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "skeleton": {
-      "identifier": "skeleton",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "easing_window": {
-      "identifier": "easing_window",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "easeable": {
-      "identifier": "easeable",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "entity_streaming_policy": {
-      "identifier": "entity_streaming_policy",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "children_streaming_policy": {
-      "identifier": "children_streaming_policy",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "capsule_light_component": {
-      "identifier": "capsule_light_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "directional_light_component": {
-      "identifier": "directional_light_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "KeyframedMovement": {
-      "identifier": "KeyframedMovement",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "module",
-      "isPublic": true
-    },
-    "easing_function": {
-      "identifier": "easing_function",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "cubic_bezier_easing_function": {
-      "identifier": "cubic_bezier_easing_function",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "linear_easing_function": {
-      "identifier": "linear_easing_function",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "ease_cubic_bezier_easing_function": {
-      "identifier": "ease_cubic_bezier_easing_function",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "ease_in_cubic_bezier_easing_function": {
-      "identifier": "ease_in_cubic_bezier_easing_function",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "ease_out_cubic_bezier_easing_function": {
-      "identifier": "ease_out_cubic_bezier_easing_function",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "ease_in_out_cubic_bezier_easing_function": {
-      "identifier": "ease_in_out_cubic_bezier_easing_function",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "keyframed_movement_playback_mode": {
-      "identifier": "keyframed_movement_playback_mode",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "oneshot_keyframed_movement_playback_mode": {
-      "identifier": "oneshot_keyframed_movement_playback_mode",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "loop_keyframed_movement_playback_mode": {
-      "identifier": "loop_keyframed_movement_playback_mode",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "pingpong_keyframed_movement_playback_mode": {
-      "identifier": "pingpong_keyframed_movement_playback_mode",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "keyframed_movement_delta": {
-      "identifier": "keyframed_movement_delta",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "keyframed_movement_component": {
-      "identifier": "keyframed_movement_component",
-      "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
-      "type": "class",
-      "isPublic": true
-    },
-    "light_component": {
-      "identifier": "light_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "mesh_component": {
-      "identifier": "mesh_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "particle_system_component": {
-      "identifier": "particle_system_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "possessable_component": {
-      "identifier": "possessable_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "rect_light_component": {
-      "identifier": "rect_light_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "sound_component": {
-      "identifier": "sound_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "sphere_light_component": {
-      "identifier": "sphere_light_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "spot_light_component": {
-      "identifier": "spot_light_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "float_range": {
-      "identifier": "float_range",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_interaction": {
-      "identifier": "collision_interaction",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_channel": {
-      "identifier": "collision_channel",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_channel_to_interaction": {
-      "identifier": "collision_channel_to_interaction",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "variable",
-      "isPublic": true
-    },
-    "collision_profile": {
-      "identifier": "collision_profile",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "CollisionChannels": {
-      "identifier": "CollisionChannels",
-      "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
-      "type": "module",
-      "isPublic": true
-    },
-    "stationary": {
-      "identifier": "stationary",
-      "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
-      "type": "class",
-      "isPublic": true
-    },
-    "dynamic": {
-      "identifier": "dynamic",
-      "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
-      "type": "class",
-      "isPublic": true
-    },
-    "avatar": {
-      "identifier": "avatar",
-      "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
-      "type": "class",
-      "isPublic": true
-    },
-    "visibility": {
-      "identifier": "visibility",
-      "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
-      "type": "class",
-      "isPublic": true
-    },
-    "camera": {
-      "identifier": "camera",
-      "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
-      "type": "class",
-      "isPublic": true
-    },
-    "physics": {
-      "identifier": "physics",
-      "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
-      "type": "class",
-      "isPublic": true
-    },
-    "CollisionProfiles": {
-      "identifier": "CollisionProfiles",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "module",
-      "isPublic": true
-    },
-    "StationaryIgnoreAll": {
-      "identifier": "StationaryIgnoreAll",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "StationaryOverlapAll": {
-      "identifier": "StationaryOverlapAll",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "StationaryBlockAll": {
-      "identifier": "StationaryBlockAll",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DynamicIgnoreAll": {
-      "identifier": "DynamicIgnoreAll",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DynamicOverlapAll": {
-      "identifier": "DynamicOverlapAll",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DynamicBlockAll": {
-      "identifier": "DynamicBlockAll",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "StationaryBlockVisible": {
-      "identifier": "StationaryBlockVisible",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "VisibilityOverlapAll": {
-      "identifier": "VisibilityOverlapAll",
-      "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
-      "type": "variable",
-      "isPublic": true
-    },
-    "overlap_hit": {
-      "identifier": "overlap_hit",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "sweep_hit": {
-      "identifier": "sweep_hit",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_volume": {
-      "identifier": "collision_volume",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_element": {
-      "identifier": "collision_element",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_capsule": {
-      "identifier": "collision_capsule",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_sphere": {
-      "identifier": "collision_sphere",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_point": {
-      "identifier": "collision_point",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "collision_box": {
-      "identifier": "collision_box",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "component": {
-      "identifier": "component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "scene_event": {
-      "identifier": "scene_event",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "entity": {
-      "identifier": "entity",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "entity_prefab": {
-      "identifier": "entity_prefab",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "icon_component": {
-      "identifier": "icon_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "origin": {
-      "identifier": "origin",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "entity_origin": {
-      "identifier": "entity_origin",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "rarity": {
-      "identifier": "rarity",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "common_rarity": {
-      "identifier": "common_rarity",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "uncommon_rarity": {
-      "identifier": "uncommon_rarity",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "rare_rarity": {
-      "identifier": "rare_rarity",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "epic_rarity": {
-      "identifier": "epic_rarity",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "legendary_rarity": {
-      "identifier": "legendary_rarity",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "rarity_component": {
-      "identifier": "rarity_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "stackable_component": {
-      "identifier": "stackable_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "change_stack_size_result": {
-      "identifier": "change_stack_size_result",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "change_max_stack_size_result": {
-      "identifier": "change_max_stack_size_result",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "has_merge_rules": {
-      "identifier": "has_merge_rules",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "basic_stackable_component": {
-      "identifier": "basic_stackable_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "tick_events": {
-      "identifier": "tick_events",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "transform_component": {
-      "identifier": "transform_component",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "execution_listenable": {
-      "identifier": "execution_listenable",
-      "modulePath": "/Verse.org/SceneGraph",
-      "type": "class",
-      "isPublic": true
-    },
-    "Progression": {
-      "identifier": "Progression",
-      "modulePath": "/Verse.org/Progression",
-      "type": "module",
-      "isPublic": true
-    },
-    "quest_participant_info": {
-      "identifier": "quest_participant_info",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "quest_membership": {
-      "identifier": "quest_membership",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "join_quest_error": {
-      "identifier": "join_quest_error",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "abandon_quest_error": {
-      "identifier": "abandon_quest_error",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "quest": {
-      "identifier": "quest",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "quest_collection": {
-      "identifier": "quest_collection",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "quest_participant": {
-      "identifier": "quest_participant",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "agent_quest_participant": {
-      "identifier": "agent_quest_participant",
-      "modulePath": "/Verse.org/Progression",
-      "type": "class",
-      "isPublic": true
-    },
-    "Presentation": {
-      "identifier": "Presentation",
-      "modulePath": "/Verse.org/Presentation",
-      "type": "module",
-      "isPublic": true
-    },
-    "description_component": {
-      "identifier": "description_component",
-      "modulePath": "/Verse.org/Presentation",
-      "type": "class",
-      "isPublic": true
-    },
-    "has_description": {
-      "identifier": "has_description",
-      "modulePath": "/Verse.org/Presentation",
-      "type": "class",
-      "isPublic": true
-    },
-    "Input": {
-      "identifier": "Input",
-      "modulePath": "/Verse.org/Input",
-      "type": "module",
-      "isPublic": true
-    },
-    "Gameplay": {
-      "identifier": "Gameplay",
-      "modulePath": "/Verse.org/Input/Gameplay",
-      "type": "module",
-      "isPublic": true
-    },
-    "HotbarMapping": {
-      "identifier": "HotbarMapping",
-      "modulePath": "/Verse.org/Input/Gameplay",
-      "type": "variable",
-      "isPublic": true
-    },
-    "input_method": {
-      "identifier": "input_method",
-      "modulePath": "/Verse.org/Input",
-      "type": "class",
-      "isPublic": true
-    },
-    "available_input_devices": {
-      "identifier": "available_input_devices",
-      "modulePath": "/Verse.org/Input",
-      "type": "class",
-      "isPublic": true
-    },
-    "GetPlayerInput": {
-      "identifier": "GetPlayerInput",
-      "modulePath": "/Verse.org/Input",
-      "type": "function",
-      "isPublic": true
-    },
-    "input_events": {
-      "identifier": "input_events",
-      "modulePath": "/Verse.org/Input",
-      "type": "class",
-      "isPublic": true
-    },
-    "player_input": {
-      "identifier": "player_input",
-      "modulePath": "/Verse.org/Input",
-      "type": "class",
-      "isPublic": true
-    },
-    "deproject_results": {
-      "identifier": "deproject_results",
-      "modulePath": "/Verse.org/Input",
-      "type": "class",
-      "isPublic": true
-    },
-    "UI": {
-      "identifier": "UI",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "module",
-      "isPublic": true
-    },
-    "MenuNavigationMapping": {
-      "identifier": "MenuNavigationMapping",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "NextTab": {
-      "identifier": "NextTab",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PreviousTab": {
-      "identifier": "PreviousTab",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "NextPage": {
-      "identifier": "NextPage",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PreviousPage": {
-      "identifier": "PreviousPage",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Back": {
-      "identifier": "Back",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "InventoryMenuMapping": {
-      "identifier": "InventoryMenuMapping",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Use": {
-      "identifier": "Use",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Inspect": {
-      "identifier": "Inspect",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Sort": {
-      "identifier": "Sort",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Drop": {
-      "identifier": "Drop",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "CraftingMenuMapping": {
-      "identifier": "CraftingMenuMapping",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Craft": {
-      "identifier": "Craft",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Favorite": {
-      "identifier": "Favorite",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Scrap": {
-      "identifier": "Scrap",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MapMenuMapping": {
-      "identifier": "MapMenuMapping",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Track": {
-      "identifier": "Track",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Reset": {
-      "identifier": "Reset",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PlaceMarker": {
-      "identifier": "PlaceMarker",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "ToggleView": {
-      "identifier": "ToggleView",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "ZoomIn": {
-      "identifier": "ZoomIn",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "ZoomOut": {
-      "identifier": "ZoomOut",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "TouchMapping": {
-      "identifier": "TouchMapping",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PointerSelect": {
-      "identifier": "PointerSelect",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PointerZoom": {
-      "identifier": "PointerZoom",
-      "modulePath": "/Verse.org/Input/UI",
-      "type": "variable",
-      "isPublic": true
-    },
-    "AgentGroup": {
-      "identifier": "AgentGroup",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "module",
-      "isPublic": true
-    },
-    "member_info_interface": {
-      "identifier": "member_info_interface",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "class",
-      "isPublic": true
-    },
-    "agent_group_interface": {
-      "identifier": "agent_group_interface",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "class",
-      "isPublic": true
-    },
-    "agent_group": {
-      "identifier": "agent_group",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "class",
-      "isPublic": true
-    },
-    "add_member_error": {
-      "identifier": "add_member_error",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "class",
-      "isPublic": true
-    },
-    "remove_member_error": {
-      "identifier": "remove_member_error",
-      "modulePath": "/Verse.org/AgentGroup",
-      "type": "class",
-      "isPublic": true
-    },
-    "Verse": {
-      "identifier": "Verse",
-      "modulePath": "/Verse.org/Verse",
-      "type": "module",
-      "isPublic": true
-    },
-    "Print": {
-      "identifier": "Print",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Concatenate": {
-      "identifier": "Concatenate",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "cancelable": {
-      "identifier": "cancelable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "classifiable_subset": {
-      "identifier": "classifiable_subset",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeClassifiableSubset": {
-      "identifier": "MakeClassifiableSubset",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "diagnostic": {
-      "identifier": "diagnostic",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "ToDiagnostic": {
-      "identifier": "ToDiagnostic",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "disposable": {
-      "identifier": "disposable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "Easing": {
-      "identifier": "Easing",
-      "modulePath": "/Verse.org/Verse/Easing",
-      "type": "module",
-      "isPublic": true
-    },
-    "CubicBezier": {
-      "identifier": "CubicBezier",
-      "modulePath": "/Verse.org/Verse/Easing",
-      "type": "function",
-      "isPublic": true
-    },
-    "Linear": {
-      "identifier": "Linear",
-      "modulePath": "/Verse.org/Verse/Easing",
-      "type": "function",
-      "isPublic": true
-    },
-    "Ease": {
-      "identifier": "Ease",
-      "modulePath": "/Verse.org/Verse/Easing",
-      "type": "function",
-      "isPublic": true
-    },
-    "EaseIn": {
-      "identifier": "EaseIn",
-      "modulePath": "/Verse.org/Verse/Easing",
-      "type": "function",
-      "isPublic": true
-    },
-    "EaseOut": {
-      "identifier": "EaseOut",
-      "modulePath": "/Verse.org/Verse/Easing",
-      "type": "function",
-      "isPublic": true
-    },
-    "EaseInOut": {
-      "identifier": "EaseInOut",
-      "modulePath": "/Verse.org/Verse/Easing",
-      "type": "function",
-      "isPublic": true
-    },
-    "enableable": {
-      "identifier": "enableable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "Err": {
-      "identifier": "Err",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "event": {
-      "identifier": "event",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "Ceil": {
-      "identifier": "Ceil",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Floor": {
-      "identifier": "Floor",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Round": {
-      "identifier": "Round",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Int": {
-      "identifier": "Int",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "ToString": {
-      "identifier": "ToString",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "GetSecondsSinceEpoch": {
-      "identifier": "GetSecondsSinceEpoch",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "invalidatable": {
-      "identifier": "invalidatable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "listenable": {
-      "identifier": "listenable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "locale": {
-      "identifier": "locale",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "message": {
-      "identifier": "message",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "Localize": {
-      "identifier": "Localize",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Join": {
-      "identifier": "Join",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "PiFloat": {
-      "identifier": "PiFloat",
-      "modulePath": "/Verse.org/Verse",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Clamp": {
-      "identifier": "Clamp",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Min": {
-      "identifier": "Min",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Max": {
-      "identifier": "Max",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Sqrt": {
-      "identifier": "Sqrt",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Sin": {
-      "identifier": "Sin",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Cos": {
-      "identifier": "Cos",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Tan": {
-      "identifier": "Tan",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "ArcSin": {
-      "identifier": "ArcSin",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "ArcCos": {
-      "identifier": "ArcCos",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "ArcTan": {
-      "identifier": "ArcTan",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Sinh": {
-      "identifier": "Sinh",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Cosh": {
-      "identifier": "Cosh",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Tanh": {
-      "identifier": "Tanh",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "ArSinh": {
-      "identifier": "ArSinh",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "ArCosh": {
-      "identifier": "ArCosh",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "ArTanh": {
-      "identifier": "ArTanh",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Pow": {
-      "identifier": "Pow",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Quotient": {
-      "identifier": "Quotient",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Mod": {
-      "identifier": "Mod",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Exp": {
-      "identifier": "Exp",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Ln": {
-      "identifier": "Ln",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Log": {
-      "identifier": "Log",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Lerp": {
-      "identifier": "Lerp",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "Sgn": {
-      "identifier": "Sgn",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "IsAlmostEqual": {
-      "identifier": "IsAlmostEqual",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "result": {
-      "identifier": "result",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeSuccess": {
-      "identifier": "MakeSuccess",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeError": {
-      "identifier": "MakeError",
-      "modulePath": "/Verse.org/Verse",
-      "type": "function",
-      "isPublic": true
-    },
-    "showable": {
-      "identifier": "showable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "signalable": {
-      "identifier": "signalable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "subscribable": {
-      "identifier": "subscribable",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "modifier": {
-      "identifier": "modifier",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "modifier_stack": {
-      "identifier": "modifier_stack",
-      "modulePath": "/Verse.org/Verse",
-      "type": "class",
-      "isPublic": true
-    },
-    "Simulation": {
-      "identifier": "Simulation",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "module",
-      "isPublic": true
-    },
-    "agent": {
-      "identifier": "agent",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "player": {
-      "identifier": "player",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "Tags": {
-      "identifier": "Tags",
-      "modulePath": "/Verse.org/Simulation/Tags",
-      "type": "module",
-      "isPublic": true
-    },
-    "has_tags": {
-      "identifier": "has_tags",
-      "modulePath": "/Verse.org/Simulation/Tags",
-      "type": "class",
-      "isPublic": true
-    },
-    "tag": {
-      "identifier": "tag",
-      "modulePath": "/Verse.org/Simulation/Tags",
-      "type": "class",
-      "isPublic": true
-    },
-    "tag_key": {
-      "identifier": "tag_key",
-      "modulePath": "/Verse.org/Simulation/Tags",
-      "type": "class",
-      "isPublic": true
-    },
-    "tag_search_sort_type": {
-      "identifier": "tag_search_sort_type",
-      "modulePath": "/Verse.org/Simulation/Tags",
-      "type": "class",
-      "isPublic": true
-    },
-    "tag_search_criteria": {
-      "identifier": "tag_search_criteria",
-      "modulePath": "/Verse.org/Simulation/Tags",
-      "type": "class",
-      "isPublic": true
-    },
-    "tag_view": {
-      "identifier": "tag_view",
-      "modulePath": "/Verse.org/Simulation/Tags",
-      "type": "class",
-      "isPublic": true
-    },
-    "editable": {
-      "identifier": "editable",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "editable_text_box": {
-      "identifier": "editable_text_box",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "editable_slider": {
-      "identifier": "editable_slider",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "editable_number": {
-      "identifier": "editable_number",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "editable_vector_slider": {
-      "identifier": "editable_vector_slider",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "editable_vector_number": {
-      "identifier": "editable_vector_number",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "editable_container": {
-      "identifier": "editable_container",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "session": {
-      "identifier": "session",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "GetSession": {
-      "identifier": "GetSession",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "function",
-      "isPublic": true
-    },
-    "session_environment": {
-      "identifier": "session_environment",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "Sleep": {
-      "identifier": "Sleep",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "function",
-      "isPublic": true
-    },
-    "GetSimulationElapsedTime": {
-      "identifier": "GetSimulationElapsedTime",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "function",
-      "isPublic": true
-    },
-    "team": {
-      "identifier": "team",
-      "modulePath": "/Verse.org/Simulation",
-      "type": "class",
-      "isPublic": true
-    },
-    "Assets": {
-      "identifier": "Assets",
-      "modulePath": "/Verse.org/Assets",
-      "type": "module",
-      "isPublic": true
-    },
-    "animation_sequence": {
-      "identifier": "animation_sequence",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "material": {
-      "identifier": "material",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "particle_system": {
-      "identifier": "particle_system",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "mesh": {
-      "identifier": "mesh",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "sound_wave": {
-      "identifier": "sound_wave",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "texture": {
-      "identifier": "texture",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "input_action": {
-      "identifier": "input_action",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "input_mapping": {
-      "identifier": "input_mapping",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "has_icon": {
-      "identifier": "has_icon",
-      "modulePath": "/Verse.org/Assets",
-      "type": "class",
-      "isPublic": true
-    },
-    "Colors": {
-      "identifier": "Colors",
-      "modulePath": "/Verse.org/Colors",
-      "type": "module",
-      "isPublic": true
-    },
-    "color": {
-      "identifier": "color",
-      "modulePath": "/Verse.org/Colors",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeColorFromSRGB": {
-      "identifier": "MakeColorFromSRGB",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeSRGBFromColor": {
-      "identifier": "MakeSRGBFromColor",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeColorFromSRGBValues": {
-      "identifier": "MakeColorFromSRGBValues",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeColorFromHex": {
-      "identifier": "MakeColorFromHex",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeColorFromHSV": {
-      "identifier": "MakeColorFromHSV",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeHSVFromColor": {
-      "identifier": "MakeHSVFromColor",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeColorFromTemperature": {
-      "identifier": "MakeColorFromTemperature",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "NamedColors": {
-      "identifier": "NamedColors",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "module",
-      "isPublic": true
-    },
-    "AliceBlue": {
-      "identifier": "AliceBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "AntiqueWhite": {
-      "identifier": "AntiqueWhite",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Aqua": {
-      "identifier": "Aqua",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Aquamarine": {
-      "identifier": "Aquamarine",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Azure": {
-      "identifier": "Azure",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Beige": {
-      "identifier": "Beige",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Bisque": {
-      "identifier": "Bisque",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Black": {
-      "identifier": "Black",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "BlanchedAlmond": {
-      "identifier": "BlanchedAlmond",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Blue": {
-      "identifier": "Blue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "BlueViolet": {
-      "identifier": "BlueViolet",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Brown": {
-      "identifier": "Brown",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Burlywood": {
-      "identifier": "Burlywood",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "CadetBlue": {
-      "identifier": "CadetBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Chartreuse": {
-      "identifier": "Chartreuse",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Chocolate": {
-      "identifier": "Chocolate",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Coral": {
-      "identifier": "Coral",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "CornflowerBlue": {
-      "identifier": "CornflowerBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Cornsilk": {
-      "identifier": "Cornsilk",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Crimson": {
-      "identifier": "Crimson",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Cyan": {
-      "identifier": "Cyan",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkBlue": {
-      "identifier": "DarkBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkCyan": {
-      "identifier": "DarkCyan",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkGoldenrod": {
-      "identifier": "DarkGoldenrod",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkGray": {
-      "identifier": "DarkGray",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkGreen": {
-      "identifier": "DarkGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkGrey": {
-      "identifier": "DarkGrey",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkKhaki": {
-      "identifier": "DarkKhaki",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkMagenta": {
-      "identifier": "DarkMagenta",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkOliveGreen": {
-      "identifier": "DarkOliveGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkOrange": {
-      "identifier": "DarkOrange",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkOrchid": {
-      "identifier": "DarkOrchid",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkRed": {
-      "identifier": "DarkRed",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkSalmon": {
-      "identifier": "DarkSalmon",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkSeaGreen": {
-      "identifier": "DarkSeaGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkSlateBlue": {
-      "identifier": "DarkSlateBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkSlateGray": {
-      "identifier": "DarkSlateGray",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkSlateGrey": {
-      "identifier": "DarkSlateGrey",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkTurquoise": {
-      "identifier": "DarkTurquoise",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DarkViolet": {
-      "identifier": "DarkViolet",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DeepPink": {
-      "identifier": "DeepPink",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DeepSkyBlue": {
-      "identifier": "DeepSkyBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DimGray": {
-      "identifier": "DimGray",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DimGrey": {
-      "identifier": "DimGrey",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "DodgerBlue": {
-      "identifier": "DodgerBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Firebrick": {
-      "identifier": "Firebrick",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "FloralWhite": {
-      "identifier": "FloralWhite",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "ForestGreen": {
-      "identifier": "ForestGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Fuchsia": {
-      "identifier": "Fuchsia",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Gainsboro": {
-      "identifier": "Gainsboro",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "GhostWhite": {
-      "identifier": "GhostWhite",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Gold": {
-      "identifier": "Gold",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Goldenrod": {
-      "identifier": "Goldenrod",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Gray": {
-      "identifier": "Gray",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Green": {
-      "identifier": "Green",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "GreenYellow": {
-      "identifier": "GreenYellow",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Grey": {
-      "identifier": "Grey",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Honeydew": {
-      "identifier": "Honeydew",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Hotpink": {
-      "identifier": "Hotpink",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "IndianRed": {
-      "identifier": "IndianRed",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Indigo": {
-      "identifier": "Indigo",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Ivory": {
-      "identifier": "Ivory",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Khaki": {
-      "identifier": "Khaki",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Lavender": {
-      "identifier": "Lavender",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LavenderBlush": {
-      "identifier": "LavenderBlush",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LawnGreen": {
-      "identifier": "LawnGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LemonChiffon": {
-      "identifier": "LemonChiffon",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightBlue": {
-      "identifier": "LightBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightCoral": {
-      "identifier": "LightCoral",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightCyan": {
-      "identifier": "LightCyan",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightGoldenrodYellow": {
-      "identifier": "LightGoldenrodYellow",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightGray": {
-      "identifier": "LightGray",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightGreen": {
-      "identifier": "LightGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightGrey": {
-      "identifier": "LightGrey",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightPink": {
-      "identifier": "LightPink",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightSalmon": {
-      "identifier": "LightSalmon",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightSeaGreen": {
-      "identifier": "LightSeaGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightSkyBlue": {
-      "identifier": "LightSkyBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightSlateGray": {
-      "identifier": "LightSlateGray",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightSlateGrey": {
-      "identifier": "LightSlateGrey",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightSteelBlue": {
-      "identifier": "LightSteelBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LightYellow": {
-      "identifier": "LightYellow",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Lime": {
-      "identifier": "Lime",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "LimeGreen": {
-      "identifier": "LimeGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Linen": {
-      "identifier": "Linen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Magenta": {
-      "identifier": "Magenta",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Maroon": {
-      "identifier": "Maroon",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumAquamarine": {
-      "identifier": "MediumAquamarine",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumBlue": {
-      "identifier": "MediumBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumOrchid": {
-      "identifier": "MediumOrchid",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumPurple": {
-      "identifier": "MediumPurple",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumSeaGreen": {
-      "identifier": "MediumSeaGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumSlateBlue": {
-      "identifier": "MediumSlateBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumSpringGreen": {
-      "identifier": "MediumSpringGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumTurquoise": {
-      "identifier": "MediumTurquoise",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MediumVioletRed": {
-      "identifier": "MediumVioletRed",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MidnightBlue": {
-      "identifier": "MidnightBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MintCream": {
-      "identifier": "MintCream",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "MistyRose": {
-      "identifier": "MistyRose",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Moccasin": {
-      "identifier": "Moccasin",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "NavajoWhite": {
-      "identifier": "NavajoWhite",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Navy": {
-      "identifier": "Navy",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "OldLace": {
-      "identifier": "OldLace",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Olive": {
-      "identifier": "Olive",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "OliveDrab": {
-      "identifier": "OliveDrab",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Orange": {
-      "identifier": "Orange",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "OrangeRed": {
-      "identifier": "OrangeRed",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Orchid": {
-      "identifier": "Orchid",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PaleGoldenrod": {
-      "identifier": "PaleGoldenrod",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PaleGreen": {
-      "identifier": "PaleGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PaleTurquoise": {
-      "identifier": "PaleTurquoise",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PaleVioletred": {
-      "identifier": "PaleVioletred",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PapayaWhip": {
-      "identifier": "PapayaWhip",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PeachPuff": {
-      "identifier": "PeachPuff",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Peru": {
-      "identifier": "Peru",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Pink": {
-      "identifier": "Pink",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Plum": {
-      "identifier": "Plum",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "PowderBlue": {
-      "identifier": "PowderBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Purple": {
-      "identifier": "Purple",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Red": {
-      "identifier": "Red",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "RosyBrown": {
-      "identifier": "RosyBrown",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "RoyalBlue": {
-      "identifier": "RoyalBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SaddleBrown": {
-      "identifier": "SaddleBrown",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Salmon": {
-      "identifier": "Salmon",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SandyBrown": {
-      "identifier": "SandyBrown",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SeaGreen": {
-      "identifier": "SeaGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SeaShell": {
-      "identifier": "SeaShell",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Sienna": {
-      "identifier": "Sienna",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Silver": {
-      "identifier": "Silver",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SkyBlue": {
-      "identifier": "SkyBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SlateBlue": {
-      "identifier": "SlateBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SlateGray": {
-      "identifier": "SlateGray",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SlateGrey": {
-      "identifier": "SlateGrey",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Snow": {
-      "identifier": "Snow",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SpringGreen": {
-      "identifier": "SpringGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "SteelBlue": {
-      "identifier": "SteelBlue",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Teal": {
-      "identifier": "Teal",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Thistle": {
-      "identifier": "Thistle",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Tomato": {
-      "identifier": "Tomato",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Turquoise": {
-      "identifier": "Turquoise",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Violet": {
-      "identifier": "Violet",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Wheat": {
-      "identifier": "Wheat",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "White": {
-      "identifier": "White",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "WhiteSmoke": {
-      "identifier": "WhiteSmoke",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "Yellow": {
-      "identifier": "Yellow",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "YellowGreen": {
-      "identifier": "YellowGreen",
-      "modulePath": "/Verse.org/Colors/NamedColors",
-      "type": "variable",
-      "isPublic": true
-    },
-    "color_alpha": {
-      "identifier": "color_alpha",
-      "modulePath": "/Verse.org/Colors",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeColorAlpha": {
-      "identifier": "MakeColorAlpha",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "Over": {
-      "identifier": "Over",
-      "modulePath": "/Verse.org/Colors",
-      "type": "function",
-      "isPublic": true
-    },
-    "SpatialMath": {
-      "identifier": "SpatialMath",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "module",
-      "isPublic": true
-    },
-    "rotation": {
-      "identifier": "rotation",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "MakeRotationRadians": {
-      "identifier": "MakeRotationRadians",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeRotationDegrees": {
-      "identifier": "MakeRotationDegrees",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeRotationFromYawPitchRollRadians": {
-      "identifier": "MakeRotationFromYawPitchRollRadians",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeRotationFromYawPitchRollDegrees": {
-      "identifier": "MakeRotationFromYawPitchRollDegrees",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeRotationFromEulerRadians": {
-      "identifier": "MakeRotationFromEulerRadians",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeRotationFromEulerDegrees": {
-      "identifier": "MakeRotationFromEulerDegrees",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "IdentityRotation": {
-      "identifier": "IdentityRotation",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "Distance": {
-      "identifier": "Distance",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "AngularDistanceRadians": {
-      "identifier": "AngularDistanceRadians",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "AngularDistanceDegrees": {
-      "identifier": "AngularDistanceDegrees",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "MakeShortestRotationBetween": {
-      "identifier": "MakeShortestRotationBetween",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "Slerp": {
-      "identifier": "Slerp",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DegreesToRadians": {
-      "identifier": "DegreesToRadians",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "RadiansToDegrees": {
-      "identifier": "RadiansToDegrees",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "transform": {
-      "identifier": "transform",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "vector3": {
-      "identifier": "vector3",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "class",
-      "isPublic": true
-    },
-    "ReflectVector": {
-      "identifier": "ReflectVector",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DotProduct": {
-      "identifier": "DotProduct",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "CrossProductLeftHanded": {
-      "identifier": "CrossProductLeftHanded",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "CrossProduct": {
-      "identifier": "CrossProduct",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DistanceSquared": {
-      "identifier": "DistanceSquared",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DistanceForwardLeft": {
-      "identifier": "DistanceForwardLeft",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "DistanceSquaredForwardLeft": {
-      "identifier": "DistanceSquaredForwardLeft",
-      "modulePath": "/Verse.org/SpatialMath",
-      "type": "function",
-      "isPublic": true
-    },
-    "Random": {
-      "identifier": "Random",
-      "modulePath": "/Verse.org/Random",
-      "type": "module",
-      "isPublic": true
-    },
-    "GetRandomFloat": {
-      "identifier": "GetRandomFloat",
-      "modulePath": "/Verse.org/Random",
-      "type": "function",
-      "isPublic": true
-    },
-    "GetRandomInt": {
-      "identifier": "GetRandomInt",
-      "modulePath": "/Verse.org/Random",
-      "type": "function",
-      "isPublic": true
-    },
-    "Shuffle": {
-      "identifier": "Shuffle",
-      "modulePath": "/Verse.org/Random",
-      "type": "function",
-      "isPublic": true
-    },
-    "Predicts": {
-      "identifier": "Predicts",
-      "modulePath": "/Verse.org/Predicts",
-      "type": "module",
-      "isPublic": true
-    },
-    "Native": {
-      "identifier": "Native",
-      "modulePath": "/Verse.org/Native",
-      "type": "module",
-      "isPublic": true
-    },
-    "Concurrency": {
-      "identifier": "Concurrency",
-      "modulePath": "/Verse.org/Concurrency",
-      "type": "module",
-      "isPublic": true
-    },
-    "awaitable": {
-      "identifier": "awaitable",
-      "modulePath": "/Verse.org/Concurrency",
-      "type": "class",
-      "isPublic": true
-    },
-    "task": {
-      "identifier": "task",
-      "modulePath": "/Verse.org/Concurrency",
-      "type": "class",
-      "isPublic": true
-    }
+    "Chat": [
+      {
+        "identifier": "Chat",
+        "modulePath": "/Verse.org/Chat",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "chat_channel": [
+      {
+        "identifier": "chat_channel",
+        "modulePath": "/Verse.org/Chat",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "has_voice_member_info": [
+      {
+        "identifier": "has_voice_member_info",
+        "modulePath": "/Verse.org/Chat",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "voice_channel": [
+      {
+        "identifier": "voice_channel",
+        "modulePath": "/Verse.org/Chat",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "add_channel_error": [
+      {
+        "identifier": "add_channel_error",
+        "modulePath": "/Verse.org/Chat",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "remove_channel_error": [
+      {
+        "identifier": "remove_channel_error",
+        "modulePath": "/Verse.org/Chat",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "SceneGraph": [
+      {
+        "identifier": "SceneGraph",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "basic_interactable_component": [
+      {
+        "identifier": "basic_interactable_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "interactable_component": [
+      {
+        "identifier": "interactable_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "interactable_cooldown": [
+      {
+        "identifier": "interactable_cooldown",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "interactable_cooldown_per_agent": [
+      {
+        "identifier": "interactable_cooldown_per_agent",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "interactable_duration": [
+      {
+        "identifier": "interactable_duration",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "interactable_success_limit": [
+      {
+        "identifier": "interactable_success_limit",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_body": [
+      {
+        "identifier": "camera_body",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_component": [
+      {
+        "identifier": "camera_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GlobalModifierPosition": [
+      {
+        "identifier": "GlobalModifierPosition",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "VisualModifierPosition": [
+      {
+        "identifier": "VisualModifierPosition",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "camera_director_component": [
+      {
+        "identifier": "camera_director_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_lens": [
+      {
+        "identifier": "camera_lens",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_modifier_stack": [
+      {
+        "identifier": "camera_modifier_stack",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "has_camera_modifier": [
+      {
+        "identifier": "has_camera_modifier",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_modifier": [
+      {
+        "identifier": "camera_modifier",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_projection_mode": [
+      {
+        "identifier": "camera_projection_mode",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_state": [
+      {
+        "identifier": "camera_state",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_transition_initial_orientation": [
+      {
+        "identifier": "camera_transition_initial_orientation",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_transition": [
+      {
+        "identifier": "camera_transition",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_mode_blend": [
+      {
+        "identifier": "camera_mode_blend",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_mode_blend_pop": [
+      {
+        "identifier": "camera_mode_blend_pop",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_mode_blend_linear": [
+      {
+        "identifier": "camera_mode_blend_linear",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_mode_blend_smoothstep": [
+      {
+        "identifier": "camera_mode_blend_smoothstep",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_mode_blend_smootherstep": [
+      {
+        "identifier": "camera_mode_blend_smootherstep",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera_mode_blend_orbit": [
+      {
+        "identifier": "camera_mode_blend_orbit",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "orthographic_camera_component": [
+      {
+        "identifier": "orthographic_camera_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "perspective_camera_component": [
+      {
+        "identifier": "perspective_camera_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "physical_camera_component": [
+      {
+        "identifier": "physical_camera_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "skeletal_animation": [
+      {
+        "identifier": "skeletal_animation",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "play_skeletal_animation_result": [
+      {
+        "identifier": "play_skeletal_animation_result",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "skeleton": [
+      {
+        "identifier": "skeleton",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "easing_window": [
+      {
+        "identifier": "easing_window",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "easeable": [
+      {
+        "identifier": "easeable",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "entity_streaming_policy": [
+      {
+        "identifier": "entity_streaming_policy",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "children_streaming_policy": [
+      {
+        "identifier": "children_streaming_policy",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "capsule_light_component": [
+      {
+        "identifier": "capsule_light_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "directional_light_component": [
+      {
+        "identifier": "directional_light_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "KeyframedMovement": [
+      {
+        "identifier": "KeyframedMovement",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "easing_function": [
+      {
+        "identifier": "easing_function",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "cubic_bezier_easing_function": [
+      {
+        "identifier": "cubic_bezier_easing_function",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "linear_easing_function": [
+      {
+        "identifier": "linear_easing_function",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ease_cubic_bezier_easing_function": [
+      {
+        "identifier": "ease_cubic_bezier_easing_function",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ease_in_cubic_bezier_easing_function": [
+      {
+        "identifier": "ease_in_cubic_bezier_easing_function",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ease_out_cubic_bezier_easing_function": [
+      {
+        "identifier": "ease_out_cubic_bezier_easing_function",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ease_in_out_cubic_bezier_easing_function": [
+      {
+        "identifier": "ease_in_out_cubic_bezier_easing_function",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "keyframed_movement_playback_mode": [
+      {
+        "identifier": "keyframed_movement_playback_mode",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "oneshot_keyframed_movement_playback_mode": [
+      {
+        "identifier": "oneshot_keyframed_movement_playback_mode",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "loop_keyframed_movement_playback_mode": [
+      {
+        "identifier": "loop_keyframed_movement_playback_mode",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "pingpong_keyframed_movement_playback_mode": [
+      {
+        "identifier": "pingpong_keyframed_movement_playback_mode",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "keyframed_movement_delta": [
+      {
+        "identifier": "keyframed_movement_delta",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "keyframed_movement_component": [
+      {
+        "identifier": "keyframed_movement_component",
+        "modulePath": "/Verse.org/SceneGraph/KeyframedMovement",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "light_component": [
+      {
+        "identifier": "light_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "mesh_component": [
+      {
+        "identifier": "mesh_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "particle_system_component": [
+      {
+        "identifier": "particle_system_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "possessable_component": [
+      {
+        "identifier": "possessable_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "rect_light_component": [
+      {
+        "identifier": "rect_light_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sound_component": [
+      {
+        "identifier": "sound_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sphere_light_component": [
+      {
+        "identifier": "sphere_light_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "spot_light_component": [
+      {
+        "identifier": "spot_light_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "float_range": [
+      {
+        "identifier": "float_range",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_interaction": [
+      {
+        "identifier": "collision_interaction",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_channel": [
+      {
+        "identifier": "collision_channel",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_channel_to_interaction": [
+      {
+        "identifier": "collision_channel_to_interaction",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "collision_profile": [
+      {
+        "identifier": "collision_profile",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CollisionChannels": [
+      {
+        "identifier": "CollisionChannels",
+        "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "stationary": [
+      {
+        "identifier": "stationary",
+        "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "dynamic": [
+      {
+        "identifier": "dynamic",
+        "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "avatar": [
+      {
+        "identifier": "avatar",
+        "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "visibility": [
+      {
+        "identifier": "visibility",
+        "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "camera": [
+      {
+        "identifier": "camera",
+        "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "physics": [
+      {
+        "identifier": "physics",
+        "modulePath": "/Verse.org/SceneGraph/CollisionChannels",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "CollisionProfiles": [
+      {
+        "identifier": "CollisionProfiles",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "StationaryIgnoreAll": [
+      {
+        "identifier": "StationaryIgnoreAll",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "StationaryOverlapAll": [
+      {
+        "identifier": "StationaryOverlapAll",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "StationaryBlockAll": [
+      {
+        "identifier": "StationaryBlockAll",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DynamicIgnoreAll": [
+      {
+        "identifier": "DynamicIgnoreAll",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DynamicOverlapAll": [
+      {
+        "identifier": "DynamicOverlapAll",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DynamicBlockAll": [
+      {
+        "identifier": "DynamicBlockAll",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "StationaryBlockVisible": [
+      {
+        "identifier": "StationaryBlockVisible",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "VisibilityOverlapAll": [
+      {
+        "identifier": "VisibilityOverlapAll",
+        "modulePath": "/Verse.org/SceneGraph/CollisionProfiles",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "overlap_hit": [
+      {
+        "identifier": "overlap_hit",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sweep_hit": [
+      {
+        "identifier": "sweep_hit",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_volume": [
+      {
+        "identifier": "collision_volume",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_element": [
+      {
+        "identifier": "collision_element",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_capsule": [
+      {
+        "identifier": "collision_capsule",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_sphere": [
+      {
+        "identifier": "collision_sphere",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_point": [
+      {
+        "identifier": "collision_point",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "collision_box": [
+      {
+        "identifier": "collision_box",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "component": [
+      {
+        "identifier": "component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "scene_event": [
+      {
+        "identifier": "scene_event",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "entity": [
+      {
+        "identifier": "entity",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "entity_prefab": [
+      {
+        "identifier": "entity_prefab",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "icon_component": [
+      {
+        "identifier": "icon_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "origin": [
+      {
+        "identifier": "origin",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "entity_origin": [
+      {
+        "identifier": "entity_origin",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "rarity": [
+      {
+        "identifier": "rarity",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "common_rarity": [
+      {
+        "identifier": "common_rarity",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "uncommon_rarity": [
+      {
+        "identifier": "uncommon_rarity",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "rare_rarity": [
+      {
+        "identifier": "rare_rarity",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "epic_rarity": [
+      {
+        "identifier": "epic_rarity",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "legendary_rarity": [
+      {
+        "identifier": "legendary_rarity",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "rarity_component": [
+      {
+        "identifier": "rarity_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "stackable_component": [
+      {
+        "identifier": "stackable_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "change_stack_size_result": [
+      {
+        "identifier": "change_stack_size_result",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "change_max_stack_size_result": [
+      {
+        "identifier": "change_max_stack_size_result",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "has_merge_rules": [
+      {
+        "identifier": "has_merge_rules",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "basic_stackable_component": [
+      {
+        "identifier": "basic_stackable_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tick_events": [
+      {
+        "identifier": "tick_events",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "transform_component": [
+      {
+        "identifier": "transform_component",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "execution_listenable": [
+      {
+        "identifier": "execution_listenable",
+        "modulePath": "/Verse.org/SceneGraph",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Progression": [
+      {
+        "identifier": "Progression",
+        "modulePath": "/Verse.org/Progression",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "quest_participant_info": [
+      {
+        "identifier": "quest_participant_info",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "quest_membership": [
+      {
+        "identifier": "quest_membership",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "join_quest_error": [
+      {
+        "identifier": "join_quest_error",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "abandon_quest_error": [
+      {
+        "identifier": "abandon_quest_error",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "quest": [
+      {
+        "identifier": "quest",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "quest_collection": [
+      {
+        "identifier": "quest_collection",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "quest_participant": [
+      {
+        "identifier": "quest_participant",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "agent_quest_participant": [
+      {
+        "identifier": "agent_quest_participant",
+        "modulePath": "/Verse.org/Progression",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Presentation": [
+      {
+        "identifier": "Presentation",
+        "modulePath": "/Verse.org/Presentation",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "description_component": [
+      {
+        "identifier": "description_component",
+        "modulePath": "/Verse.org/Presentation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "has_description": [
+      {
+        "identifier": "has_description",
+        "modulePath": "/Verse.org/Presentation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Input": [
+      {
+        "identifier": "Input",
+        "modulePath": "/Verse.org/Input",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Gameplay": [
+      {
+        "identifier": "Gameplay",
+        "modulePath": "/Verse.org/Input/Gameplay",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "HotbarMapping": [
+      {
+        "identifier": "HotbarMapping",
+        "modulePath": "/Verse.org/Input/Gameplay",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "input_method": [
+      {
+        "identifier": "input_method",
+        "modulePath": "/Verse.org/Input",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "available_input_devices": [
+      {
+        "identifier": "available_input_devices",
+        "modulePath": "/Verse.org/Input",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GetPlayerInput": [
+      {
+        "identifier": "GetPlayerInput",
+        "modulePath": "/Verse.org/Input",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "input_events": [
+      {
+        "identifier": "input_events",
+        "modulePath": "/Verse.org/Input",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player_input": [
+      {
+        "identifier": "player_input",
+        "modulePath": "/Verse.org/Input",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "deproject_results": [
+      {
+        "identifier": "deproject_results",
+        "modulePath": "/Verse.org/Input",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "UI": [
+      {
+        "identifier": "UI",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "MenuNavigationMapping": [
+      {
+        "identifier": "MenuNavigationMapping",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "NextTab": [
+      {
+        "identifier": "NextTab",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PreviousTab": [
+      {
+        "identifier": "PreviousTab",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "NextPage": [
+      {
+        "identifier": "NextPage",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PreviousPage": [
+      {
+        "identifier": "PreviousPage",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Back": [
+      {
+        "identifier": "Back",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "InventoryMenuMapping": [
+      {
+        "identifier": "InventoryMenuMapping",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Use": [
+      {
+        "identifier": "Use",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Inspect": [
+      {
+        "identifier": "Inspect",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Sort": [
+      {
+        "identifier": "Sort",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Drop": [
+      {
+        "identifier": "Drop",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "CraftingMenuMapping": [
+      {
+        "identifier": "CraftingMenuMapping",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Craft": [
+      {
+        "identifier": "Craft",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Favorite": [
+      {
+        "identifier": "Favorite",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Scrap": [
+      {
+        "identifier": "Scrap",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MapMenuMapping": [
+      {
+        "identifier": "MapMenuMapping",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Track": [
+      {
+        "identifier": "Track",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Reset": [
+      {
+        "identifier": "Reset",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PlaceMarker": [
+      {
+        "identifier": "PlaceMarker",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "ToggleView": [
+      {
+        "identifier": "ToggleView",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "ZoomIn": [
+      {
+        "identifier": "ZoomIn",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "ZoomOut": [
+      {
+        "identifier": "ZoomOut",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "TouchMapping": [
+      {
+        "identifier": "TouchMapping",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PointerSelect": [
+      {
+        "identifier": "PointerSelect",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PointerZoom": [
+      {
+        "identifier": "PointerZoom",
+        "modulePath": "/Verse.org/Input/UI",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "AgentGroup": [
+      {
+        "identifier": "AgentGroup",
+        "modulePath": "/Verse.org/AgentGroup",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "member_info_interface": [
+      {
+        "identifier": "member_info_interface",
+        "modulePath": "/Verse.org/AgentGroup",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "agent_group_interface": [
+      {
+        "identifier": "agent_group_interface",
+        "modulePath": "/Verse.org/AgentGroup",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "agent_group": [
+      {
+        "identifier": "agent_group",
+        "modulePath": "/Verse.org/AgentGroup",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "add_member_error": [
+      {
+        "identifier": "add_member_error",
+        "modulePath": "/Verse.org/AgentGroup",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "remove_member_error": [
+      {
+        "identifier": "remove_member_error",
+        "modulePath": "/Verse.org/AgentGroup",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Verse": [
+      {
+        "identifier": "Verse",
+        "modulePath": "/Verse.org/Verse",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Print": [
+      {
+        "identifier": "Print",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Concatenate": [
+      {
+        "identifier": "Concatenate",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "cancelable": [
+      {
+        "identifier": "cancelable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "classifiable_subset": [
+      {
+        "identifier": "classifiable_subset",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeClassifiableSubset": [
+      {
+        "identifier": "MakeClassifiableSubset",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "diagnostic": [
+      {
+        "identifier": "diagnostic",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ToDiagnostic": [
+      {
+        "identifier": "ToDiagnostic",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "disposable": [
+      {
+        "identifier": "disposable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Easing": [
+      {
+        "identifier": "Easing",
+        "modulePath": "/Verse.org/Verse/Easing",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "CubicBezier": [
+      {
+        "identifier": "CubicBezier",
+        "modulePath": "/Verse.org/Verse/Easing",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Linear": [
+      {
+        "identifier": "Linear",
+        "modulePath": "/Verse.org/Verse/Easing",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Ease": [
+      {
+        "identifier": "Ease",
+        "modulePath": "/Verse.org/Verse/Easing",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "EaseIn": [
+      {
+        "identifier": "EaseIn",
+        "modulePath": "/Verse.org/Verse/Easing",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "EaseOut": [
+      {
+        "identifier": "EaseOut",
+        "modulePath": "/Verse.org/Verse/Easing",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "EaseInOut": [
+      {
+        "identifier": "EaseInOut",
+        "modulePath": "/Verse.org/Verse/Easing",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "enableable": [
+      {
+        "identifier": "enableable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Err": [
+      {
+        "identifier": "Err",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "event": [
+      {
+        "identifier": "event",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Ceil": [
+      {
+        "identifier": "Ceil",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Floor": [
+      {
+        "identifier": "Floor",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Round": [
+      {
+        "identifier": "Round",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Int": [
+      {
+        "identifier": "Int",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ToString": [
+      {
+        "identifier": "ToString",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      },
+      {
+        "identifier": "ToString",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "GetSecondsSinceEpoch": [
+      {
+        "identifier": "GetSecondsSinceEpoch",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "invalidatable": [
+      {
+        "identifier": "invalidatable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "listenable": [
+      {
+        "identifier": "listenable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "locale": [
+      {
+        "identifier": "locale",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "message": [
+      {
+        "identifier": "message",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Localize": [
+      {
+        "identifier": "Localize",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Join": [
+      {
+        "identifier": "Join",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "PiFloat": [
+      {
+        "identifier": "PiFloat",
+        "modulePath": "/Verse.org/Verse",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Clamp": [
+      {
+        "identifier": "Clamp",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Min": [
+      {
+        "identifier": "Min",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Max": [
+      {
+        "identifier": "Max",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Sqrt": [
+      {
+        "identifier": "Sqrt",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Sin": [
+      {
+        "identifier": "Sin",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Cos": [
+      {
+        "identifier": "Cos",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Tan": [
+      {
+        "identifier": "Tan",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      },
+      {
+        "identifier": "Tan",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "ArcSin": [
+      {
+        "identifier": "ArcSin",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ArcCos": [
+      {
+        "identifier": "ArcCos",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ArcTan": [
+      {
+        "identifier": "ArcTan",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Sinh": [
+      {
+        "identifier": "Sinh",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Cosh": [
+      {
+        "identifier": "Cosh",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Tanh": [
+      {
+        "identifier": "Tanh",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ArSinh": [
+      {
+        "identifier": "ArSinh",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ArCosh": [
+      {
+        "identifier": "ArCosh",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "ArTanh": [
+      {
+        "identifier": "ArTanh",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Pow": [
+      {
+        "identifier": "Pow",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Quotient": [
+      {
+        "identifier": "Quotient",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Mod": [
+      {
+        "identifier": "Mod",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Exp": [
+      {
+        "identifier": "Exp",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Ln": [
+      {
+        "identifier": "Ln",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Log": [
+      {
+        "identifier": "Log",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Lerp": [
+      {
+        "identifier": "Lerp",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      },
+      {
+        "identifier": "Lerp",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Sgn": [
+      {
+        "identifier": "Sgn",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "IsAlmostEqual": [
+      {
+        "identifier": "IsAlmostEqual",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      },
+      {
+        "identifier": "IsAlmostEqual",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "result": [
+      {
+        "identifier": "result",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeSuccess": [
+      {
+        "identifier": "MakeSuccess",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeError": [
+      {
+        "identifier": "MakeError",
+        "modulePath": "/Verse.org/Verse",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "showable": [
+      {
+        "identifier": "showable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "signalable": [
+      {
+        "identifier": "signalable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "subscribable": [
+      {
+        "identifier": "subscribable",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "modifier": [
+      {
+        "identifier": "modifier",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "modifier_stack": [
+      {
+        "identifier": "modifier_stack",
+        "modulePath": "/Verse.org/Verse",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Simulation": [
+      {
+        "identifier": "Simulation",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "agent": [
+      {
+        "identifier": "agent",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "player": [
+      {
+        "identifier": "player",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Tags": [
+      {
+        "identifier": "Tags",
+        "modulePath": "/Verse.org/Simulation/Tags",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "has_tags": [
+      {
+        "identifier": "has_tags",
+        "modulePath": "/Verse.org/Simulation/Tags",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tag": [
+      {
+        "identifier": "tag",
+        "modulePath": "/Verse.org/Simulation/Tags",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tag_key": [
+      {
+        "identifier": "tag_key",
+        "modulePath": "/Verse.org/Simulation/Tags",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tag_search_sort_type": [
+      {
+        "identifier": "tag_search_sort_type",
+        "modulePath": "/Verse.org/Simulation/Tags",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tag_search_criteria": [
+      {
+        "identifier": "tag_search_criteria",
+        "modulePath": "/Verse.org/Simulation/Tags",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "tag_view": [
+      {
+        "identifier": "tag_view",
+        "modulePath": "/Verse.org/Simulation/Tags",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "editable": [
+      {
+        "identifier": "editable",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "editable_text_box": [
+      {
+        "identifier": "editable_text_box",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "editable_slider": [
+      {
+        "identifier": "editable_slider",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "editable_number": [
+      {
+        "identifier": "editable_number",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "editable_vector_slider": [
+      {
+        "identifier": "editable_vector_slider",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "editable_vector_number": [
+      {
+        "identifier": "editable_vector_number",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "editable_container": [
+      {
+        "identifier": "editable_container",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "session": [
+      {
+        "identifier": "session",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "GetSession": [
+      {
+        "identifier": "GetSession",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "session_environment": [
+      {
+        "identifier": "session_environment",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Sleep": [
+      {
+        "identifier": "Sleep",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "GetSimulationElapsedTime": [
+      {
+        "identifier": "GetSimulationElapsedTime",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "team": [
+      {
+        "identifier": "team",
+        "modulePath": "/Verse.org/Simulation",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Assets": [
+      {
+        "identifier": "Assets",
+        "modulePath": "/Verse.org/Assets",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "animation_sequence": [
+      {
+        "identifier": "animation_sequence",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "material": [
+      {
+        "identifier": "material",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "particle_system": [
+      {
+        "identifier": "particle_system",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "mesh": [
+      {
+        "identifier": "mesh",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "sound_wave": [
+      {
+        "identifier": "sound_wave",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "texture": [
+      {
+        "identifier": "texture",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "input_action": [
+      {
+        "identifier": "input_action",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "input_mapping": [
+      {
+        "identifier": "input_mapping",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "has_icon": [
+      {
+        "identifier": "has_icon",
+        "modulePath": "/Verse.org/Assets",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "Colors": [
+      {
+        "identifier": "Colors",
+        "modulePath": "/Verse.org/Colors",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "color": [
+      {
+        "identifier": "color",
+        "modulePath": "/Verse.org/Colors",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeColorFromSRGB": [
+      {
+        "identifier": "MakeColorFromSRGB",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeSRGBFromColor": [
+      {
+        "identifier": "MakeSRGBFromColor",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeColorFromSRGBValues": [
+      {
+        "identifier": "MakeColorFromSRGBValues",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeColorFromHex": [
+      {
+        "identifier": "MakeColorFromHex",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeColorFromHSV": [
+      {
+        "identifier": "MakeColorFromHSV",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeHSVFromColor": [
+      {
+        "identifier": "MakeHSVFromColor",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeColorFromTemperature": [
+      {
+        "identifier": "MakeColorFromTemperature",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "NamedColors": [
+      {
+        "identifier": "NamedColors",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "AliceBlue": [
+      {
+        "identifier": "AliceBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "AntiqueWhite": [
+      {
+        "identifier": "AntiqueWhite",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Aqua": [
+      {
+        "identifier": "Aqua",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Aquamarine": [
+      {
+        "identifier": "Aquamarine",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Azure": [
+      {
+        "identifier": "Azure",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Beige": [
+      {
+        "identifier": "Beige",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Bisque": [
+      {
+        "identifier": "Bisque",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Black": [
+      {
+        "identifier": "Black",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "BlanchedAlmond": [
+      {
+        "identifier": "BlanchedAlmond",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Blue": [
+      {
+        "identifier": "Blue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "BlueViolet": [
+      {
+        "identifier": "BlueViolet",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Brown": [
+      {
+        "identifier": "Brown",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Burlywood": [
+      {
+        "identifier": "Burlywood",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "CadetBlue": [
+      {
+        "identifier": "CadetBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Chartreuse": [
+      {
+        "identifier": "Chartreuse",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Chocolate": [
+      {
+        "identifier": "Chocolate",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Coral": [
+      {
+        "identifier": "Coral",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "CornflowerBlue": [
+      {
+        "identifier": "CornflowerBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Cornsilk": [
+      {
+        "identifier": "Cornsilk",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Crimson": [
+      {
+        "identifier": "Crimson",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Cyan": [
+      {
+        "identifier": "Cyan",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkBlue": [
+      {
+        "identifier": "DarkBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkCyan": [
+      {
+        "identifier": "DarkCyan",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkGoldenrod": [
+      {
+        "identifier": "DarkGoldenrod",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkGray": [
+      {
+        "identifier": "DarkGray",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkGreen": [
+      {
+        "identifier": "DarkGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkGrey": [
+      {
+        "identifier": "DarkGrey",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkKhaki": [
+      {
+        "identifier": "DarkKhaki",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkMagenta": [
+      {
+        "identifier": "DarkMagenta",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkOliveGreen": [
+      {
+        "identifier": "DarkOliveGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkOrange": [
+      {
+        "identifier": "DarkOrange",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkOrchid": [
+      {
+        "identifier": "DarkOrchid",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkRed": [
+      {
+        "identifier": "DarkRed",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkSalmon": [
+      {
+        "identifier": "DarkSalmon",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkSeaGreen": [
+      {
+        "identifier": "DarkSeaGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkSlateBlue": [
+      {
+        "identifier": "DarkSlateBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkSlateGray": [
+      {
+        "identifier": "DarkSlateGray",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkSlateGrey": [
+      {
+        "identifier": "DarkSlateGrey",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkTurquoise": [
+      {
+        "identifier": "DarkTurquoise",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DarkViolet": [
+      {
+        "identifier": "DarkViolet",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DeepPink": [
+      {
+        "identifier": "DeepPink",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DeepSkyBlue": [
+      {
+        "identifier": "DeepSkyBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DimGray": [
+      {
+        "identifier": "DimGray",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DimGrey": [
+      {
+        "identifier": "DimGrey",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "DodgerBlue": [
+      {
+        "identifier": "DodgerBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Firebrick": [
+      {
+        "identifier": "Firebrick",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "FloralWhite": [
+      {
+        "identifier": "FloralWhite",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "ForestGreen": [
+      {
+        "identifier": "ForestGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Fuchsia": [
+      {
+        "identifier": "Fuchsia",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Gainsboro": [
+      {
+        "identifier": "Gainsboro",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "GhostWhite": [
+      {
+        "identifier": "GhostWhite",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Gold": [
+      {
+        "identifier": "Gold",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Goldenrod": [
+      {
+        "identifier": "Goldenrod",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Gray": [
+      {
+        "identifier": "Gray",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Green": [
+      {
+        "identifier": "Green",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "GreenYellow": [
+      {
+        "identifier": "GreenYellow",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Grey": [
+      {
+        "identifier": "Grey",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Honeydew": [
+      {
+        "identifier": "Honeydew",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Hotpink": [
+      {
+        "identifier": "Hotpink",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "IndianRed": [
+      {
+        "identifier": "IndianRed",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Indigo": [
+      {
+        "identifier": "Indigo",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Ivory": [
+      {
+        "identifier": "Ivory",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Khaki": [
+      {
+        "identifier": "Khaki",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Lavender": [
+      {
+        "identifier": "Lavender",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LavenderBlush": [
+      {
+        "identifier": "LavenderBlush",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LawnGreen": [
+      {
+        "identifier": "LawnGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LemonChiffon": [
+      {
+        "identifier": "LemonChiffon",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightBlue": [
+      {
+        "identifier": "LightBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightCoral": [
+      {
+        "identifier": "LightCoral",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightCyan": [
+      {
+        "identifier": "LightCyan",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightGoldenrodYellow": [
+      {
+        "identifier": "LightGoldenrodYellow",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightGray": [
+      {
+        "identifier": "LightGray",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightGreen": [
+      {
+        "identifier": "LightGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightGrey": [
+      {
+        "identifier": "LightGrey",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightPink": [
+      {
+        "identifier": "LightPink",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightSalmon": [
+      {
+        "identifier": "LightSalmon",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightSeaGreen": [
+      {
+        "identifier": "LightSeaGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightSkyBlue": [
+      {
+        "identifier": "LightSkyBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightSlateGray": [
+      {
+        "identifier": "LightSlateGray",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightSlateGrey": [
+      {
+        "identifier": "LightSlateGrey",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightSteelBlue": [
+      {
+        "identifier": "LightSteelBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LightYellow": [
+      {
+        "identifier": "LightYellow",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Lime": [
+      {
+        "identifier": "Lime",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "LimeGreen": [
+      {
+        "identifier": "LimeGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Linen": [
+      {
+        "identifier": "Linen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Magenta": [
+      {
+        "identifier": "Magenta",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Maroon": [
+      {
+        "identifier": "Maroon",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumAquamarine": [
+      {
+        "identifier": "MediumAquamarine",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumBlue": [
+      {
+        "identifier": "MediumBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumOrchid": [
+      {
+        "identifier": "MediumOrchid",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumPurple": [
+      {
+        "identifier": "MediumPurple",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumSeaGreen": [
+      {
+        "identifier": "MediumSeaGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumSlateBlue": [
+      {
+        "identifier": "MediumSlateBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumSpringGreen": [
+      {
+        "identifier": "MediumSpringGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumTurquoise": [
+      {
+        "identifier": "MediumTurquoise",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MediumVioletRed": [
+      {
+        "identifier": "MediumVioletRed",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MidnightBlue": [
+      {
+        "identifier": "MidnightBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MintCream": [
+      {
+        "identifier": "MintCream",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "MistyRose": [
+      {
+        "identifier": "MistyRose",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Moccasin": [
+      {
+        "identifier": "Moccasin",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "NavajoWhite": [
+      {
+        "identifier": "NavajoWhite",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Navy": [
+      {
+        "identifier": "Navy",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "OldLace": [
+      {
+        "identifier": "OldLace",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Olive": [
+      {
+        "identifier": "Olive",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "OliveDrab": [
+      {
+        "identifier": "OliveDrab",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Orange": [
+      {
+        "identifier": "Orange",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "OrangeRed": [
+      {
+        "identifier": "OrangeRed",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Orchid": [
+      {
+        "identifier": "Orchid",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PaleGoldenrod": [
+      {
+        "identifier": "PaleGoldenrod",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PaleGreen": [
+      {
+        "identifier": "PaleGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PaleTurquoise": [
+      {
+        "identifier": "PaleTurquoise",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PaleVioletred": [
+      {
+        "identifier": "PaleVioletred",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PapayaWhip": [
+      {
+        "identifier": "PapayaWhip",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PeachPuff": [
+      {
+        "identifier": "PeachPuff",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Peru": [
+      {
+        "identifier": "Peru",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Pink": [
+      {
+        "identifier": "Pink",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Plum": [
+      {
+        "identifier": "Plum",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "PowderBlue": [
+      {
+        "identifier": "PowderBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Purple": [
+      {
+        "identifier": "Purple",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Red": [
+      {
+        "identifier": "Red",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "RosyBrown": [
+      {
+        "identifier": "RosyBrown",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "RoyalBlue": [
+      {
+        "identifier": "RoyalBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SaddleBrown": [
+      {
+        "identifier": "SaddleBrown",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Salmon": [
+      {
+        "identifier": "Salmon",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SandyBrown": [
+      {
+        "identifier": "SandyBrown",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SeaGreen": [
+      {
+        "identifier": "SeaGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SeaShell": [
+      {
+        "identifier": "SeaShell",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Sienna": [
+      {
+        "identifier": "Sienna",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Silver": [
+      {
+        "identifier": "Silver",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SkyBlue": [
+      {
+        "identifier": "SkyBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SlateBlue": [
+      {
+        "identifier": "SlateBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SlateGray": [
+      {
+        "identifier": "SlateGray",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SlateGrey": [
+      {
+        "identifier": "SlateGrey",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Snow": [
+      {
+        "identifier": "Snow",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SpringGreen": [
+      {
+        "identifier": "SpringGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "SteelBlue": [
+      {
+        "identifier": "SteelBlue",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Teal": [
+      {
+        "identifier": "Teal",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Thistle": [
+      {
+        "identifier": "Thistle",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Tomato": [
+      {
+        "identifier": "Tomato",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Turquoise": [
+      {
+        "identifier": "Turquoise",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Violet": [
+      {
+        "identifier": "Violet",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Wheat": [
+      {
+        "identifier": "Wheat",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "White": [
+      {
+        "identifier": "White",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "WhiteSmoke": [
+      {
+        "identifier": "WhiteSmoke",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "Yellow": [
+      {
+        "identifier": "Yellow",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "YellowGreen": [
+      {
+        "identifier": "YellowGreen",
+        "modulePath": "/Verse.org/Colors/NamedColors",
+        "type": "variable",
+        "isPublic": true
+      }
+    ],
+    "color_alpha": [
+      {
+        "identifier": "color_alpha",
+        "modulePath": "/Verse.org/Colors",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeColorAlpha": [
+      {
+        "identifier": "MakeColorAlpha",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Over": [
+      {
+        "identifier": "Over",
+        "modulePath": "/Verse.org/Colors",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "SpatialMath": [
+      {
+        "identifier": "SpatialMath",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "rotation": [
+      {
+        "identifier": "rotation",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "MakeRotationRadians": [
+      {
+        "identifier": "MakeRotationRadians",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeRotationDegrees": [
+      {
+        "identifier": "MakeRotationDegrees",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeRotationFromYawPitchRollRadians": [
+      {
+        "identifier": "MakeRotationFromYawPitchRollRadians",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeRotationFromYawPitchRollDegrees": [
+      {
+        "identifier": "MakeRotationFromYawPitchRollDegrees",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeRotationFromEulerRadians": [
+      {
+        "identifier": "MakeRotationFromEulerRadians",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeRotationFromEulerDegrees": [
+      {
+        "identifier": "MakeRotationFromEulerDegrees",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "IdentityRotation": [
+      {
+        "identifier": "IdentityRotation",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Distance": [
+      {
+        "identifier": "Distance",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "AngularDistanceRadians": [
+      {
+        "identifier": "AngularDistanceRadians",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "AngularDistanceDegrees": [
+      {
+        "identifier": "AngularDistanceDegrees",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "MakeShortestRotationBetween": [
+      {
+        "identifier": "MakeShortestRotationBetween",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Slerp": [
+      {
+        "identifier": "Slerp",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DegreesToRadians": [
+      {
+        "identifier": "DegreesToRadians",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "RadiansToDegrees": [
+      {
+        "identifier": "RadiansToDegrees",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "transform": [
+      {
+        "identifier": "transform",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "vector3": [
+      {
+        "identifier": "vector3",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "ReflectVector": [
+      {
+        "identifier": "ReflectVector",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DotProduct": [
+      {
+        "identifier": "DotProduct",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "CrossProductLeftHanded": [
+      {
+        "identifier": "CrossProductLeftHanded",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "CrossProduct": [
+      {
+        "identifier": "CrossProduct",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DistanceSquared": [
+      {
+        "identifier": "DistanceSquared",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DistanceForwardLeft": [
+      {
+        "identifier": "DistanceForwardLeft",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "DistanceSquaredForwardLeft": [
+      {
+        "identifier": "DistanceSquaredForwardLeft",
+        "modulePath": "/Verse.org/SpatialMath",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Random": [
+      {
+        "identifier": "Random",
+        "modulePath": "/Verse.org/Random",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "GetRandomFloat": [
+      {
+        "identifier": "GetRandomFloat",
+        "modulePath": "/Verse.org/Random",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "GetRandomInt": [
+      {
+        "identifier": "GetRandomInt",
+        "modulePath": "/Verse.org/Random",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Shuffle": [
+      {
+        "identifier": "Shuffle",
+        "modulePath": "/Verse.org/Random",
+        "type": "function",
+        "isPublic": true
+      }
+    ],
+    "Predicts": [
+      {
+        "identifier": "Predicts",
+        "modulePath": "/Verse.org/Predicts",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Native": [
+      {
+        "identifier": "Native",
+        "modulePath": "/Verse.org/Native",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "Concurrency": [
+      {
+        "identifier": "Concurrency",
+        "modulePath": "/Verse.org/Concurrency",
+        "type": "module",
+        "isPublic": true
+      }
+    ],
+    "awaitable": [
+      {
+        "identifier": "awaitable",
+        "modulePath": "/Verse.org/Concurrency",
+        "type": "class",
+        "isPublic": true
+      }
+    ],
+    "task": [
+      {
+        "identifier": "task",
+        "modulePath": "/Verse.org/Concurrency",
+        "type": "class",
+        "isPublic": true
+      }
+    ]
   },
   "moduleIndex": {
     "/Verse.org/Chat": [

--- a/src/scripts/parseDigestFiles.ts
+++ b/src/scripts/parseDigestFiles.ts
@@ -24,7 +24,9 @@ interface PrecompiledDigest {
     moduleIndex: ReturnType<typeof parseDigestContent>["moduleIndex"];
 }
 
-const VERSION = "1.0.0";
+// 2.0.0 keys each identifier to a list of declarations rather than one, so a
+// name declared by several modules keeps every module it can be imported from.
+const VERSION = "2.0.0";
 
 /**
  * The UEFN build a digest came from, as stamped in its header

--- a/src/services/DigestParser.ts
+++ b/src/services/DigestParser.ts
@@ -75,6 +75,9 @@ export class DigestParser {
      *
      * The match is exact on purpose. Matching by substring returned every entry
      * whose name merely contained the identifier - 226 of them for `device`.
+     *
+     * The live array, not a copy: pushing into it adds a module the digests
+     * never declared, and the next lookup serves it.
      */
     async lookupIdentifier(identifier: string): Promise<DigestEntry[]> {
         const index = await this.getDigestIndex();

--- a/src/services/DigestParser.ts
+++ b/src/services/DigestParser.ts
@@ -30,7 +30,7 @@ export class DigestParser {
     }
 
     /** The identifier index, empty when the digest data could not be loaded. */
-    async getDigestIndex(): Promise<Map<string, DigestEntry>> {
+    async getDigestIndex(): Promise<Map<string, DigestEntry[]>> {
         if (!this.precompiledLoader) {
             return new Map();
         }
@@ -66,19 +66,19 @@ export class DigestParser {
     }
 
     /**
-     * The entry declaring this exact identifier, as a list so the caller can
-     * treat "none" and "one" alike.
+     * Every entry declaring this exact identifier, one per module that declares
+     * it, led by the module the digest precedence order prefers.
+     *
+     * More than one is the normal case for a name two modules both export, and
+     * the diagnostics handler reads the extras as a choice to offer, or under an
+     * `auto_*` multi-option strategy to make on the user's behalf.
      *
      * The match is exact on purpose. Matching by substring returned every entry
-     * whose name merely contained the identifier - 226 of them for `device` -
-     * and the diagnostics handler reads more than one suggestion as a choice to
-     * offer, or under an `auto_*` multi-option strategy to make on the user's
-     * behalf.
+     * whose name merely contained the identifier - 226 of them for `device`.
      */
     async lookupIdentifier(identifier: string): Promise<DigestEntry[]> {
         const index = await this.getDigestIndex();
-        const match = index.get(identifier);
-        return match ? [match] : [];
+        return index.get(identifier) ?? [];
     }
 
     /** Drops the loaded index, so the next lookup re-reads it from disk. */

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -15,7 +15,7 @@ export interface PrecompiledDigest {
     generatedAt: string;
     sourceFile: string;
     sourceBuild: string;
-    entries: Record<string, DigestEntry>;
+    entries: Record<string, DigestEntry[]>;
     moduleIndex: Record<string, string[]>;
 }
 
@@ -29,7 +29,7 @@ export interface PrecompiledDigest {
  * no second source to fall back to, so DigestParser surfaces that to the user.
  */
 export class PrecompiledDigestLoader {
-    private digestCache: Map<string, DigestEntry> = new Map();
+    private digestCache: Map<string, DigestEntry[]> = new Map();
     private moduleIndex: Map<string, string[]> = new Map();
     private loaded: boolean = false;
     private loadError: Error | null = null;
@@ -100,13 +100,19 @@ export class PrecompiledDigestLoader {
                 const content = fs.readFileSync(filePath, "utf8");
                 const digest: PrecompiledDigest = JSON.parse(content);
 
-                // First file to declare an identifier wins, so
-                // BUNDLED_DIGEST_NAMES order is the precedence between the
-                // three domains.
-                for (const [identifier, entry] of Object.entries(digest.entries)) {
-                    if (!this.digestCache.has(identifier)) {
-                        this.digestCache.set(identifier, entry);
+                // Every declaring module is kept, one per module path, so a
+                // lookup can offer the choice. BUNDLED_DIGEST_NAMES order is
+                // still the precedence between the three domains: it decides
+                // which path leads the list, and the lead is what a caller
+                // picking one answer takes.
+                for (const [identifier, declarations] of Object.entries(digest.entries)) {
+                    const merged = this.digestCache.get(identifier) ?? [];
+                    for (const declaration of declarations) {
+                        if (!merged.some((existing) => existing.modulePath === declaration.modulePath)) {
+                            merged.push(declaration);
+                        }
                     }
+                    this.digestCache.set(identifier, merged);
                 }
 
                 // The module index unions instead, so a module re-declared
@@ -129,8 +135,9 @@ export class PrecompiledDigestLoader {
         return successCount;
     }
 
-    getEntry(identifier: string): DigestEntry | undefined {
-        return this.digestCache.get(identifier);
+    /** Every module that declares this identifier, empty if none does. */
+    getEntry(identifier: string): DigestEntry[] {
+        return this.digestCache.get(identifier) ?? [];
     }
 
     getModuleIdentifiers(modulePath: string): string[] {
@@ -138,7 +145,7 @@ export class PrecompiledDigestLoader {
     }
 
     /** The live cache, not a copy: mutating it corrupts the index. */
-    getAllEntries(): Map<string, DigestEntry> {
+    getAllEntries(): Map<string, DigestEntry[]> {
         return this.digestCache;
     }
 

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { logger } from "../utils";
 import { DigestEntry } from "./DigestParser";
+import { appendDeclaration } from "./digestParsing";
 import { BUNDLED_DIGEST_NAMES, digestDataFile } from "./digestManifest";
 
 /**
@@ -108,9 +109,7 @@ export class PrecompiledDigestLoader {
                 for (const [identifier, declarations] of Object.entries(digest.entries)) {
                     const merged = this.digestCache.get(identifier) ?? [];
                     for (const declaration of declarations) {
-                        if (!merged.some((existing) => existing.modulePath === declaration.modulePath)) {
-                            merged.push(declaration);
-                        }
+                        appendDeclaration(merged, declaration);
                     }
                     this.digestCache.set(identifier, merged);
                 }
@@ -135,7 +134,12 @@ export class PrecompiledDigestLoader {
         return successCount;
     }
 
-    /** Every module that declares this identifier, empty if none does. */
+    /**
+     * Every module that declares this identifier, empty if none does.
+     *
+     * The live array, not a copy: pushing into it adds a module the digests
+     * never declared, and the next lookup serves it.
+     */
     getEntry(identifier: string): DigestEntry[] {
         return this.digestCache.get(identifier) ?? [];
     }

--- a/src/services/__tests__/DigestParser.test.ts
+++ b/src/services/__tests__/DigestParser.test.ts
@@ -33,14 +33,16 @@ describe("DigestParser", () => {
      * Identifiers chosen so that one is a strict substring of the others - the
      * shape that produced a 226-entry quick-fix list for `device`.
      */
-    const FORTNITE_ENTRIES: Record<string, DigestEntry> = {
-        device: entry("device", "/Fortnite.com/Devices"),
-        button_device: entry("button_device", "/Fortnite.com/Devices"),
-        trigger_device: entry("trigger_device", "/Fortnite.com/Devices"),
+    const FORTNITE_ENTRIES: Record<string, DigestEntry[]> = {
+        device: [entry("device", "/Fortnite.com/Devices")],
+        button_device: [entry("button_device", "/Fortnite.com/Devices")],
+        trigger_device: [entry("trigger_device", "/Fortnite.com/Devices")],
     };
 
     /** Whether the data directory and its files can be read this test. */
     let dataReadable: boolean;
+    /** The digest files the mocked data directory holds, keyed by file name. */
+    let digestFiles: Record<string, Record<string, DigestEntry[]>>;
     let parser: DigestParser;
 
     const showErrorMessage = vscode.window.showErrorMessage as unknown as jest.Mock;
@@ -52,6 +54,7 @@ describe("DigestParser", () => {
 
     beforeEach(() => {
         dataReadable = true;
+        digestFiles = { "Fortnite.digest.json": FORTNITE_ENTRIES };
         showErrorMessage.mockClear();
 
         jest.spyOn(fs, "existsSync").mockImplementation((target) => {
@@ -59,11 +62,18 @@ describe("DigestParser", () => {
                 return false;
             }
             const asString = String(target);
-            return asString === DATA_DIR || asString === path.join(DATA_DIR, "Fortnite.digest.json");
+            return asString === DATA_DIR || Object.keys(digestFiles).some((fileName) => asString === path.join(DATA_DIR, fileName));
         });
 
-        jest.spyOn(fs, "readFileSync").mockImplementation((() =>
-            JSON.stringify({ version: "1", generatedAt: "", sourceFile: "", sourceBuild: "", entries: FORTNITE_ENTRIES, moduleIndex: {} })) as unknown as typeof fs.readFileSync);
+        jest.spyOn(fs, "readFileSync").mockImplementation(((target: fs.PathOrFileDescriptor) =>
+            JSON.stringify({
+                version: "2",
+                generatedAt: "",
+                sourceFile: "",
+                sourceBuild: "",
+                entries: digestFiles[path.basename(String(target))] ?? {},
+                moduleIndex: {},
+            })) as unknown as typeof fs.readFileSync);
 
         parser = newParser();
     });
@@ -91,6 +101,43 @@ describe("DigestParser", () => {
 
         it("returns nothing for an identifier the digests do not declare", async () => {
             expect(await parser.lookupIdentifier("no_such_identifier")).toEqual([]);
+        });
+    });
+
+    /**
+     * Regression tests for issue #375.
+     *
+     * An identifier public in more than one module used to resolve to whichever
+     * file BUNDLED_DIGEST_NAMES reached first, so the whole SpatialMath surface
+     * answered with the deprecated /UnrealEngine.com/Temporary path and the user
+     * was never shown that /Verse.org/SpatialMath existed.
+     */
+    describe("when more than one module declares an identifier", () => {
+        beforeEach(() => {
+            digestFiles = {
+                "UnrealEngine.digest.json": {
+                    Distance: [entry("Distance", "/UnrealEngine.com/Temporary/SpatialMath")],
+                },
+                "Verse.digest.json": {
+                    Distance: [entry("Distance", "/Verse.org/SpatialMath")],
+                },
+            };
+        });
+
+        it("returns every declaring module, led by the one the manifest prefers", async () => {
+            const results = await parser.lookupIdentifier("Distance");
+
+            expect(results.map((result) => result.modulePath)).toEqual(["/UnrealEngine.com/Temporary/SpatialMath", "/Verse.org/SpatialMath"]);
+        });
+
+        it("keeps one entry per module path when a file repeats a declaration", async () => {
+            digestFiles["Verse.digest.json"] = {
+                Distance: [entry("Distance", "/Verse.org/SpatialMath"), entry("Distance", "/Verse.org/SpatialMath")],
+            };
+
+            const results = await parser.lookupIdentifier("Distance");
+
+            expect(results.map((result) => result.modulePath)).toEqual(["/UnrealEngine.com/Temporary/SpatialMath", "/Verse.org/SpatialMath"]);
         });
     });
 

--- a/src/services/__tests__/digestParsing.test.ts
+++ b/src/services/__tests__/digestParsing.test.ts
@@ -27,7 +27,7 @@ describe("parseDigestContent - module path resolution", () => {
 
         const { entries } = parseDigestContent(digest, "/Fortnite.com");
 
-        expect(entries["Chat"].modulePath).toBe("/Some.custom/Path");
+        expect(entries["Chat"][0].modulePath).toBe("/Some.custom/Path");
     });
 
     it("resolves a comment-less top-level module against the file's root domain", () => {
@@ -35,8 +35,8 @@ describe("parseDigestContent - module path resolution", () => {
 
         const { entries } = parseDigestContent(digest, "/Fortnite.com");
 
-        expect(entries["Devices"].modulePath).toBe("/Fortnite.com/Devices");
-        expect(entries["button_device"].modulePath).toBe("/Fortnite.com/Devices");
+        expect(entries["Devices"][0].modulePath).toBe("/Fortnite.com/Devices");
+        expect(entries["button_device"][0].modulePath).toBe("/Fortnite.com/Devices");
     });
 
     it("resolves a nested module from its own indented comment", () => {
@@ -50,9 +50,9 @@ describe("parseDigestContent - module path resolution", () => {
 
         const { entries } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["Simulation"].modulePath).toBe("/Verse.org/Simulation");
-        expect(entries["Tags"].modulePath).toBe("/Verse.org/Simulation/Tags");
-        expect(entries["tag"].modulePath).toBe("/Verse.org/Simulation/Tags");
+        expect(entries["Simulation"][0].modulePath).toBe("/Verse.org/Simulation");
+        expect(entries["Tags"][0].modulePath).toBe("/Verse.org/Simulation/Tags");
+        expect(entries["tag"][0].modulePath).toBe("/Verse.org/Simulation/Tags");
     });
 
     it("resolves a scope-qualified module from its '(/path:)' prefix", () => {
@@ -60,7 +60,7 @@ describe("parseDigestContent - module path resolution", () => {
 
         const { entries } = parseDigestContent(digest, "/Fortnite.com");
 
-        expect(entries["Assets"].modulePath).toBe("/Fortnite.com/Assets");
+        expect(entries["Assets"][0].modulePath).toBe("/Fortnite.com/Assets");
     });
 
     it("applies a pending comment to the next module only, not a later comment-less module", () => {
@@ -77,9 +77,9 @@ describe("parseDigestContent - module path resolution", () => {
 
         const { entries } = parseDigestContent(digest, "/Fortnite.com");
 
-        expect(entries["movement_types"].modulePath).toBe("/Fortnite.com/AI/movement_types");
-        expect(entries["Devices"].modulePath).toBe("/Fortnite.com/Devices");
-        expect(entries["button_device"].modulePath).toBe("/Fortnite.com/Devices");
+        expect(entries["movement_types"][0].modulePath).toBe("/Fortnite.com/AI/movement_types");
+        expect(entries["Devices"][0].modulePath).toBe("/Fortnite.com/Devices");
+        expect(entries["button_device"][0].modulePath).toBe("/Fortnite.com/Devices");
     });
 
     it("attributes declarations to the parent module after a nested module's block ends", () => {
@@ -89,9 +89,9 @@ describe("parseDigestContent - module path resolution", () => {
 
         const { entries } = parseDigestContent(digest, "/Fortnite.com");
 
-        expect(entries["Inner"].modulePath).toBe("/Fortnite.com/Outer/Inner");
-        expect(entries["inner_thing"].modulePath).toBe("/Fortnite.com/Outer/Inner");
-        expect(entries["outer_thing"].modulePath).toBe("/Fortnite.com/Outer");
+        expect(entries["Inner"][0].modulePath).toBe("/Fortnite.com/Outer/Inner");
+        expect(entries["inner_thing"][0].modulePath).toBe("/Fortnite.com/Outer/Inner");
+        expect(entries["outer_thing"][0].modulePath).toBe("/Fortnite.com/Outer");
     });
 });
 
@@ -105,12 +105,12 @@ describe("parseDigestContent - declaration recognition", () => {
 
         const { entries } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["creative_device"]).toMatchObject({
+        expect(entries["creative_device"][0]).toMatchObject({
             modulePath: "/Verse.org/Simulation",
             type: "class",
             isPublic: true,
         });
-        expect(entries["vector3"]).toMatchObject({
+        expect(entries["vector3"][0]).toMatchObject({
             modulePath: "/Verse.org/Simulation",
             type: "class",
             isPublic: true,
@@ -124,7 +124,7 @@ describe("parseDigestContent - declaration recognition", () => {
 
         const { entries } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["agent"]).toMatchObject({ modulePath: "/Verse.org/Simulation", isPublic: true });
+        expect(entries["agent"][0]).toMatchObject({ modulePath: "/Verse.org/Simulation", isPublic: true });
         expect(entries["internal_type"]).toBeUndefined();
     });
 
@@ -159,7 +159,7 @@ describe("parseDigestContent - declaration recognition", () => {
 
         const { entries } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["subscribable"]).toMatchObject({
+        expect(entries["subscribable"][0]).toMatchObject({
             modulePath: "/Verse.org/Verse",
             type: "class",
             isPublic: true,
@@ -178,8 +178,8 @@ describe("parseDigestContent - declaration recognition", () => {
 
         const { entries } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["event"]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "class" });
-        expect(entries["listenable"]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "class" });
+        expect(entries["event"][0]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "class" });
+        expect(entries["listenable"][0]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "class" });
         expect(entries["Await"]).toBeUndefined();
         expect(entries["Length"]).toBeUndefined();
     });
@@ -196,7 +196,7 @@ describe("parseDigestContent - declaration recognition", () => {
 
         const { entries, moduleIndex } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["agent_group"]).toMatchObject({
+        expect(entries["agent_group"][0]).toMatchObject({
             modulePath: "/Verse.org/AgentGroup",
             type: "class",
             isPublic: true,
@@ -213,7 +213,7 @@ describe("parseDigestContent - declaration recognition", () => {
 
         const { entries } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["deep"]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "class" });
+        expect(entries["deep"][0]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "class" });
         expect(entries["Unwrap"]).toBeUndefined();
     });
 
@@ -224,7 +224,7 @@ describe("parseDigestContent - declaration recognition", () => {
 
         const { entries } = parseDigestContent(digest, "/Verse.org");
 
-        expect(entries["MakeGroup"]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "function" });
+        expect(entries["MakeGroup"][0]).toMatchObject({ modulePath: "/Verse.org/Verse", type: "function" });
     });
 
     it("skips receiver-style extension methods", () => {
@@ -237,18 +237,55 @@ describe("parseDigestContent - declaration recognition", () => {
 });
 
 describe("parseDigestContent - deduplication and module index", () => {
-    it("keeps the first occurrence of an identifier across different modules", () => {
+    it("keeps every module that declares an identifier, in declaration order", () => {
         const digest = ["Devices<public> := module:", "    shared_thing<public> := class<concrete>(base):", "", "Other<public> := module:", "    shared_thing<public> := class<concrete>(base):"].join(
             "\n",
         );
 
         const { entries, moduleIndex } = parseDigestContent(digest, "/Fortnite.com");
 
-        // Entry dedups to the first occurrence...
-        expect(entries["shared_thing"].modulePath).toBe("/Fortnite.com/Devices");
-        // ...but every occurrence is still indexed under its own module.
+        // Both modules can be imported to reach the name, so both are offered;
+        // the first declared leads, because that is the one a caller taking a
+        // single answer gets.
+        expect(entries["shared_thing"].map((declaration) => declaration.modulePath)).toEqual(["/Fortnite.com/Devices", "/Fortnite.com/Other"]);
         expect(moduleIndex["/Fortnite.com/Devices"]).toContain("shared_thing");
         expect(moduleIndex["/Fortnite.com/Other"]).toContain("shared_thing");
+    });
+
+    it("keeps a name declared with different types in each module distinct", () => {
+        // `Ease` is a variable in Fortnite's InterpolationTypes and a function
+        // in Verse's Easing, and the quick-fix label names the type, so one
+        // shared type across the paths would mislabel one of them.
+        const digest = [
+            "Devices<public> := module:",
+            "    Ease<public>:interpolation_type = external {}",
+            "",
+            "Easing<public> := module:",
+            "    Ease<public>(X:float)<reads>:float = external {}",
+        ].join("\n");
+
+        const { entries } = parseDigestContent(digest, "/Fortnite.com");
+
+        expect(entries["Ease"]).toEqual([
+            expect.objectContaining({ modulePath: "/Fortnite.com/Devices", type: "variable" }),
+            expect.objectContaining({ modulePath: "/Fortnite.com/Easing", type: "function" }),
+        ]);
+    });
+
+    it("records a module-scope overload once, not once per declaration", () => {
+        // `ToString` is declared four times in its own module in the shipped
+        // Verse digest. One entry per declaration would offer the identical
+        // import that many times.
+        const digest = [
+            "Verse<public> := module:",
+            "    ToString<public>(X:int)<reads>:string = external {}",
+            "    ToString<public>(X:float)<reads>:string = external {}",
+            "    ToString<public>(X:logic)<reads>:string = external {}",
+        ].join("\n");
+
+        const { entries } = parseDigestContent(digest, "/Verse.org");
+
+        expect(entries["ToString"].map((declaration) => declaration.modulePath)).toEqual(["/Verse.org/Verse"]);
     });
 
     it("accumulates every member of a re-opened module in the module index", () => {

--- a/src/services/__tests__/digestSourceInvariants.test.ts
+++ b/src/services/__tests__/digestSourceInvariants.test.ts
@@ -156,10 +156,18 @@ describe.each(BUNDLED_DIGEST_NAMES)("bundled digest invariants (%s)", (digestNam
         // plain declaration branch and is recorded as a function.
         expect(parametricHeads.length).toBeGreaterThan(0);
 
+        // A name can carry a declaration per module, so the head is classified
+        // correctly as long as one of them bears the expected type.
         const misclassified = parametricHeads
             .filter((head) => entries[head.name] !== undefined)
-            .filter((head) => entries[head.name].type !== (head.keyword === "module" ? "module" : "class"))
-            .map((head) => `${fileName}:${head.line} ${head.name} recorded as ${entries[head.name].type}, expected ${head.keyword === "module" ? "module" : "class"}`);
+            .filter((head) => {
+                const expected = head.keyword === "module" ? "module" : "class";
+                return !entries[head.name].some((declaration) => declaration.type === expected);
+            })
+            .map(
+                (head) =>
+                    `${fileName}:${head.line} ${head.name} recorded as ${entries[head.name].map((declaration) => declaration.type).join("/")}, expected ${head.keyword === "module" ? "module" : "class"}`,
+            );
 
         expect(misclassified).toEqual([]);
     });

--- a/src/services/__tests__/precompiledDigestData.test.ts
+++ b/src/services/__tests__/precompiledDigestData.test.ts
@@ -12,7 +12,7 @@ import * as path from "path";
  */
 interface PrecompiledDigest {
     sourceBuild: string;
-    entries: Record<string, { identifier: string; modulePath: string; type: string; isPublic: boolean }>;
+    entries: Record<string, { identifier: string; modulePath: string; type: string; isPublic: boolean }[]>;
     moduleIndex: Record<string, string[]>;
 }
 
@@ -37,17 +37,34 @@ describe("precompiled digest data (41.30)", () => {
     it("resolves Fortnite device classes to /Fortnite.com/Devices", () => {
         for (const id of ["creative_device", "button_device", "trigger_device"]) {
             expect(fortnite.entries[id]).toBeDefined();
-            expect(fortnite.entries[id].modulePath).toBe("/Fortnite.com/Devices");
+            expect(fortnite.entries[id][0].modulePath).toBe("/Fortnite.com/Devices");
         }
     });
 
     it("resolves agent and player to /Verse.org/Simulation", () => {
-        expect(verse.entries["agent"].modulePath).toBe("/Verse.org/Simulation");
-        expect(verse.entries["player"].modulePath).toBe("/Verse.org/Simulation");
+        expect(verse.entries["agent"][0].modulePath).toBe("/Verse.org/Simulation");
+        expect(verse.entries["player"][0].modulePath).toBe("/Verse.org/Simulation");
     });
 
     it("resolves vector3 to /Verse.org/SpatialMath", () => {
-        expect(verse.entries["vector3"].modulePath).toBe("/Verse.org/SpatialMath");
+        expect(verse.entries["vector3"][0].modulePath).toBe("/Verse.org/SpatialMath");
+    });
+
+    it("keeps both SpatialMath homes of the identifiers they share (issue #375)", () => {
+        // The two SpatialMath modules are a live migration in the 41.30 data:
+        // both are importable and their vector3 types are distinct, so serving
+        // only one silently picks for the user. Each file records its own home;
+        // the loader is what puts the two together.
+        for (const id of ["Distance", "vector3", "rotation", "transform"]) {
+            expect(unrealEngine.entries[id].map((declaration) => declaration.modulePath)).toEqual(["/UnrealEngine.com/Temporary/SpatialMath"]);
+            expect(verse.entries[id].map((declaration) => declaration.modulePath)).toEqual(["/Verse.org/SpatialMath"]);
+        }
+    });
+
+    it("records a module-scope overload once per module, not once per declaration", () => {
+        // ToString is declared four times across two Verse modules. One entry
+        // per declaration would offer the same import several times over.
+        expect(verse.entries["ToString"].map((declaration) => declaration.modulePath)).toEqual(["/Verse.org/Verse", "/Verse.org/SpatialMath"]);
     });
 
     it("indexes button_device under the /Fortnite.com/Devices module", () => {
@@ -62,13 +79,13 @@ describe("precompiled digest data (41.30)", () => {
         // Regenerating from an older digest would silently restore the old names.
         for (const id of ["ai_session", "ai_error", "ai_description"]) {
             expect(unrealEngine.entries[id]).toBeDefined();
-            expect(unrealEngine.entries[id].modulePath).toBe("/UnrealEngine.com/Conversations");
+            expect(unrealEngine.entries[id][0].modulePath).toBe("/UnrealEngine.com/Conversations");
         }
         for (const gone of ["llm_session", "llm_prompt_error", "llm_description", "lily_voice"]) {
             expect(unrealEngine.entries[gone]).toBeUndefined();
         }
         expect(unrealEngine.entries["peely_voice"]).toBeDefined();
-        expect(unrealEngine.entries["peely_voice"].modulePath).toBe("/UnrealEngine.com/Conversations");
+        expect(unrealEngine.entries["peely_voice"][0].modulePath).toBe("/UnrealEngine.com/Conversations");
     });
 
     it("records parametric types but not their members (no leak)", () => {
@@ -76,7 +93,7 @@ describe("precompiled digest data (41.30)", () => {
         // out of the importable entries (issue #97 follow-up).
         for (const id of ["subscribable", "listenable", "event", "result"]) {
             expect(verse.entries[id]).toBeDefined();
-            expect(verse.entries[id].type).toBe("class");
+            expect(verse.entries[id][0].type).toBe("class");
         }
         for (const leaked of ["Subscribe", "Signal", "GetSuccess"]) {
             expect(verse.entries[leaked]).toBeUndefined();
@@ -92,7 +109,7 @@ describe("precompiled digest data (41.30)", () => {
         // and reads the head as a function.
         for (const id of ["chat_channel", "voice_channel", "agent_group_interface", "agent_group"]) {
             expect(verse.entries[id]).toBeDefined();
-            expect(verse.entries[id].type).toBe("class");
+            expect(verse.entries[id][0].type).toBe("class");
         }
     });
 

--- a/src/services/digestManifest.ts
+++ b/src/services/digestManifest.ts
@@ -14,8 +14,10 @@
  */
 
 /**
- * The bundled digests, in load precedence order. The first file to declare an
- * identifier wins, so reordering this changes which domain answers a lookup.
+ * The bundled digests, in load precedence order. A lookup keeps every module
+ * that declares an identifier, so this order no longer decides which one
+ * answers - it decides which one leads the list, and the lead is what the
+ * quick-fix menu prefers and what an `auto_first` strategy applies unasked.
  */
 export const BUNDLED_DIGEST_NAMES = ["Fortnite", "UnrealEngine", "Verse"] as const;
 

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -49,6 +49,26 @@ export interface ParsedDigest {
     moduleIndex: Record<string, string[]>;
 }
 
+/**
+ * Appends a declaration unless the identifier already has one from that module,
+ * and reports whether it was appended.
+ *
+ * Shared by the two places that build an identifier's declaration list - the
+ * parser within one file, the loader across files - because both rest on the
+ * same invariant: one entry per module path, so a name is never offered as the
+ * same import twice. Module-scope overloads make that a live case rather than a
+ * defensive one, `ToString` being declared four times in its own module.
+ *
+ * @param declarations Mutated in place.
+ */
+export function appendDeclaration(declarations: DigestEntry[], declaration: DigestEntry): boolean {
+    if (declarations.some((existing) => existing.modulePath === declaration.modulePath)) {
+        return false;
+    }
+    declarations.push(declaration);
+    return true;
+}
+
 /** An open module on the indentation stack, holding its resolved import path. */
 interface ModuleFrame {
     path: string;
@@ -206,13 +226,7 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
         members.add(identifier);
 
         const declarations = entries[identifier] ?? (entries[identifier] = []);
-        // One declaration per module path, not per declaration line: module-scope
-        // overloads repeat a name in its own module (`ToString` four times), and
-        // each repeat would otherwise become a duplicate of the same import.
-        if (declarations.some((declaration) => declaration.modulePath === modulePath)) {
-            return;
-        }
-        declarations.push({ identifier, modulePath, type, isPublic });
+        appendDeclaration(declarations, { identifier, modulePath, type, isPublic });
     };
 
     // Explicit path from the most recent `# Module import path:` comment, applied

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -34,11 +34,18 @@ export interface DigestEntry {
 }
 
 /**
- * The result of parsing one digest file: entries keyed by identifier (first
- * occurrence wins) plus an index from module path to the identifiers it exposes.
+ * The result of parsing one digest file: every declaration of an identifier
+ * keyed by that identifier, plus an index from module path to the identifiers
+ * it exposes.
+ *
+ * An identifier maps to a list because one name is often public in several
+ * modules at once - `Distance` is declared by both SpatialMath modules - and
+ * each of those modules is a valid `using` target the user may need to choose
+ * between. The list holds one declaration per module path, in declaration
+ * order.
  */
 export interface ParsedDigest {
-    entries: Record<string, DigestEntry>;
+    entries: Record<string, DigestEntry[]>;
     moduleIndex: Record<string, string[]>;
 }
 
@@ -176,15 +183,15 @@ function containingModulePath(qualifierPath: string | null, stack: ModuleFrame[]
  * Parses the raw text of a Verse API digest file into module-scoped entries.
  *
  * Only public, module-scope declarations are recorded; class/struct/interface/enum
- * members are skipped by indentation tracking. Entries deduplicate on first
- * occurrence, while the module index records every occurrence so a re-opened
- * module still contributes all of its members.
+ * members are skipped by indentation tracking. An identifier declared in several
+ * modules keeps one entry per module, while the module index records every
+ * occurrence so a re-opened module still contributes all of its members.
  *
  * @param content Raw text of a `*.digest.verse` file.
  * @param rootDomain Root module domain for the file, from {@link rootDomainForDigestFile}.
  */
 export function parseDigestContent(content: string, rootDomain: string): ParsedDigest {
-    const entries: Record<string, DigestEntry> = {};
+    const entries: Record<string, DigestEntry[]> = {};
     const moduleIndex = new Map<string, Set<string>>();
 
     const addEntry = (identifier: string, modulePath: string, type: DigestEntry["type"], isPublic: boolean): void => {
@@ -198,10 +205,14 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
         }
         members.add(identifier);
 
-        if (entries[identifier]) {
-            return; // First occurrence wins.
+        const declarations = entries[identifier] ?? (entries[identifier] = []);
+        // One declaration per module path, not per declaration line: module-scope
+        // overloads repeat a name in its own module (`ToString` four times), and
+        // each repeat would otherwise become a duplicate of the same import.
+        if (declarations.some((declaration) => declaration.modulePath === modulePath)) {
+            return;
         }
-        entries[identifier] = { identifier, modulePath, type, isPublic };
+        declarations.push({ identifier, modulePath, type, isPublic });
     };
 
     // Explicit path from the most recent `# Module import path:` comment, applied


### PR DESCRIPTION
## What

An identifier public in more than one bundled digest module resolved to whichever module the digests reached first, and every other path was discarded one step short of the multi-option quick-fix flow that was already built to present it.

The collision was thrown away at three points:

- `digestParsing.ts` — `if (entries[identifier]) return; // First occurrence wins.` within one file.
- `PrecompiledDigestLoader.ts` — `if (!this.digestCache.has(identifier))`, first file wins across files.
- `DigestParser.ts` — `lookupIdentifier` read a `Map<string, DigestEntry>`, so it could only ever return `[match]` or `[]`.

Each identifier is now keyed to a list of declarations, one per declaring module, deduped by module path and kept in the existing `BUNDLED_DIGEST_NAMES` precedence order.

## Effect

32 identifiers in the shipped 41.30 data gain their alternatives. The whole SpatialMath surface — `Distance`, `rotation`, `vector3`, `transform`, `Lerp`, `IsAlmostEqual` and the rest — answered only with the deprecated `/UnrealEngine.com/Temporary/SpatialMath`; `/Verse.org/SpatialMath` ships with 28 members and could never win. Both are now offered.

This matters beyond tidiness: `UnrealEngine.digest.verse` imports both SpatialMath modules into one scope and overloads `DrawSphere` on each module's **distinct** `vector3`, so picking the wrong module is a type error rather than a cosmetic difference.

**Behaviour change under the default `multiOptionStrategy: "quickfix"`:** for those 32 identifiers, auto-import no longer applies a single path silently and the quick-fix menu offers the choice instead. That is the point of the ticket. `auto_first` users see no change, because the leading path is unchanged.

## Two deliberate deviations from the ticket

**The ticket's `modulePaths: string[]` was not used.** 6 of the colliding identifiers declare a different `type` per module: `Linear`, `Ease`, `EaseIn`, `EaseOut` and `EaseInOut` are a `variable` in `/Fortnite.com/Devices/CreativeAnimation/InterpolationTypes` and a `function` in `/Verse.org/Verse/Easing`, and `Tan` is a `function` in `/Verse.org/Verse` and a `variable` in `/Verse.org/Colors/NamedColors`. The quick-fix label is `${entry.type} from ${entry.modulePath}`, so one entry carrying several paths would mislabel one option on each of them. A full entry per module keeps each type with its own path.

**Dedupe is on `(identifier, modulePath)`, not per declaration.** Module-scope overloads repeat a name inside its own module — `ToString` four times, `Print` three, `Distance` twice — and one entry per declaration would have offered the identical `using` line that many times.

**Path order is deliberately unchanged.** `/UnrealEngine.com/Temporary/*` still leads, so `isPreferred` and `auto_first` return exactly what they do today and only the alternatives are new. Preferring non-deprecated paths would change what `auto_first` silently picks for ~25 identifiers, which is a second behaviour change the ticket does not ask for; filed separately as #416.

## Data format

`src/data/*.digest.json` is regenerated by `npm run parse-digest`, never hand-edited. `VERSION` moves to `2.0.0` to mark the shape change. The loader does not read `version`, so nothing gates on it.

## Tests

- `DigestParser.test.ts` — new: two digest files declaring one identifier at different paths, asserting both come back in manifest order, and that a repeated declaration collapses to one. Cross-file collision was asserted nowhere before this. Drives the real `PrecompiledDigestLoader` through a mocked `fs`.
- `digestParsing.test.ts` — the test pinning the old first-wins behaviour now asserts both module homes survive in declaration order; added cases for divergent types and for module-scope overloads.
- `precompiledDigestData.test.ts` — every existing assertion preserved against the real shipped data, plus the SpatialMath dual-home and the `ToString` overload cases.
- `digestSourceInvariants.test.ts` — the parametric-head check now asks whether the list holds a declaration of the expected type.

**The tests were proven to detect the defect.** With the production code reverted to the pre-fix commit and the tests left in place, `returns every declaring module, led by the one the manifest prefers` fails on assertion:

```
- Expected  - 2
+ Received  + 1
  Array [
-   "/UnrealEngine.com/Temporary/SpatialMath",
-   "/Verse.org/SpatialMath",
```

## Verification

```
$ npm run compile
> tsc -p ./
(no output)

$ npm test
Test Suites: 46 passed, 46 total
Tests:       1381 passed, 1381 total

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!

$ npx jest src/imports/__tests__
Test Suites: 10 passed, 10 total
Tests:       836 passed, 836 total
```

The `src/imports/__tests__` run is the repo's extractor-order check: no pattern was added, moved or broadened in `ImportSuggestionExtractor.ts` — that file is not touched — and nothing in its suites changed shape.

An exhaustive old-versus-new comparison over all 2453 merged identifiers confirms the merge is additive only:

```
identifiers before: 2453, now: 2453
lead changed: 0, lost: 0, with duplicate paths: 0
identifiers now offering more than one module: 32
```

`npm run parse-digest` reproduces the committed `src/data` exactly, with only the `generatedAt` timestamp differing.

## Review

One round at `opus`, verdict PASS_WITH_SUGGESTIONS, no Critical findings. It probed the change end to end through the `ImportHandler` facade against the real shipped data, and independently reproduced the merge invariants above and the ticket's collision counts.

Fixed from that round:

- The `BUNDLED_DIGEST_NAMES` doc comment still claimed "the first file to declare an identifier wins", which is no longer true of anything.
- The dedupe rule was written twice, once over a `Record` and once over a `Map`; extracted as `appendDeclaration` so the two cannot drift.
- Both new array-returning accessors hand out the live cache where the old `lookupIdentifier` allocated a fresh array per call; that constraint is now recorded, matching the note `getAllEntries` already carried.

Left unfixed, deliberately:

- `getEntry` and `getModuleIdentifiers` have no callers anywhere. Deleting dead public surface is outside this ticket.
- `digestSourceInvariants.test.ts` now asks whether *some* declaration bears the expected type. Nothing is masked today — within a single file only `ToString`, `Tan`, `Lerp` and `IsAlmostEqual` carry more than one declaration and none is a parametric head — but a stricter form would match on module path.

Closes #375
