### PR TITLE
feat(visibility): preview the module visibility edit before applying it

### DIFF
--- a/changelog.d/394.changed.md
+++ b/changelog.d/394.changed.md
@@ -1,0 +1,1 @@
+**Module visibility**: The make-public quick fix now opens VS Code's refactor preview, so every file it would change is shown for you to confirm before anything is written.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -72,6 +72,12 @@ class EventEmitter<T> {
     }
 }
 
+interface WorkspaceEditEntryMetadata {
+    needsConfirmation: boolean;
+    label: string;
+    description?: string;
+}
+
 interface RecordedEditOperation {
     kind: "insert" | "delete" | "replace" | "createFile";
     uri: unknown;
@@ -79,26 +85,28 @@ interface RecordedEditOperation {
     range?: Range;
     text?: string;
     options?: { overwrite?: boolean; ignoreIfExists?: boolean };
+    /** Carried because `needsConfirmation` is what opens the refactor preview. */
+    metadata?: WorkspaceEditEntryMetadata;
 }
 
 /** Records edit operations so tests can assert on them. */
 class WorkspaceEdit {
     readonly operations: RecordedEditOperation[] = [];
 
-    insert(uri: unknown, position: Position, text: string): void {
-        this.operations.push({ kind: "insert", uri, position, text });
+    insert(uri: unknown, position: Position, text: string, metadata?: WorkspaceEditEntryMetadata): void {
+        this.operations.push({ kind: "insert", uri, position, text, metadata });
     }
 
-    delete(uri: unknown, range: Range): void {
-        this.operations.push({ kind: "delete", uri, range });
+    delete(uri: unknown, range: Range, metadata?: WorkspaceEditEntryMetadata): void {
+        this.operations.push({ kind: "delete", uri, range, metadata });
     }
 
-    replace(uri: unknown, range: Range, text: string): void {
-        this.operations.push({ kind: "replace", uri, range, text });
+    replace(uri: unknown, range: Range, text: string, metadata?: WorkspaceEditEntryMetadata): void {
+        this.operations.push({ kind: "replace", uri, range, text, metadata });
     }
 
-    createFile(uri: unknown, options?: { overwrite?: boolean; ignoreIfExists?: boolean }): void {
-        this.operations.push({ kind: "createFile", uri, options });
+    createFile(uri: unknown, options?: { overwrite?: boolean; ignoreIfExists?: boolean }, metadata?: WorkspaceEditEntryMetadata): void {
+        this.operations.push({ kind: "createFile", uri, options, metadata });
     }
 
     /**

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -100,8 +100,10 @@ export class ModuleVisibilityWriter {
         if (!applied) {
             // A cancelled preview, a preview nothing was selected in, and a
             // failed apply all arrive as false, so neither the log line nor
-            // the notification can claim which of them happened.
-            logger.warn("ModuleVisibilityWriter", `Nothing written for ${request.targetPath}: the preview was cancelled or empty, or the edit failed`);
+            // the notification can claim which of them happened. Logged at
+            // info because cancelling is an ordinary user action and the most
+            // likely way to get here.
+            logger.info("ModuleVisibilityWriter", `Nothing written for ${request.targetPath}: the preview was cancelled or empty, or the edit failed`);
             vscode.window.showInformationMessage(`Verse Auto Imports: no changes were written for '${request.moduleName}'.`);
             return;
         }
@@ -172,8 +174,9 @@ export class ModuleVisibilityWriter {
 
         // needsConfirmation on an entry is the only thing an extension can set
         // that opens the refactor preview, and it must go on every entry the
-        // user is meant to see. The editor groups entries by equal label, so
-        // one shared label keeps the whole change under a single node.
+        // user is meant to see - one without it is applied unseen. One shared
+        // label names the whole refactoring, and gathers the entries under a
+        // single node in the preview's group-by-category view.
         const confirm = (description: string): vscode.WorkspaceEditEntryMetadata => ({
             needsConfirmation: true,
             label: `Make module '${request.moduleName}' public`,
@@ -207,7 +210,10 @@ export class ModuleVisibilityWriter {
             const withEdits = applySpecifierEdits(existing, inDefinitions);
             const content = appendDeclarationBlock(withEdits, buildDeclarationBlock(resolved.chain));
 
-            const metadata = confirm(path.basename(definitionsUri.fsPath));
+            // The module path, as the specifier entries carry, rather than the
+            // file name: the preview groups by file by default, so the name is
+            // already on the node above and the description would say nothing.
+            const metadata = confirm(resolved.chain.map((segment) => segment.name).join("/"));
             if (existing.length === 0 && !scannedDefinitions) {
                 edit.createFile(definitionsUri, { ignoreIfExists: true }, metadata);
                 edit.insert(definitionsUri, new vscode.Position(0, 0), content, metadata);
@@ -228,6 +234,14 @@ export class ModuleVisibilityWriter {
      * them. VS Code offers nothing atomic here - WorkspaceEdit carries no
      * version and applyEdit accepts none - so this narrows the window to the
      * gap before the apply rather than closing it.
+     *
+     * That window is now the whole preview session, because applyEdit does not
+     * return until the user dismisses the preview. Text edits still fail closed
+     * past this point: the extension host stamps a version on edits to
+     * documents it knows, and a stale one aborts the apply. The createFile path
+     * does not, having no document to stamp - a definitions file created while
+     * the preview sits open is kept by `ignoreIfExists`, and the block is then
+     * prepended to it.
      */
     private async findDrift(snapshots: readonly Snapshot[]): Promise<vscode.Uri | null> {
         for (const snapshot of snapshots) {

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -64,13 +64,15 @@ export class ModuleVisibilityWriter {
     ) {}
 
     /**
-     * Makes the requested module reachable from the importing scope, and
-     * reports what it did.
+     * Puts the `<public>` declarations that make the requested module
+     * reachable through the refactor preview, and reports what came back.
      *
      * Refuses rather than half-applying: a module declared anything but
      * `<public>` or `<internal>` is left alone, whether it is the one to
      * publicize or one a new declaration would sit inside, and so is everything
-     * else the same request would have changed.
+     * else the same request would have changed. That governs what is offered,
+     * not what lands - the preview lets the user apply a subset, so what is
+     * reported afterwards is intent rather than outcome.
      */
     async makeModulePublic(request: ModuleVisibilityRequest): Promise<void> {
         const outcome = await this.buildEdit(request);
@@ -91,15 +93,23 @@ export class ModuleVisibilityWriter {
             return;
         }
 
-        const applied = await vscode.workspace.applyEdit(outcome.edit);
+        // isRefactoring does not open the preview - it only makes
+        // files.refactoring.autoSave apply. The preview comes from the
+        // needsConfirmation metadata buildEdit puts on every entry.
+        const applied = await vscode.workspace.applyEdit(outcome.edit, { isRefactoring: true });
         if (!applied) {
-            logger.warn("ModuleVisibilityWriter", `Edit rejected for ${request.targetPath}`);
-            vscode.window.showWarningMessage(`Verse Auto Imports: could not write the module visibility change for '${request.moduleName}'.`);
+            // A cancelled preview, a preview nothing was selected in, and a
+            // failed apply all arrive as false, so neither the log line nor
+            // the notification can claim which of them happened.
+            logger.warn("ModuleVisibilityWriter", `Nothing written for ${request.targetPath}: the preview was cancelled or empty, or the edit failed`);
+            vscode.window.showInformationMessage(`Verse Auto Imports: no changes were written for '${request.moduleName}'.`);
             return;
         }
 
-        logger.info("ModuleVisibilityWriter", `Made ${request.targetPath} public`, { summary: outcome.summary });
-        vscode.window.showInformationMessage(`Verse Auto Imports: ${outcome.summary}`);
+        // Only what was offered is known, never what was ticked, so the
+        // summary is logged as intent and kept out of the notification.
+        logger.info("ModuleVisibilityWriter", `Applied the previewed changes for ${request.targetPath}`, { intended: outcome.summary });
+        vscode.window.showInformationMessage(`Verse Auto Imports: applied the previewed changes for '${request.moduleName}'.`);
     }
 
     /**
@@ -160,6 +170,16 @@ export class ModuleVisibilityWriter {
 
         const edit = new vscode.WorkspaceEdit();
 
+        // needsConfirmation on an entry is the only thing an extension can set
+        // that opens the refactor preview, and it must go on every entry the
+        // user is meant to see. The editor groups entries by equal label, so
+        // one shared label keeps the whole change under a single node.
+        const confirm = (description: string): vscode.WorkspaceEditEntryMetadata => ({
+            needsConfirmation: true,
+            label: `Make module '${request.moduleName}' public`,
+            description,
+        });
+
         // Every scanned file, not only the ones an edit addresses: the text of
         // each fed resolveVisibility's ruling, so a change to any of them
         // invalidates the whole result rather than one offset.
@@ -171,7 +191,7 @@ export class ModuleVisibilityWriter {
         const inDefinitions = resolved.chain.length > 0 ? resolved.edits.filter((specifierEdit) => specifierEdit.file === definitionsKey) : [];
         const elsewhere = resolved.edits.filter((specifierEdit) => !inDefinitions.includes(specifierEdit));
 
-        this.addSpecifierEdits(edit, elsewhere, scanned);
+        this.addSpecifierEdits(edit, elsewhere, scanned, confirm);
 
         if (resolved.chain.length > 0) {
             const scannedDefinitions = scanned.get(definitionsKey);
@@ -187,11 +207,12 @@ export class ModuleVisibilityWriter {
             const withEdits = applySpecifierEdits(existing, inDefinitions);
             const content = appendDeclarationBlock(withEdits, buildDeclarationBlock(resolved.chain));
 
+            const metadata = confirm(path.basename(definitionsUri.fsPath));
             if (existing.length === 0 && !scannedDefinitions) {
-                edit.createFile(definitionsUri, { ignoreIfExists: true });
-                edit.insert(definitionsUri, new vscode.Position(0, 0), content);
+                edit.createFile(definitionsUri, { ignoreIfExists: true }, metadata);
+                edit.insert(definitionsUri, new vscode.Position(0, 0), content, metadata);
             } else {
-                edit.replace(definitionsUri, new vscode.Range(new vscode.Position(0, 0), positionAt(existing, existing.length)), content);
+                edit.replace(definitionsUri, new vscode.Range(new vscode.Position(0, 0), positionAt(existing, existing.length)), content, metadata);
             }
         }
 
@@ -233,8 +254,19 @@ export class ModuleVisibilityWriter {
         return null;
     }
 
-    /** Adds one specifier rewrite per existing declaration, resolving offsets against the text they came from. */
-    private addSpecifierEdits(edit: vscode.WorkspaceEdit, specifierEdits: readonly SpecifierEdit[], scanned: ReadonlyMap<string, ScannedFile>): void {
+    /**
+     * Adds one specifier rewrite per existing declaration, resolving offsets
+     * against the text they came from.
+     *
+     * @param confirm builds the metadata each entry carries into the preview,
+     * from the description that entry should show.
+     */
+    private addSpecifierEdits(
+        edit: vscode.WorkspaceEdit,
+        specifierEdits: readonly SpecifierEdit[],
+        scanned: ReadonlyMap<string, ScannedFile>,
+        confirm: (description: string) => vscode.WorkspaceEditEntryMetadata,
+    ): void {
         for (const specifierEdit of specifierEdits) {
             const file = scanned.get(specifierEdit.file);
             if (!file) {
@@ -245,11 +277,12 @@ export class ModuleVisibilityWriter {
                 throw new Error(`ModuleVisibilityWriter: no scanned text for ${specifierEdit.file}`);
             }
 
+            const metadata = confirm(specifierEdit.path);
             const { start, end } = specifierEdit.span;
             if (start === end) {
-                edit.insert(file.uri, positionAt(file.text, start), specifierEdit.text);
+                edit.insert(file.uri, positionAt(file.text, start), specifierEdit.text, metadata);
             } else {
-                edit.replace(file.uri, new vscode.Range(positionAt(file.text, start), positionAt(file.text, end)), specifierEdit.text);
+                edit.replace(file.uri, new vscode.Range(positionAt(file.text, start), positionAt(file.text, end)), specifierEdit.text, metadata);
             }
         }
     }
@@ -436,7 +469,11 @@ export class ModuleVisibilityWriter {
         return null;
     }
 
-    /** What the user is told happened, naming the declarations that were rewritten. */
+    /**
+     * What the edit would do, naming the declarations it rewrites. This is the
+     * offer, not the result: the user can apply part of it in the preview, so
+     * it is logged rather than shown as a report of what was written.
+     */
     private summarize(moduleName: string, edits: readonly SpecifierEdit[], wroteDefinitions: boolean): string {
         const rewritten = [...new Set(edits.map((edit) => edit.path))];
 

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { ProjectPathHandler } from "../../project";
+import { logger } from "../../utils";
 import { ModuleVisibilityWriter } from "../ModuleVisibilityWriter";
 
 const PROJECT = "/mygame@fortnite.com/mygame";
@@ -96,6 +97,12 @@ const appliedOperations = (): any[] => {
     return calls.length === 0 ? [] : calls[calls.length - 1][0].operations;
 };
 
+/** The metadata argument of the last applyEdit call, or undefined when there was none. */
+const appliedMetadata = (): any => {
+    const calls = (vscode.workspace.applyEdit as jest.Mock).mock.calls;
+    return calls.length === 0 ? undefined : calls[calls.length - 1][1];
+};
+
 const forwardSlashed = (uri: { fsPath: string }): string => String(uri.fsPath).replace(/\\/g, "/");
 
 describe("ModuleVisibilityWriter", () => {
@@ -186,12 +193,18 @@ describe("ModuleVisibilityWriter", () => {
         expect(operations[0].position).toEqual(new vscode.Position(0, 5));
     });
 
-    it("names the declaration it rewrote", async () => {
+    it("names the declaration it offered to rewrite", async () => {
+        // In the log rather than the notification: the preview can apply a
+        // subset, so this names what was offered, not what was written.
         givenProject({ "Content/Gadgets/tools.verse": "Tools := module {}\n" });
+        const info = jest.spyOn(logger, "info").mockImplementation();
 
         await writer().makeModulePublic(REQUEST);
 
-        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("declaring Gadgets/Tools public in place"));
+        expect(info).toHaveBeenCalledWith("ModuleVisibilityWriter", expect.any(String), {
+            intended: expect.stringContaining("declaring Gadgets/Tools public in place"),
+        });
+        info.mockRestore();
     });
 
     it("refuses to widen a module the project deliberately narrowed", async () => {
@@ -342,13 +355,16 @@ describe("ModuleVisibilityWriter", () => {
         expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("no 'Content' folder"));
     });
 
-    it("warns when the edit is rejected", async () => {
+    it("reports nothing written when the preview comes back empty", async () => {
+        // A cancelled preview, one nothing was ticked in, and a failed apply
+        // are one boolean, so this must not be phrased as a failure.
         givenProject({ "Content/Scripts/main.verse": "" });
         (vscode.workspace.applyEdit as jest.Mock).mockResolvedValue(false);
 
         await writer().makeModulePublic(REQUEST);
 
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("could not write"));
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("no changes were written"));
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
     });
 
     it("refuses when a project file the scan listed cannot be read", async () => {
@@ -394,5 +410,61 @@ describe("ModuleVisibilityWriter", () => {
         await writer().makeModulePublic(REQUEST);
 
         expect(appliedOperations()[0]).toMatchObject({ kind: "insert", text: "<public>" });
+    });
+
+    describe("refactor preview", () => {
+        // needsConfirmation on an entry is the only lever an extension has on
+        // the preview: applyEdit's isRefactoring flag maps to the auto-save
+        // setting and opens nothing. An entry without it applies unseen.
+        it("marks every entry of a definitions-file write as needing confirmation", async () => {
+            givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+            await writer().makeModulePublic(REQUEST);
+
+            const operations = appliedOperations();
+            expect(operations.length).toBeGreaterThan(0);
+            for (const operation of operations) {
+                expect(operation.metadata).toMatchObject({ needsConfirmation: true });
+            }
+        });
+
+        it("marks a specifier rewrite as needing confirmation too", async () => {
+            givenProject({ "Gadgets/tools.verse": "Tools := module {}\n" }, "/repo/Content");
+
+            await writer().makeModulePublic(REQUEST);
+
+            expect(appliedOperations()[0]).toMatchObject({
+                kind: "insert",
+                text: "<public>",
+                metadata: { needsConfirmation: true },
+            });
+        });
+
+        it("gives every entry one label, which is what groups them under a single node", async () => {
+            givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+            await writer().makeModulePublic(REQUEST);
+
+            const labels = new Set(appliedOperations().map((operation) => operation.metadata?.label));
+            expect([...labels]).toEqual(["Make module 'Tools' public"]);
+        });
+
+        it("tells the editor the edit is a refactoring, so files.refactoring.autoSave applies", async () => {
+            givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+            await writer().makeModulePublic(REQUEST);
+
+            expect(appliedMetadata()).toEqual({ isRefactoring: true });
+        });
+
+        it("does not claim which declarations landed, since the preview can apply a subset", async () => {
+            givenProject({ "Content/Gadgets/tools.verse": "Tools := module {}\n" });
+
+            await writer().makeModulePublic(REQUEST);
+
+            const [message] = (vscode.window.showInformationMessage as jest.Mock).mock.calls[0];
+            expect(message).toContain("previewed");
+            expect(message).not.toContain("declaring");
+        });
     });
 });

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -199,12 +199,17 @@ describe("ModuleVisibilityWriter", () => {
         givenProject({ "Content/Gadgets/tools.verse": "Tools := module {}\n" });
         const info = jest.spyOn(logger, "info").mockImplementation();
 
-        await writer().makeModulePublic(REQUEST);
+        try {
+            await writer().makeModulePublic(REQUEST);
 
-        expect(info).toHaveBeenCalledWith("ModuleVisibilityWriter", expect.any(String), {
-            intended: expect.stringContaining("declaring Gadgets/Tools public in place"),
-        });
-        info.mockRestore();
+            expect(info).toHaveBeenCalledWith("ModuleVisibilityWriter", expect.any(String), {
+                intended: expect.stringContaining("declaring Gadgets/Tools public in place"),
+            });
+        } finally {
+            // The logger is a singleton, so leaving the stub installed would
+            // silently swallow errors in any test added after this one.
+            jest.restoreAllMocks();
+        }
     });
 
     it("refuses to widen a module the project deliberately narrowed", async () => {
@@ -424,7 +429,9 @@ describe("ModuleVisibilityWriter", () => {
             const operations = appliedOperations();
             expect(operations.length).toBeGreaterThan(0);
             for (const operation of operations) {
-                expect(operation.metadata).toMatchObject({ needsConfirmation: true });
+                // The module path, not the file name, so the description still
+                // says something in the preview's default group-by-file view.
+                expect(operation.metadata).toMatchObject({ needsConfirmation: true, description: "Gadgets/Tools" });
             }
         });
 
@@ -435,6 +442,37 @@ describe("ModuleVisibilityWriter", () => {
 
             expect(appliedOperations()[0]).toMatchObject({
                 kind: "insert",
+                text: "<public>",
+                metadata: { needsConfirmation: true },
+            });
+        });
+
+        // The two replace sites, which the insert cases above do not reach.
+        // Rewriting the definitions file end to end is the most destructive
+        // entry the writer emits, so an unpreviewed one is the worst version
+        // of the defect this ticket exists to close.
+        it("marks a whole-file rewrite of an existing definitions file as needing confirmation", async () => {
+            givenProject({ "Content/_definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
+
+            await writer().makeModulePublic({
+                targetPath: `${PROJECT}/Gadgets/Deep/Tools`,
+                importerPath: `${PROJECT}/Scripts`,
+                moduleName: "Tools",
+            });
+
+            expect(appliedOperations()[0]).toMatchObject({
+                kind: "replace",
+                metadata: { needsConfirmation: true },
+            });
+        });
+
+        it("marks a widened specifier as needing confirmation", async () => {
+            givenProject({ "Content/Gadgets/tools.verse": "Tools<internal> := module {}\n" });
+
+            await writer().makeModulePublic(REQUEST);
+
+            expect(appliedOperations()[0]).toMatchObject({
+                kind: "replace",
                 text: "<public>",
                 metadata: { needsConfirmation: true },
             });


### PR DESCRIPTION
Closes #394

## What

The make-public quick fix rewrote up to N project files plus `_definitions.verse` behind a single click, with a post-hoc notification as the only surface. The first sight of a misfire was a broken build, arriving after a success message.

Every entry of the edit now carries `needsConfirmation`, so VS Code opens the refactor preview and the user sees the whole change before any of it lands.

## The ticket's prescribed fix does not work

The issue proposes `workspace.applyEdit(edit, { isRefactoring: true })`. That flag never opens a preview. Verified against the VS Code source at `release/1.85`, matching the `^1.85.0` engine and the pinned `@types/vscode@1.85.0`:

- `mainThreadBulkEdits.ts`, `$tryApplyWorkspaceEdit` maps it to `respectAutoSaveConfig` and nothing else, which only gates `files.refactoring.autoSave`.
- `bulkEditService.ts`, `apply()`: `if (this._previewHandler && (options?.showPreview || edits.some(value => value.metadata?.needsConfirmation)))`. `showPreview` is unreachable from the extension API, so per-entry `needsConfirmation` is the only lever an extension has.

`isRefactoring: true` is still passed, because the edit genuinely is a refactoring and that is what makes the auto-save setting apply. It is commented as not being the thing that opens the preview, since that is the obvious wrong conclusion for the next reader.

## Consequences, and how they are handled

Three more facts from the same source shaped the rest of the change:

- `bulkEditPreview.ts`: `this.checked.updateChecked(edit, !edit.metadata?.needsConfirmation)` — a flagged entry starts **unchecked**, so the user ticks what they want. Accepted, not worked around.
- `bulkEdit.contribution.ts`, `_previewEdit`: `return await view.setInput(edits, session.cts.token) ?? []`, and `apply()` returns `isApplied: edits.length > 0`. A cancelled preview therefore arrives as `applyEdit === false`, indistinguishable from a failed apply — so the false branch now reports "no changes were written" informationally instead of warning that the write failed.
- A partial apply arrives as `true`. The writer cannot know what was ticked, so the enumerated summary moved out of the notification and into the log as `intended`. The notification says only that the previewed changes were applied.

No rescan-to-verify was added; that was weighed and declined as too costly for a second full workspace scan per fix.

## Not touched

`ModuleVisibilityCodeActionProvider` — the issue floats a `CodeAction` carrying an edit as an alternative, but that route is closed by an existing documented decision: the action cannot carry an edit because computing one is a workspace scan and a provider must answer fast enough for a lightbulb. Also untouched: the scan, the `findDrift` staleness check, every refusal path, and what the edit contains.

ABS-4, the compile-validated `_definitions.verse` fixture the issue mentions alongside this, is a separate concern and is not addressed here.

## Tests

Pinned at `makeModulePublic`, the entry point the issue names. Seven new cases plus two repointed: every entry carries `needsConfirmation` on all four emit shapes — `createFile`, both `insert` sites, and both `replace` sites; all entries share one label; `applyEdit` receives `{ isRefactoring: true }`; a false result reports nothing-written and does not warn; a success does not claim which declarations landed.

`src/__mocks__/vscode.ts` now records the trailing `metadata` argument on `insert`/`delete`/`replace`/`createFile`, which it previously dropped.

Two proofs that the tests bite:

- With `src/visibility/ModuleVisibilityWriter.ts` and `src/__mocks__/vscode.ts` stashed, exactly the 7 new-or-changed tests fail.
- Mutating only the two `replace` calls to drop their metadata argument kills exactly the two tests written for them. Before those two were added the same mutant survived the entire file green, which is how the gap was found.

## Review

One round at `opus` in a fresh context: `PASS_WITH_SUGGESTIONS`, 0 Critical, 2 Important, 5 Suggestions. Both Important findings and four of the five Suggestions are fixed in `108890d`:

- The `replace`-site coverage gap above (found by mutation testing).
- `findDrift`'s comment claimed the check narrows the drift window to the gap before the apply. That gap is now the whole preview session, since `applyEdit` no longer returns until the preview is dismissed. The comment now says so, including that text edits still fail closed on a stamped document version while the `createFile` path has no document to stamp.
- The false branch logs at `info` rather than `warn` — cancelling is an ordinary action, and `warn` reaches the user-visible channel.
- The definitions entry's preview description carries the module path rather than the file name, which the default group-by-file view already shows on the node above.
- The logger spy is restored in a `finally`, matching the precedent in `ProjectPathCache.invalidate.test.ts`; an inline restore is skipped when the assertion throws.

Left alone, as a judgement call the reviewer itself flagged as one: `Make module '<name>' public` is now built in both `ModuleVisibilityWriter` and `ModuleVisibilityCodeActionProvider`. Keeping the preview heading equal to the quick-fix title is deliberate, but nothing ties them together, so a rename could desync them. Extracting a shared constant is worth doing when a third caller appears.

## Verification

```
$ npm run compile
> verse-auto-imports@0.11.1 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 46 passed, 46 total
Tests:       1382 passed, 1382 total
Snapshots:   0 total
Time:        8.968 s, estimated 9 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Not smoke-tested in the Extension Development Host; the preview pane itself is VS Code's, and the assertions above cover what the extension controls.
