### PR TITLE
fix(imports): route both conversion directions through one resolver

### DIFF
--- a/changelog.d/392.fixed.md
+++ b/changelog.d/392.fixed.md
@@ -1,0 +1,1 @@
+**Relative path conversion**: converting an import to its relative form now declines when the shorter spelling would reach a different module or none, instead of writing an import that silently points elsewhere.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -657,15 +657,19 @@ export class ImportPathConverter {
      * find. None means nothing here can place the module, which is exactly the
      * position this check exists to stop a conversion being written from.
      *
-     * Two blind spots, both inherited from the search rather than added here.
-     * A namesake that exists only as an explicit `X := module` declaration is
-     * invisible while a folder answers first, because the declaration scan runs
-     * only when the folder phases found nothing. And a folder whose name
-     * differs from the reference only in case satisfies the search on a
-     * case-insensitive filesystem, so this confirms the casing it asked about
-     * rather than the casing on disk.
+     * The check is only as good as the search under it, and that search has
+     * blind spots this does not close - these among them, rather than these
+     * alone. A namesake that exists only as an explicit `X := module`
+     * declaration is invisible while a folder answers first, because the
+     * declaration scan runs only when the folder phases found nothing. A folder
+     * whose name differs from the reference only in case satisfies the search
+     * on a case-insensitive filesystem, so this confirms the casing it asked
+     * about rather than the casing on disk. And the scanning phases read
+     * `workspaceFolders[0]` rather than the folder holding the document, so in
+     * a multi-root workspace they can answer from a tree the importing file is
+     * nowhere in.
      */
-    private async referenceResolvesTo(reference: string, fullPath: string, documentUri: vscode.Uri | undefined, projectVersePath: string): Promise<boolean> {
+    private async referenceResolvesTo(reference: string, fullPath: string, documentUri: vscode.Uri, projectVersePath: string): Promise<boolean> {
         const referenceSegments = reference.split(".");
         const firstSegment = referenceSegments[0];
         const fullSegments = ImportPathConverter.splitPath(fullPath);

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -649,14 +649,21 @@ export class ImportPathConverter {
      * descends the segments after it byte-exact from whichever match it takes.
      * So a nearer module of that name decides the whole reference, and one that
      * does not carry the rest of the chain breaks a reference whose full chain
-     * exists elsewhere - which is why matching the whole chain would confirm a
-     * spelling the compiler cannot read.
+     * exists elsewhere.
      *
      * Anything but one location refuses. Two or more mean a nearer namesake
      * shadows the target or clashes with it, and no relative spelling reaches
      * past it, so there is no conversion to offer rather than a longer one to
      * find. None means nothing here can place the module, which is exactly the
      * position this check exists to stop a conversion being written from.
+     *
+     * Two blind spots, both inherited from the search rather than added here.
+     * A namesake that exists only as an explicit `X := module` declaration is
+     * invisible while a folder answers first, because the declaration scan runs
+     * only when the folder phases found nothing. And a folder whose name
+     * differs from the reference only in case satisfies the search on a
+     * case-insensitive filesystem, so this confirms the casing it asked about
+     * rather than the casing on disk.
      */
     private async referenceResolvesTo(reference: string, fullPath: string, documentUri: vscode.Uri | undefined, projectVersePath: string): Promise<boolean> {
         const referenceSegments = reference.split(".");
@@ -686,7 +693,10 @@ export class ImportPathConverter {
      * The relative form of an absolute import, in the style the author wrote,
      * or null when there is none to give: a built-in module, an import that
      * was never absolute, a workspace with no `.uefnproject` to take the
-     * project path from, or a path that shortens to nothing.
+     * project path from, a path outside the project, a path that shortens to
+     * nothing, an importing file the Content root does not hold, or a
+     * shortened form that does not resolve back to the module the absolute
+     * path named.
      *
      * Shortened against the module the importing file sits in, which is the
      * dialect the compiler speaks: its own suggestions arrive spelled that way
@@ -698,18 +708,15 @@ export class ImportPathConverter {
      * choose between.
      *
      * Shortening is proposed, not trusted: the reference is resolved back
-     * through the same workspace search the other direction uses, and a
-     * reference that does not name the module the absolute path named is
-     * refused. Refusing is the only safe answer available - the conversion
-     * writes over an import that compiles today, so a spelling this cannot
-     * confirm would trade a working import for a broken or a silently
-     * different one.
+     * through the same workspace search the other direction uses. Refusing is
+     * the only safe answer available, because the conversion writes over an
+     * import that compiles today.
      *
-     * @param documentUri The file the import is written in. Without it the
-     *   project root stands in as the scope, which is what shortens an import
-     *   when the file cannot be placed under Content.
+     * @param documentUri The file the import is written in. It must sit under
+     *   the project's Content root, since that placement is both the scope to
+     *   shorten against and the vantage point the result is verified from.
      */
-    async convertFromFullPath(importStatement: string, documentUri?: vscode.Uri, line?: number): Promise<ImportConversionResult | null> {
+    async convertFromFullPath(importStatement: string, documentUri: vscode.Uri, line?: number): Promise<ImportConversionResult | null> {
         if (this.isBuiltinModule(importStatement)) {
             logger.debug("ImportPathConverter", "Cannot convert built-in module to relative path");
             return null;
@@ -749,7 +756,18 @@ export class ImportPathConverter {
             return null;
         }
 
-        const scopePath = (documentUri && this.enclosingModulePath(documentUri, projectVersePath)) || projectVersePath;
+        // A file the Content root does not hold has no module scope, and
+        // standing the project root in for one was a guess the verification
+        // cannot catch: only the first phase of the module search walks outward
+        // from the document, and the phases behind it scan the workspace, so
+        // they answer the same for any file that asks. They would confirm a
+        // reference written into a scope nothing here can name.
+        const scopePath = this.enclosingModulePath(documentUri, projectVersePath);
+        if (!scopePath) {
+            logger.debug("ImportPathConverter", `Cannot place the importing file under the project's Content root: ${documentUri.fsPath}`);
+            return null;
+        }
+
         const shortened = ImportPathConverter.relativizeAgainst(fullPath, scopePath, projectSegments.length);
 
         // Nothing left over means the target is the importing file's own module

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -538,29 +538,72 @@ export class ImportPathConverter {
         return locations;
     }
 
+    /** Path segments with the leading slash and any empty segments dropped. */
+    private static splitPath(versePath: string): string[] {
+        return versePath.split("/").filter((segment) => segment);
+    }
+
+    /**
+     * How many leading segments two paths share, comparing the first
+     * `foldSegments` of them folded ASCII-only and every segment after that
+     * byte-exact.
+     *
+     * The fold is bounded because the two halves of a Verse path answer to
+     * different rules. The project prefix is not resolved by anything: it names
+     * the package, and the same package reaches this code spelled two ways -
+     * one from the `.uefnproject`, one from a compiler diagnostic - so folding
+     * it absorbs a drift that is not a difference. Every segment below the
+     * prefix is a module name the compiler resolves byte-exact, so `Shop` and
+     * `shop` there are two modules, and folding them names the wrong one.
+     *
+     * Epic folds the whole path (ConvertFullVersePathToRelativeDotSyntax), but
+     * only ever for a definition it has already resolved in the same package,
+     * so the fold never has to be right about which module a segment names.
+     *
+     * Segments are compared whole, a deliberate divergence: Epic walks
+     * characters and, when one path runs out inside the other's segment, ends
+     * the common part mid-label, so `/proj/Economy/Shop` against a scope at
+     * `/proj/Econ` yields `omy.Shop` there.
+     */
+    private static sharedSegmentCount(pathSegments: string[], baseSegments: string[], foldSegments: number): number {
+        const foldAscii = (segment: string): string => segment.replace(/[a-z]/g, (character) => character.toUpperCase());
+
+        let common = 0;
+        while (common < pathSegments.length && common < baseSegments.length) {
+            const matches = common < foldSegments ? foldAscii(pathSegments[common]) === foldAscii(baseSegments[common]) : pathSegments[common] === baseSegments[common];
+            if (!matches) break;
+            common++;
+        }
+
+        return common;
+    }
+
+    /**
+     * Whether two absolute Verse paths name the same module, under the same
+     * prefix rule sharedSegmentCount applies.
+     *
+     * Needed because the two paths reaching the round-trip check are spelled by
+     * different sources: the rebuilt one carries the `.uefnproject` prefix and
+     * the one from the document carries whatever the author wrote.
+     */
+    private static namesSameModule(pathA: string, pathB: string, foldSegments: number): boolean {
+        const segmentsA = ImportPathConverter.splitPath(pathA);
+        const segmentsB = ImportPathConverter.splitPath(pathB);
+
+        return segmentsA.length === segmentsB.length && ImportPathConverter.sharedSegmentCount(segmentsA, segmentsB, foldSegments) === segmentsA.length;
+    }
+
     /**
      * The dotted reference naming `fullPath` from a scope at `basePath`: the
      * segments left after the longest prefix the two paths share, joined with
      * ".". Empty when nothing is left, which is a path naming the base itself.
      *
-     * Segments are compared whole and folded ASCII-only, which is Epic's rule
-     * for this one conversion rather than a claim that Verse resolves paths
-     * case-insensitively - it does not.
-     *
-     * Comparing whole segments is a deliberate divergence. Epic walks
-     * characters and, when one path runs out inside the other's segment, ends
-     * the common part mid-label: `/proj/Economy/Shop` against a scope at
-     * `/proj/Econ` yields `omy.Shop` there.
+     * @param foldSegments how many leading segments are the project prefix, the
+     *   only part compared case-insensitively
      */
-    private static relativizeAgainst(fullPath: string, basePath: string): string {
-        const foldAscii = (segment: string): string => segment.replace(/[a-z]/g, (character) => character.toUpperCase());
-        const fullSegments = fullPath.split("/").filter((segment) => segment);
-        const baseSegments = basePath.split("/").filter((segment) => segment);
-
-        let common = 0;
-        while (common < fullSegments.length && common < baseSegments.length && foldAscii(fullSegments[common]) === foldAscii(baseSegments[common])) {
-            common++;
-        }
+    private static relativizeAgainst(fullPath: string, basePath: string, foldSegments: number): string {
+        const fullSegments = ImportPathConverter.splitPath(fullPath);
+        const common = ImportPathConverter.sharedSegmentCount(fullSegments, ImportPathConverter.splitPath(basePath), foldSegments);
 
         return fullSegments.slice(common).join(".");
     }
@@ -597,6 +640,49 @@ export class ImportPathConverter {
     }
 
     /**
+     * Whether `reference`, written in the file at `documentUri`, names the
+     * module `fullPath` names.
+     *
+     * Only the reference's first segment is looked up, because only that
+     * segment is resolved through the scope chain: the compiler walks the
+     * importing scope's parents collecting a match at every level, then
+     * descends the segments after it byte-exact from whichever match it takes.
+     * So a nearer module of that name decides the whole reference, and one that
+     * does not carry the rest of the chain breaks a reference whose full chain
+     * exists elsewhere - which is why matching the whole chain would confirm a
+     * spelling the compiler cannot read.
+     *
+     * Anything but one location refuses. Two or more mean a nearer namesake
+     * shadows the target or clashes with it, and no relative spelling reaches
+     * past it, so there is no conversion to offer rather than a longer one to
+     * find. None means nothing here can place the module, which is exactly the
+     * position this check exists to stop a conversion being written from.
+     */
+    private async referenceResolvesTo(reference: string, fullPath: string, documentUri: vscode.Uri | undefined, projectVersePath: string): Promise<boolean> {
+        const referenceSegments = reference.split(".");
+        const firstSegment = referenceSegments[0];
+        const fullSegments = ImportPathConverter.splitPath(fullPath);
+
+        // The first segment names the path with one segment dropped for each
+        // segment written after it.
+        const expectedPath = `/${fullSegments.slice(0, fullSegments.length - (referenceSegments.length - 1)).join("/")}`;
+
+        const locations = await this.findModuleLocations(firstSegment, documentUri);
+        if (locations.length !== 1) {
+            logger.debug("ImportPathConverter", `Refusing '${reference}' for ${fullPath}: '${firstSegment}' resolves to ${locations.length} locations, not one`);
+            return false;
+        }
+
+        const resolved = ImportPathConverter.buildFullVersePath(projectVersePath, locations[0], firstSegment);
+        if (!ImportPathConverter.namesSameModule(resolved, expectedPath, ImportPathConverter.splitPath(projectVersePath).length)) {
+            logger.debug("ImportPathConverter", `Refusing '${reference}' for ${fullPath}: '${firstSegment}' resolves to ${resolved}, not ${expectedPath}`);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * The relative form of an absolute import, in the style the author wrote,
      * or null when there is none to give: a built-in module, an import that
      * was never absolute, a workspace with no `.uefnproject` to take the
@@ -611,10 +697,13 @@ export class ImportPathConverter {
      * The other direction has a whole workspace of candidate locations to
      * choose between.
      *
-     * A path outside this project is not refused, only shortened by whatever
-     * prefix it does share: another project under the same account keeps its
-     * own project segment, a different account keeps every segment. Neither
-     * resolves here.
+     * Shortening is proposed, not trusted: the reference is resolved back
+     * through the same workspace search the other direction uses, and a
+     * reference that does not name the module the absolute path named is
+     * refused. Refusing is the only safe answer available - the conversion
+     * writes over an import that compiles today, so a spelling this cannot
+     * confirm would trade a working import for a broken or a silently
+     * different one.
      *
      * @param documentUri The file the import is written in. Without it the
      *   project root stands in as the scope, which is what shortens an import
@@ -646,8 +735,22 @@ export class ImportPathConverter {
             return null;
         }
 
+        const projectSegments = ImportPathConverter.splitPath(projectVersePath);
+
+        // A path the project does not contain has no relative form from inside
+        // it, whatever prefix the two happen to share. Shortening one anyway
+        // emits a first segment that either cannot lex - `@` is not an Ident
+        // character, so a foreign account's segment is a parse error - or names
+        // whatever local module happens to answer to it. Both replace a broken
+        // import with a differently broken one that can no longer be converted
+        // back.
+        if (ImportPathConverter.sharedSegmentCount(ImportPathConverter.splitPath(fullPath), projectSegments, projectSegments.length) < projectSegments.length) {
+            logger.debug("ImportPathConverter", `Cannot shorten a path outside the project: ${fullPath}`);
+            return null;
+        }
+
         const scopePath = (documentUri && this.enclosingModulePath(documentUri, projectVersePath)) || projectVersePath;
-        const shortened = ImportPathConverter.relativizeAgainst(fullPath, scopePath);
+        const shortened = ImportPathConverter.relativizeAgainst(fullPath, scopePath, projectSegments.length);
 
         // Nothing left over means the target is the importing file's own module
         // or an ancestor of it. The module still has a name, and whatever
@@ -657,11 +760,15 @@ export class ImportPathConverter {
         // this does not hold for: what encloses it is the registry rather than
         // a scope the file sits in. That test shortens against the root rather
         // than comparing prefixes, so both halves fold case the same way.
-        const belowProjectRoot = ImportPathConverter.relativizeAgainst(fullPath, projectVersePath);
+        const belowProjectRoot = ImportPathConverter.relativizeAgainst(fullPath, projectVersePath, projectSegments.length);
         const relativeImportPath = shortened || (belowProjectRoot ? fullPath.substring(fullPath.lastIndexOf("/") + 1) : "");
 
         if (!relativeImportPath) {
             logger.debug("ImportPathConverter", "Could not extract relative path from full path");
+            return null;
+        }
+
+        if (!(await this.referenceResolvesTo(relativeImportPath, fullPath, documentUri, projectVersePath))) {
             return null;
         }
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -568,17 +568,19 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
     });
 
     // The two below used to shorten against the project root as a fallback. A
-    // file the module search cannot place is a file whose scope is unknown, and
-    // a reference written into an unknown scope is a guess: nothing here can
-    // say which module it reaches, or whether it reaches one at all. The
-    // conversion overwrites an import that compiles, so a guess is the one
-    // thing it must not write.
+    // file the Content root does not hold has no module scope, and a reference
+    // written into a scope nothing can name is a guess: neither which module it
+    // reaches nor whether it reaches one is answerable. The conversion
+    // overwrites an import that compiles, so a guess is the one thing it must
+    // not write.
     it("offers no conversion for a file outside Content", async () => {
         expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Plugins/Feature.verse`))).toBeUndefined();
     });
 
     it("offers no conversion when no workspace folder holds the file", async () => {
-        setWorkspaceFolders(undefined);
+        // A folder is open, just not one this file sits under - which is what
+        // leaves the file unplaceable, rather than the workspace being empty.
+        setWorkspaceFolders([{ uri: { fsPath: "C:/Elsewhere" }, name: "Elsewhere", index: 0 }]);
 
         expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, fileAt("Systems/Economy"))).toBeUndefined();
     });
@@ -642,6 +644,23 @@ describe("ImportPathConverter.convertFromFullPath resolve-back", () => {
     afterEach(() => {
         setWorkspaceFolders(undefined);
         (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+    });
+
+    it("offers no conversion for a file the Content root does not hold, even with the project scanned", async () => {
+        // The check cannot speak for a file it cannot place. Only the first
+        // phase of the module search walks outward from the document; the
+        // phases behind it scan the workspace, and answer the same for any
+        // file that asks - so they confirm a reference for a scope nothing
+        // here knows, and the conversion writes it.
+        //
+        // Stubbing findFiles is what makes this test honest. Left at the
+        // mock's empty default it passes against the unguarded code too,
+        // which is not the case production runs.
+        stubFolderTree(workspaceRoot, ["Systems", "Systems/Economy", "Systems/Economy/Shop"]);
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([vscode.Uri.file(`${workspaceRoot}/Content/Systems/Economy/Shop/Item.verse`)]);
+
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Plugins/Feature.verse`))).toBeUndefined();
     });
 
     it("offers no conversion when a namesake sits between the file and the target", async () => {

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -323,6 +323,28 @@ function applyOperation(text: string, operation: RecordedOperation, eol: "\n" | 
     return text.slice(0, offsetOf(operation.range!.start)) + operation.text + text.slice(offsetOf(operation.range!.end));
 }
 
+/** workspaceFolders is readonly in the real typings; the mock is writable. */
+function setWorkspaceFolders(folders: unknown): void {
+    (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+}
+
+/**
+ * Answers `fs.stat` from a list of Content-relative directories, so a test can
+ * express the project as the tree the module search walks.
+ *
+ * Case-sensitive, unlike a Windows filesystem, which is what lets a test hold
+ * `Shop` and `shop` as two directories: the conversion has to keep them apart
+ * because the compiler resolves module names byte-exact, and a stat that folded
+ * them would hide the very drift under test.
+ */
+function stubFolderTree(workspaceRoot: string, folders: string[]): void {
+    (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+        const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${workspaceRoot}/Content/`, "");
+        if (!folders.includes(contentRelative)) throw new Error("ENOENT");
+        return { type: vscode.FileType.Directory };
+    });
+}
+
 /** A converter with project path resolution pinned, so conversion is pure string work. */
 function converterWithProjectPath(projectVersePath: string): ImportPathConverter {
     const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
@@ -365,9 +387,24 @@ describe("ImportPathConverter import classification", () => {
 
 describe("ImportPathConverter.convertFromFullPath", () => {
     const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+
+    /**
+     * The importing file, at the Content root so the project root is the scope
+     * it shortens against - which is what these assertions were written for,
+     * back when the conversion took no document at all.
+     */
+    const documentUri = vscode.Uri.file(`${workspaceRoot}/Content/Feature.verse`);
 
     beforeEach(() => {
         applyEditMock().mockClear();
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubFolderTree(workspaceRoot, ["Economy", "Economy/Shop"]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
     });
 
     it("leaves the comment trailing a dotted import out of the converted path", async () => {
@@ -376,7 +413,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         // restores it, writes it twice.
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # only the shop, not the vendor", undefined, 0);
+        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # only the shop, not the vendor", documentUri, 0);
 
         expect(result?.convertedImport).toBe("using. Economy.Shop");
         expect(result?.moduleName).toBe("Shop");
@@ -385,7 +422,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
     it("leaves the comment trailing a braced import out of the converted path", async () => {
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # only the shop", undefined, 0);
+        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # only the shop", documentUri, 0);
 
         expect(result?.convertedImport).toBe("using { Economy.Shop }");
     });
@@ -396,7 +433,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         // author asking for braced syntax.
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # use {braces} here", undefined, 0);
+        const result = await converter.convertFromFullPath("using. /mygame@fortnite.com/mygame/Economy/Shop # use {braces} here", documentUri, 0);
 
         expect(result?.convertedImport).toBe("using. Economy.Shop");
     });
@@ -406,7 +443,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         // a braced import its braces, whatever the comment happens to hold.
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # see {Vendor}", undefined, 0);
+        const result = await converter.convertFromFullPath("using { /mygame@fortnite.com/mygame/Economy/Shop } # see {Vendor}", documentUri, 0);
 
         expect(result?.convertedImport).toBe("using { Economy.Shop }");
     });
@@ -420,7 +457,7 @@ describe("ImportPathConverter.convertFromFullPath", () => {
         const document = fakeDocument([line, "", "code()"]);
         const converter = converterWithProjectPath(projectVersePath);
 
-        const result = await converter.convertFromFullPath(line, undefined, 0);
+        const result = await converter.convertFromFullPath(line, documentUri, 0);
         expect(await converter.applyConversion(document, result!)).toBe(true);
 
         expect(replacedOperation().text).toBe("using. Economy.Shop # see Economy/Vendor");
@@ -431,10 +468,18 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
     const projectVersePath = "/mygame@fortnite.com/mygame";
     const workspaceRoot = "C:/Project";
 
-    /** workspaceFolders is readonly in the real typings; the mock is writable. */
-    const setWorkspaceFolders = (folders: unknown): void => {
-        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
-    };
+    /**
+     * Every folder the project holds, as Content-relative paths.
+     *
+     * The whole suite runs against a real tree, not only the round trip below
+     * it: the conversion resolves the reference it emits back through the
+     * module search, so a shortening asserted over an empty workspace would be
+     * asserting the refusal rather than the spelling.
+     */
+    // UI/Shop is a namesake of Systems/Economy/Shop parked off the walk out of
+    // Systems/Economy, so the suite also holds the conversion open: only a
+    // namesake the compiler would actually reach may refuse one.
+    const folders = ["Systems", "Systems/Economy", "Systems/Economy/Shop", "Systems/Inventory", "UI", "UI/HUD", "UI/HUD/Textures", "UI/Shop"];
 
     /** A file in a module under the project's Content root, which is what places the importing scope. */
     const fileAt = (contentRelativeDir: string): vscode.Uri => vscode.Uri.file(`${workspaceRoot}/Content/${contentRelativeDir}/Feature.verse`);
@@ -448,10 +493,12 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
 
     beforeEach(() => {
         setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubFolderTree(workspaceRoot, folders);
     });
 
     afterEach(() => {
         setWorkspaceFolders(undefined);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
     });
 
     it("names a module in the importing file's own module by its bare name", async () => {
@@ -479,6 +526,13 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
         // Epic's own converter walks characters and ends the common part
         // mid-label when one path runs out inside the other's segment, which
         // would make this `omy.Shop`.
+        //
+        // Its own tree: a Content-level Economy beside the suite's
+        // Systems/Economy would be a second module of that name on the walk out
+        // of Systems/Economy, which the conversion refuses - correctly, and for
+        // a reason this test is not about.
+        stubFolderTree(workspaceRoot, ["Econ", "Economy", "Economy/Shop"]);
+
         expect(await relativeFormOf(`${projectVersePath}/Economy/Shop`, fileAt("Econ"))).toBe("using. Economy.Shop");
     });
 
@@ -507,20 +561,26 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
         expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Content/Systems/Economy/Feature.verse`))).toBe("using. Shop");
     });
 
-    // The three fallbacks below are the pre-existing root-relative behaviour,
-    // which is what a file with no module of its own to shorten against gets.
     it("shortens against the project root for a file at the Content root", async () => {
+        // The project root is a scope the file really does sit in, so the
+        // reference it produces resolves - unlike the two fallbacks below.
         expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Content/Feature.verse`))).toBe("using. Systems.Economy.Shop");
     });
 
-    it("shortens against the project root for a file outside Content", async () => {
-        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Plugins/Feature.verse`))).toBe("using. Systems.Economy.Shop");
+    // The two below used to shorten against the project root as a fallback. A
+    // file the module search cannot place is a file whose scope is unknown, and
+    // a reference written into an unknown scope is a guess: nothing here can
+    // say which module it reaches, or whether it reaches one at all. The
+    // conversion overwrites an import that compiles, so a guess is the one
+    // thing it must not write.
+    it("offers no conversion for a file outside Content", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, vscode.Uri.file(`${workspaceRoot}/Plugins/Feature.verse`))).toBeUndefined();
     });
 
-    it("shortens against the project root when no workspace folder holds the file", async () => {
+    it("offers no conversion when no workspace folder holds the file", async () => {
         setWorkspaceFolders(undefined);
 
-        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, fileAt("Systems/Economy"))).toBe("using. Systems.Economy.Shop");
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Economy/Shop`, fileAt("Systems/Economy"))).toBeUndefined();
     });
 
     it("names an ancestor of the importing file's module by its own name", async () => {
@@ -542,21 +602,6 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
     // assumes, so it recomposes the path from its own input and cannot see the
     // reverse direction failing to place a spelling this one writes.
     describe("round trip through the real module search", () => {
-        /** Every folder the project holds, as Content-relative paths. */
-        const folders = ["Systems", "Systems/Economy", "Systems/Economy/Shop", "Systems/Inventory", "UI", "UI/HUD", "UI/HUD/Textures"];
-
-        beforeEach(() => {
-            (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
-                const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${workspaceRoot}/Content/`, "");
-                if (!folders.includes(contentRelative)) throw new Error("ENOENT");
-                return { type: vscode.FileType.Directory };
-            });
-        });
-
-        afterEach(() => {
-            (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
-        });
-
         it.each([
             ["a module inside the file's own module", "Systems/Economy/Shop"],
             ["a module beside the file's own module", "Systems/Inventory"],
@@ -572,6 +617,86 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
 
             expect((await converter.convertToFullPath(relative!.convertedImport, fileUri, 0))?.convertedImport).toBe(absolute);
         });
+    });
+});
+
+// The relative form is a proposal until the module search confirms it names
+// the module the absolute path named. Before that check, going relative was
+// string arithmetic that consulted nothing, so every case below wrote a
+// compiling import that reached a different module, or none.
+describe("ImportPathConverter.convertFromFullPath resolve-back", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+
+    const fileAt = (contentRelativeDir: string): vscode.Uri => vscode.Uri.file(`${workspaceRoot}/Content/${contentRelativeDir}/Feature.verse`);
+
+    async function relativeFormOf(fullPath: string, fileUri: vscode.Uri): Promise<string | undefined> {
+        const converter = converterWithProjectPath(projectVersePath);
+        return (await converter.convertFromFullPath(`using. ${fullPath}`, fileUri, 0))?.convertedImport;
+    }
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("offers no conversion when a namesake sits between the file and the target", async () => {
+        // `using. Weapons` in Content/Systems resolves through Systems first,
+        // where a Weapons of its own is waiting. The file still compiles, and
+        // imports the other module.
+        stubFolderTree(workspaceRoot, ["Weapons", "Systems", "Systems/Weapons"]);
+
+        expect(await relativeFormOf(`${projectVersePath}/Weapons`, fileAt("Systems"))).toBeUndefined();
+    });
+
+    it("offers no conversion when a nearer namesake takes the first segment and carries nothing below it", async () => {
+        // Systems/UI holds no HUD, so `using. UI.HUD.Textures` resolves UI to
+        // the near one and then fails - while the chain it was shortened from
+        // exists whole at the Content root. This is why the first segment is
+        // what gets resolved: matching UI/HUD/Textures as one path finds the
+        // root copy, reports a single location, and confirms a reference the
+        // compiler cannot read.
+        stubFolderTree(workspaceRoot, ["UI", "UI/HUD", "UI/HUD/Textures", "Systems", "Systems/UI"]);
+
+        expect(await relativeFormOf(`${projectVersePath}/UI/HUD/Textures`, fileAt("Systems"))).toBeUndefined();
+    });
+
+    it("keeps a conversion whose only namesake is off the path the compiler walks", async () => {
+        // The other half of that rule: a namesake the scope walk never reaches
+        // is not a reason to refuse.
+        stubFolderTree(workspaceRoot, ["UI", "UI/Weapons", "Systems", "Systems/Weapons"]);
+
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Weapons`, fileAt("Systems"))).toBe("using. Weapons");
+    });
+
+    it.each([
+        ["a foreign account", "/other@fortnite.com/mygame/Gadgets"],
+        ["a sibling project under the same account", "/mygame@fortnite.com/otherproject/Gadgets"],
+    ])("offers no conversion for a path outside the project: %s", async (_name, fullPath) => {
+        // Shortened by whatever prefix it shared, the foreign account emitted
+        // `other@fortnite.com.mygame.Gadgets`, whose first segment cannot lex -
+        // `@` is not an identifier character - and the sibling project emitted
+        // a reference that resolves nowhere here. Both replaced an import that
+        // was already broken with one that no longer converts back.
+        stubFolderTree(workspaceRoot, ["Systems", "Gadgets"]);
+
+        expect(await relativeFormOf(fullPath, fileAt("Systems"))).toBeUndefined();
+    });
+
+    it("keeps two folder names that differ only in case apart", async () => {
+        // The case fold used to run the length of the walk, so `shop` and
+        // `Shop` counted as one segment and the reference came out as `Item` -
+        // shop's own Item, or nothing. Only the project prefix is folded now,
+        // because that is where one package legitimately reaches this code
+        // spelled two ways; below it a segment is a module name the compiler
+        // resolves byte-exact.
+        stubFolderTree(workspaceRoot, ["shop", "Shop", "Shop/Item"]);
+
+        expect(await relativeFormOf(`${projectVersePath}/Shop/Item`, fileAt("shop"))).toBe("using. Shop.Item");
     });
 });
 


### PR DESCRIPTION
Closes #392

Going relative was pure string arithmetic that never consulted the module search the other direction runs, so nothing established that the reference it emitted named the module the absolute path named.

## What changed

**The reference is resolved back before it is written.** After building the relative form, `convertFromFullPath` resolves its **first segment** through `findModuleLocations` and requires the one location it returns to rebuild the path that segment must name. First segment, not the whole chain: the compiler resolves only that through the scope chain and then descends byte-exact from whichever match it takes (`SemanticScope.cpp:521-535`), so a nearer namesake carrying nothing below it breaks a reference whose full chain matches elsewhere — and matching the chain as one path would confirm a spelling the compiler cannot read. Anything but one location refuses: two or more mean no relative spelling reaches past the namesake at all.

**A path the project does not contain is refused** rather than shortened by whatever prefix it happened to share. That emitted a first segment containing `@`, which cannot lex (`VerseGrammar.h:1953-1954`), or one naming whatever local module answered to it.

**The ASCII case fold is bounded to the project prefix.** Below it a segment is a module name the compiler resolves byte-exact (`SemanticAnalyzer.cpp:6240-6243`), so folding made `shop` and `Shop` one module. The prefix stays folded because one package legitimately reaches this code spelled two ways. Epic folds the whole path, but only behind a same-package gate (`SemanticAnalyzer.cpp:12145-12184`, `12234-12236`); this adds the gate.

**An importing file the Content root does not hold is refused.** Standing the project root in for the scope was a guess the verification could not catch, because only the search's first phase walks outward from the document. `documentUri` is now required rather than optional, which is where the fallback came from; every caller already passed one.

## Behaviour this removes

Fail-closed, agreed with the maintainer before implementing. A conversion that cannot be confirmed is declined, where before it was written:

- A `.verse` file outside the project's Content root no longer offers the conversion. Two tests that pinned the old root-relative fallback now assert the refusal.
- An explicitly declared target module in a project past `searchExplicitModuleDefinitions`' documented 100-file cap resolves to nothing, so it is refused where string arithmetic used to produce an answer.

## Known limits, all inherited from the search rather than added here

Named in `referenceResolvesTo`'s doc comment so the next reader does not over-trust the check:

- A namesake existing only as an explicit `X := module` declaration is invisible while a folder answers first — the declaration scan runs only when the folder phases return nothing. This is half of H-01, and it overlaps #395.
- On a case-insensitive filesystem the search confirms the casing it asked about, not the casing on disk, so H-03's guarantee is not verifiable through this search on Windows.
- The scanning phases read `workspaceFolders[0]` rather than the folder holding the document, so a multi-root workspace can confirm from a tree the file is nowhere in. That is #396's H-14.

Two things found during review that belong elsewhere, not fixed here:

- `convertAllToRelativePath` reports "No absolute path imports found to convert." when every import was refused, and under-counts on a partial refusal. Filing separately.
- The `<project>/Plugins/<Name>/Content` layout that `ProjectPathHandler` documents supporting is now refused when the workspace is opened at the project root, since `enclosingModulePath` only accepts `Content` at the top of the workspace folder. That is the `Content`-boundary work in #396.

## Review

Two rounds, fresh context each, at `models.review`.

Round 1 returned **FAIL** on a real defect I verified independently before fixing: the fail-closed behaviour was not implemented for an unplaceable file, because `findModuleLocations`' phases 2 and 3 ignore `documentUri` and glob the workspace — so the first segment still resolved uniquely from the project-wide scan. The two tests pinning that refusal were passing only because the suite never stubs `vscode.workspace.findFiles`, which the mock defaults to `[]`. Fixed in 9f21e41, with a regression test that stubs `findFiles` the way production populates it.

Round 2 returned **PASS_WITH_SUGGESTIONS**, having re-run the branch's tests against `origin/main` (8 failures — all three ticket findings genuinely pinned) and against the pre-fix commit (the new guard test fails there for the reason it claims). Its remaining `Important` is the multi-root case above, which `convertToFullPath` already shared and which #396 owns; its suggestions on comment honesty and the `documentUri` signature are applied in 5214b08. Its suggestion to memoize first-segment lookups across a document-wide run is left for the follow-up.

## Verification

```
$ npm run compile
> verse-auto-imports@0.11.1 compile
> tsc -p ./

$ npm test
Test Suites: 46 passed, 46 total
Tests:       1416 passed, 1416 total
Snapshots:   0 total
Time:        12.729 s

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

`npx jest src/imports/__tests__` also run whole and read in full — 10 suites, 847 tests, nothing shadowed a neighbouring case.
