### PR TITLE
fix(imports): serialize the writes on one document

### DIFF
--- a/changelog.d/390.fixed.md
+++ b/changelog.d/390.fixed.md
@@ -1,0 +1,1 @@
+**Imports**: a quick fix invoked while an auto-import is still being written now waits for it, so the second edit is computed from the first one's result instead of landing at coordinates it invalidated.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -267,16 +267,21 @@ export class ImportDocumentEditor {
      * prevent. The spacing pass a writer runs on its own result calls the
      * unserialized applyEmptyLinesAfterImports for the same reason it must:
      * queued here it would wait on the write running it.
+     *
+     * A document's queue only ever moves on when its applyEdit settles. Nothing
+     * times one out, so a write that never settles holds every write behind it.
      */
     private serialize<T>(document: vscode.TextDocument, write: () => Promise<T>): Promise<T> {
         const key = document.uri.toString();
         const previous = this.writes.get(key) ?? Promise.resolve();
 
-        // Both arms run `write`: a rejected predecessor is a write that is over,
-        // not a reason to abandon the queue behind it.
+        // The queued promise below never rejects, so only the first arm can run
+        // today. The second is what keeps that from being load-bearing: a
+        // predecessor that failed is a write that is over, not a reason to
+        // abandon the queue behind it.
         const run = previous.then(write, write);
 
-        // The queued promise never rejects, so a failed write does not reject
+        // Settling rather than rejecting, so a failed write does not reject
         // every write queued behind it as well.
         const queued = run.then(
             () => undefined,
@@ -1370,11 +1375,11 @@ export class ImportDocumentEditor {
      * addImportsToDocument this reorganizes even when nothing new is added.
      */
     async organizeImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath = NO_DIAGNOSTIC_LINES): Promise<boolean> {
-        return this.serialize(document, () => this.applyOrganized(document, additionalPaths, diagnosticLinesByPath));
+        return this.serialize(document, () => this.applyOrganizedImports(document, additionalPaths, diagnosticLinesByPath));
     }
 
     /** organizeImports, without the wait for the writes ahead of it. */
-    private async applyOrganized(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath): Promise<boolean> {
+    private async applyOrganizedImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath): Promise<boolean> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const sortAlphabetically = config.get<boolean>("behavior.sortImportsAlphabetically", true);

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -237,11 +237,63 @@ const NO_DIAGNOSTIC_LINES: DiagnosticLinesByPath = new Map();
 export class ImportDocumentEditor {
     private readonly formatter: ImportFormatter;
 
+    /**
+     * The write queued last for each document, keyed on its URI, or no entry
+     * once nothing is queued. See serialize.
+     */
+    private readonly writes = new Map<string, Promise<void>>();
+
     constructor(
         private outputChannel: vscode.OutputChannel,
         formatter: ImportFormatter,
     ) {
         this.formatter = formatter;
+    }
+
+    /**
+     * Runs `write` once every write already queued for `document` has settled,
+     * and queues it as the one the next caller waits behind.
+     *
+     * Each writer reads the document, computes an edit from that text and
+     * applies it as three separate steps, so two overlapping writes both
+     * compute against the text as it was before either applied, and the second
+     * lands at coordinates the first has already invalidated. A WorkspaceEdit
+     * carries no document version and applyEdit accepts none, so there is
+     * nothing for the apply itself to fail on. Waiting here is what makes the
+     * second write read the first one's result.
+     *
+     * The whole body of a writer has to sit inside `write`, the read included -
+     * a read taken before the wait is exactly the stale snapshot this exists to
+     * prevent. The spacing pass a writer runs on its own result calls the
+     * unserialized applyEmptyLinesAfterImports for the same reason it must:
+     * queued here it would wait on the write running it.
+     */
+    private serialize<T>(document: vscode.TextDocument, write: () => Promise<T>): Promise<T> {
+        const key = document.uri.toString();
+        const previous = this.writes.get(key) ?? Promise.resolve();
+
+        // Both arms run `write`: a rejected predecessor is a write that is over,
+        // not a reason to abandon the queue behind it.
+        const run = previous.then(write, write);
+
+        // The queued promise never rejects, so a failed write does not reject
+        // every write queued behind it as well.
+        const queued = run.then(
+            () => undefined,
+            () => undefined,
+        );
+        this.writes.set(key, queued);
+
+        void queued.then(() => {
+            // Only when nothing queued behind this one, which would otherwise
+            // lose its predecessor and run against a document still being
+            // written.
+            if (this.writes.get(key) === queued) {
+                this.writes.delete(key);
+            }
+        });
+
+        return run;
     }
 
     /**
@@ -637,6 +689,11 @@ export class ImportDocumentEditor {
      *   import that failed to resolve from one that merely looks like it could.
      */
     async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: DiagnosticLinesByStatement): Promise<boolean> {
+        return this.serialize(document, () => this.applyImports(document, importStatements, diagnosticLinesByStatement));
+    }
+
+    /** addImportsToDocument, without the wait for the writes ahead of it. */
+    private async applyImports(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: DiagnosticLinesByStatement): Promise<boolean> {
         logger.info("ImportDocumentEditor", `Adding ${importStatements.length} import statements to document`);
 
         const config = vscode.workspace.getConfiguration("verseAutoImports");
@@ -1059,7 +1116,7 @@ export class ImportDocumentEditor {
             logger.info("ImportDocumentEditor", success ? "Successfully updated imports in document" : "Failed to update imports in document");
 
             if (success) {
-                await this.ensureEmptyLinesAfterImports(document);
+                await this.applyEmptyLinesAfterImports(document);
             }
 
             return success;
@@ -1313,6 +1370,11 @@ export class ImportDocumentEditor {
      * addImportsToDocument this reorganizes even when nothing new is added.
      */
     async organizeImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath = NO_DIAGNOSTIC_LINES): Promise<boolean> {
+        return this.serialize(document, () => this.applyOrganized(document, additionalPaths, diagnosticLinesByPath));
+    }
+
+    /** organizeImports, without the wait for the writes ahead of it. */
+    private async applyOrganized(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath): Promise<boolean> {
         const config = vscode.workspace.getConfiguration("verseAutoImports");
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const sortAlphabetically = config.get<boolean>("behavior.sortImportsAlphabetically", true);
@@ -1351,7 +1413,7 @@ export class ImportDocumentEditor {
             logger.info("ImportDocumentEditor", success ? "Organized imports in document" : "Failed to organize imports");
 
             if (success) {
-                await this.ensureEmptyLinesAfterImports(document);
+                await this.applyEmptyLinesAfterImports(document);
             }
 
             return success;
@@ -1464,6 +1526,15 @@ export class ImportDocumentEditor {
      * The save path uses computeEmptyLinesAfterImportsEdits instead.
      */
     async ensureEmptyLinesAfterImports(document: vscode.TextDocument): Promise<boolean> {
+        return this.serialize(document, () => this.applyEmptyLinesAfterImports(document));
+    }
+
+    /**
+     * ensureEmptyLinesAfterImports, without the wait for the writes ahead of
+     * it. This is the one the writers call on their own result: they are
+     * already the write at the head of the queue, so waiting would deadlock.
+     */
+    private async applyEmptyLinesAfterImports(document: vscode.TextDocument): Promise<boolean> {
         const edits = this.computeEmptyLinesAfterImportsEdits(document);
 
         if (edits.length === 0) {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -2730,3 +2730,123 @@ describe("ImportDocumentEditor.computeEmptyLinesAfterImportsEdits", () => {
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
     });
 });
+
+/**
+ * Two writes on one document, overlapping - a quick fix arriving while a
+ * debounced auto-import is in flight. Each writer reads, computes and applies
+ * as three separate steps, so what these pin is that the second writer does
+ * not read while the first is still applying.
+ */
+describe("ImportDocumentEditor write serialization", () => {
+    let editor: ImportDocumentEditor;
+    const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
+
+    /**
+     * Every read and every apply, in the order they happened. A read is
+     * getText, which is the snapshot a writer computes its coordinates from.
+     */
+    let trace: string[];
+
+    /** The applyEdit calls not yet let through, in the order they were made. */
+    let pendingApplies: Array<() => void>;
+
+    const input = ["using { /Verse.org/Simulation }", "", "hello := 1"].join("\n");
+
+    /** A document that records its reads. */
+    const tracedDocument = (uri: string): vscode.TextDocument =>
+        ({
+            ...fakeDocument(input),
+            uri: { toString: () => uri },
+            getText: () => {
+                trace.push("read");
+                return input;
+            },
+        }) as unknown as vscode.TextDocument;
+
+    /** Lets the queued microtasks run without releasing any applyEdit. */
+    const settle = async (): Promise<void> => {
+        for (let i = 0; i < 20; i++) {
+            await Promise.resolve();
+        }
+    };
+
+    const releaseApplies = async (): Promise<void> => {
+        while (pendingApplies.length > 0) {
+            pendingApplies.shift()!();
+            await settle();
+        }
+    };
+
+    beforeEach(() => {
+        const outputChannel = vscode.window.createOutputChannel("test");
+        editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
+        trace = [];
+        pendingApplies = [];
+        applyEditMock().mockReset();
+        applyEditMock().mockImplementation(() => {
+            trace.push("apply");
+            return new Promise<boolean>((resolve) => pendingApplies.push(() => resolve(true)));
+        });
+    });
+
+    // The mock is shared across this file, and every other test here expects
+    // an apply that resolves true on its own.
+    afterEach(() => {
+        applyEditMock().mockReset();
+        applyEditMock().mockResolvedValue(true);
+    });
+
+    it("does not let a second write read the document while the first is applying", async () => {
+        const document = tracedDocument("file:///test.verse");
+
+        const first = editor.addImportsToDocument(document, ["using { /Fortnite.com/Devices }"]);
+        const second = editor.organizeImports(document, ["/UnrealEngine.com/Temporary/SpatialMath"]);
+
+        await settle();
+
+        // Unserialized, the second writer runs on to its own applyEdit here,
+        // off text the first one has not finished writing over.
+        expect(trace).toEqual(["read", "apply"]);
+
+        await releaseApplies();
+        expect(await first).toBe(true);
+        expect(await second).toBe(true);
+
+        expect(trace.lastIndexOf("read")).toBeGreaterThan(trace.indexOf("apply"));
+    });
+
+    it("runs a write queued behind one whose apply rejected", async () => {
+        const document = tracedDocument("file:///test.verse");
+
+        applyEditMock().mockImplementationOnce(() => {
+            trace.push("apply");
+            return Promise.reject(new Error("apply rejected"));
+        });
+
+        const first = editor.addImportsToDocument(document, ["using { /Fortnite.com/Devices }"]);
+        const second = editor.organizeImports(document, ["/UnrealEngine.com/Temporary/SpatialMath"]);
+
+        await settle();
+        await releaseApplies();
+
+        expect(await first).toBe(false);
+        expect(await second).toBe(true);
+        expect(trace.filter((entry) => entry === "apply").length).toBeGreaterThan(1);
+    });
+
+    it("does not queue a write on one document behind a write on another", async () => {
+        const one = tracedDocument("file:///one.verse");
+        const other = tracedDocument("file:///other.verse");
+
+        const first = editor.addImportsToDocument(one, ["using { /Fortnite.com/Devices }"]);
+        const second = editor.addImportsToDocument(other, ["using { /Fortnite.com/Devices }"]);
+
+        await settle();
+
+        expect(trace).toEqual(["read", "apply", "read", "apply"]);
+
+        await releaseApplies();
+        expect(await first).toBe(true);
+        expect(await second).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #390

## What

The three public writers on `ImportDocumentEditor` each read the document, compute a `WorkspaceEdit` from that text and apply it as separate steps, with nothing holding a second writer off in between. A quick fix invoked while a debounced auto-import was applying computed its coordinates from the pre-edit text and landed at positions the first write had already invalidated — a whole statement at the wrong line, or a stale replace or delete taking user text with it.

## The change

`serialize` keys the write queued last for each document on its URI. Each public writer — `addImportsToDocument`, `organizeImports`, `ensureEmptyLinesAfterImports` — now runs behind whatever is already queued for that document, so the read that starts it happens after the previous apply has settled. `WorkspaceEdit` carries no document version and `applyEdit` accepts none, so waiting is what closes this rather than a check the apply could fail on.

The whole body of each writer sits inside the queued callback, the read included: a read taken before the wait is exactly the stale snapshot this exists to prevent. The spacing pass a writer runs on its own result calls the unserialized `applyEmptyLinesAfterImports`, because queued it would wait on the write running it.

A rejected write does not reject the writes behind it, and the map entry is dropped once nothing is queued behind it.

Nothing outside `ImportDocumentEditor` changed: the facade and both call sites keep their signatures and their return values.

## Tests

Three regression tests at the writers themselves, in `src/imports/__tests__/ImportDocumentEditor.test.ts`: a second write not reading while the first is applying, a write queued behind one whose apply rejected, and two documents not blocking each other. The `applyEdit` mock holds each apply open so the interleave is observable.

Verified against the unfixed code — reverting `ImportDocumentEditor.ts` alone fails the first of them with the exact reported shape:

```
    - Expected  - 0
    + Received  + 2

      Array [
        "read",
        "apply",
    +   "read",
    +   "apply",
      ]
```

## Verification

```
$ npm run compile

> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

```
$ npm test

> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 46 passed, 46 total
Tests:       1412 passed, 1412 total
Snapshots:   0 total
Time:        12.811 s
Ran all test suites.
```

```
$ npm run format:check

> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
