### PR TITLE
fix(config): scope settings reads and derive the write target

### DIFF
--- a/changelog.d/359.fixed.md
+++ b/changelog.d/359.fixed.md
@@ -1,0 +1,1 @@
+**Settings**: toggles in the status menu and the command palette now take effect when a workspace or folder already sets the value, and per-folder settings apply in multi-root workspaces.

--- a/package.json
+++ b/package.json
@@ -182,24 +182,28 @@
       "title": "Verse Auto Imports",
       "properties": {
         "verseAutoImports.general.autoImport": {
+          "scope": "resource",
           "type": "boolean",
           "default": true,
           "description": "Automatically add missing imports when errors are detected",
           "order": 1
         },
         "verseAutoImports.general.diagnosticDelay": {
+          "scope": "window",
           "type": "number",
           "default": 1000,
           "description": "[DEPRECATED - Use autoImportDebounceDelay instead] Delay in milliseconds before processing diagnostics",
           "order": 2
         },
         "verseAutoImports.general.autoImportDebounceDelay": {
+          "scope": "window",
           "type": "number",
           "default": 3000,
           "description": "Debounce delay in milliseconds before auto-importing. Waits for this duration after the last diagnostic change before triggering auto-imports (while you're typing).",
           "order": 3
         },
         "verseAutoImports.general.autoImportScope": {
+          "scope": "window",
           "type": "string",
           "enum": [
             "allFiles",
@@ -211,6 +215,7 @@
           "order": 4
         },
         "verseAutoImports.behavior.importSyntax": {
+          "scope": "resource",
           "type": "string",
           "enum": [
             "curly",
@@ -221,18 +226,21 @@
           "order": 10
         },
         "verseAutoImports.behavior.preserveImportLocations": {
+          "scope": "resource",
           "type": "boolean",
           "default": true,
           "description": "When true, keeps existing imports where they are and only adds new imports at the top. When false, consolidates all imports at the top of the file.",
           "order": 11
         },
         "verseAutoImports.behavior.sortImportsAlphabetically": {
+          "scope": "resource",
           "type": "boolean",
           "default": true,
           "description": "When true, sorts imports: absolute paths and dotted references alphabetically, while bare local imports keep their relative order and precede dotted ones to preserve Verse's top-down using resolution. When false, preserves the original order.",
           "order": 12
         },
         "verseAutoImports.behavior.importGrouping": {
+          "scope": "resource",
           "type": "string",
           "enum": [
             "none",
@@ -244,6 +252,7 @@
           "order": 13
         },
         "verseAutoImports.behavior.emptyLinesAfterImports": {
+          "scope": "resource",
           "type": "integer",
           "default": 1,
           "minimum": -1,
@@ -252,12 +261,14 @@
           "order": 14
         },
         "verseAutoImports.behavior.ambiguousImports": {
+          "scope": "window",
           "type": "object",
           "default": {},
           "description": "Mappings for class names that appear in multiple modules. Format: {\"className\": \"preferredModulePath\"}",
           "order": 15
         },
         "verseAutoImports.behavior.multiOptionStrategy": {
+          "scope": "resource",
           "type": "string",
           "enum": [
             "quickfix",
@@ -270,6 +281,7 @@
           "order": 16
         },
         "verseAutoImports.behavior.digestImportPrefixes": {
+          "scope": "window",
           "type": "array",
           "items": {
             "type": "string"
@@ -283,24 +295,28 @@
           "order": 17
         },
         "verseAutoImports.quickFix.sortAlphabetically": {
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "description": "When true, sorts quick fix options alphabetically. When false, preserves original order.",
           "order": 20
         },
         "verseAutoImports.quickFix.showDescriptions": {
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "description": "Show descriptive text in quick fix menu items (e.g., 'class from /Fortnite.com/Devices')",
           "order": 21
         },
         "verseAutoImports.pathConversion.enableCodeLens": {
+          "scope": "resource",
           "type": "boolean",
           "default": true,
           "description": "Show CodeLens actions above import statements to convert between absolute and relative paths",
           "order": 30
         },
         "verseAutoImports.pathConversion.codeLensVisibility": {
+          "scope": "window",
           "type": "string",
           "enum": [
             "hover",
@@ -311,6 +327,7 @@
           "order": 31
         },
         "verseAutoImports.pathConversion.codeLensHideDelay": {
+          "scope": "window",
           "type": "number",
           "default": 1000,
           "minimum": 500,
@@ -319,30 +336,35 @@
           "order": 32
         },
         "verseAutoImports.moduleVisibility.definitionsFileName": {
+          "scope": "resource",
           "type": "string",
           "default": "_definitions.verse",
           "description": "Name of the file at the Content root that the 'Make Module Public' quick fix writes <public> module declarations into. Existing declarations elsewhere in the project are edited in place instead, whatever this is set to.",
           "order": 35
         },
         "verseAutoImports.experimental.useDigestFiles": {
+          "scope": "window",
           "type": "boolean",
           "default": false,
           "description": "⚠️ Enable lookup of unknown identifiers in Verse digest files for intelligent import suggestions",
           "order": 40
         },
         "verseAutoImports.cache.enableProjectCache": {
+          "scope": "window",
           "type": "boolean",
           "default": true,
           "description": "Enable project path tree caching for faster module resolution (requires a window reload to take effect)",
           "order": 50
         },
         "verseAutoImports.cache.autoRebuildOnStartup": {
+          "scope": "window",
           "type": "boolean",
           "default": false,
           "description": "Automatically rebuild the project cache when VS Code starts (slower startup but ensures fresh cache)",
           "order": 51
         },
         "verseAutoImports.cache.watcherDebounceMs": {
+          "scope": "window",
           "type": "number",
           "default": 500,
           "minimum": 100,

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -287,7 +287,6 @@ const workspace = {
         get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
         update: jest.fn().mockResolvedValue(undefined),
         inspect: jest.fn().mockReturnValue(undefined),
-        has: jest.fn().mockReturnValue(false),
     }),
     // A fresh disposable per registration, as real VS Code returns. A single
     // shared one would make "every listener this class registered was
@@ -430,7 +429,7 @@ const ConfigurationTarget = {
     WorkspaceFolder: 3,
 };
 
-/** Real VS Code has no Default member; a row without a kind is a normal item. */
+/** Only the member the menus use; a row without a kind is a normal item. */
 const QuickPickItemKind = {
     Separator: -1,
 };

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -279,9 +279,15 @@ class FileSystemWatcher {
 }
 
 const workspace = {
+    // inspect() is part of the contract, not an extra: the write target is
+    // derived from it, so a stub without it throws rather than answering.
+    // Undefined is the honest default - it says no level overrides the key,
+    // which is what an untouched test workspace looks like.
     getConfiguration: jest.fn().mockReturnValue({
         get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
         update: jest.fn().mockResolvedValue(undefined),
+        inspect: jest.fn().mockReturnValue(undefined),
+        has: jest.fn().mockReturnValue(false),
     }),
     // A fresh disposable per registration, as real VS Code returns. A single
     // shared one would make "every listener this class registered was
@@ -366,6 +372,10 @@ const window = {
     showWarningMessage: jest.fn(),
     showErrorMessage: jest.fn(),
     showQuickPick: jest.fn(),
+    // Settable, like workspaceFolders. Command surfaces scope a setting to the
+    // file in front of the user, so undefined here is the real "no editor
+    // open" case rather than a gap - a test that needs one assigns it.
+    activeTextEditor: undefined as { document: { uri: unknown } } | undefined,
     setStatusBarMessage: jest.fn(),
     /**
      * Runs the task straight away, as real VS Code does, so a command wrapped
@@ -418,6 +428,11 @@ const ConfigurationTarget = {
     Global: 1,
     Workspace: 2,
     WorkspaceFolder: 3,
+};
+
+/** Real VS Code has no Default member; a row without a kind is a normal item. */
+const QuickPickItemKind = {
+    Separator: -1,
 };
 
 const EndOfLine = {
@@ -478,6 +493,7 @@ export {
     DiagnosticSeverity,
     StatusBarAlignment,
     ConfigurationTarget,
+    QuickPickItemKind,
     ProgressLocation,
     EndOfLine,
     FileType,

--- a/src/__tests__/settingsResolution.test.ts
+++ b/src/__tests__/settingsResolution.test.ts
@@ -179,6 +179,36 @@ describe("a toggle writes where the override already lives", () => {
         expect(config.update).toHaveBeenCalledWith("general.autoImport", true, vscode.ConfigurationTarget.Workspace);
     });
 
+    // A window-scoped setting toggled with an editor open is the permutation
+    // that throws rather than misfires: a single-root workspace registers one
+    // model as both its workspace and its folder configuration, so inspect()
+    // offers a folder value here - and update() rejects a window setting aimed
+    // at a folder. Toggling this one used to raise "does not support the folder
+    // resource scope" at the user.
+    it("toggleDigestFiles keeps a window-scoped setting off the workspace folder", async () => {
+        const config = {
+            get: jest.fn().mockReturnValue(true),
+            update: jest.fn().mockResolvedValue(undefined),
+            inspect: jest.fn().mockReturnValue({
+                key: "verseAutoImports.experimental.useDigestFiles",
+                workspaceValue: true,
+                workspaceFolderValue: true,
+            }),
+        };
+        getConfiguration.mockReturnValue(config);
+        (vscode.window as { activeTextEditor?: unknown }).activeTextEditor = { document: { uri: vscode.Uri.file(DOCUMENT_PATH) } };
+
+        try {
+            await new CommandsHandler({
+                statusBarHandler: { updateDisplay: jest.fn() } as unknown as StatusBarHandler,
+            } as unknown as CommandsDependencies).toggleDigestFiles();
+
+            expect(config.update).toHaveBeenCalledWith("experimental.useDigestFiles", false, vscode.ConfigurationTarget.Workspace);
+        } finally {
+            (vscode.window as { activeTextEditor?: unknown }).activeTextEditor = undefined;
+        }
+    });
+
     it("resolves the toggle against the file the user is editing", async () => {
         overriddenAtWorkspace();
         const uri = vscode.Uri.file(DOCUMENT_PATH);

--- a/src/__tests__/settingsResolution.test.ts
+++ b/src/__tests__/settingsResolution.test.ts
@@ -1,0 +1,228 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { CommandsHandler, CommandsDependencies } from "../commands";
+import { StatusBarHandler } from "../ui";
+import { DiagnosticsHandler } from "../diagnostics";
+import { ImportHandler, ImportCodeActionProvider, ImportCodeLensProvider } from "../imports";
+
+/**
+ * Guard for issue #359's defect class, in both halves.
+ *
+ * No setting declared a scope, so a folder's value was ignored without error in
+ * the multi-root workspace UEFN generates; and every write hardcoded
+ * ConfigurationTarget.Global, so a workspace-level override permanently
+ * shadowed every toggle - the toggle changed a value nothing read, which reads
+ * to the user as a control that does nothing.
+ *
+ * Both are pinned at the entry points a user reaches, not at the settings
+ * module beneath them: the module can be correct while the path that calls it
+ * passes no resource, which is exactly what the reported defect was.
+ */
+
+const getConfiguration = vscode.workspace.getConfiguration as unknown as jest.Mock;
+
+/** The resource every read below is expected to be scoped to. */
+const DOCUMENT_PATH = "C:\\Project\\Content\\Scripts\\device.verse";
+
+function makeDocument(text = "using { /Fortnite.com/Devices }\r\n"): vscode.TextDocument {
+    return {
+        getText: () => text,
+        uri: vscode.Uri.file(DOCUMENT_PATH),
+        fileName: DOCUMENT_PATH,
+        languageId: "verse",
+    } as unknown as vscode.TextDocument;
+}
+
+/** Every resource getConfiguration was asked for, in call order. */
+function scopesAskedFor(): unknown[] {
+    return getConfiguration.mock.calls.filter((call) => call[0] === "verseAutoImports").map((call) => call[1]);
+}
+
+describe("every contributed setting declares a scope", () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf8"));
+    const registered: Record<string, { scope?: string }> = manifest.contributes.configuration.properties;
+
+    // The whole read half of #359 is that an undeclared scope silently defaults
+    // to window, so this is the assertion that stops it recurring: a setting
+    // added without a scope fails here rather than shipping the defect again.
+    it("names a scope on every one, so none defaults to window by accident", () => {
+        const undeclared = Object.keys(registered).filter((key) => !registered[key].scope);
+
+        expect(undeclared).toEqual([]);
+    });
+
+    it("uses only the two scopes this extension has decided between", () => {
+        const used = [...new Set(Object.values(registered).map((property) => property.scope))].sort();
+
+        expect(used).toEqual(["resource", "window"]);
+    });
+
+    // resource is a promise that a folder's value is honoured. It is declared
+    // only where a read passes a resource, so this list and the threading in
+    // the reads below have to move together.
+    it("declares resource on exactly the settings a scoped read consumes", () => {
+        const resourceScoped = Object.keys(registered)
+            .filter((key) => registered[key].scope === "resource")
+            .sort();
+
+        expect(resourceScoped).toEqual(
+            [
+                "verseAutoImports.behavior.emptyLinesAfterImports",
+                "verseAutoImports.behavior.importGrouping",
+                "verseAutoImports.behavior.importSyntax",
+                "verseAutoImports.behavior.multiOptionStrategy",
+                "verseAutoImports.behavior.preserveImportLocations",
+                "verseAutoImports.behavior.sortImportsAlphabetically",
+                "verseAutoImports.general.autoImport",
+                "verseAutoImports.moduleVisibility.definitionsFileName",
+                "verseAutoImports.pathConversion.enableCodeLens",
+                "verseAutoImports.quickFix.showDescriptions",
+                "verseAutoImports.quickFix.sortAlphabetically",
+            ].sort(),
+        );
+    });
+});
+
+describe("reads are scoped to the document they decide about", () => {
+    afterEach(() => {
+        getConfiguration.mockClear();
+    });
+
+    it("provideCodeActions asks for the edited document's configuration", async () => {
+        const importHandler = { extractImportSuggestions: jest.fn().mockResolvedValue([]) } as unknown as ImportHandler;
+        const provider = new ImportCodeActionProvider(vscode.window.createOutputChannel("test"), importHandler);
+
+        await provider.provideCodeActions(
+            makeDocument(),
+            {} as unknown as vscode.Range,
+            { diagnostics: [{ message: "Unknown identifier `button_device`", range: { start: { line: 7 } } }] } as unknown as vscode.CodeActionContext,
+            {} as unknown as vscode.CancellationToken,
+        );
+
+        expect(scopesAskedFor()).toContainEqual(vscode.Uri.file(DOCUMENT_PATH));
+    });
+
+    it("provideCodeLenses asks for the lensed document's configuration", async () => {
+        const provider = new ImportCodeLensProvider(vscode.window.createOutputChannel("test"));
+
+        await provider.provideCodeLenses(makeDocument(), {} as vscode.CancellationToken);
+
+        expect(scopesAskedFor()).toContainEqual(vscode.Uri.file(DOCUMENT_PATH));
+    });
+
+    // The authoritative auto-import decision, per the comment on the
+    // onDidChangeDiagnostics listener: the debounce callback re-reads when its
+    // timer fires, and that read is the one that governs.
+    it("the debounce callback asks for the diagnosed document's configuration", async () => {
+        jest.useFakeTimers();
+        (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([{ message: "Unknown identifier `button_device`.", range: { start: { line: 7 } } }]);
+
+        try {
+            const importHandler = {
+                extractImportSuggestions: jest.fn().mockResolvedValue([]),
+                addImportsToDocument: jest.fn().mockResolvedValue(true),
+            } as unknown as ImportHandler;
+            const handler = new DiagnosticsHandler(vscode.window.createOutputChannel("test"), importHandler, () => false);
+            handler.setDelay(10);
+
+            await handler.handle(makeDocument());
+            await jest.advanceTimersByTimeAsync(10);
+
+            expect(scopesAskedFor()).toContainEqual(vscode.Uri.file(DOCUMENT_PATH));
+        } finally {
+            jest.clearAllTimers();
+            jest.useRealTimers();
+            (vscode.languages.getDiagnostics as jest.Mock).mockReturnValue([]);
+        }
+    });
+});
+
+describe("a toggle writes where the override already lives", () => {
+    /** A configuration whose inspect() reports the workspace holding the value. */
+    function overriddenAtWorkspace(): { update: jest.Mock } {
+        const config = {
+            get: jest.fn().mockReturnValue(false),
+            update: jest.fn().mockResolvedValue(undefined),
+            inspect: jest.fn().mockReturnValue({ key: "verseAutoImports.general.autoImport", workspaceValue: false }),
+        };
+        getConfiguration.mockReturnValue(config);
+        return config;
+    }
+
+    afterEach(() => {
+        getConfiguration.mockReset();
+        getConfiguration.mockReturnValue({
+            get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+            update: jest.fn().mockResolvedValue(undefined),
+            inspect: jest.fn().mockReturnValue(undefined),
+        });
+    });
+
+    // The reported defect: a team repo commits general.autoImport false in
+    // .vscode/settings.json, the user clicks the toggle, the write lands in
+    // user settings, the workspace value keeps winning, and the row still reads
+    // Disabled. Writing Global here is what made the control inert.
+    it("toggleAutoImport writes to the workspace, not over it into user settings", async () => {
+        const config = overriddenAtWorkspace();
+        const handler = new CommandsHandler({
+            statusBarHandler: { updateDisplay: jest.fn() } as unknown as StatusBarHandler,
+        } as unknown as CommandsDependencies);
+
+        await handler.toggleAutoImport();
+
+        expect(config.update).toHaveBeenCalledWith("general.autoImport", true, vscode.ConfigurationTarget.Workspace);
+    });
+
+    it("resolves the toggle against the file the user is editing", async () => {
+        overriddenAtWorkspace();
+        const uri = vscode.Uri.file(DOCUMENT_PATH);
+        (vscode.window as { activeTextEditor?: unknown }).activeTextEditor = { document: { uri } };
+
+        try {
+            await new CommandsHandler({
+                statusBarHandler: { updateDisplay: jest.fn() } as unknown as StatusBarHandler,
+            } as unknown as CommandsDependencies).toggleAutoImport();
+
+            expect(scopesAskedFor()).toContainEqual(uri);
+        } finally {
+            (vscode.window as { activeTextEditor?: unknown }).activeTextEditor = undefined;
+        }
+    });
+});
+
+// #359 names this as the second implementation of one toggle: the row wrote
+// configuration itself instead of invoking the command that already existed,
+// and inverted a value snapshotted when the menu opened rather than read at
+// click time.
+describe("the status menu drives its toggles through the registered commands", () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+        getConfiguration.mockReturnValue({
+            get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+            update: jest.fn().mockResolvedValue(undefined),
+            inspect: jest.fn().mockReturnValue(undefined),
+        });
+    });
+
+    /** Opens the menu, picks the row whose label contains `label`, and runs it. */
+    async function pickMenuRow(label: string): Promise<void> {
+        (vscode.window.showQuickPick as jest.Mock).mockImplementation(async (items: Array<{ label: string; action?: () => Promise<void> }>) => items.find((item) => item.label.includes(label)));
+
+        await new StatusBarHandler(vscode.window.createOutputChannel("test")).showMenu();
+    }
+
+    it("the Auto Import row invokes the command and writes nothing itself", async () => {
+        const config = {
+            get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+            update: jest.fn().mockResolvedValue(undefined),
+            inspect: jest.fn().mockReturnValue(undefined),
+        };
+        getConfiguration.mockReturnValue(config);
+
+        await pickMenuRow("Auto Import");
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith("verseAutoImports.toggleAutoImport");
+        expect(config.update).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/settingsResolution.test.ts
+++ b/src/__tests__/settingsResolution.test.ts
@@ -4,10 +4,11 @@ import * as vscode from "vscode";
 import { CommandsHandler, CommandsDependencies } from "../commands";
 import { StatusBarHandler } from "../ui";
 import { DiagnosticsHandler } from "../diagnostics";
-import { ImportHandler, ImportCodeActionProvider, ImportCodeLensProvider } from "../imports";
+import { ImportHandler, ImportCodeActionProvider, ImportCodeLensProvider, ImportDocumentEditor, ImportFormatter } from "../imports";
+import { RESOURCE_SCOPED } from "../utils";
 
 /**
- * Guard for issue #359's defect class, in both halves.
+ * Guard for two defects with one cause: settings access owned by nobody.
  *
  * No setting declared a scope, so a folder's value was ignored without error in
  * the multi-root workspace UEFN generates; and every write hardcoded
@@ -43,9 +44,9 @@ describe("every contributed setting declares a scope", () => {
     const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf8"));
     const registered: Record<string, { scope?: string }> = manifest.contributes.configuration.properties;
 
-    // The whole read half of #359 is that an undeclared scope silently defaults
-    // to window, so this is the assertion that stops it recurring: a setting
-    // added without a scope fails here rather than shipping the defect again.
+    // The whole read half of the defect is that an undeclared scope silently
+    // defaults to window, so this is the assertion that stops it recurring: a
+    // setting added without a scope fails here rather than shipping it again.
     it("names a scope on every one, so none defaults to window by accident", () => {
         const undeclared = Object.keys(registered).filter((key) => !registered[key].scope);
 
@@ -58,29 +59,18 @@ describe("every contributed setting declares a scope", () => {
         expect(used).toEqual(["resource", "window"]);
     });
 
-    // resource is a promise that a folder's value is honoured. It is declared
-    // only where a read passes a resource, so this list and the threading in
-    // the reads below have to move together.
-    it("declares resource on exactly the settings a scoped read consumes", () => {
-        const resourceScoped = Object.keys(registered)
+    // The write path decides whether a workspace folder may hold a setting from
+    // RESOURCE_SCOPED, because inspect() cannot tell it: a single-root
+    // workspace reports a folder value for window-scoped settings too, and
+    // update() rejects those. The manifest is the source of truth, so the two
+    // drifting apart is a thrown write at a user's keystroke - fail here first.
+    it("keeps RESOURCE_SCOPED in step with the scopes the manifest declares", () => {
+        const declared = Object.keys(registered)
             .filter((key) => registered[key].scope === "resource")
+            .map((key) => key.replace("verseAutoImports.", ""))
             .sort();
 
-        expect(resourceScoped).toEqual(
-            [
-                "verseAutoImports.behavior.emptyLinesAfterImports",
-                "verseAutoImports.behavior.importGrouping",
-                "verseAutoImports.behavior.importSyntax",
-                "verseAutoImports.behavior.multiOptionStrategy",
-                "verseAutoImports.behavior.preserveImportLocations",
-                "verseAutoImports.behavior.sortImportsAlphabetically",
-                "verseAutoImports.general.autoImport",
-                "verseAutoImports.moduleVisibility.definitionsFileName",
-                "verseAutoImports.pathConversion.enableCodeLens",
-                "verseAutoImports.quickFix.showDescriptions",
-                "verseAutoImports.quickFix.sortAlphabetically",
-            ].sort(),
-        );
+        expect(declared).toEqual([...RESOURCE_SCOPED].sort());
     });
 });
 
@@ -107,6 +97,21 @@ describe("reads are scoped to the document they decide about", () => {
         const provider = new ImportCodeLensProvider(vscode.window.createOutputChannel("test"));
 
         await provider.provideCodeLenses(makeDocument(), {} as vscode.CancellationToken);
+
+        expect(scopesAskedFor()).toContainEqual(vscode.Uri.file(DOCUMENT_PATH));
+    });
+
+    // These four decide the text written into the user's file - the syntax, the
+    // ordering, the grouping and the spacing after the block. They are the
+    // reads a wrong scope corrupts a document with, so they matter most.
+    it.each([
+        ["addImportsToDocument", (editor: ImportDocumentEditor, document: vscode.TextDocument) => editor.addImportsToDocument(document, ["using { /Fortnite.com/Devices }"])],
+        ["organizeImports", (editor: ImportDocumentEditor, document: vscode.TextDocument) => editor.organizeImports(document, [])],
+        ["computeEmptyLinesAfterImportsEdits", async (editor: ImportDocumentEditor, document: vscode.TextDocument) => void editor.computeEmptyLinesAfterImportsEdits(document)],
+    ])("%s asks for the edited document's configuration", async (_name, run) => {
+        const editor = new ImportDocumentEditor(vscode.window.createOutputChannel("test"), new ImportFormatter());
+
+        await run(editor, makeDocument());
 
         expect(scopesAskedFor()).toContainEqual(vscode.Uri.file(DOCUMENT_PATH));
     });
@@ -191,11 +196,22 @@ describe("a toggle writes where the override already lives", () => {
     });
 });
 
-// #359 names this as the second implementation of one toggle: the row wrote
-// configuration itself instead of invoking the command that already existed,
-// and inverted a value snapshotted when the menu opened rather than read at
-// click time.
+// One toggle had two implementations: the row wrote configuration itself
+// instead of invoking the command that already existed, and inverted a value
+// snapshotted when the menu opened rather than read at click time.
 describe("the status menu drives its toggles through the registered commands", () => {
+    /** Every command id CommandsHandler registers, taken from the real registration. */
+    function registeredCommandIds(): string[] {
+        const register = vscode.commands.registerCommand as jest.Mock;
+        register.mockClear();
+
+        new CommandsHandler({
+            statusBarHandler: { updateDisplay: jest.fn() } as unknown as StatusBarHandler,
+        } as unknown as CommandsDependencies).registerAll({ subscriptions: [] } as unknown as vscode.ExtensionContext);
+
+        return register.mock.calls.map((call) => call[0] as string);
+    }
+
     afterEach(() => {
         jest.clearAllMocks();
         getConfiguration.mockReturnValue({
@@ -206,23 +222,40 @@ describe("the status menu drives its toggles through the registered commands", (
     });
 
     /** Opens the menu, picks the row whose label contains `label`, and runs it. */
-    async function pickMenuRow(label: string): Promise<void> {
-        (vscode.window.showQuickPick as jest.Mock).mockImplementation(async (items: Array<{ label: string; action?: () => Promise<void> }>) => items.find((item) => item.label.includes(label)));
-
-        await new StatusBarHandler(vscode.window.createOutputChannel("test")).showMenu();
-    }
-
-    it("the Auto Import row invokes the command and writes nothing itself", async () => {
+    async function pickMenuRow(label: string): Promise<{ update: jest.Mock }> {
         const config = {
             get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
             update: jest.fn().mockResolvedValue(undefined),
             inspect: jest.fn().mockReturnValue(undefined),
         };
         getConfiguration.mockReturnValue(config);
+        (vscode.window.showQuickPick as jest.Mock).mockImplementation(async (items: Array<{ label: string; action?: () => Promise<void> }>) => items.find((item) => item.label.includes(label)));
 
-        await pickMenuRow("Auto Import");
+        await new StatusBarHandler(vscode.window.createOutputChannel("test")).showMenu();
+        return config;
+    }
 
-        expect(vscode.commands.executeCommand).toHaveBeenCalledWith("verseAutoImports.toggleAutoImport");
+    // Each row's label paired with the command it must dispatch instead of
+    // writing. A row that writes its own copy is the defect; a row naming a
+    // command nothing registers is the way the fix silently rots.
+    const DELEGATED_ROWS: Array<[string, string]> = [
+        ["Auto Import", "verseAutoImports.toggleAutoImport"],
+        ["Preserve Import Locations", "verseAutoImports.togglePreserveLocations"],
+        ["Dot Syntax", "verseAutoImports.toggleImportSyntax"],
+        ["Path Conversion Helper", "verseAutoImports.toggleFullPathCodeLens"],
+        ["Use Digest Files", "verseAutoImports.toggleDigestFiles"],
+    ];
+
+    it.each(DELEGATED_ROWS)("the %s row invokes its command and writes nothing itself", async (label, command) => {
+        const config = await pickMenuRow(label);
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(command);
         expect(config.update).not.toHaveBeenCalled();
+    });
+
+    it("dispatches only commands that are actually registered", () => {
+        const registered = registeredCommandIds();
+
+        expect(registered).toEqual(expect.arrayContaining(DELEGATED_ROWS.map(([, command]) => command)));
     });
 });

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger, settingsFor, writeSetting } from "../utils";
+import { logger, activeResource, settingsFor, writeSetting } from "../utils";
 import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../imports";
 import { StatusBarHandler } from "../ui";
 import { ProjectPathCache } from "../services";
@@ -231,8 +231,8 @@ export class CommandsHandler {
     }
 
     /**
-     * Writes the opposite of a setting's current value to global scope, then
-     * refreshes the status bar.
+     * Writes the opposite of a setting's current value to whichever level
+     * already overrides it, then refreshes the status bar.
      *
      * Reports its own failures and swallows what it reports, so none of the
      * five toggle commands built on it rejects. The refresh is inside that
@@ -247,10 +247,11 @@ export class CommandsHandler {
             // Scoped to the file in front of the user, so a resource-scoped
             // setting is read and written for the folder they are working in
             // rather than for whichever folder happens to be first.
-            const resource = vscode.window.activeTextEditor?.document.uri;
+            const resource = activeResource();
             const current = settingsFor(resource).get<T>(configKey);
             const newValue = toggleFn ? toggleFn(current as T) : !current;
             await writeSetting(configKey, newValue, resource);
+            logger.debug("CommandsHandler", `${configKey} toggled to: ${newValue}`);
             this.deps.statusBarHandler.updateDisplay();
         } catch (error) {
             logger.error("CommandsHandler", `Failed to toggle ${configKey}`, error);

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger } from "../utils";
+import { logger, settingsFor, writeSetting } from "../utils";
 import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../imports";
 import { StatusBarHandler } from "../ui";
 import { ProjectPathCache } from "../services";
@@ -244,10 +244,13 @@ export class CommandsHandler {
      */
     private async toggleConfig<T>(configKey: string, toggleFn?: (current: T) => T): Promise<void> {
         try {
-            const config = vscode.workspace.getConfiguration("verseAutoImports");
-            const current = config.get<T>(configKey);
+            // Scoped to the file in front of the user, so a resource-scoped
+            // setting is read and written for the folder they are working in
+            // rather than for whichever folder happens to be first.
+            const resource = vscode.window.activeTextEditor?.document.uri;
+            const current = settingsFor(resource).get<T>(configKey);
             const newValue = toggleFn ? toggleFn(current as T) : !current;
-            await config.update(configKey, newValue, vscode.ConfigurationTarget.Global);
+            await writeSetting(configKey, newValue, resource);
             this.deps.statusBarHandler.updateDisplay();
         } catch (error) {
             logger.error("CommandsHandler", `Failed to toggle ${configKey}`, error);

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -510,6 +510,9 @@ describe("CommandsHandler failure logging", () => {
     const WORKING_CONFIGURATION = {
         get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
         update: jest.fn().mockResolvedValue(undefined),
+        // The write target is derived from inspect(), so a configuration stub
+        // without it throws before the write is reached.
+        inspect: jest.fn().mockReturnValue(undefined),
     };
 
     let errors: jest.SpyInstance;
@@ -548,6 +551,7 @@ describe("CommandsHandler failure logging", () => {
             (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
                 get: jest.fn().mockReturnValue(false),
                 update: jest.fn().mockRejectedValue(new Error("EACCES: settings.json is read-only")),
+                inspect: jest.fn().mockReturnValue(undefined),
             });
         }
 

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { logger } from "../utils";
+import { logger, settingsFor } from "../utils";
 import { ImportSuggestion } from "../types";
 import { ImportHandler } from "../imports";
 
@@ -152,7 +152,7 @@ export class DiagnosticsHandler {
 
                 logger.debug("DiagnosticsHandler", `Processing diagnostics for ${displayName} after delay`);
 
-                const config = vscode.workspace.getConfiguration("verseAutoImports");
+                const config = settingsFor(document.uri);
                 const autoImportEnabled = config.get<boolean>("general.autoImport", true) && !this.isAutoImportSuppressed();
                 const multiOptionStrategy = config.get<string>("behavior.multiOptionStrategy", "quickfix");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger, collectEnvironment, formatHostSummary, readSessionState } from "./utils";
+import { logger, collectEnvironment, formatHostSummary, readSessionState, settingsFor, explicitSetting } from "./utils";
 import { DiagnosticsHandler } from "./diagnostics";
 import { ImportHandler, ImportPathConverter, ImportCodeActionProvider, ImportOrganizeCodeActionProvider, ImportCodeLensProvider, ImportFormatter } from "./imports";
 import { CommandsHandler, CommandsDependencies } from "./commands";
@@ -17,18 +17,6 @@ const CACHE_SETTING = "cache.enableProjectCache";
 const CACHE_SETTING_DEFAULT = true;
 
 /**
- * Reads the explicit user-set value of a setting, ignoring its registered
- * default. config.get cannot distinguish the two: for a registered setting it
- * returns the package.json default instead of the passed fallback.
- * Language-scoped values ("[verse]" blocks) are intentionally not consulted;
- * the config is fetched without a scope, so they have never applied here.
- */
-function getExplicitSetting(config: vscode.WorkspaceConfiguration, key: string): number | undefined {
-    const info = config.inspect<number>(key);
-    return info?.workspaceFolderValue ?? info?.workspaceValue ?? info?.globalValue;
-}
-
-/**
  * The debounce delay in milliseconds, honouring the deprecated
  * diagnosticDelay setting. Only explicit overrides are considered, so
  * diagnosticDelay's registered default (1000) cannot shadow
@@ -36,11 +24,11 @@ function getExplicitSetting(config: vscode.WorkspaceConfiguration, key: string):
  * explicit legacy value.
  */
 function getConfiguredDebounceDelay(config: vscode.WorkspaceConfiguration): number {
-    const explicitDelay = getExplicitSetting(config, "general.autoImportDebounceDelay");
+    const explicitDelay = explicitSetting(config, "general.autoImportDebounceDelay");
     if (explicitDelay !== undefined) {
         return explicitDelay;
     }
-    const explicitLegacyDelay = getExplicitSetting(config, "general.diagnosticDelay");
+    const explicitLegacyDelay = explicitSetting(config, "general.diagnosticDelay");
     if (explicitLegacyDelay !== undefined) {
         return explicitLegacyDelay;
     }
@@ -73,7 +61,7 @@ export function activate(context: vscode.ExtensionContext) {
     // StatusBarHandler showing the channel.
     const outputChannel = logger.getUserChannel();
 
-    const config = vscode.workspace.getConfiguration("verseAutoImports");
+    const config = settingsFor();
     const cacheEnabled = config.get<boolean>(CACHE_SETTING, CACHE_SETTING_DEFAULT);
 
     logger.debug("Extension", "Creating handlers");
@@ -169,7 +157,7 @@ export function activate(context: vscode.ExtensionContext) {
             { language: "verse" },
             {
                 provideHover(document, position) {
-                    const config = vscode.workspace.getConfiguration("verseAutoImports");
+                    const config = settingsFor(document.uri);
                     if (!config.get<boolean>("pathConversion.enableCodeLens", true)) {
                         return null;
                     }
@@ -197,7 +185,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((event) => {
             if (event.affectsConfiguration("verseAutoImports.general.diagnosticDelay") || event.affectsConfiguration("verseAutoImports.general.autoImportDebounceDelay")) {
-                const newConfig = vscode.workspace.getConfiguration("verseAutoImports");
+                const newConfig = settingsFor();
                 const finalDelay = getConfiguredDebounceDelay(newConfig);
                 diagnosticsHandler.setDelay(finalDelay);
                 logger.info("Extension", `Debounce delay updated to ${finalDelay}ms`);
@@ -215,7 +203,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
             // A change back to what activation captured needs no reload; the
             // window already behaves the way the setting now reads.
-            const newValue = vscode.workspace.getConfiguration("verseAutoImports").get<boolean>(CACHE_SETTING, CACHE_SETTING_DEFAULT);
+            const newValue = settingsFor().get<boolean>(CACHE_SETTING, CACHE_SETTING_DEFAULT);
             if (newValue === cacheEnabled) {
                 return;
             }
@@ -264,7 +252,7 @@ export function activate(context: vscode.ExtensionContext) {
             // again when its timer fires, and that read is the authoritative
             // one - hoisting it up here would be a different change, and a wrong
             // one, since it is what makes a mid-loop toggle harmless.
-            const config = vscode.workspace.getConfiguration("verseAutoImports");
+            const config = settingsFor();
             const scope = config.get<string>("general.autoImportScope", "allFiles");
             const autoImportEnabled = config.get<boolean>("general.autoImport", true);
             const visibility = !DiagnosticsHandler.scopeRestrictsDocuments(scope)

--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger } from "../utils";
+import { logger, settingsFor } from "../utils";
 import { ImportSuggestion } from "../types";
 import { ImportHandler } from "./ImportHandler";
 
@@ -24,7 +24,7 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
      */
     async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[] | undefined> {
         const codeActions: vscode.CodeAction[] = [];
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor(document.uri);
         const sortAlphabetically = config.get<boolean>("quickFix.sortAlphabetically", false);
         // Only a caller with no registered setting behind it, such as a test,
         // ever sees this fallback - config.get returns the registered default

--- a/src/imports/ImportCodeLensProvider.ts
+++ b/src/imports/ImportCodeLensProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger } from "../utils";
+import { logger, settingsFor } from "../utils";
 import { ImportPathConverter } from "./ImportPathConverter";
 import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
@@ -49,12 +49,12 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
 
     /** The configured delay before the lenses are hidden, in milliseconds. */
     private getHideDelay(): number {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor();
         return config.get<number>("pathConversion.codeLensHideDelay", 1000);
     }
 
     private getVisibilityMode(): "hover" | "always" {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor();
         return config.get<"hover" | "always">("pathConversion.codeLensVisibility", "hover");
     }
 
@@ -130,7 +130,7 @@ export class ImportCodeLensProvider implements vscode.CodeLensProvider {
     async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.CodeLens[]> {
         const codeLenses: vscode.CodeLens[] = [];
 
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor(document.uri);
         const showCodeLens = config.get<boolean>("pathConversion.enableCodeLens", true);
 
         if (!showCodeLens) {

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger } from "../utils";
+import { logger, settingsFor } from "../utils";
 import { DiagnosticLinesByPath, DiagnosticLinesByStatement } from "../types";
 import { ImportFormatter } from "./ImportFormatter";
 import { QueuedEdit, verifyImportEdits, verifyOrganizedRewrite } from "./ImportRewriteGuard";
@@ -639,7 +639,7 @@ export class ImportDocumentEditor {
     async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: DiagnosticLinesByStatement): Promise<boolean> {
         logger.info("ImportDocumentEditor", `Adding ${importStatements.length} import statements to document`);
 
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor(document.uri);
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const preserveImportLocations = config.get<boolean>("behavior.preserveImportLocations", true);
         const sortAlphabetically = config.get<boolean>("behavior.sortImportsAlphabetically", true);
@@ -1313,7 +1313,7 @@ export class ImportDocumentEditor {
      * addImportsToDocument this reorganizes even when nothing new is added.
      */
     async organizeImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath = NO_DIAGNOSTIC_LINES): Promise<boolean> {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor(document.uri);
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const sortAlphabetically = config.get<boolean>("behavior.sortImportsAlphabetically", true);
         const importGrouping = config.get<string>("behavior.importGrouping", "none");
@@ -1371,7 +1371,7 @@ export class ImportDocumentEditor {
      * leave the tab dirty the moment it was saved.
      */
     computeEmptyLinesAfterImportsEdits(document: vscode.TextDocument): vscode.TextEdit[] {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor(document.uri);
         const emptyLinesAfterImports = config.get<number>("behavior.emptyLinesAfterImports", 1);
 
         // A negative value means "leave the file's own spacing alone";

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { settingsFor } from "../utils";
 
 /** Options controlling `ImportFormatter.isModuleImport`'s classification. */
 export interface IsModuleImportOptions {
@@ -289,7 +290,7 @@ export class ImportFormatter {
             path = this.extractPathFromImport(importPath) || importPath;
         }
 
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor();
         const digestPrefixes = config.get<string[]>("behavior.digestImportPrefixes", ["/Verse.org/", "/Fortnite.com/", "/UnrealEngine.com/"]);
 
         return digestPrefixes.some((prefix) => path.startsWith(prefix));

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger } from "../utils";
+import { logger, settingsFor } from "../utils";
 import { ImportSuggestion, ImportSuggestionSource, ImportConfidence, MissingImports } from "../types";
 import { DigestParser, AssetsDigestParser } from "../services";
 import { ImportFormatter } from "./ImportFormatter";
@@ -363,7 +363,7 @@ export class ImportSuggestionExtractor {
      * entry it returns declares the name the compiler could not resolve.
      */
     private async lookupIdentifierInDigest(identifier: string): Promise<ImportSuggestion[]> {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor();
         const useDigestFiles = config.get<boolean>("experimental.useDigestFiles", false);
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
 
@@ -408,7 +408,7 @@ export class ImportSuggestionExtractor {
     async extractImportSuggestions(errorMessage: string): Promise<ImportSuggestion[]> {
         logger.debug("ImportSuggestionExtractor", `Extracting import suggestions from error: ${errorMessage}`);
 
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor();
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const ambiguousImportMappings = config.get<Record<string, string>>("behavior.ambiguousImports", DEFAULT_AMBIGUOUS_IMPORTS);
 

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { logger } from "../utils";
+import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathScanner } from "./ProjectPathScanner";
 import { PROJECT_CACHE_VERSION, ProjectPathData, ProjectPathNode, SerializedProjectPathCache } from "../types";
@@ -43,7 +43,7 @@ export class ProjectPathCache {
      * next file change instead of waiting for a window reload.
      */
     private getDebounceMs(): number {
-        return vscode.workspace.getConfiguration("verseAutoImports").get<number>("cache.watcherDebounceMs", ProjectPathCache.DEBOUNCE_MS);
+        return settingsFor().get<number>("cache.watcherDebounceMs", ProjectPathCache.DEBOUNCE_MS);
     }
 
     /**
@@ -66,7 +66,7 @@ export class ProjectPathCache {
         logger.info("ProjectPathCache", "Initializing project path cache...");
 
         try {
-            const autoRebuild = vscode.workspace.getConfiguration("verseAutoImports").get<boolean>("cache.autoRebuildOnStartup", ProjectPathCache.AUTO_REBUILD_ON_STARTUP);
+            const autoRebuild = settingsFor().get<boolean>("cache.autoRebuildOnStartup", ProjectPathCache.AUTO_REBUILD_ON_STARTUP);
 
             if (autoRebuild) {
                 logger.info("ProjectPathCache", "cache.autoRebuildOnStartup is on, rebuilding instead of loading the stored cache...");

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger } from "../utils";
+import { logger, settingsFor, writeSetting } from "../utils";
 
 interface QuickPickItemWithAction extends vscode.QuickPickItem {
     /** What selecting the item does. Separators and labels carry none. */
@@ -46,7 +46,7 @@ export class StatusBarHandler {
                 // field, not isSnoozeActive(): the question here is whether
                 // there is any snooze to clear, an expired one included.
                 if (event.affectsConfiguration("verseAutoImports.general.autoImport") && this.snoozeEndTime !== null) {
-                    const config = vscode.workspace.getConfiguration("verseAutoImports");
+                    const config = settingsFor();
                     const autoImportEnabled = config.get<boolean>("general.autoImport", true);
 
                     if (autoImportEnabled) {
@@ -99,7 +99,10 @@ export class StatusBarHandler {
      * setting changed elsewhere is reflected the next time it is shown.
      */
     async showMenu(): Promise<void> {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        // The rows describe what will happen to the file in front of the user,
+        // so the settings behind them are read for that file.
+        const resource = vscode.window.activeTextEditor?.document.uri;
+        const config = settingsFor(resource);
         const autoImportEnabled = config.get<boolean>("general.autoImport", true);
         const preserveLocations = config.get<boolean>("behavior.preserveImportLocations", true);
         const useDigestFiles = config.get<boolean>("experimental.useDigestFiles", false);
@@ -144,9 +147,11 @@ export class StatusBarHandler {
         items.push({
             label: toggleIcon(autoImportEnabled, "Auto Import"),
             description: autoImportDescription,
+            // Through the command rather than a second write of the same
+            // setting: the command re-reads at click time, where the row's
+            // captured value is a snapshot from when the menu opened.
             action: async () => {
-                await config.update("general.autoImport", !autoImportEnabled, vscode.ConfigurationTarget.Global);
-                logger.debug("StatusBarHandler", `Auto import toggled: ${!autoImportEnabled}`);
+                await vscode.commands.executeCommand("verseAutoImports.toggleAutoImport");
             },
         });
 
@@ -187,16 +192,17 @@ export class StatusBarHandler {
             label: toggleIcon(preserveLocations, "Preserve Import Locations"),
             description: preserveLocations ? "Keep imports in place" : "Consolidate at top",
             action: async () => {
-                await config.update("behavior.preserveImportLocations", !preserveLocations, vscode.ConfigurationTarget.Global);
-                logger.debug("StatusBarHandler", `Preserve import locations toggled: ${!preserveLocations}`);
+                await vscode.commands.executeCommand("verseAutoImports.togglePreserveLocations");
             },
         });
 
         items.push({
             label: toggleIcon(sortImports, "Sort Imports Alphabetically"),
             description: sortImports ? "Sorted A-Z" : "Original order preserved",
+            // No registered command backs this one, so it writes through the
+            // settings module directly.
             action: async () => {
-                await config.update("behavior.sortImportsAlphabetically", !sortImports, vscode.ConfigurationTarget.Global);
+                await writeSetting("behavior.sortImportsAlphabetically", !sortImports, resource);
                 logger.debug("StatusBarHandler", `Sort imports alphabetically toggled: ${!sortImports}`);
             },
         });
@@ -232,9 +238,7 @@ export class StatusBarHandler {
             label: toggleIcon(isDotSyntax, "Dot Syntax (using.)"),
             description: isDotSyntax ? "using. /Path" : "using { /Path }",
             action: async () => {
-                const newSyntax = isDotSyntax ? "curly" : "dot";
-                await config.update("behavior.importSyntax", newSyntax, vscode.ConfigurationTarget.Global);
-                logger.debug("StatusBarHandler", `Import syntax changed to: ${newSyntax}`);
+                await vscode.commands.executeCommand("verseAutoImports.toggleImportSyntax");
             },
         });
 
@@ -247,8 +251,7 @@ export class StatusBarHandler {
             label: toggleIcon(showCodeLens, "Path Conversion Helper"),
             description: showCodeLens ? "Enabled" : "Disabled",
             action: async () => {
-                await config.update("pathConversion.enableCodeLens", !showCodeLens, vscode.ConfigurationTarget.Global);
-                logger.debug("StatusBarHandler", `Path conversion CodeLens toggled: ${!showCodeLens}`);
+                await vscode.commands.executeCommand("verseAutoImports.toggleFullPathCodeLens");
             },
         });
 
@@ -270,8 +273,7 @@ export class StatusBarHandler {
             label: toggleIcon(useDigestFiles, "Use Digest Files"),
             description: useDigestFiles ? "Enabled" : "Disabled",
             action: async () => {
-                await config.update("experimental.useDigestFiles", !useDigestFiles, vscode.ConfigurationTarget.Global);
-                logger.debug("StatusBarHandler", `Use digest files toggled: ${!useDigestFiles}`);
+                await vscode.commands.executeCommand("verseAutoImports.toggleDigestFiles");
             },
         });
 
@@ -321,7 +323,8 @@ export class StatusBarHandler {
 
     /** Shows the import-grouping submenu, and returns to the main menu on Back. */
     async showImportGroupingMenu(): Promise<void> {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const resource = vscode.window.activeTextEditor?.document.uri;
+        const config = settingsFor(resource);
         const currentGrouping = config.get<string>("behavior.importGrouping", "none");
 
         const items: QuickPickItemWithAction[] = [];
@@ -343,7 +346,7 @@ export class StatusBarHandler {
             label: toggleIcon(currentGrouping === "none", "No Grouping"),
             description: "All imports mixed together (default)",
             action: async () => {
-                await config.update("behavior.importGrouping", "none", vscode.ConfigurationTarget.Global);
+                await writeSetting("behavior.importGrouping", "none", resource);
                 logger.debug("StatusBarHandler", "Import grouping changed to: none");
                 vscode.window.showInformationMessage("Import grouping disabled");
             },
@@ -353,7 +356,7 @@ export class StatusBarHandler {
             label: toggleIcon(currentGrouping === "digestFirst", "Digest First"),
             description: "Digest imports (/Verse.org, /Fortnite.com, /UnrealEngine.com), then local imports",
             action: async () => {
-                await config.update("behavior.importGrouping", "digestFirst", vscode.ConfigurationTarget.Global);
+                await writeSetting("behavior.importGrouping", "digestFirst", resource);
                 logger.debug("StatusBarHandler", "Import grouping changed to: digestFirst");
                 vscode.window.showInformationMessage("Import grouping: Digest imports first");
             },
@@ -363,7 +366,7 @@ export class StatusBarHandler {
             label: toggleIcon(currentGrouping === "localFirst", "Local First"),
             description: "Local imports, then digest imports",
             action: async () => {
-                await config.update("behavior.importGrouping", "localFirst", vscode.ConfigurationTarget.Global);
+                await writeSetting("behavior.importGrouping", "localFirst", resource);
                 logger.debug("StatusBarHandler", "Import grouping changed to: localFirst");
                 vscode.window.showInformationMessage("Import grouping: Local imports first");
             },
@@ -386,7 +389,7 @@ export class StatusBarHandler {
 
     /** Shows the CodeLens visibility submenu, and returns to the main menu on Back. */
     async showCodeLensVisibilityMenu(): Promise<void> {
-        const config = vscode.workspace.getConfiguration("verseAutoImports");
+        const config = settingsFor();
         const currentVisibility = config.get<string>("pathConversion.codeLensVisibility", "hover");
 
         const items: QuickPickItemWithAction[] = [];
@@ -408,7 +411,7 @@ export class StatusBarHandler {
             label: toggleIcon(currentVisibility === "hover", "Hover Only"),
             description: "Show only when hovering over imports (default)",
             action: async () => {
-                await config.update("pathConversion.codeLensVisibility", "hover", vscode.ConfigurationTarget.Global);
+                await writeSetting("pathConversion.codeLensVisibility", "hover");
                 logger.debug("StatusBarHandler", "CodeLens visibility changed to: hover");
                 vscode.window.showInformationMessage("CodeLens visibility: Hover only");
             },
@@ -418,7 +421,7 @@ export class StatusBarHandler {
             label: toggleIcon(currentVisibility === "always", "Always Visible"),
             description: "Always show above import statements",
             action: async () => {
-                await config.update("pathConversion.codeLensVisibility", "always", vscode.ConfigurationTarget.Global);
+                await writeSetting("pathConversion.codeLensVisibility", "always");
                 logger.debug("StatusBarHandler", "CodeLens visibility changed to: always");
                 vscode.window.showInformationMessage("CodeLens visibility: Always visible");
             },

--- a/src/ui/StatusBarHandler.ts
+++ b/src/ui/StatusBarHandler.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger, settingsFor, writeSetting } from "../utils";
+import { logger, activeResource, settingsFor, writeSetting } from "../utils";
 
 interface QuickPickItemWithAction extends vscode.QuickPickItem {
     /** What selecting the item does. Separators and labels carry none. */
@@ -101,7 +101,7 @@ export class StatusBarHandler {
     async showMenu(): Promise<void> {
         // The rows describe what will happen to the file in front of the user,
         // so the settings behind them are read for that file.
-        const resource = vscode.window.activeTextEditor?.document.uri;
+        const resource = activeResource();
         const config = settingsFor(resource);
         const autoImportEnabled = config.get<boolean>("general.autoImport", true);
         const preserveLocations = config.get<boolean>("behavior.preserveImportLocations", true);
@@ -323,7 +323,7 @@ export class StatusBarHandler {
 
     /** Shows the import-grouping submenu, and returns to the main menu on Back. */
     async showImportGroupingMenu(): Promise<void> {
-        const resource = vscode.window.activeTextEditor?.document.uri;
+        const resource = activeResource();
         const config = settingsFor(resource);
         const currentGrouping = config.get<string>("behavior.importGrouping", "none");
 

--- a/src/utils/__tests__/settings.test.ts
+++ b/src/utils/__tests__/settings.test.ts
@@ -1,0 +1,120 @@
+import * as vscode from "vscode";
+import { settingsFor, writeSetting, writeTargetFor } from "../settings";
+
+const getConfiguration = vscode.workspace.getConfiguration as unknown as jest.Mock;
+
+/** The levels inspect() reports as carrying an explicit value. */
+interface Levels {
+    workspaceFolderValue?: unknown;
+    workspaceValue?: unknown;
+    globalValue?: unknown;
+}
+
+/**
+ * A configuration whose inspect() reports exactly `levels`. Pass undefined for
+ * the answer VS Code gives an unregistered key or a non-leaf section.
+ */
+function stubConfiguration(levels: Levels | undefined = {}): vscode.WorkspaceConfiguration {
+    const config = {
+        get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+        update: jest.fn().mockResolvedValue(undefined),
+        inspect: jest.fn().mockReturnValue(levels === undefined ? undefined : { key: "verseAutoImports.behavior.importSyntax", ...levels }),
+    };
+    getConfiguration.mockReturnValue(config);
+    return config as unknown as vscode.WorkspaceConfiguration;
+}
+
+afterEach(() => {
+    getConfiguration.mockClear();
+});
+
+describe("settingsFor", () => {
+    it("passes the resource through, so a folder value can resolve", () => {
+        stubConfiguration();
+        const uri = vscode.Uri.file("C:\\Project\\Content\\device.verse");
+
+        settingsFor(uri);
+
+        expect(getConfiguration).toHaveBeenCalledWith("verseAutoImports", uri);
+    });
+
+    it("asks for the window's configuration when the caller holds no resource", () => {
+        stubConfiguration();
+
+        settingsFor();
+
+        expect(getConfiguration).toHaveBeenCalledWith("verseAutoImports", undefined);
+    });
+});
+
+describe("writeTargetFor", () => {
+    it("writes to the workspace folder when one already overrides the setting", () => {
+        const config = stubConfiguration({ workspaceFolderValue: "dot", globalValue: "curly" });
+
+        expect(writeTargetFor(config, "behavior.importSyntax", true)).toBe(vscode.ConfigurationTarget.WorkspaceFolder);
+    });
+
+    it("never picks the workspace folder for an unscoped configuration, which update rejects", () => {
+        const config = stubConfiguration({ workspaceFolderValue: "dot" });
+
+        expect(writeTargetFor(config, "behavior.importSyntax", false)).toBe(vscode.ConfigurationTarget.Global);
+    });
+
+    it("writes to the workspace when it holds the override, not over it", () => {
+        const config = stubConfiguration({ workspaceValue: "dot", globalValue: "curly" });
+
+        expect(writeTargetFor(config, "behavior.importSyntax", true)).toBe(vscode.ConfigurationTarget.Workspace);
+    });
+
+    it("prefers the folder over the workspace, matching how the two resolve", () => {
+        const config = stubConfiguration({ workspaceFolderValue: "dot", workspaceValue: "curly" });
+
+        expect(writeTargetFor(config, "behavior.importSyntax", true)).toBe(vscode.ConfigurationTarget.WorkspaceFolder);
+    });
+
+    it("writes to user settings when only they override the setting", () => {
+        const config = stubConfiguration({ globalValue: "dot" });
+
+        expect(writeTargetFor(config, "behavior.importSyntax", true)).toBe(vscode.ConfigurationTarget.Global);
+    });
+
+    it("writes to user settings when nothing overrides the setting", () => {
+        const config = stubConfiguration({});
+
+        expect(writeTargetFor(config, "behavior.importSyntax", true)).toBe(vscode.ConfigurationTarget.Global);
+    });
+
+    it("writes to user settings when inspect answers nothing at all", () => {
+        const config = stubConfiguration(undefined);
+
+        expect(writeTargetFor(config, "behavior.importSyntax", true)).toBe(vscode.ConfigurationTarget.Global);
+    });
+
+    // A false workspaceValue is an override like any other. Testing presence
+    // with a truthiness check would read it as absent and write Global, which
+    // is the shape of the defect for every boolean toggle the extension has.
+    it("treats an explicit false as an override", () => {
+        const config = stubConfiguration({ workspaceValue: false });
+
+        expect(writeTargetFor(config, "general.autoImport", true)).toBe(vscode.ConfigurationTarget.Workspace);
+    });
+});
+
+describe("writeSetting", () => {
+    it("writes at the level the override already lives on", async () => {
+        const config = stubConfiguration({ workspaceValue: false });
+
+        await writeSetting("general.autoImport", true);
+
+        expect(config.update).toHaveBeenCalledWith("general.autoImport", true, vscode.ConfigurationTarget.Workspace);
+    });
+
+    it("scopes the configuration it writes through to the resource it was given", async () => {
+        stubConfiguration({});
+        const uri = vscode.Uri.file("C:\\Project\\Content\\device.verse");
+
+        await writeSetting("general.autoImport", false, uri);
+
+        expect(getConfiguration).toHaveBeenCalledWith("verseAutoImports", uri);
+    });
+});

--- a/src/utils/__tests__/settings.test.ts
+++ b/src/utils/__tests__/settings.test.ts
@@ -60,6 +60,22 @@ describe("writeTargetFor", () => {
         expect(writeTargetFor(config, "behavior.importSyntax", false)).toBe(vscode.ConfigurationTarget.Global);
     });
 
+    // A single-root workspace registers one model as both its workspace and its
+    // folder configuration, so inspect() reports a folder value for a
+    // window-scoped setting - and update() rejects a window setting aimed at a
+    // folder. Trusting workspaceFolderValue alone throws at the user's click.
+    it("never picks the workspace folder for a window-scoped setting, which update also rejects", () => {
+        const config = stubConfiguration({ workspaceFolderValue: true, workspaceValue: true });
+
+        expect(writeTargetFor(config, "experimental.useDigestFiles", true)).toBe(vscode.ConfigurationTarget.Workspace);
+    });
+
+    it("falls back to user settings when a window-scoped setting has only a folder value", () => {
+        const config = stubConfiguration({ workspaceFolderValue: true });
+
+        expect(writeTargetFor(config, "pathConversion.codeLensVisibility", true)).toBe(vscode.ConfigurationTarget.Global);
+    });
+
     it("writes to the workspace when it holds the override, not over it", () => {
         const config = stubConfiguration({ workspaceValue: "dot", globalValue: "curly" });
 

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { settingsFor } from "./settings";
 
 /**
  * The facts that identify a build and cannot change while the window is open.
@@ -54,7 +55,7 @@ export function describeWorkspaceShape(folderCount: number, hasWorkspaceFile: bo
  * never cached.
  */
 export function readSessionState(): SessionState {
-    const config = vscode.workspace.getConfiguration("verseAutoImports");
+    const config = settingsFor();
     const settings: Record<string, string> = {};
     for (const key of REPORTED_SETTINGS) {
         // Flattened to one line: VS Code does not enforce a setting's declared

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { logger } from "./logger";
 export { collectEnvironment, formatHostSummary, readSessionState } from "./environment";
+export { SECTION, settingsFor, writeSetting, writeTargetFor, explicitSetting } from "./settings";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { logger } from "./logger";
 export { collectEnvironment, formatHostSummary, readSessionState } from "./environment";
-export { SECTION, settingsFor, writeSetting, writeTargetFor, explicitSetting } from "./settings";
+export { RESOURCE_SCOPED, activeResource, settingsFor, writeSetting, writeTargetFor, explicitSetting } from "./settings";

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 /** The configuration section every setting this extension contributes lives under. */
-export const SECTION = "verseAutoImports";
+const SECTION = "verseAutoImports";
 
 /**
  * The settings package.json declares `"scope": "resource"`, and so the only

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,0 +1,63 @@
+import * as vscode from "vscode";
+
+/** The configuration section every setting this extension contributes lives under. */
+export const SECTION = "verseAutoImports";
+
+/**
+ * The extension's configuration, resolved for `resource` when the caller has
+ * one. Settings declared `"scope": "resource"` in package.json only resolve a
+ * folder's value when the read passes the file it is deciding about; without
+ * one they answer for the window, and a folder override is ignored in silence.
+ *
+ * @param resource The file the setting is being read about. A `Uri` and never a
+ * `TextDocument`: a document carries a languageId, which would also switch on
+ * `[verse]` language-block resolution, and nothing here consults those.
+ */
+export function settingsFor(resource?: vscode.Uri): vscode.WorkspaceConfiguration {
+    return vscode.workspace.getConfiguration(SECTION, resource);
+}
+
+/**
+ * The level a write must land on for the user to see it take effect: the one
+ * that already holds an override, because a more specific level outranks
+ * anything written below it. Writing Global under a workspace override changes
+ * a value nothing reads, which reads to the user as a toggle that does nothing.
+ *
+ * @param scopedToResource Whether `config` was obtained with a resource. Only
+ * then may WorkspaceFolder be returned - `update` throws when it is asked for a
+ * workspace folder on a configuration that is not scoped to a resource.
+ */
+export function writeTargetFor(config: vscode.WorkspaceConfiguration, key: string, scopedToResource: boolean): vscode.ConfigurationTarget {
+    // Absent for an unregistered key, and for anything that is not a leaf of
+    // the configuration tree.
+    const info = config.inspect(key);
+    if (scopedToResource && info?.workspaceFolderValue !== undefined) {
+        return vscode.ConfigurationTarget.WorkspaceFolder;
+    }
+    if (info?.workspaceValue !== undefined) {
+        return vscode.ConfigurationTarget.Workspace;
+    }
+    return vscode.ConfigurationTarget.Global;
+}
+
+/**
+ * Writes a setting to whichever level already overrides it, falling back to
+ * user settings when nothing does.
+ */
+export async function writeSetting(key: string, value: unknown, resource?: vscode.Uri): Promise<void> {
+    const config = settingsFor(resource);
+    await config.update(key, value, writeTargetFor(config, key, resource !== undefined));
+}
+
+/**
+ * Reads the explicit user-set value of a setting, ignoring its registered
+ * default. config.get cannot distinguish the two: for a registered setting it
+ * returns the package.json default instead of the passed fallback.
+ * Language-scoped values ("[verse]" blocks) are intentionally not consulted;
+ * callers pass a config fetched without a scope, so they have never applied
+ * here.
+ */
+export function explicitSetting(config: vscode.WorkspaceConfiguration, key: string): number | undefined {
+    const info = config.inspect<number>(key);
+    return info?.workspaceFolderValue ?? info?.workspaceValue ?? info?.globalValue;
+}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -4,14 +4,46 @@ import * as vscode from "vscode";
 export const SECTION = "verseAutoImports";
 
 /**
+ * The settings package.json declares `"scope": "resource"`, and so the only
+ * ones a workspace folder may hold. Kept here rather than read back from the
+ * manifest because the write path needs it on every toggle; a test asserts the
+ * two agree, so a setting whose scope changes fails there rather than at a
+ * user's keystroke.
+ *
+ * The presence of a `workspaceFolderValue` cannot stand in for this list. A
+ * single-root workspace registers one model as both its workspace and its
+ * folder configuration, so inspect() reports a folder value for window-scoped
+ * settings too - and update() rejects those, per its "window configuration to
+ * workspace folder" contract.
+ */
+export const RESOURCE_SCOPED: ReadonlySet<string> = new Set([
+    "behavior.emptyLinesAfterImports",
+    "behavior.importGrouping",
+    "behavior.importSyntax",
+    "behavior.multiOptionStrategy",
+    "behavior.preserveImportLocations",
+    "behavior.sortImportsAlphabetically",
+    "general.autoImport",
+    "moduleVisibility.definitionsFileName",
+    "pathConversion.enableCodeLens",
+    "quickFix.showDescriptions",
+    "quickFix.sortAlphabetically",
+]);
+
+/** The file the user is looking at, which command surfaces resolve settings against. */
+export function activeResource(): vscode.Uri | undefined {
+    return vscode.window.activeTextEditor?.document.uri;
+}
+
+/**
  * The extension's configuration, resolved for `resource` when the caller has
  * one. Settings declared `"scope": "resource"` in package.json only resolve a
  * folder's value when the read passes the file it is deciding about; without
  * one they answer for the window, and a folder override is ignored in silence.
  *
- * @param resource The file the setting is being read about. A `Uri` and never a
- * `TextDocument`: a document carries a languageId, which would also switch on
- * `[verse]` language-block resolution, and nothing here consults those.
+ * @param resource The file or folder the setting is being read about. A `Uri`
+ * and never a `TextDocument`: a document carries a languageId, which would also
+ * switch on `[verse]` language-block resolution, and nothing here consults those.
  */
 export function settingsFor(resource?: vscode.Uri): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration(SECTION, resource);
@@ -23,15 +55,17 @@ export function settingsFor(resource?: vscode.Uri): vscode.WorkspaceConfiguratio
  * anything written below it. Writing Global under a workspace override changes
  * a value nothing reads, which reads to the user as a toggle that does nothing.
  *
- * @param scopedToResource Whether `config` was obtained with a resource. Only
- * then may WorkspaceFolder be returned - `update` throws when it is asked for a
- * workspace folder on a configuration that is not scoped to a resource.
+ * Both conditions on WorkspaceFolder are throw conditions of `update`, not
+ * preferences: it rejects a workspace folder asked of a configuration that is
+ * not scoped to a resource, and rejects one asked for a window-scoped setting.
+ *
+ * @param scopedToResource Whether `config` was obtained with a resource.
  */
 export function writeTargetFor(config: vscode.WorkspaceConfiguration, key: string, scopedToResource: boolean): vscode.ConfigurationTarget {
     // Absent for an unregistered key, and for anything that is not a leaf of
     // the configuration tree.
     const info = config.inspect(key);
-    if (scopedToResource && info?.workspaceFolderValue !== undefined) {
+    if (scopedToResource && RESOURCE_SCOPED.has(key) && info?.workspaceFolderValue !== undefined) {
         return vscode.ConfigurationTarget.WorkspaceFolder;
     }
     if (info?.workspaceValue !== undefined) {

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import { logger } from "../utils";
+import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { appendDeclarationBlock, buildDeclarationBlock } from "./definitionsContent";
 import { findExplicitModuleDeclarations } from "./moduleDeclarations";
@@ -328,7 +328,7 @@ export class ModuleVisibilityWriter {
      * reported success.
      */
     private definitionsUri(contentRoot: vscode.Uri): vscode.Uri | null {
-        const fileName = vscode.workspace.getConfiguration("verseAutoImports").get<string>("moduleVisibility.definitionsFileName", "_definitions.verse").trim();
+        const fileName = settingsFor(contentRoot).get<string>("moduleVisibility.definitionsFileName", "_definitions.verse").trim();
 
         if (!/^[^\\/:*?"<>|]+\.verse$/.test(fileName)) {
             return null;


### PR DESCRIPTION
Closes #359

Settings access had no owner, and both halves were wrong as a class.

**Read half.** `package.json` contributed 22 settings and none declared a `scope`. An undeclared scope defaults to `window`, so a folder's `.vscode/settings.json` value was ignored without error in the multi-root workspace UEFN generates.

**Write half.** All 12 production write sites passed `vscode.ConfigurationTarget.Global`. With a workspace-level override committed in a team repo, clicking a toggle wrote to user settings, the workspace value kept winning, and the row still read Disabled — the control visibly did nothing.

The issue cites 16 unscoped reads; there were **24** in production by the time this was picked up.

## What changed

**`src/utils/settings.ts`** — one module owning scoping and write-target choice:

- `settingsFor(resource?)` returns `getConfiguration("verseAutoImports", resource)`. It owns *scoping*, not *reading* — call sites still write `.get<T>("key", default)` on what it returns. That is deliberate: `src/__tests__/configurationDefaults.test.ts:48` statically scans every non-test `.ts` for that literal shape and asserts each fallback matches the manifest default. Typed getters would have made that guard silently stop scanning while continuing to pass.
- `writeTargetFor()` walks `workspaceFolderValue -> workspaceValue -> globalValue`, the same ladder `extension.ts` already walked for reads, so the precedence exists once.
- `explicitSetting()` moved here from `extension.ts` unchanged.
- Scoping is by `Uri`, never `TextDocument`. A document carries a languageId, so passing one would silently switch on `[verse]` language-block resolution that has never applied here.

**Manifest** — an explicit scope on all 22 settings, 11 `resource` and 11 `window`, inserted without reformatting anything else.

`resource` is declared **only where a functional read passes a resource**. Declaring it where no read honours it would re-create the exact bug this fixes: advertising folder-configurability that is silently ignored.

**Reads** — the resource is threaded at the nine sites that hold one: `extension.ts` (hover), `DiagnosticsHandler` (the authoritative debounce read), `ImportCodeLensProvider.provideCodeLenses`, `ImportCodeActionProvider`, all three `ImportDocumentEditor` entry points, `ModuleVisibilityWriter`, and the two command surfaces, which scope to the active editor.

**Writes** — the five menu rows with a registered command now call `executeCommand`, matching how the same menu already invokes `optimizeImports`. That removes the second implementation of the Auto Import toggle and fixes a latent bug for free: those rows inverted a value snapshotted when the menu opened, where `toggleConfig` re-reads at click time. The three rows with no command write through the module.

## Two deviations from the issue, deliberate

**`general.autoImportScope` is `window`**, though #359 names it as a per-project example. It is read once per diagnostics event and evaluated against a snapshot of every open tab — it describes the editor's file set, not any one file — and the comment at `extension.ts` explicitly forbids moving that read per-uri. `resource` would be a promise the design cannot keep.

**`pathConversion.codeLensVisibility` and `experimental.useDigestFiles` are `window`**, because their functional reads hold no resource. Only the menu's display read could be scoped, and scoping the display while the behaviour stayed unscoped would show one value and use another.

## Review

Two rounds at `opus`, both driven against a real extension host rather than read off the page.

**Round 1 returned FAIL on a genuine Critical.** A **single-root** workspace registers one model as both its workspace and its folder configuration, so `inspect()` reports a `workspaceFolderValue` for window-scoped settings too. The first guard only checked that a resource had been passed, so it picked `WorkspaceFolder` for a window setting and `update()` threw — a regression against `main`, where the Global write merely did nothing. Toggling `experimental.useDigestFiles` in a single-root project that sets it would have raised `Action failed: ... does not support the folder resource scope`.

Fixed by deriving the folder target from the scopes the manifest declares (`RESOURCE_SCOPED`) rather than from `inspect()` alone, with a test asserting the set and the manifest agree — proven to fail in both directions, so they cannot drift into a thrown write.

Round 1 also exposed two coverage gaps by breaking the code and watching the suite stay green: unscoping the read in `addImportsToDocument`, and pointing a converted row at a dead command id. Round 2 exposed a third: the Critical's own fix was pinned only in the unit tests, with no case at the toggle a user clicks. All three now fail when broken.

**Round 2: PASS_WITH_SUGGESTIONS**, no Critical, no Important. It re-ran the probe that caught the Critical and confirmed the write now lands on `Workspace` and succeeds, and that the keys which legitimately reach `WorkspaceFolder` still do, across single-root and multi-root workspaces, with the overridden values rewritten in place at the level that held them.

Every guard in this PR was proven to detect its defect by removing the fix and watching only the matching test fail.

## Verification

```
$ npm run compile
> tsc -p ./
(clean)

$ npm test
Test Suites: 49 passed, 49 total
Tests:       1468 passed, 1468 total

$ npm run format:check
All matched files use Prettier code style!

$ npx jest src/imports/__tests__
Test Suites: 10 passed, 10 total
Tests:       857 passed, 857 total
```

`src/imports/__tests__` was run in full for the repo's extractor/facade check: no pattern was added, moved or broadened in `ImportSuggestionExtractor`, nothing gained a path around `ImportHandler`, and no unrelated case changed shape.

CI is green, including `test-integration`, which exercises this change against a real multi-root extension host — the layer the unit suite's mocked `vscode` cannot reach.

`main` moved under this branch mid-flight (#423, #424, #427); it is merged in, and the one resolution that mattered kept `main`'s new lexer-based `ImportFormatter.commentStartIndex` from #424.

## Follow-ups, not fixed here

- **Quick-fix label can disagree with the text it inserts.** `behavior.importSyntax` is `resource`, but `ImportSuggestionExtractor` reads it unscoped, so in a multi-root workspace a folder overriding it gets a quick-fix *title* in the other syntax. The inserted text is correct — `ImportDocumentEditor` re-keys to the path and re-formats with its own scoped read — only the title is wrong, and it takes a folder-level override to appear. To be precise about what this is: it is not a pre-existing bug, it is a new capability with an incomplete edge, since before this change both reads were window-scoped and always agreed. Deferred because the fix touches `ImportHandler.extractImportSuggestions`'s signature. The cheap version is an **optional** trailing `resource?: vscode.Uri` forwarded to the two reads, which is source-compatible with every existing caller.
- **`ImportCodeLensProvider` leaks a hover timer in its own tests.** `npx jest src/imports/__tests__` intermittently prints "worker process has failed to exit gracefully"; the provider arms a `setTimeout` that only some of its tests dispose. Pre-existing and reproducible on this branch, which edits none of those tests and adds no timer.
- **`ModuleVisibilityWriter` pins `contentRoot` to `workspaceFolders[0]`** regardless of which folder the module lives in. Pre-existing, untouched here.
- **The extension-host suite's snooze coverage should be re-pointed.** `test-integration` runs in CI and **passes** on this branch, against the real multi-root `.code-workspace` harness. But it writes at `ConfigurationTarget.Workspace` while `commands.itest.ts` asserts on `.globalValue`, so now that writes are no longer unconditionally Global, its regression guard for "snooze must not write the setting" checks a level the code may no longer write to. It passes for a weaker reason than it used to.
