### PR TITLE
fix(imports): let the lexer say where a using statement's comment starts

### DIFF
--- a/changelog.d/420.fixed.md
+++ b/changelog.d/420.fixed.md
@@ -1,0 +1,1 @@
+**Verse file scanning**: a path whose quoted segment suffix holds a `#`, such as `Mod'a#b'`, now reads whole, so Organize Imports no longer rewrites it into a different module or adds a duplicate import of it.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -183,13 +183,13 @@ export class ImportFormatter {
      * already imports it. An unbalanced `'` matches neither branch, so the
      * capture ends before it and the remainder pins the line.
      *
-     * A `#` reaching the capture makes the path and the leftover disagree about
-     * where the statement ends, because matchImport strips the comment from the
-     * capture but measures `end` on the unstripped text. The class keeps one
-     * out; the quoted alternative does not, so `using. Foo'a#b'` is only kept
-     * away by isModuleImport, which refuses `Foo'a` before the line is scanned.
-     * Relaxing that gate, or widening this class, brings the disagreement into
-     * reach.
+     * matchImport strips the trailing comment from the capture but measures
+     * `end` on the unstripped text, so anything this class admits that the
+     * strip then removes leaves the path and the leftover disagreeing about
+     * where the statement ended. The class keeps `#` out for that reason. The
+     * quoted alternative admits it and must: a bare `#` inside a suffix is
+     * identifier text, and the strip leaves it alone, so the two still measure
+     * the same characters.
      */
     private static readonly DOTTED_STATEMENT = /^using\.\s*((?:[A-Za-z0-9_./@:()-]|'[^']*')*)/;
 

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { lexVerseLine } from "../utils/verseLexer";
 
 /** Options controlling `ImportFormatter.isModuleImport`'s classification. */
 export interface IsModuleImportOptions {
@@ -23,10 +24,10 @@ export class ImportFormatter {
      *
      * A comment left on the content is re-emitted inside the braces -
      * `using { /X # note }`, where it swallows the closing brace and the
-     * statement no longer parses. A path may hold no `#`, but the captures that
-     * produce one may: the braced capture stops only at its `}`, and the dotted
-     * and indented forms read to end of line. So the comment arrives here still
-     * attached, and this is where it comes off.
+     * statement no longer parses. The captures that produce the content reach
+     * past the statement: the braced capture stops only at its `}`, and the
+     * dotted and indented forms read to end of line. So the comment arrives
+     * here still attached, and this is where it comes off.
      */
     static stripTrailingComment(content: string): string {
         const commentStart = ImportFormatter.commentStartIndex(content);
@@ -53,17 +54,17 @@ export class ImportFormatter {
      * has none. One home for the rule, so the two halves of the split cannot
      * drift apart.
      *
-     * `#` opens a line comment and `<#` opens a block comment. Neither
-     * character is legal in a module path, so the first `#` is always the
-     * start of trivia rather than of the path.
+     * Which `#` opens a comment is the lexer's question, not one to re-decide
+     * here: `IsIdentifierQuotable` (VerseGrammar.h:377) admits a bare `#` inside
+     * a quoted segment suffix, so `Mod'a#b'` is one identifier and splitting at
+     * that `#` yields a different module plus an unterminated suffix left
+     * behind as a comment.
+     *
+     * Content that ends inside an unterminated literal reports no comment, and
+     * so is kept whole rather than split at a `#` the lexer never resolved.
      */
     private static commentStartIndex(content: string): number {
-        const hashIndex = content.indexOf("#");
-        if (hashIndex === -1) {
-            return -1;
-        }
-        // For a `<#` block comment the `<` opens the comment, not the path.
-        return hashIndex > 0 && content[hashIndex - 1] === "<" ? hashIndex - 1 : hashIndex;
+        return lexVerseLine(content, { depth: 0, markerIndent: null }).commentStart;
     }
 
     /**

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -96,6 +96,22 @@ describe("ImportFormatter.stripTrailingComment", () => {
     it("returns an empty string when the content is only a comment", () => {
         expect(ImportFormatter.stripTrailingComment(" # just a note")).toBe("");
     });
+
+    it("keeps a `#` inside a quoted segment suffix, which is identifier text", () => {
+        expect(ImportFormatter.stripTrailingComment(" /mygame@fortnite.com/mygame/Mod'a#b' ")).toBe("/mygame@fortnite.com/mygame/Mod'a#b'");
+    });
+
+    it("splits at the comment after a suffix holding a `#`, not at the one inside it", () => {
+        expect(ImportFormatter.stripTrailingComment("/mygame@fortnite.com/mygame/Mod'a#b' # note")).toBe("/mygame@fortnite.com/mygame/Mod'a#b'");
+    });
+
+    it("splits at the first opener, at an offset into the original text", () => {
+        // Split at the `<#`, as it always has been. Pinned because the offset
+        // is the one thing the lexer's code strings cannot supply: the comment
+        // is removed with nothing in its place, so the code half here is eleven
+        // characters longer than the split point rather than equal to it.
+        expect(ImportFormatter.stripTrailingComment("us<##>ing { /A } # note")).toBe("us");
+    });
 });
 
 describe("ImportFormatter.extractTrailingComment", () => {
@@ -113,6 +129,10 @@ describe("ImportFormatter.extractTrailingComment", () => {
 
     it("returns an empty string when there is no comment", () => {
         expect(ImportFormatter.extractTrailingComment("using { /A }")).toBe("");
+    });
+
+    it("returns an empty string for a `#` inside a quoted segment suffix", () => {
+        expect(ImportFormatter.extractTrailingComment("using { /mygame@fortnite.com/mygame/Mod'a#b' }")).toBe("");
     });
 
     it("recomposes the original with stripTrailingComment, which splits at the same point", () => {

--- a/src/imports/__tests__/ImportFormatter.test.ts
+++ b/src/imports/__tests__/ImportFormatter.test.ts
@@ -106,10 +106,9 @@ describe("ImportFormatter.stripTrailingComment", () => {
     });
 
     it("splits at the first opener, at an offset into the original text", () => {
-        // Split at the `<#`, as it always has been. Pinned because the offset
-        // is the one thing the lexer's code strings cannot supply: the comment
-        // is removed with nothing in its place, so the code half here is eleven
-        // characters longer than the split point rather than equal to it.
+        // Split at the `<#`, as it always has been. Pinned because the split
+        // needs an offset into the original text, which no length taken from
+        // the comment-free code can stand in for.
         expect(ImportFormatter.stripTrailingComment("us<##>ing { /A } # note")).toBe("us");
     });
 });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -5,6 +5,13 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using { /A }", "using { Features }", "using { Economy.Shop }", "code()"])).toEqual(["/A", "Features", "Economy.Shop"]);
     });
 
+    // Truncated at the `#` in its suffix, the path counts as a different module
+    // and the one the file really imports reads as absent, so a diagnostic
+    // asking for it writes a second copy above the `using` already making it.
+    it("collects a path whose quoted segment suffix holds a `#`", () => {
+        expect(allUsingPaths(["using { /mygame@fortnite.com/mygame/Mod'a#b' }"])).toEqual(["/mygame@fortnite.com/mygame/Mod'a#b'"]);
+    });
+
     // The whole reason this exists: scanModuleImports skips indented lines, so
     // an import in a module body is invisible to it.
     // No line of the span writes a `using` statement holding this path: the
@@ -942,6 +949,23 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(lines)).toEqual([
             { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<# disabled below" },
             { path: "/B", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+    });
+
+    it("keeps a path whose quoted segment suffix holds a `#`", () => {
+        // `IsIdentifierQuotable` (VerseGrammar.h:377) excludes `#` only before
+        // a `>`, so a bare one inside a suffix is part of the identifier. Split
+        // at it the entry is still rewritable, and a rebuild from the truncated
+        // path writes a different module with the rest of the real one left
+        // behind as an unterminated comment.
+        expect(scanModuleImports(["using { /mygame@fortnite.com/mygame/Mod'a#b' }"])).toEqual([
+            { path: "/mygame@fortnite.com/mygame/Mod'a#b'", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+        ]);
+    });
+
+    it("splits the real trailing comment of a line whose suffix holds a `#`", () => {
+        expect(scanModuleImports(["using { /mygame@fortnite.com/mygame/Mod'a#b' } # note"])).toEqual([
+            { path: "/mygame@fortnite.com/mygame/Mod'a#b'", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# note" },
         ]);
     });
 

--- a/src/utils/__tests__/verseLexer.test.ts
+++ b/src/utils/__tests__/verseLexer.test.ts
@@ -1,0 +1,55 @@
+import { lexVerseLine } from "../verseLexer";
+
+/** The lexer's entry state for a line nothing above it left open. */
+const atCodeScope = { depth: 0, markerIndent: null };
+
+describe("lexVerseLine commentStart", () => {
+    it("reports -1 for a line holding no comment", () => {
+        expect(lexVerseLine("using { /A }", atCodeScope).commentStart).toBe(-1);
+    });
+
+    it("reports the offset of a line comment", () => {
+        expect(lexVerseLine("using { /A } # note", atCodeScope).commentStart).toBe(13);
+    });
+
+    it("reports the offset of the `<` a block comment opens with", () => {
+        expect(lexVerseLine("using { /A } <# note #>", atCodeScope).commentStart).toBe(13);
+    });
+
+    it("reports the offset of an indented comment marker", () => {
+        expect(lexVerseLine("using { /A } <#> note", atCodeScope).commentStart).toBe(13);
+    });
+
+    it("keeps the first opener when the line holds several", () => {
+        expect(lexVerseLine("us<##>ing { /A } # note", atCodeScope).commentStart).toBe(2);
+    });
+
+    it("passes over a `#` inside a quoted segment suffix", () => {
+        // `IsIdentifierQuotable` (VerseGrammar.h:377) excludes `#` only before a
+        // `>`, so this one is identifier text and the comment is the later one.
+        expect(lexVerseLine("using { /Mod'a#b' } # note", atCodeScope).commentStart).toBe(20);
+    });
+
+    it("passes over a `#` inside a string or char literal", () => {
+        expect(lexVerseLine('Msg := "a#b" # note', atCodeScope).commentStart).toBe(13);
+        expect(lexVerseLine("Hash := '#' # note", atCodeScope).commentStart).toBe(12);
+    });
+
+    it("reports none for a `#` the lexer never resolved, inside an unterminated literal", () => {
+        expect(lexVerseLine("using { /A'x # note", atCodeScope).commentStart).toBe(-1);
+    });
+
+    it("reports 0 for a line whose opener is above it", () => {
+        // 0 even where the line closes that comment and carries live code, which
+        // is why only a depthBefore-0 line may be split on the offset.
+        expect(lexVerseLine("still comment text", { depth: 1, markerIndent: null }).commentStart).toBe(0);
+
+        const closes = lexVerseLine("#> using { /A }", { depth: 1, markerIndent: null });
+        expect(closes.commentStart).toBe(0);
+        expect(closes.hasCode).toBe(true);
+    });
+
+    it("reports 0 for a line inside the body of a `<#>` marker", () => {
+        expect(lexVerseLine("    body text", { depth: 0, markerIndent: 0 }).commentStart).toBe(0);
+    });
+});

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -133,8 +133,12 @@ export interface LexedLine {
      * `codeWithoutComments` removes comments without replacement, so on a line
      * with an interior comment it is shorter than the offset it would be read
      * as, and `masked` blanks literals as well and so cannot tell trivia from
-     * literal text. A caller splitting a line into its code and its trailing
-     * annotation reads this.
+     * literal text.
+     *
+     * Only a split at `depthBefore` 0 may be taken from this. A line that
+     * begins inside a comment reports 0 and can still close it and carry live
+     * code - `#> using { /A }` at depth 1 - so a caller slicing on the offset
+     * there reads a whole statement as annotation.
      */
     commentStart: number;
     /**

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -125,6 +125,19 @@ export interface LexedLine {
      */
     endedOpen: boolean;
     /**
+     * Index into the line of the first comment opener on it, or -1 when it
+     * holds none. 0 when the line opens already inside a comment, whose opener
+     * is above it.
+     *
+     * An offset into the original text, which neither code string can supply:
+     * `codeWithoutComments` removes comments without replacement, so on a line
+     * with an interior comment it is shorter than the offset it would be read
+     * as, and `masked` blanks literals as well and so cannot tell trivia from
+     * literal text. A caller splitting a line into its code and its trailing
+     * annotation reads this.
+     */
+    commentStart: number;
+    /**
      * The line's text with every comment removed and nothing put in its place,
      * so text on either side of one joins. That is what it is for: a comment
      * splicing a token apart, `us<##>ing { /A }`, rejoins into a `using` a
@@ -208,6 +221,9 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     // a line comment ends with its line - but what it opened need not, so this
     // says only that the text left is trivia, never that it holds no opener.
     let insideLineComment = false;
+    // Already inside one when the line begins, so the opener is above it and
+    // every character from the first is trivia.
+    let commentStart = depthBefore > 0 || insideIndentedComment ? 0 : -1;
     let i = 0;
 
     // What is open at this point, innermost last, and empty at code scope. A
@@ -221,6 +237,13 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     /** Records one character as comment text: blanked in `masked`, absent from both code strings. */
     const commentChar = (): void => {
         masked += " ";
+    };
+
+    /** Records that trivia opens here, keeping the first opener when the line holds several. */
+    const opensComment = (): void => {
+        if (commentStart === -1) {
+            commentStart = i;
+        }
     };
 
     while (i < line.length) {
@@ -277,6 +300,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
             // opener of its own: at `EPlace::IndCmt` a `<#>` nests another
             // indented comment rather than a block.
             opensIndentedComment = true;
+            opensComment();
             for (; i < line.length; i++) {
                 commentChar();
             }
@@ -296,6 +320,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         // S05, so there is no depth for it to close.
         if (line[i] === "#" && innermost?.kind !== "literal") {
             insideLineComment = true;
+            opensComment();
             commentChar();
             i += 1;
             continue;
@@ -303,6 +328,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
 
         if (line.startsWith("<#", i)) {
             nesting += 1;
+            opensComment();
             commentChar();
             commentChar();
             i += 2;
@@ -390,6 +416,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         opensIndentedComment,
         hasCode,
         endedOpen: open.length > 0,
+        commentStart,
         codeWithoutComments,
         codeOutsideLiterals,
         masked,


### PR DESCRIPTION
Closes #420

## The defect

`ImportFormatter.commentStartIndex` found a `using` statement's trailing comment with a raw `content.indexOf("#")`, under a doc comment asserting that no `#` is legal in a module path. The grammar does not say that. `IsIdentifierQuotable` (`VerseGrammar.h:377`) reads

```cpp
... && (c0 != '<' || c1 != '#') && (c0 != '#' || c1 != '>')
```

so a bare `#` inside a quoted segment suffix is identifier text; only `#>` is excluded. `src/utils/verseLexer.ts` already encodes exactly that, and `masked` and `codeOutsideLiterals` both keep such a suffix whole. Only the formatter's own scan disagreed.

For `using { /mygame@fortnite.com/mygame/Mod'a#b' }` the scan recorded `path` as `/mygame@fortnite.com/mygame/Mod'a` and `trailingComment` as `#b' }`, while leaving `rebuildLosesText: false`. Organize Imports could then rebuild the line as `using { /mygame@fortnite.com/mygame/Mod'a } #b' }` — a different module, with an unterminated suffix behind it. The truncated path also failed to count as present, so the file could gain a duplicate import of a module it already named.

## The change

`lexVerseLine` now reports the offset of the first comment opener on a line as `LexedLine.commentStart`, recorded at the three sites the walk already recognises one. `commentStartIndex` reads that instead of re-deciding the rule, so both halves of the split keep their single home and still recompose.

The issue suggested deriving the code half from `codeWithoutComments`. That was not taken: it removes comments with no replacement, so on a line holding an interior comment its length is not the split offset and the slice cuts mid-token — and being a string rather than an offset, it can serve `stripTrailingComment` but leaves `extractTrailingComment` with nothing to split on, which is exactly the drift the "one home for the rule" contract exists to prevent.

Two doc comments went with the change: the false grammar claim on `commentStartIndex`, and a paragraph on `DOTTED_STATEMENT` warning of a path/`end` disagreement that this fix removes.

Semantics are otherwise unchanged. An exhaustive A/B over every string of length ≤ 4 across `# < > ' " { } A / space` found 1028 differences from the old implementation and **zero** where the new split is earlier or finds a comment the old one missed — the change is a strict narrowing.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`:

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 47 passed, 47 total
Tests:       1426 passed, 1426 total
Snapshots:   0 total
Time:        9.941 s
Ran all test suites.
```

`npm run format:check`:

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The regression tests were proved to detect the defect: with the two sources reverted to their pre-fix state, 6 of the 7 new import tests fail with exactly the values the issue predicted (`path` truncated to `.../Mod'a`, `trailingComment` `#b' }`). The seventh pins existing first-opener behaviour and passes either way, by design.

## Review

One round at opus, verdict `PASS_WITH_SUGGESTIONS` — no Critical, no Important findings. It probed 19 areas, including all three `using` styles, fragment-versus-whole-line lexing, unterminated literals, interpolation, CRLF and tabs, and the local-scope `using{Instance}` meaning. All four suggestions were applied: the stale `DOTTED_STATEMENT` paragraph, a contract bound on `commentStart` for lines that begin inside a comment, a trimmed test comment, and direct coverage of the new field in `src/utils/__tests__/verseLexer.test.ts`.
