### PR TITLE
refactor(services): read one declaration-head grammar in three places

### DIFF
--- a/changelog.d/410.fixed.md
+++ b/changelog.d/410.fixed.md
@@ -1,0 +1,1 @@
+**Project path scan**: Declarations it silently dropped now reach project path completion - an enum with stacked specifiers or a braced body, a signature holding nested parentheses, and a parametric type head.

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { logger } from "../utils";
-import { matchDeclarationHead } from "../utils/verseDeclarationHead";
+import { DeclarationHead, matchDeclarationHead } from "../utils/verseDeclarationHead";
 import { lineIndentWidth, popClosedBlocks } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 
@@ -14,6 +14,24 @@ import { ProjectPathHandler } from "../project";
  * keeps ordinary constant assignments out.
  */
 const EXTERNAL_INSTANCE_TAIL = /^\s*\w+\s*=\s*external\b/;
+
+/**
+ * Whether the head declares an asset instance rather than a function: a plain
+ * typed name whose value is `external`.
+ *
+ * The parameter-list test is load-bearing and not redundant. A module-scope
+ * function is written `GetColor<public>()<transacts>:vector3 = external {}`,
+ * whose tail is an instance's tail exactly - only the parameter list tells the
+ * two apart. Recording one here puts a function name into the asset-class set,
+ * and `ImportSuggestionExtractor.splitModulePathAndClass` truncates a dotted
+ * module path at the first segment that set accepts, so it emits a short
+ * `using` path.
+ *
+ * @param line The trimmed declaration line the head was read from.
+ */
+export function declaresExternalInstance(head: DeclarationHead, line: string): boolean {
+    return head.keyword === null && head.params === null && head.receiver === null && head.operator === ":" && EXTERNAL_INSTANCE_TAIL.test(line.slice(head.end));
+}
 
 /**
  * The set of asset type names UEFN generated for this project, read from its
@@ -172,7 +190,7 @@ export class AssetsDigestParser {
             }
 
             // Instances only count at module scope, never as class/struct members.
-            if (classBodyIndents.length === 0 && head.operator === ":" && EXTERNAL_INSTANCE_TAIL.test(line.slice(head.end))) {
+            if (classBodyIndents.length === 0 && declaresExternalInstance(head, line)) {
                 names.add(head.name);
             }
         }

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -3,27 +3,17 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { logger } from "../utils";
+import { matchDeclarationHead } from "../utils/verseDeclarationHead";
 import { lineIndentWidth, popClosedBlocks } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 
 /**
- * Matches a class or struct declaration in Assets.digest.verse, e.g.
- * `TestMaterial<scoped {...}> := class<final><scoped {...}>(mesh_component):`.
- * Specifiers may be absent, single, or stacked, and may carry `{...}` arguments,
- * on both the declared name and the `class`/`struct` keyword. Captures the type
- * name. Any specifier keyword is accepted (`public`, `protected`, `private`,
- * `internal`, `scoped`, `final`, ...), matching how ProjectPathScanner reads the
- * same grammar rather than the pre-41.10 `public|internal|private` allowlist.
+ * The right-hand side of an asset instance declaration, read after the head's
+ * `:` - a type name, then `= external`. Textures, meshes, and niagara systems
+ * are emitted as instances rather than classes in 41.10. The `external` anchor
+ * keeps ordinary constant assignments out.
  */
-const CLASS_OR_STRUCT_DECL = /^(\w+)(?:<[^>]*>)*\s*:=\s*(?:class|struct)\b/;
-
-/**
- * Matches an asset instance declaration at module scope, e.g.
- * `image1<scoped {...}>:texture = external {}`. Textures, meshes, and niagara
- * systems are emitted as instances rather than classes in 41.10. Captures the
- * instance name. The `external` anchor keeps ordinary constant assignments out.
- */
-const INSTANCE_DECL = /^(\w+)(?:<[^>]*>)*\s*:\s*\w+\s*=\s*external\b/;
+const EXTERNAL_INSTANCE_TAIL = /^\s*\w+\s*=\s*external\b/;
 
 /**
  * The set of asset type names UEFN generated for this project, read from its
@@ -135,9 +125,10 @@ export class AssetsDigestParser {
     /**
      * Extracts asset type names from Assets.digest.verse content.
      *
-     * Recognizes both 41.10 and pre-41.10 declaration shapes:
-     * - Class/struct declarations with single, stacked, or argument-bearing
-     *   specifiers on either side of `:=`, e.g.
+     * Heads are read by `matchDeclarationHead`, shared with the API digest
+     * parser and the project scan; the policy over its answer is what lives
+     * here, and recognizes both 41.10 and pre-41.10 shapes:
+     * - Class/struct declarations, e.g.
      *   `TestSphere<scoped {...}> := class<final><scoped {...}>(mesh_component):`.
      * - Module-scope asset instances, e.g. `image1<scoped {...}>:texture = external {}`.
      *
@@ -169,19 +160,20 @@ export class AssetsDigestParser {
 
             popClosedBlocks(classBodyIndents, indent);
 
-            const classMatch = line.match(CLASS_OR_STRUCT_DECL);
-            if (classMatch) {
-                names.add(classMatch[1]);
+            const head = matchDeclarationHead(line);
+            if (!head || head.receiver !== null) {
+                continue;
+            }
+
+            if (head.keyword === "class" || head.keyword === "struct") {
+                names.add(head.name);
                 classBodyIndents.push(indent);
                 continue;
             }
 
             // Instances only count at module scope, never as class/struct members.
-            if (classBodyIndents.length === 0) {
-                const instanceMatch = line.match(INSTANCE_DECL);
-                if (instanceMatch) {
-                    names.add(instanceMatch[1]);
-                }
+            if (classBodyIndents.length === 0 && head.operator === ":" && EXTERNAL_INSTANCE_TAIL.test(line.slice(head.end))) {
+                names.add(head.name);
             }
         }
 

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -19,18 +19,20 @@ const EXTERNAL_INSTANCE_TAIL = /^\s*\w+\s*=\s*external\b/;
  * Whether the head declares an asset instance rather than a function: a plain
  * typed name whose value is `external`.
  *
- * The parameter-list test is load-bearing and not redundant. A module-scope
- * function is written `GetColor<public>()<transacts>:vector3 = external {}`,
- * whose tail is an instance's tail exactly - only the parameter list tells the
- * two apart. Recording one here puts a function name into the asset-class set,
- * and `ImportSuggestionExtractor.splitModulePathAndClass` truncates a dotted
- * module path at the first segment that set accepts, so it emits a short
- * `using` path.
+ * The parameter-list test is what separates the two, and nothing else does. A
+ * module-scope function is written `GetColor<public>()<transacts>:vector3 =
+ * external {}`, whose tail is an instance's tail exactly. Recording one here
+ * puts a function name into the asset-class set, and
+ * `ImportSuggestionExtractor.splitModulePathAndClass` truncates a dotted module
+ * path at the first segment that set accepts, so it emits a short `using` path.
+ *
+ * The receiver test is belt and braces - the caller skips a receiver head
+ * already - and is kept so the predicate answers on its own.
  *
  * @param line The trimmed declaration line the head was read from.
  */
-export function declaresExternalInstance(head: DeclarationHead, line: string): boolean {
-    return head.keyword === null && head.params === null && head.receiver === null && head.operator === ":" && EXTERNAL_INSTANCE_TAIL.test(line.slice(head.end));
+function declaresExternalInstance(head: DeclarationHead, line: string): boolean {
+    return head.params === null && head.receiver === null && head.operator === ":" && EXTERNAL_INSTANCE_TAIL.test(line.slice(head.end));
 }
 
 /**

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -9,21 +9,28 @@ import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 const SCAN_CONCURRENCY = 8;
 
 /**
- * What kind of declaration a head makes.
+ * What kind of declaration a head makes, or null where it makes none.
  *
  * A module head does not reach here: it opens a body this cannot bound, so the
  * scan takes it in its own branch beforehand.
  *
  * A receiver-style extension method is a function declared in this module, and
- * is indexed here where the two digest parsers deliberately skip it. Anything
- * carrying a parameter list is a function whichever operator follows, including
- * an unclosed one, which is a signature continuing on the line below.
+ * is indexed here where the two digest parsers deliberately skip it.
+ *
+ * An unclosed `(` is declined rather than guessed at. In a digest it can only
+ * be a signature wrapping to the next line, which is why the digest parser
+ * reads it as a function; this scan reads project source, where the same shape
+ * is far more often a call wrapping inside a function body, and recording those
+ * would fill the index with statements.
  */
-function declarationType(head: DeclarationHead): ProjectPathNode["type"] {
+function declarationType(head: DeclarationHead): ProjectPathNode["type"] | null {
     if (head.keyword) {
         return head.keyword;
     }
-    if (head.receiver !== null || head.params !== null || head.operator === "(") {
+    if (head.operator === "(") {
+        return null;
+    }
+    if (head.receiver !== null || head.params !== null) {
         return "function";
     }
     return "variable";
@@ -433,13 +440,11 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            // One head, one decision. The five near-identical branches this
-            // replaced each carried their own spelling of the same grammar, and
-            // the backstop that caught what they missed carried a sixth - so a
-            // keyword rule had two independent homes and a missing one was paid
-            // for twice. `declarationType` reads the head the module branch
-            // above already matched, which is what leaves no shape for a
-            // backstop to be needed for.
+            const type = declarationType(head);
+            if (type === null) {
+                continue;
+            }
+
             const visibility = extractVisibility(head.specifiers);
             if (shouldSkipDeclaration(visibility)) {
                 continue;
@@ -448,7 +453,7 @@ export class ProjectPathScanner {
             nodes.push({
                 name: head.name,
                 fullPath: currentModulePath ? `${currentModulePath}.${head.name}` : head.name,
-                type: declarationType(head),
+                type,
                 isPublic: visibility === "public",
                 sourceFile: filePath,
                 sourceLine: i + 1,

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -21,7 +21,9 @@ const SCAN_CONCURRENCY = 8;
  * be a signature wrapping to the next line, which is why the digest parser
  * reads it as a function; this scan reads project source, where the same shape
  * is far more often a call wrapping inside a function body, and recording those
- * would fill the index with statements.
+ * would fill the index with statements. The cost is a genuine module-scope
+ * signature that wraps across lines, which is lost here - as it was by the
+ * patterns this replaced, which needed a closing `)` and a `:` on one line.
  */
 function declarationType(head: DeclarationHead): ProjectPathNode["type"] | null {
     if (head.keyword) {

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { logger } from "../utils";
+import { DeclarationHead, matchDeclarationHead } from "../utils/verseDeclarationHead";
 import { countBraces, indentOf, maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
@@ -8,17 +9,25 @@ import { ProjectPathData, ProjectPathNode, ProjectScanOptions } from "../types";
 const SCAN_CONCURRENCY = 8;
 
 /**
- * A declaration keyword introducing the right-hand side of a `:=`, for the
- * backstop that catches a type whose own pattern did not match the exact shape
- * written.
+ * What kind of declaration a head makes.
  *
- * Anchored at the `:=` and closed with `\b`, because a keyword this recognises
- * loosely costs a whole declaration: a substring test reads
- * `Items := classify_items(X)` as a type and drops the line, where the same
- * missing boundary in the class, struct and interface patterns above only
- * mistyped it. Nothing here may be tested with `includes`.
+ * A module head does not reach here: it opens a body this cannot bound, so the
+ * scan takes it in its own branch beforehand.
+ *
+ * A receiver-style extension method is a function declared in this module, and
+ * is indexed here where the two digest parsers deliberately skip it. Anything
+ * carrying a parameter list is a function whichever operator follows, including
+ * an unclosed one, which is a signature continuing on the line below.
  */
-const DECLARATION_KEYWORD_AFTER_ASSIGN = /:=\s*(?:class|struct|module|interface|enum)\b/;
+function declarationType(head: DeclarationHead): ProjectPathNode["type"] {
+    if (head.keyword) {
+        return head.keyword;
+    }
+    if (head.receiver !== null || head.params !== null || head.operator === "(") {
+        return "function";
+    }
+    return "variable";
+}
 
 /**
  * The keywords a Verse block macro is spelled with, and the operators and types
@@ -277,36 +286,6 @@ export class ProjectPathScanner {
             return false;
         };
 
-        // Every pattern below captures [1] the declared name and [2] the
-        // specifiers attached to that name, matching the shape
-        // `Name<spec><spec> := type<typespec>(parent):`. Specifiers to the
-        // right of `:=` belong to the type, not the name, and are skipped
-        // rather than captured - except by modulePattern, which allows none
-        // there and so does not match a module carrying them.
-        //
-        // A module body takes any of the three styles Verse gives a macro, so
-        // the keyword ends at `:`, `{` or `.` - or at the line end, which is
-        // how a next-line brace reaches a scan that sees one line at a time.
-        // `>` holds parity with the two other spellings of this grammar,
-        // ImportPathConverter.buildModuleDefinitionRegex and
-        // moduleDeclarations' MODULE_DECLARATION. [3] captures which of them
-        // ended the keyword, and is undefined for the line end alone; the
-        // module stack needs that to know a body is still to open.
-        const modulePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*module\s*(?:([:>{.])|$)/;
-        // `\b` after the keyword, or `Foo := classify_items(X)` declares a class
-        // named Foo: everything after `class` here is optional, so the pattern
-        // matches the prefix of any identifier beginning with one of these
-        // words. modulePattern and enumPattern need no such boundary - each
-        // requires a terminator that a continuing identifier cannot supply.
-        const classPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*class\b\s*(?:<[^>]+>)*\s*[\(:]?/;
-        const structPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*struct\b\s*(?:<[^>]+>)*\s*[\(:]?/;
-        const interfacePattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*interface\b\s*(?:<[^>]+>)*\s*[\(:]?/;
-        const enumPattern = /^(\w+)((?:<[^>]+>)*)\s*:=\s*enum\s*(?:<[^>]+>)?\s*:/;
-        /** `Name<specifiers>(params)<effects>:` */
-        const functionPattern = /^(\w+)((?:<[^>]+>)*)\s*\([^)]*\)\s*(?:<[^>]+>)*\s*:/;
-        /** `(Type:type).Name<specifiers>(params)<effects>:` */
-        const extensionMethodPattern = /^\([^)]+\)\.(\w+)((?:<[^>]+>)*)\s*\([^)]*\)/;
-        const variablePattern = /^(\w+)((?:<[^>]+>)*)\s*:/;
         /** The word a line opens with, absent where it opens with anything else. */
         const leadingWordPattern = /^(\w+)/;
 
@@ -405,12 +384,16 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            const moduleMatch = line.match(modulePattern);
-            if (moduleMatch) {
-                const [, name, specifiers, bodyTerminator] = moduleMatch;
+            const head = matchDeclarationHead(line);
+            if (!head) {
+                continue;
+            }
+
+            if (head.keyword === "module") {
+                const { name, specifiers, bodyTerminator } = head;
                 const visibility = extractVisibility(specifiers);
                 const isPublic = visibility === "public";
-                const awaitingBrace = bodyTerminator === undefined;
+                const awaitingBrace = bodyTerminator === null;
                 // A `{` here opens the body on this line, and it opens from the
                 // depth the line started at: everything left of it belongs to
                 // the declaration, whose only braces are a `scoped{...}` list
@@ -450,182 +433,26 @@ export class ProjectPathScanner {
                 continue;
             }
 
-            const classMatch = line.match(classPattern);
-            if (classMatch) {
-                const [, name, specifiers] = classMatch;
-                const visibility = extractVisibility(specifiers);
-                const isPublic = visibility === "public";
-
-                if (shouldSkipDeclaration(visibility)) {
-                    continue;
-                }
-
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-
-                nodes.push({
-                    name,
-                    fullPath,
-                    type: "class",
-                    isPublic,
-                    sourceFile: filePath,
-                    sourceLine: i + 1,
-                });
+            // One head, one decision. The five near-identical branches this
+            // replaced each carried their own spelling of the same grammar, and
+            // the backstop that caught what they missed carried a sixth - so a
+            // keyword rule had two independent homes and a missing one was paid
+            // for twice. `declarationType` reads the head the module branch
+            // above already matched, which is what leaves no shape for a
+            // backstop to be needed for.
+            const visibility = extractVisibility(head.specifiers);
+            if (shouldSkipDeclaration(visibility)) {
                 continue;
             }
 
-            const structMatch = line.match(structPattern);
-            if (structMatch) {
-                const [, name, specifiers] = structMatch;
-                const visibility = extractVisibility(specifiers);
-                const isPublic = visibility === "public";
-
-                if (shouldSkipDeclaration(visibility)) {
-                    continue;
-                }
-
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-
-                nodes.push({
-                    name,
-                    fullPath,
-                    type: "struct",
-                    isPublic,
-                    sourceFile: filePath,
-                    sourceLine: i + 1,
-                });
-                continue;
-            }
-
-            const interfaceMatch = line.match(interfacePattern);
-            if (interfaceMatch) {
-                const [, name, specifiers] = interfaceMatch;
-                const visibility = extractVisibility(specifiers);
-                const isPublic = visibility === "public";
-
-                if (shouldSkipDeclaration(visibility)) {
-                    continue;
-                }
-
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-
-                nodes.push({
-                    name,
-                    fullPath,
-                    type: "interface",
-                    isPublic,
-                    sourceFile: filePath,
-                    sourceLine: i + 1,
-                });
-                continue;
-            }
-
-            const enumMatch = line.match(enumPattern);
-            if (enumMatch) {
-                const [, name, specifiers] = enumMatch;
-                const visibility = extractVisibility(specifiers);
-                const isPublic = visibility === "public";
-
-                if (shouldSkipDeclaration(visibility)) {
-                    continue;
-                }
-
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-
-                nodes.push({
-                    name,
-                    fullPath,
-                    type: "enum",
-                    isPublic,
-                    sourceFile: filePath,
-                    sourceLine: i + 1,
-                });
-                continue;
-            }
-
-            const extensionMatch = line.match(extensionMethodPattern);
-            if (extensionMatch) {
-                const [, name, specifiers] = extensionMatch;
-                const visibility = extractVisibility(specifiers);
-                const isPublic = visibility === "public";
-
-                if (shouldSkipDeclaration(visibility)) {
-                    continue;
-                }
-
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-
-                nodes.push({
-                    name,
-                    fullPath,
-                    type: "function",
-                    isPublic,
-                    sourceFile: filePath,
-                    sourceLine: i + 1,
-                });
-                continue;
-            }
-
-            const functionMatch = line.match(functionPattern);
-            if (functionMatch) {
-                const [, name, specifiers] = functionMatch;
-                const visibility = extractVisibility(specifiers);
-                const isPublic = visibility === "public";
-
-                if (shouldSkipDeclaration(visibility)) {
-                    continue;
-                }
-
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-
-                nodes.push({
-                    name,
-                    fullPath,
-                    type: "function",
-                    isPublic,
-                    sourceFile: filePath,
-                    sourceLine: i + 1,
-                });
-                continue;
-            }
-
-            // Last, and it must stay last. The `:` this pattern needs is also
-            // the first character of the `:=` that opens a type declaration, so
-            // it matches those too; the branches above only win by being asked
-            // first, and the guards below cover the shapes they did not match.
-            const variableMatch = line.match(variablePattern);
-            if (variableMatch) {
-                const [, name, specifiers] = variableMatch;
-                const visibility = extractVisibility(specifiers);
-                const isPublic = visibility === "public";
-
-                if (shouldSkipDeclaration(visibility)) {
-                    continue;
-                }
-
-                // Both guards are backstops for a declaration whose specific
-                // pattern above did not match the exact shape written: a type,
-                // recognised by `:=` with a declaration keyword, and a function,
-                // recognised by a parameter list before the colon. Either would
-                // otherwise be recorded as a variable.
-                if (DECLARATION_KEYWORD_AFTER_ASSIGN.test(line)) {
-                    continue;
-                }
-
-                if (/\([^)]*\)\s*(?:<[^>]+>)?\s*:/.test(line)) {
-                    continue;
-                }
-
-                const fullPath = currentModulePath ? `${currentModulePath}.${name}` : name;
-
-                nodes.push({
-                    name,
-                    fullPath,
-                    type: "variable",
-                    isPublic,
-                    sourceFile: filePath,
-                    sourceLine: i + 1,
-                });
-            }
+            nodes.push({
+                name: head.name,
+                fullPath: currentModulePath ? `${currentModulePath}.${head.name}` : head.name,
+                type: declarationType(head),
+                isPublic: visibility === "public",
+                sourceFile: filePath,
+                sourceLine: i + 1,
+            });
         }
 
         return nodes;

--- a/src/services/digestParsing.ts
+++ b/src/services/digestParsing.ts
@@ -14,6 +14,10 @@
  * explicit `# Module import path:` comment, a scope qualifier `(/path:)`, the
  * enclosing module on the stack, or the file's root domain.
  *
+ * Declaration heads are recognized by `matchDeclarationHead`, shared with the
+ * assets parser and the project scan; only the policy over its answer lives
+ * here.
+ *
  * Comments are skipped only where `#` is the line's first non-whitespace
  * character. Verse also has `<# #>` and `<#>` comments, and a `#` after code or
  * inside a string is not a comment at all, so this is a narrower rule than the
@@ -22,6 +26,7 @@
  * ProjectPathScanner does.
  */
 
+import { DeclarationKeyword, matchDeclarationHead } from "../utils/verseDeclarationHead";
 import { lineIndentWidth, popClosedBlocks } from "../utils/verseText";
 
 /** A single importable declaration extracted from a digest file. */
@@ -83,70 +88,8 @@ interface ModuleFrame {
  */
 const QUALIFIER_RE = /^\((\/[^()]*):\)/;
 
-/**
- * A module-scope declaration head: an identifier, its own specifier groups, and
- * the operator that follows (`:=`, `:`, or `(`). Captures name, specifiers, and
- * operator. Specifier groups on the declaration's right-hand side (for example
- * `class<concrete>`) are intentionally excluded from the captured specifiers.
- */
-const DECL_RE = /^(\w+)((?:<[^>]+>)*)\s*(:=|:|\()/;
-
-/** The start of a parametric type head: an identifier, its specifier groups, and the `(` opening its type-parameter list. */
-const PARAM_TYPE_HEAD_RE = /^(\w+)((?:<[^>]+>)*)\(/;
-
-/** The `:=` and declaration keyword that must follow a parametric type's parameter list. */
-const PARAM_TYPE_TAIL_RE = /^\s*:=\s*(module|class|struct|interface|enum)\b/;
-
-/** Recognizes the declaration keyword after `:=` (module, class, struct, ...). */
-const DECL_KEYWORD_RE = /^\s*(module|class|struct|interface|enum)\b/;
-
 /** Extracts the explicit module import path from a `# Module import path:` comment. */
 const MODULE_PATH_COMMENT_RE = /#\s*Module import path:\s*(\S+)/;
-
-/**
- * A parametric type declared with a type-parameter list, such as
- * `subscribable<public>(t:type) := interface:` or
- * `agent_group<native><public>(member_info:subtype(member_info_interface)) := class(...):`,
- * or null where the line is not one.
- *
- * Must be tried before {@link DECL_RE}, whose `(` alternative would otherwise read
- * the type-parameter list as a function signature and leak the type's members to
- * module scope.
- *
- * The parameter list is walked for its matching `)` rather than matched by a
- * regex, because a Verse parenthesized parameter list holds general expressions
- * (`Paren := '(' List ')' Space`, VerseGrammar.h) and a parameter may itself be
- * an invocation carrying another paren group, to any depth. Any fixed depth here
- * would hold only until a digest refresh exceeded it.
- *
- * @param work The trimmed line with any scope qualifier prefix already removed.
- */
-function matchParametricTypeHead(work: string): { name: string; specifiers: string; keyword: string } | null {
-    const head = work.match(PARAM_TYPE_HEAD_RE);
-    if (!head) {
-        return null;
-    }
-
-    let depth = 0;
-    let index = head[0].length - 1;
-    for (; index < work.length; index++) {
-        if (work[index] === "(") {
-            depth++;
-        } else if (work[index] === ")") {
-            depth--;
-            if (depth === 0) {
-                index++;
-                break;
-            }
-        }
-    }
-    if (depth !== 0) {
-        return null;
-    }
-
-    const tail = work.slice(index).match(PARAM_TYPE_TAIL_RE);
-    return tail ? { name: head[1], specifiers: head[2], keyword: tail[1] } : null;
-}
 
 /**
  * Maps a digest file name to the root module domain its top-level declarations
@@ -242,7 +185,7 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
     // a module opens a new frame; a class/struct/interface/enum records itself and
     // opens a body whose members are skipped. Shared by the plain and parametric
     // (type-parameter-bearing) declaration paths.
-    const recordModuleOrType = (name: string, isPublic: boolean, keyword: string, qualifierPath: string | null, indent: number): void => {
+    const recordModuleOrType = (name: string, isPublic: boolean, keyword: DeclarationKeyword, qualifierPath: string | null, indent: number): void => {
         if (keyword === "module") {
             const modulePath = resolveModulePath(name, pendingModulePath, qualifierPath, moduleStack, rootDomain);
             pendingModulePath = null;
@@ -291,43 +234,32 @@ export function parseDigestContent(content: string, rootDomain: string): ParsedD
         if (qualifierMatch) {
             qualifierPath = qualifierMatch[1];
             work = line.slice(qualifierMatch[0].length);
-        } else if (line.startsWith("(")) {
-            // Receiver-style extension method or other parenthesized form: skip.
+        }
+
+        const head = matchDeclarationHead(work);
+        if (!head) {
             continue;
         }
 
-        // Before DECL_RE: the order is load-bearing, and matchParametricTypeHead says why.
-        const paramType = matchParametricTypeHead(work);
-        if (paramType) {
-            recordModuleOrType(paramType.name, paramType.specifiers.includes("<public>"), paramType.keyword, qualifierPath, indent);
+        // A receiver-style extension method declares a name in this module, and
+        // this index deliberately does not offer it: the project scan reads the
+        // same head and does index one. Policy, not a difference of grammar -
+        // see matchDeclarationHead's `receiver`.
+        if (head.receiver !== null) {
             continue;
         }
 
-        const decl = work.match(DECL_RE);
-        if (!decl) {
-            continue;
-        }
-        const name = decl[1];
-        const identifierSpecifiers = decl[2];
-        const operator = decl[3];
-        const isPublic = identifierSpecifiers.includes("<public>");
+        const isPublic = head.specifiers.includes("<public>");
 
-        if (operator === ":=") {
-            const keywordMatch = work.slice(decl[0].length).match(DECL_KEYWORD_RE);
-            const keyword = keywordMatch ? keywordMatch[1] : null;
-
-            if (keyword) {
-                // module or class / struct / interface / enum.
-                recordModuleOrType(name, isPublic, keyword, qualifierPath, indent);
-                continue;
-            }
-
-            addEntry(name, containingModulePath(qualifierPath, moduleStack, rootDomain), "variable", isPublic);
+        if (head.keyword) {
+            recordModuleOrType(head.name, isPublic, head.keyword, qualifierPath, indent);
             continue;
         }
 
-        const type: DigestEntry["type"] = operator === "(" ? "function" : "variable";
-        addEntry(name, containingModulePath(qualifierPath, moduleStack, rootDomain), type, isPublic);
+        // A parameter list makes it a function whichever operator follows, and
+        // an unclosed one - a signature continuing below - reports as `(`.
+        const type: DigestEntry["type"] = head.params !== null || head.operator === "(" ? "function" : "variable";
+        addEntry(head.name, containingModulePath(qualifierPath, moduleStack, rootDomain), type, isPublic);
     }
 
     const moduleIndexRecord: Record<string, string[]> = {};

--- a/src/utils/__tests__/verseDeclarationHeadCorpus.test.ts
+++ b/src/utils/__tests__/verseDeclarationHeadCorpus.test.ts
@@ -1,0 +1,203 @@
+import { AssetsDigestParser } from "../../services/AssetsDigestParser";
+import { parseDigestContent } from "../../services/digestParsing";
+import { ProjectPathScanner } from "../../services/ProjectPathScanner";
+import { DeclarationHead, matchDeclarationHead } from "../verseDeclarationHead";
+
+/**
+ * One probe corpus read by every caller of the declaration-head matcher, so a
+ * grammar rule learned in one of them cannot quietly go unlearned in the others.
+ *
+ * Each probe is a construct the three matchers this replaced disagreed about,
+ * and each is asserted twice: once that the shared matcher's answer is the
+ * language's, cited below to the compiler grammar or to a compile-validated
+ * book test, and once that every caller reports exactly what its own policy
+ * says about that answer. The second half is what a future divergence trips
+ * over - a rule added to one caller and not the shared matcher fails here even
+ * where nobody thought to write the case down.
+ *
+ * The two halves are independent. A probe whose head is wrong fails the first;
+ * a caller that re-decides the grammar for itself fails the second.
+ */
+
+const scanner = new ProjectPathScanner(
+    { appendLine: jest.fn() } as unknown as ConstructorParameters<typeof ProjectPathScanner>[0],
+    {} as unknown as ConstructorParameters<typeof ProjectPathScanner>[1],
+);
+
+/** The part of a head the callers' policies turn on. */
+interface HeadShape {
+    name: string;
+    keyword: DeclarationHead["keyword"];
+    hasParams: boolean;
+    hasReceiver: boolean;
+}
+
+function shapeOf(head: DeclarationHead | null): HeadShape | null {
+    return head && { name: head.name, keyword: head.keyword, hasParams: head.params !== null, hasReceiver: head.receiver !== null };
+}
+
+/**
+ * What each caller's documented policy makes of a head, written once so the
+ * expectations below are derived from the shared grammar rather than restated
+ * per caller - restating them is how three matchers drifted apart in the first
+ * place.
+ *
+ * The two `false` answers are the deliberate divergences, and they are policy
+ * rather than grammar: all three callers see the same head and choose.
+ */
+function policy(head: DeclarationHead | null, line: string): { digest: boolean; assets: boolean; scanner: boolean } {
+    if (!head) {
+        return { digest: false, assets: false, scanner: false };
+    }
+    const isExternalInstance = head.operator === ":" && /^\s*\w+\s*=\s*external\b/.test(line.slice(head.end));
+    return {
+        // The API digest index declines receiver-style extension methods.
+        digest: head.receiver === null,
+        // The assets parser wants asset type names only: a class, a struct, or
+        // an `external` instance at module scope.
+        assets: head.receiver === null && (head.keyword === "class" || head.keyword === "struct" || isExternalInstance),
+        // The project scan indexes every declaration, extension methods included.
+        scanner: true,
+    };
+}
+
+/** The names each caller records, in the order it records them. */
+function reported(source: string): { digest: string[]; assets: string[]; scanner: string[] } {
+    return {
+        digest: Object.keys(parseDigestContent(source, "/mygame@fortnite.com/mygame").entries),
+        assets: AssetsDigestParser.parseDigestContent(source),
+        scanner: scanner.extractDeclarations(source, "declarations.verse").map((node) => node.name),
+    };
+}
+
+interface Probe {
+    /** What the construct is, phrased as the rule it tests. */
+    name: string;
+    source: string;
+    /** The head the language gives this line. */
+    head: HeadShape;
+}
+
+const probes: Probe[] = [
+    {
+        // ProjectPathScanner allowed one specifier group after `enum` where it
+        // allowed any number after `class`. Two are `assert_valid` at book
+        // Tests/CompatibilityConstraints.versetest:1147.
+        name: "an enum takes as many specifier groups on its keyword as a class does",
+        source: "Colour<public> := enum<open><persistable>:\n",
+        head: { name: "Colour", keyword: "enum", hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "an enum with one keyword specifier is the same rule",
+        source: "Colour<public> := enum<open>:\n",
+        head: { name: "Colour", keyword: "enum", hasParams: false, hasReceiver: false },
+    },
+    {
+        // ProjectPathScanner's enum required a `:`, so a braced body was
+        // dropped. Braced enums are book Tests/Any.versetest:5 and
+        // Tests/Attributes/available.versetest:40.
+        name: "an enum body opens with a brace as readily as with a colon",
+        source: "Colour<public> := enum<open> { A, B }\n",
+        head: { name: "Colour", keyword: "enum", hasParams: false, hasReceiver: false },
+    },
+    {
+        // `\([^)]*\)` cannot cross the inner `)`, so ProjectPathScanner dropped
+        // the whole declaration. `Paren := '(' List ')' Space` makes a parameter
+        // an expression, so the list nests to any depth and must be walked.
+        name: "a parameter list nests, and is walked rather than matched",
+        source: "GetComponent<public>(component_type:castable_subtype(component))<transacts>:void = external {}\n",
+        head: { name: "GetComponent", keyword: null, hasParams: true, hasReceiver: false },
+    },
+    {
+        // A type-parameter list before the `:=`. digestParsing walked it;
+        // ProjectPathScanner had no pattern for it at all.
+        name: "a type-parameter list precedes the declaration keyword",
+        source: "Pair<public>(t:subtype(comparable)) := class:\n",
+        head: { name: "Pair", keyword: "class", hasParams: true, hasReceiver: false },
+    },
+    {
+        // The kept divergence: one head, two policies. The receiver is walked
+        // for its matching `)` like any other paren group.
+        name: "a receiver-style extension method is one head the callers answer differently",
+        source: "(Prop:creative_prop).Method<public>()<transacts>:void = external {}\n",
+        head: { name: "Method", keyword: null, hasParams: true, hasReceiver: true },
+    },
+    {
+        // #373's C-04. A keyword that only prefixes the identifier opens no
+        // body, so the line declares a variable and is not dropped either - the
+        // two ways this has been got wrong.
+        name: "a keyword that merely prefixes an identifier declares no type",
+        source: "Items<public> := classify_items(X)\n",
+        head: { name: "Items", keyword: null, hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "a class takes stacked keyword specifiers and a superclass list",
+        source: "Thing<public> := class<abstract><castable>(base_device):\n",
+        head: { name: "Thing", keyword: "class", hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "a class body opens with a brace",
+        source: "Thing<public> := class { }\n",
+        head: { name: "Thing", keyword: "class", hasParams: false, hasReceiver: false },
+    },
+    {
+        // Four groups, as shipped in Verse.digest.verse.
+        name: "specifier groups stack without bound",
+        source: "Point<public> := struct<concrete><computes><persistable><uht_comparable>:\n",
+        head: { name: "Point", keyword: "struct", hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "an interface is the same head as a class",
+        source: "Shape<public> := interface<epic_internal>:\n",
+        head: { name: "Shape", keyword: "interface", hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "a module declares with a colon",
+        source: "Inner<public> := module:\n",
+        head: { name: "Inner", keyword: "module", hasParams: false, hasReceiver: false },
+    },
+    {
+        // The brace opens on the line below, which is the only reason a head
+        // ending at the line end is a declaration and not a fragment.
+        name: "a module whose brace opens on the next line is still a module",
+        source: "Inner<public> := module\n{\n}\n",
+        head: { name: "Inner", keyword: "module", hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "an external instance is a typed name, not a keyword declaration",
+        source: "image1<public>:texture = external {}\n",
+        head: { name: "image1", keyword: null, hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "a typed constant declares a variable",
+        source: "Score<public>:int = 0\n",
+        head: { name: "Score", keyword: null, hasParams: false, hasReceiver: false },
+    },
+    {
+        name: "an inferred constant declares a variable",
+        source: "Total<public> := 5\n",
+        head: { name: "Total", keyword: null, hasParams: false, hasReceiver: false },
+    },
+];
+
+describe("the one declaration-head grammar", () => {
+    for (const probe of probes) {
+        it(`${probe.name}: the head is the language's answer`, () => {
+            expect(shapeOf(matchDeclarationHead(probe.source.split("\n")[0].trim()))).toEqual(probe.head);
+        });
+    }
+});
+
+describe("every caller reads that grammar and adds only its own policy", () => {
+    for (const probe of probes) {
+        it(`${probe.name}: each caller reports what its policy says, and nothing else`, () => {
+            const line = probe.source.split("\n")[0].trim();
+            const expected = policy(matchDeclarationHead(line), line);
+            expect(reported(probe.source)).toEqual({
+                digest: expected.digest ? [probe.head.name] : [],
+                assets: expected.assets ? [probe.head.name] : [],
+                scanner: expected.scanner ? [probe.head.name] : [],
+            });
+        });
+    }
+});

--- a/src/utils/__tests__/verseDeclarationHeadCorpus.test.ts
+++ b/src/utils/__tests__/verseDeclarationHeadCorpus.test.ts
@@ -28,37 +28,13 @@ const scanner = new ProjectPathScanner(
 interface HeadShape {
     name: string;
     keyword: DeclarationHead["keyword"];
+    operator: DeclarationHead["operator"];
     hasParams: boolean;
     hasReceiver: boolean;
 }
 
 function shapeOf(head: DeclarationHead | null): HeadShape | null {
-    return head && { name: head.name, keyword: head.keyword, hasParams: head.params !== null, hasReceiver: head.receiver !== null };
-}
-
-/**
- * What each caller's documented policy makes of a head, written once so the
- * expectations below are derived from the shared grammar rather than restated
- * per caller - restating them is how three matchers drifted apart in the first
- * place.
- *
- * The two `false` answers are the deliberate divergences, and they are policy
- * rather than grammar: all three callers see the same head and choose.
- */
-function policy(head: DeclarationHead | null, line: string): { digest: boolean; assets: boolean; scanner: boolean } {
-    if (!head) {
-        return { digest: false, assets: false, scanner: false };
-    }
-    const isExternalInstance = head.operator === ":" && /^\s*\w+\s*=\s*external\b/.test(line.slice(head.end));
-    return {
-        // The API digest index declines receiver-style extension methods.
-        digest: head.receiver === null,
-        // The assets parser wants asset type names only: a class, a struct, or
-        // an `external` instance at module scope.
-        assets: head.receiver === null && (head.keyword === "class" || head.keyword === "struct" || isExternalInstance),
-        // The project scan indexes every declaration, extension methods included.
-        scanner: true,
-    };
+    return head && { name: head.name, keyword: head.keyword, operator: head.operator, hasParams: head.params !== null, hasReceiver: head.receiver !== null };
 }
 
 /** The names each caller records, in the order it records them. */
@@ -76,7 +52,23 @@ interface Probe {
     source: string;
     /** The head the language gives this line. */
     head: HeadShape;
+    /**
+     * Which callers record the declared name, written out rather than derived
+     * from the callers' own policy code.
+     *
+     * Deriving it was tried and is what let a widened `assets` rule ship: an
+     * oracle that recomputes what it is checking agrees with the bug. Both
+     * halves of this corpus are authored, so the second can fail while the
+     * first passes.
+     */
+    reports: { digest: boolean; assets: boolean; scanner: boolean };
 }
+
+/** Records in the digest index and the project scan, but is no asset type. */
+const NOT_AN_ASSET_TYPE = { digest: true, assets: false, scanner: true };
+
+/** Records everywhere: a class or struct is an asset type name too. */
+const EVERYWHERE = { digest: true, assets: true, scanner: true };
 
 const probes: Probe[] = [
     {
@@ -85,12 +77,14 @@ const probes: Probe[] = [
         // Tests/CompatibilityConstraints.versetest:1147.
         name: "an enum takes as many specifier groups on its keyword as a class does",
         source: "Colour<public> := enum<open><persistable>:\n",
-        head: { name: "Colour", keyword: "enum", hasParams: false, hasReceiver: false },
+        head: { name: "Colour", keyword: "enum", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         name: "an enum with one keyword specifier is the same rule",
         source: "Colour<public> := enum<open>:\n",
-        head: { name: "Colour", keyword: "enum", hasParams: false, hasReceiver: false },
+        head: { name: "Colour", keyword: "enum", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         // ProjectPathScanner's enum required a `:`, so a braced body was
@@ -98,7 +92,8 @@ const probes: Probe[] = [
         // Tests/Attributes/available.versetest:40.
         name: "an enum body opens with a brace as readily as with a colon",
         source: "Colour<public> := enum<open> { A, B }\n",
-        head: { name: "Colour", keyword: "enum", hasParams: false, hasReceiver: false },
+        head: { name: "Colour", keyword: "enum", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         // `\([^)]*\)` cannot cross the inner `)`, so ProjectPathScanner dropped
@@ -106,77 +101,109 @@ const probes: Probe[] = [
         // an expression, so the list nests to any depth and must be walked.
         name: "a parameter list nests, and is walked rather than matched",
         source: "GetComponent<public>(component_type:castable_subtype(component))<transacts>:void = external {}\n",
-        head: { name: "GetComponent", keyword: null, hasParams: true, hasReceiver: false },
+        head: { name: "GetComponent", keyword: null, operator: ":", hasParams: true, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
+    },
+    {
+        // A function's tail is an asset instance's tail exactly, so only the
+        // parameter list separates them. Recording one as an asset type name
+        // moves where a dotted suggestion is split into module and class.
+        name: "a module-scope function ending in `= external` is not an asset instance",
+        source: "GetColor<public>()<transacts>:vector3 = external {}\n",
+        head: { name: "GetColor", keyword: null, operator: ":", hasParams: true, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         // A type-parameter list before the `:=`. digestParsing walked it;
         // ProjectPathScanner had no pattern for it at all.
         name: "a type-parameter list precedes the declaration keyword",
         source: "Pair<public>(t:subtype(comparable)) := class:\n",
-        head: { name: "Pair", keyword: "class", hasParams: true, hasReceiver: false },
+        head: { name: "Pair", keyword: "class", operator: ":=", hasParams: true, hasReceiver: false },
+        reports: EVERYWHERE,
     },
     {
         // The kept divergence: one head, two policies. The receiver is walked
         // for its matching `)` like any other paren group.
         name: "a receiver-style extension method is one head the callers answer differently",
         source: "(Prop:creative_prop).Method<public>()<transacts>:void = external {}\n",
-        head: { name: "Method", keyword: null, hasParams: true, hasReceiver: true },
+        head: { name: "Method", keyword: null, operator: ":", hasParams: true, hasReceiver: true },
+        reports: { digest: false, assets: false, scanner: true },
     },
     {
-        // #373's C-04. A keyword that only prefixes the identifier opens no
-        // body, so the line declares a variable and is not dropped either - the
-        // two ways this has been got wrong.
+        // The other kept divergence. In a digest an unclosed `(` can only be a
+        // signature wrapping to the next line; in project source it is far more
+        // often a call wrapping inside a body, so the scan declines it. The
+        // test below this corpus carries that second reading in full.
+        name: "an unclosed parameter list is a signature to one caller and a statement to another",
+        source: "WrapFunc<public>(\n",
+        head: { name: "WrapFunc", keyword: null, operator: "(", hasParams: false, hasReceiver: false },
+        reports: { digest: true, assets: false, scanner: false },
+    },
+    {
+        // A keyword that only prefixes the identifier opens no body, so the
+        // line declares a variable - and is not dropped either, which is the
+        // other way this has been got wrong.
         name: "a keyword that merely prefixes an identifier declares no type",
         source: "Items<public> := classify_items(X)\n",
-        head: { name: "Items", keyword: null, hasParams: false, hasReceiver: false },
+        head: { name: "Items", keyword: null, operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         name: "a class takes stacked keyword specifiers and a superclass list",
         source: "Thing<public> := class<abstract><castable>(base_device):\n",
-        head: { name: "Thing", keyword: "class", hasParams: false, hasReceiver: false },
+        head: { name: "Thing", keyword: "class", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: EVERYWHERE,
     },
     {
         name: "a class body opens with a brace",
         source: "Thing<public> := class { }\n",
-        head: { name: "Thing", keyword: "class", hasParams: false, hasReceiver: false },
+        head: { name: "Thing", keyword: "class", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: EVERYWHERE,
     },
     {
         // Four groups, as shipped in Verse.digest.verse.
         name: "specifier groups stack without bound",
         source: "Point<public> := struct<concrete><computes><persistable><uht_comparable>:\n",
-        head: { name: "Point", keyword: "struct", hasParams: false, hasReceiver: false },
+        head: { name: "Point", keyword: "struct", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: EVERYWHERE,
     },
     {
         name: "an interface is the same head as a class",
         source: "Shape<public> := interface<epic_internal>:\n",
-        head: { name: "Shape", keyword: "interface", hasParams: false, hasReceiver: false },
+        head: { name: "Shape", keyword: "interface", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         name: "a module declares with a colon",
         source: "Inner<public> := module:\n",
-        head: { name: "Inner", keyword: "module", hasParams: false, hasReceiver: false },
+        head: { name: "Inner", keyword: "module", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         // The brace opens on the line below, which is the only reason a head
         // ending at the line end is a declaration and not a fragment.
         name: "a module whose brace opens on the next line is still a module",
         source: "Inner<public> := module\n{\n}\n",
-        head: { name: "Inner", keyword: "module", hasParams: false, hasReceiver: false },
+        head: { name: "Inner", keyword: "module", operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         name: "an external instance is a typed name, not a keyword declaration",
         source: "image1<public>:texture = external {}\n",
-        head: { name: "image1", keyword: null, hasParams: false, hasReceiver: false },
+        head: { name: "image1", keyword: null, operator: ":", hasParams: false, hasReceiver: false },
+        reports: EVERYWHERE,
     },
     {
         name: "a typed constant declares a variable",
         source: "Score<public>:int = 0\n",
-        head: { name: "Score", keyword: null, hasParams: false, hasReceiver: false },
+        head: { name: "Score", keyword: null, operator: ":", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
     {
         name: "an inferred constant declares a variable",
         source: "Total<public> := 5\n",
-        head: { name: "Total", keyword: null, hasParams: false, hasReceiver: false },
+        head: { name: "Total", keyword: null, operator: ":=", hasParams: false, hasReceiver: false },
+        reports: NOT_AN_ASSET_TYPE,
     },
 ];
 
@@ -191,13 +218,22 @@ describe("the one declaration-head grammar", () => {
 describe("every caller reads that grammar and adds only its own policy", () => {
     for (const probe of probes) {
         it(`${probe.name}: each caller reports what its policy says, and nothing else`, () => {
-            const line = probe.source.split("\n")[0].trim();
-            const expected = policy(matchDeclarationHead(line), line);
             expect(reported(probe.source)).toEqual({
-                digest: expected.digest ? [probe.head.name] : [],
-                assets: expected.assets ? [probe.head.name] : [],
-                scanner: expected.scanner ? [probe.head.name] : [],
+                digest: probe.reports.digest ? [probe.head.name] : [],
+                assets: probe.reports.assets ? [probe.head.name] : [],
+                scanner: probe.reports.scanner ? [probe.head.name] : [],
             });
         });
     }
+});
+
+describe("a statement inside a function body declares nothing", () => {
+    // The realistic shape behind the unclosed-parameter-list probe: project
+    // source holds statements, and a call wrapping across lines opens a `(`
+    // that its own line never closes.
+    const source = ["my_device<public> := class(creative_device):", "    OnBegin<override>()<suspends>:void=", "        SpawnProp(", "            Asset,", "            Position)", ""].join("\n");
+
+    it("the project scan records the class and its method, and neither line of the call", () => {
+        expect(scanner.extractDeclarations(source, "declarations.verse").map((node) => `${node.type}:${node.name}`)).toEqual(["class:my_device", "function:OnBegin"]);
+    });
 });

--- a/src/utils/__tests__/verseDeclarationHeadCorpus.test.ts
+++ b/src/utils/__tests__/verseDeclarationHeadCorpus.test.ts
@@ -53,13 +53,11 @@ interface Probe {
     /** The head the language gives this line. */
     head: HeadShape;
     /**
-     * Which callers record the declared name, written out rather than derived
-     * from the callers' own policy code.
+     * Which callers record the declared name.
      *
-     * Deriving it was tried and is what let a widened `assets` rule ship: an
-     * oracle that recomputes what it is checking agrees with the bug. Both
-     * halves of this corpus are authored, so the second can fail while the
-     * first passes.
+     * Written out rather than computed from the callers' policy: an oracle that
+     * recomputes what it is checking agrees with the bug. Authoring both halves
+     * is what lets the second fail while the first passes.
      */
     reports: { digest: boolean; assets: boolean; scanner: boolean };
 }
@@ -130,10 +128,8 @@ const probes: Probe[] = [
         reports: { digest: false, assets: false, scanner: true },
     },
     {
-        // The other kept divergence. In a digest an unclosed `(` can only be a
-        // signature wrapping to the next line; in project source it is far more
-        // often a call wrapping inside a body, so the scan declines it. The
-        // test below this corpus carries that second reading in full.
+        // The other kept divergence; `ProjectPathScanner.declarationType` says
+        // why. The test below this corpus carries the scan's reading in full.
         name: "an unclosed parameter list is a signature to one caller and a statement to another",
         source: "WrapFunc<public>(\n",
         head: { name: "WrapFunc", keyword: null, operator: "(", hasParams: false, hasReceiver: false },

--- a/src/utils/verseDeclarationHead.ts
+++ b/src/utils/verseDeclarationHead.ts
@@ -1,0 +1,258 @@
+/**
+ * The one matcher for the head of a Verse declaration.
+ *
+ * Every reader in the extension that has to decide "does this line declare a
+ * name, and what kind" goes through this, so the head grammar is learned in one
+ * place. Nothing outside this file may re-decide what a declared name, a
+ * specifier group, a parameter list or a declaration keyword looks like; a
+ * second opinion about any of them is what the three matchers this replaced
+ * disagreed over, each having gained a grammar fix the others did not.
+ *
+ * No VS Code dependencies, so importing this from a pure module is safe.
+ *
+ * **This is a recognizer, not a validator.** It answers what the parser accepts
+ * and encodes no attribute allowlist, because attribute legality is a later
+ * semantic phase: `M := module<castable>:` parses and then fails as
+ * `assert_semantic_error(3604)` (book `Tests/Castable.versetest:29`), while
+ * `enum<open>` and `enum<persistable>` are ordinary. A caller wanting only what
+ * compiles must apply that itself.
+ *
+ * **Comments and literals are the caller's problem.** This takes a trimmed line
+ * and reads every character of it as code, so a caller whose input may hold a
+ * comment or a string must mask first - `ProjectPathScanner` does, and the two
+ * digest parsers rely on their input being machine-generated instead. The cost
+ * of not masking is a paren or a keyword inside a string literal on the head
+ * line being read as structure.
+ *
+ * The rules below are the compiler's, taken from `VerseGrammar.h` in the
+ * VerseCompiler source rather than from any matcher here. Line references are to
+ * that file.
+ *
+ * - **Specifier groups stack without bound, and the production is shared by
+ *   every target.** A `<...>` group becomes an `EMode::With` call appended by
+ *   `Target.UpdateLastCall`, which then re-enters through `Invoke` to read the
+ *   next one (:2796-2807). Nothing bounds the count and nothing is specific to
+ *   one keyword, so `struct<concrete><computes><persistable><uht_comparable>`
+ *   (shipped in `Verse.digest.verse`) and `enum<open><persistable>` (book
+ *   `Tests/CompatibilityConstraints.versetest:1147`, `assert_valid`) are the
+ *   same rule as a single group.
+ * - **A parameter list holds general expressions and nests to any depth**, so it
+ *   is walked for its matching `)` rather than matched by a regex: `Paren :=
+ *   '(' List ')' Space`, and a parameter may itself be an invocation carrying
+ *   another paren group. Any fixed depth would hold only until a digest refresh
+ *   exceeded it. `GetComponent<public>(component_type:castable_subtype(component))<transacts>:`
+ *   is the shape that breaks a `\([^)]*\)`.
+ * - **A macro body opens in any of the three styles Verse gives a macro**, so a
+ *   declaration keyword ends at `:`, `{` or `.` - or at the line end, which is
+ *   how a next-line brace reaches a reader that sees one line at a time.
+ *   Anything else after the keyword means the line does not declare that type.
+ */
+
+/** The keywords that declare a module or a named type. The one alternation. */
+export const DECLARATION_KEYWORDS = ["module", "class", "struct", "interface", "enum"] as const;
+
+export type DeclarationKeyword = (typeof DECLARATION_KEYWORDS)[number];
+
+/**
+ * What may end a declaration keyword. `:`, `{` and `.` are the three body
+ * styles; `>` is not Verse and matches only the literal `M := module>`, kept
+ * because two further spellings of the module grammar outside this file -
+ * `ImportPathConverter.buildModuleDefinitionRegex` and `moduleDeclarations`'
+ * `MODULE_DECLARATION` - accept it, and dropping it here alone would put this
+ * matcher out of step with them.
+ */
+const BODY_TERMINATORS = new Set([":", "{", ".", ">"]);
+
+/** A declared name and the specifier groups written on it. */
+const NAME_HEAD_RE = /^(\w+)((?:<[^>]+>)*)/;
+
+/** A run of specifier groups, possibly empty. */
+const SPECIFIERS_RE = /^((?:<[^>]+>)*)/;
+
+const KEYWORD_RE = new RegExp(`^(${DECLARATION_KEYWORDS.join("|")})\\b`);
+
+/**
+ * A Verse declaration head, as far as the operator that follows it.
+ *
+ * The grammar, once:
+ * `[Receiver '.'] Name Specifiers* [ParamList] Specifiers* Operator [Keyword Specifiers* [SuperList] [Terminator]]`
+ */
+export interface DeclarationHead {
+    /** The declared identifier. */
+    name: string;
+    /** The specifier groups written on the name, verbatim ("<native><public>"), or "". */
+    specifiers: string;
+    /**
+     * The parameter list with its parentheses, or null where the head carries
+     * none. Also null where a `(` opened one that the line never closed, which
+     * {@link DeclarationHead.operator} reports as `(` instead.
+     */
+    params: string | null;
+    /** What follows the head: `:=` declares, `:` types, `(` is an unclosed parameter list. */
+    operator: ":=" | ":" | "(";
+    /**
+     * The index just past {@link DeclarationHead.operator}, so a caller can read
+     * the declaration's right-hand side without re-deriving where the head
+     * ended.
+     */
+    end: number;
+    /** The declaration keyword after `:=`, or null where none follows one. */
+    keyword: DeclarationKeyword | null;
+    /** The specifier groups written on the keyword, verbatim, or "". */
+    keywordSpecifiers: string;
+    /**
+     * What ended the keyword, or null where the line did. Null is what tells a
+     * caller a braced body is still to open on a later line; it is meaningful
+     * only where {@link DeclarationHead.keyword} is set.
+     */
+    bodyTerminator: string | null;
+    /**
+     * The receiver of a receiver-style extension method, with its parentheses
+     * (`(Prop:creative_prop)`), or null. Whether such a head declares an
+     * importable name is the caller's policy, and the two digest parsers and the
+     * project scan deliberately answer it differently.
+     */
+    receiver: string | null;
+}
+
+/**
+ * The index just past the `)` matching the `(` at `start`, or -1 where the line
+ * never closes it.
+ *
+ * @param start Index of the opening `(`.
+ */
+function skipParenGroup(line: string, start: number): number {
+    let depth = 0;
+    for (let index = start; index < line.length; index++) {
+        if (line[index] === "(") {
+            depth++;
+        } else if (line[index] === ")") {
+            depth--;
+            if (depth === 0) {
+                return index + 1;
+            }
+        }
+    }
+    return -1;
+}
+
+/** The index of the first non-space character at or after `from`. */
+function skipSpace(line: string, from: number): number {
+    let index = from;
+    while (index < line.length && (line[index] === " " || line[index] === "\t")) {
+        index++;
+    }
+    return index;
+}
+
+/**
+ * The declaration head the line opens with, or null where it opens with
+ * something that declares no name.
+ *
+ * @param line One line, trimmed, with comments and literals already masked if
+ * the caller's input can hold them.
+ */
+export function matchDeclarationHead(line: string): DeclarationHead | null {
+    let cursor = 0;
+    let receiver: string | null = null;
+
+    if (line[0] === "(") {
+        const afterReceiver = skipParenGroup(line, 0);
+        if (afterReceiver === -1 || line[afterReceiver] !== ".") {
+            return null;
+        }
+        receiver = line.slice(0, afterReceiver);
+        cursor = afterReceiver + 1;
+    }
+
+    const nameHead = line.slice(cursor).match(NAME_HEAD_RE);
+    if (!nameHead) {
+        return null;
+    }
+    const name = nameHead[1];
+    const specifiers = nameHead[2];
+    cursor += nameHead[0].length;
+
+    const head = (rest: Partial<DeclarationHead> & Pick<DeclarationHead, "operator" | "end">): DeclarationHead => ({
+        name,
+        specifiers,
+        params: null,
+        keyword: null,
+        keywordSpecifiers: "",
+        bodyTerminator: null,
+        receiver,
+        ...rest,
+    });
+
+    let params: string | null = null;
+    cursor = skipSpace(line, cursor);
+    if (line[cursor] === "(") {
+        const afterParams = skipParenGroup(line, cursor);
+        if (afterParams === -1) {
+            // An unclosed list is a signature continuing on the line below. The
+            // head is still a declaration, and reporting the bare `(` is what
+            // lets a caller record it as a function rather than lose it.
+            return head({ operator: "(", end: cursor + 1 });
+        }
+        params = line.slice(cursor, afterParams);
+        cursor = afterParams;
+    }
+
+    // Effect specifiers, between the parameter list and the operator. Consumed
+    // rather than reported: no caller reads them, and the visibility a caller
+    // does read is on the name.
+    cursor = skipSpace(line, cursor);
+    cursor += line.slice(cursor).match(SPECIFIERS_RE)![0].length;
+
+    cursor = skipSpace(line, cursor);
+    let operator: DeclarationHead["operator"];
+    if (line.startsWith(":=", cursor)) {
+        operator = ":=";
+        cursor += 2;
+    } else if (line[cursor] === ":") {
+        operator = ":";
+        cursor += 1;
+    } else {
+        return null;
+    }
+
+    const end = cursor;
+    if (operator !== ":=") {
+        return head({ params, operator, end });
+    }
+
+    cursor = skipSpace(line, cursor);
+    const keywordMatch = line.slice(cursor).match(KEYWORD_RE);
+    if (!keywordMatch) {
+        return head({ params, operator, end });
+    }
+    const keyword = keywordMatch[1] as DeclarationKeyword;
+    let afterKeyword = cursor + keywordMatch[0].length;
+
+    afterKeyword = skipSpace(line, afterKeyword);
+    const keywordSpecifiers = line.slice(afterKeyword).match(SPECIFIERS_RE)![0];
+    afterKeyword += keywordSpecifiers.length;
+
+    // A superclass or interface list sits between the keyword and its body.
+    afterKeyword = skipSpace(line, afterKeyword);
+    if (line[afterKeyword] === "(") {
+        const afterSuper = skipParenGroup(line, afterKeyword);
+        if (afterSuper === -1) {
+            return head({ params, operator, end });
+        }
+        afterKeyword = afterSuper;
+    }
+
+    afterKeyword = skipSpace(line, afterKeyword);
+    if (afterKeyword === line.length) {
+        return head({ params, operator, end, keyword, keywordSpecifiers, bodyTerminator: null });
+    }
+    if (!BODY_TERMINATORS.has(line[afterKeyword])) {
+        // The keyword opens no body here, so the line declares no type of that
+        // kind - it is an ordinary declaration whose value happens to start with
+        // the word. Falling through rather than matching is what keeps
+        // `Items := classify_items(X)` from recording a class.
+        return head({ params, operator, end });
+    }
+    return head({ params, operator, end, keyword, keywordSpecifiers, bodyTerminator: line[afterKeyword] });
+}

--- a/src/utils/verseDeclarationHead.ts
+++ b/src/utils/verseDeclarationHead.ts
@@ -4,9 +4,7 @@
  * Every reader in the extension that has to decide "does this line declare a
  * name, and what kind" goes through this, so the head grammar is learned in one
  * place. Nothing outside this file may re-decide what a declared name, a
- * specifier group, a parameter list or a declaration keyword looks like; a
- * second opinion about any of them is what the three matchers this replaced
- * disagreed over, each having gained a grammar fix the others did not.
+ * specifier group, a parameter list or a declaration keyword looks like.
  *
  * No VS Code dependencies, so importing this from a pure module is safe.
  *
@@ -59,7 +57,9 @@ export type DeclarationKeyword = (typeof DECLARATION_KEYWORDS)[number];
  * because two further spellings of the module grammar outside this file -
  * `ImportPathConverter.buildModuleDefinitionRegex` and `moduleDeclarations`'
  * `MODULE_DECLARATION` - accept it, and dropping it here alone would put this
- * matcher out of step with them.
+ * matcher out of step with them. Parity with those two is partial either way:
+ * both end at `module\s*[:>{.]`, so neither admits the keyword specifiers this
+ * does.
  */
 const BODY_TERMINATORS = new Set([":", "{", ".", ">"]);
 
@@ -78,7 +78,6 @@ const KEYWORD_RE = new RegExp(`^(${DECLARATION_KEYWORDS.join("|")})\\b`);
  * `[Receiver '.'] Name Specifiers* [ParamList] Specifiers* Operator [Keyword Specifiers* [SuperList] [Terminator]]`
  */
 export interface DeclarationHead {
-    /** The declared identifier. */
     name: string;
     /** The specifier groups written on the name, verbatim ("<native><public>"), or "". */
     specifiers: string;


### PR DESCRIPTION
Closes #410

Takes the second half of #373: the three separately-implemented readers of a Verse declaration head become one, with per-caller policy on top. #373's lexical half landed as PR #413.

## What was wrong

Three files each spelled "what does a declaration head look like", so a grammar fix landed in one and not its siblings. Measured on `origin/main` by running the same lines through all three, `ProjectPathScanner` dropped four shapes `digestParsing` kept:

| line | digestParsing | ProjectPathScanner |
|---|---|---|
| `Colour<public> := enum<open><persistable>:` | `Colour` | dropped |
| `Colour<public> := enum<open> { A, B }` | `Colour` | dropped |
| `GetComponent<public>(ct:castable_subtype(component))<transacts>:` | `GetComponent` | dropped |
| `Pair<public>(t:subtype(comparable)) := class:` | `Pair` | dropped |

Each is a declaration missing from project-path completion, and each is the same root cause. Two of the four the ticket did not name; they fell out of the shared matcher the moment `ProjectPathScanner` used the donor's paren walk.

The last two drop rather than mistype because of the second half of the disease, which #373's C-04 found: a keyword rule inside `ProjectPathScanner` had to be spelled twice, once in the per-type pattern and once in the fall-through backstop, so the backstop turned a pattern's miss into a silent drop.

## What changed

**`src/utils/verseDeclarationHead.ts` (new).** One recognizer over a trimmed line, implementing the head grammar once:

```
[Receiver '.'] Name Specifiers* [ParamList] Specifiers* Operator [Keyword Specifiers* [SuperList] [Terminator]]
```

`DECLARATION_KEYWORDS` is the single keyword alternation; every regex derives from it. It sits beside `verseLexer.ts`, where #373 put the lexical half, and imports no `vscode` so the build-time digest precompiler can use it.

**`src/services/digestParsing.ts`.** `DECL_RE`, `PARAM_TYPE_HEAD_RE`, `PARAM_TYPE_TAIL_RE`, `DECL_KEYWORD_RE` and `matchParametricTypeHead` are deleted. `QUALIFIER_RE` stays: a scope qualifier is a prefix before the head, not part of it.

**`src/services/AssetsDigestParser.ts`.** `CLASS_OR_STRUCT_DECL` and `INSTANCE_DECL` become policy over the shared head, the latter as an exported `declaresExternalInstance`. Its parameter-list test is load-bearing rather than defensive: a module-scope function ends `:type = external` exactly as an instance does, so only the parameter list separates them, and the old regex got that for free by being unable to cross a `(`.

**`src/services/ProjectPathScanner.ts`.** The five near-identical type branches collapse into one head match and a switch, 256 lines down. **`DECLARATION_KEYWORD_AFTER_ASSIGN` is deleted**, its job done by `head.keyword` on the head the branches already matched. That is the ticket's own repair: a keyword rule stops having two independent homes.

### The rules, and what settles each

Cited to the compiler grammar and to compile-validated book tests, never to the matchers under repair:

- **Specifier groups stack without bound, on the name and the keyword alike, and nothing is keyword-specific.** A `<...>` group becomes an `EMode::With` call appended by `Target.UpdateLastCall`, which re-enters through `Invoke` to read the next (`VerseGrammar.h:2796-2807`). Live: `struct<concrete><computes><persistable><uht_comparable>` ships in `Verse.digest.verse`, and `enum1 := enum<open><persistable>:` is `assert_valid` at book `Tests/CompatibilityConstraints.versetest:1147`. That is the whole of the enum-arity divergence.
- **A parameter list holds general expressions and nests to any depth**, so it is walked rather than matched (`Paren := '(' List ')' Space`). `digestParsing` already walked; `ProjectPathScanner`'s `\([^)]*\)` could not cross the inner `)`.
- **A macro body opens in any of the three styles**, so a keyword ends at `:`, `{` or `.`, or at the line end where the brace opens below. Braced enums are book `Tests/Any.versetest:5` and `Tests/Attributes/available.versetest:40`.
- **Attribute legality is a semantic phase, not the parser**, so the matcher is a **recognizer, not a validator** and encodes no attribute allowlist.

That last rule stopped a change that looked obviously right. `modulePattern` allowing no specifiers after its keyword reads like the same gap as `enumPattern`, and it is not: `M := module<castable>:` is `assert_semantic_error(3604)` (`Tests/Castable.versetest:29`), as are `m := module<allocates>:` (`Tests/Attributes/allocates.versetest:36`) and `m:=module<computes>{}` (`Tests/Attributes/InvalidAttributeLocations.versetest:21`). Widening it for symmetry would have encoded a rule the language does not have.

The consequence the recognizer stance does carry is that `M := module<public>:` is now recognized where it was dropped. It is `3604`, so no compiling project can reach it.

### Two divergences kept, and named

Both were the maintainer's call, and the corpus pins each as deliberate rather than accidental:

- **Extension methods.** The matcher reports `receiver`; `digestParsing` skips, `ProjectPathScanner` indexes. One head, two policies. Converging it would widen `src/data/*.digest.json`, which is a feature question rather than this refactor's — filed as #426.
- **Comment masking.** Only `ProjectPathScanner` masks. The matcher takes a trimmed line and says nothing about comments, so "who masks" is now explicitly the caller's job, documented in one place instead of being a fourth implicit answer.

A third divergence is new, and was not obvious until the review probed it: **an unclosed `(`**. In a digest it can only be a signature wrapping to the next line, so `digestParsing` reads it as a function. In project source the same shape is far more often a call wrapping inside a body, so `ProjectPathScanner` declines it — which is also what the patterns it replaced did, by accident of requiring a closing `)` and a `:`. Recording those would have filled the index with statements.

`digestSourceInvariants.test.ts` re-derives the head grammar a fourth time and is left alone: its own doc says the re-derivation is deliberate, an independent second opinion that catches a parser regression. Routing it through the shared matcher would destroy what it is for.

## Tests

`src/utils/__tests__/verseDeclarationHeadCorpus.test.ts` is the shared probe corpus the ticket asks for. Eighteen probes, each asserted twice: that the shared matcher's head is the language's answer, and that every caller records exactly the names its own policy calls for.

**Both halves are hand-authored, and the first version was not.** The caller half originally derived its expectation by recomputing each caller's policy in the test. That reads as rigorous and is worthless: an oracle that recomputes what it is checking agrees with the bug. It did — see below. Every expectation is now written out, so the second half can fail while the first passes.

**Proved to detect the defect.** Reverting the three callers to `origin/main` while keeping the new matcher and corpus fails exactly the four measured drops and passes the other 33 assertions:

```
● an enum takes as many specifier groups on its keyword as a class does
● an enum body opens with a brace as readily as with a colon
● a parameter list nests, and is walked rather than matched
● a type-parameter list precedes the declaration keyword
```

Stated precisely, because the ticket's "each probe is shown to fail before the change" is not literally met: the 16 head assertions are vacuous before the change, since the matcher did not exist, and 14 of the 18 caller assertions pass unchanged. Those 14 are regression pins rather than defect detectors, and two of them pin bugs this branch introduced and then removed rather than anything on `origin/main`. Four assertions detect the four defects.

No existing test was modified or removed.

## What the review gate caught

Worth recording, because the corpus was supposed to prevent exactly this and did not.

**Critical, fixed.** An asset instance and a module-scope function have the same tail — `:type = external` — and the shared head's `end` points past the parameter list, so `GetColor<public>()<transacts>:vector3 = external {}` reached the instance rule and put a function name into the asset-class set. `ImportSuggestionExtractor.splitModulePathAndClass` truncates a dotted module path at the first segment that set accepts, so it would have emitted a short `using` path. The replaced `INSTANCE_DECL` regex got the guard for free by being unable to cross a `(`; making the rule explicit lost it. The corpus passed because its oracle recomputed the same missing guard.

**Important, fixed.** `head.operator === "("` recorded a wrapped call as a module-scope function, covered above.

Old-versus-new differentials over every `.verse` file in the repo, after both fixes:

- `ProjectPathScanner.extractDeclarations`: **0 declarations dropped**, 118 added. Twenty are retypes, all correct — `function` to `class` or `interface` for parametric types such as `entitlement_change`, `input_events` and `listenable`. The rest are functions whose nested-paren signatures the old `\([^)]*\)` could not match: `SetGlobalTransform`, `ApplyLinearImpulse`, `TeleportTo` and their kind.
- `AssetsDigestParser.parseDigestContent`: +13 names in `Verse.digest.verse`, all parametric classes the old regex could not reach (`chat_channel`, `agent_group`, `editable_slider`, `task`); +1 in `Fortnite.digest.verse`; four names dropped, all correct — `ShowPreserveRatio` and friends are members of `editable_vector_slider`, which old code leaked to module scope because it never recognized the parametric class head and so never opened a body to suppress them.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 47 passed, 47 total
Tests:       1446 passed, 1446 total
Snapshots:   0 total
Time:        12.699 s
Ran all test suites.
```

Baseline on `origin/main` was 46 suites / 1409 tests. All 1409 still pass unmodified; the 37 added are the corpus.

`npm run format:check`

```
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

`npx jest src/services/__tests__ src/utils/__tests__` — 21 suites, 363 tests, all passing, read in full rather than by summary: a shared matcher that changed a rule surfaces as an unrelated existing case changing shape, not as the failure you predicted.

### The load-bearing check: the digest index did not move

`src/data/*.digest.json` is a protected generated path, and `precompiledDigestData.test.ts` pins its contents without re-deriving them — so a widening in `digestParsing` would stale it silently, with nothing failing. Parsing all three bundled `src/utils/*.digest.verse` through `parseDigestContent` before and after gives **byte-identical** output, 426,908 bytes:

```
digestParsing output byte-identical to origin/main: true (426908 bytes)
  Fortnite: 1855 identifiers, 25 modules
  UnrealEngine: 170 identifiers, 13 modules
  Verse: 461 identifiers, 23 modules
```

So no regeneration is needed and none was done.

## Not in this change

- Whether the digest index should offer receiver-style extension methods at all — a feature question, filed as #426.
- `ImportPathConverter.buildModuleDefinitionRegex` and `moduleDeclarations`' `MODULE_DECLARATION`, two further spellings of the *module* declaration grammar outside this ticket's three files. Same disease, different subsystem; filed as #425 rather than widening this diff.
- `digestSourceInvariants.test.ts` re-derives the head grammar a fourth time and is left alone. Its own doc says the re-derivation is deliberate — an independent second opinion that catches a parser regression — and routing it through the shared matcher would destroy what it is for.
- A continuation line inside a wrapped signature is still read as its own declaration: given `WrapFunc<public>(` over `    Amount:int`, the scan records `Amount` as a variable. Pre-existing and byte-identical on `origin/main`, since the scan reads one line at a time; noticed while writing the corpus and left alone.

## Review

Two rounds against a fresh context, at the session model, plus a third commit taking round 2's suggestions.

**Round 1: FAIL**, one Critical and four Important. **Round 2: PASS_WITH_SUGGESTIONS**, scoped to the delta, no Critical and no Important, all four round-1 findings confirmed resolved by mutation testing rather than by reading.

The reviewer verified all five grammar claims at `VerseGrammar.h` and the book's `Tests/` itself rather than taking them, ran the old-versus-new differentials independently, and traced the Critical through the real `ImportSuggestionExtractor.splitModulePathAndClass` to show it produced `{modulePath: "MyProject"}` where it should have produced `{modulePath: "MyProject.GetColor"}`.

Its mutation checks are the part worth keeping: deleting the `params` guard fails two corpus probes, and folding the `(` decline back into the function branch fails a probe and the wrapped-call test. It also found that two of the predicate's four guards were dead — the whole suite stayed green without them — which is the third commit here.

Round 2 left five suggestions, four applied. The one not applied is a note that the scan still records a wrapped signature's parameter lines as declarations; it is byte-identical on `origin/main` and is recorded under "not in this change" instead.

## Changelog

`changelog.d/410.fixed.md`. The four grammar fixes change what project-path completion offers, so this is user-facing despite the `refactor` commit type.
