### PR TITLE
fix(imports): read the import syntax scoped to the file being fixed

### DIFF
--- a/changelog.d/433.fixed.md
+++ b/changelog.d/433.fixed.md
@@ -1,0 +1,1 @@
+**Quick fixes**: In a multi-root workspace, the quick-fix menu now labels an import in the syntax the file's own folder sets, matching the text it inserts.

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -175,7 +175,7 @@ export class DiagnosticsHandler {
                 let hasMultiOptionSuggestions = false;
 
                 for (const diagnostic of currentDiagnostics) {
-                    const suggestions = await this.importHandler.extractImportSuggestions(diagnostic.message);
+                    const suggestions = await this.importHandler.extractImportSuggestions(diagnostic.message, document.uri);
 
                     if (suggestions.length === 0) {
                         continue;

--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -32,7 +32,7 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
         const showDescriptions = config.get<boolean>("quickFix.showDescriptions", false);
 
         for (const diagnostic of context.diagnostics) {
-            const suggestions = await this.importHandler.extractImportSuggestions(diagnostic.message);
+            const suggestions = await this.importHandler.extractImportSuggestions(diagnostic.message, document.uri);
 
             if (suggestions.length === 0) {
                 continue;

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -29,8 +29,15 @@ export class ImportHandler {
         this.documentEditor = new ImportDocumentEditor(outputChannel, this.formatter);
     }
 
-    async extractImportSuggestions(errorMessage: string): Promise<ImportSuggestion[]> {
-        return this.suggestionExtractor.extractImportSuggestions(errorMessage);
+    /**
+     * @param resource The document the message was reported on. Pass it
+     *   wherever one exists: the suggestion carries the formatted statement,
+     *   and `behavior.importSyntax` is resource-scoped, so without it a
+     *   suggestion can be written in the window's syntax while
+     *   addImportsToDocument inserts the folder's.
+     */
+    async extractImportSuggestions(errorMessage: string, resource?: vscode.Uri): Promise<ImportSuggestion[]> {
+        return this.suggestionExtractor.extractImportSuggestions(errorMessage, resource);
     }
 
     async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: DiagnosticLinesByStatement): Promise<boolean> {

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -31,10 +31,8 @@ export class ImportHandler {
 
     /**
      * @param resource The document the message was reported on. Pass it
-     *   wherever one exists: the suggestion carries the formatted statement,
-     *   and `behavior.importSyntax` is resource-scoped, so without it a
-     *   suggestion can be written in the window's syntax while
-     *   addImportsToDocument inserts the folder's.
+     *   wherever one exists: the suggestion carries a formatted statement, and
+     *   the syntax it is formatted in is resource-scoped.
      */
     async extractImportSuggestions(errorMessage: string, resource?: vscode.Uri): Promise<ImportSuggestion[]> {
         return this.suggestionExtractor.extractImportSuggestions(errorMessage, resource);

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -362,8 +362,8 @@ export class ImportSuggestionExtractor {
      * Always high confidence: the lookup matches the identifier exactly, so an
      * entry it returns declares the name the compiler could not resolve.
      */
-    private async lookupIdentifierInDigest(identifier: string): Promise<ImportSuggestion[]> {
-        const config = settingsFor();
+    private async lookupIdentifierInDigest(identifier: string, resource?: vscode.Uri): Promise<ImportSuggestion[]> {
+        const config = settingsFor(resource);
         const useDigestFiles = config.get<boolean>("experimental.useDigestFiles", false);
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
 
@@ -404,11 +404,17 @@ export class ImportSuggestionExtractor {
      * An unknown identifier is resolved in a fixed order: a configured
      * ambiguous mapping first, then the digest lookup, then the path inferred
      * from a "Did you mean". The order is the precedence, most specific first.
+     *
+     * @param resource The document the message was reported on. Pass it
+     *   wherever one exists: `behavior.importSyntax` is resource-scoped, and a
+     *   statement formatted without it carries the window's syntax while
+     *   ImportDocumentEditor writes the folder's, so in a multi-root workspace
+     *   the quick-fix title stops describing the text the fix inserts.
      */
-    async extractImportSuggestions(errorMessage: string): Promise<ImportSuggestion[]> {
+    async extractImportSuggestions(errorMessage: string, resource?: vscode.Uri): Promise<ImportSuggestion[]> {
         logger.debug("ImportSuggestionExtractor", `Extracting import suggestions from error: ${errorMessage}`);
 
-        const config = settingsFor();
+        const config = settingsFor(resource);
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const ambiguousImportMappings = config.get<Record<string, string>>("behavior.ambiguousImports", DEFAULT_AMBIGUOUS_IMPORTS);
 
@@ -440,7 +446,7 @@ export class ImportSuggestionExtractor {
                     return [this.createImportSuggestion(importStatement, "error_message", "high", `Configured import for ${classification.identifier}`)];
                 }
 
-                const digestSuggestions = await this.lookupIdentifierInDigest(classification.identifier);
+                const digestSuggestions = await this.lookupIdentifierInDigest(classification.identifier, resource);
                 if (digestSuggestions.length > 0) {
                     logger.debug("ImportSuggestionExtractor", `Found digest-based suggestions for unknown identifier: ${classification.identifier}`);
                     return digestSuggestions;

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -42,6 +42,48 @@ describe("ImportCodeActionProvider quick fix titles", () => {
         expect(await titlesFor([suggestion({ confidence: "low" })])).toEqual(["Add import: using { /Fortnite.com/Devices }"]);
     });
 
+    // The writer reads behavior.importSyntax scoped to the document's folder,
+    // so a labeller reading it window-scoped offers a title in one syntax and
+    // inserts the other. Driven through a real ImportHandler: a stubbed
+    // extractor hands the provider a statement someone else formatted, which
+    // is the one thing this cannot assert.
+    it("titles the action in the syntax the document's folder sets", async () => {
+        const getConfiguration = vscode.workspace.getConfiguration as unknown as jest.Mock;
+        const original = getConfiguration.getMockImplementation();
+        const folder = "file:///Project/Content/Scripts/";
+        getConfiguration.mockImplementation((_section: string, resource?: { toString(): string }) => ({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                if (key === "behavior.importSyntax") {
+                    return resource?.toString().startsWith(folder) ? "dot" : "curly";
+                }
+                return defaultValue;
+            }),
+            update: jest.fn().mockResolvedValue(undefined),
+            inspect: jest.fn().mockReturnValue(undefined),
+        }));
+
+        try {
+            const importHandler = new ImportHandler({ appendLine: jest.fn() } as unknown as vscode.OutputChannel);
+            const provider = new ImportCodeActionProvider({ appendLine: jest.fn() } as unknown as vscode.OutputChannel, importHandler);
+
+            const actions = await provider.provideCodeActions(
+                { uri: { toString: () => `${folder}device.verse` } } as unknown as vscode.TextDocument,
+                {} as unknown as vscode.Range,
+                {
+                    diagnostics: [{ message: "Unknown identifier `player`. Did you forget to specify using { /Verse.org/Simulation }", range: { start: { line: 7 } } }],
+                } as unknown as vscode.CodeActionContext,
+                {} as unknown as vscode.CancellationToken,
+            );
+
+            expect((actions ?? []).map((action) => action.title)).toEqual(["Add import: using. /Verse.org/Simulation"]);
+        } finally {
+            getConfiguration.mockReset();
+            if (original) {
+                getConfiguration.mockImplementation(original);
+            }
+        }
+    });
+
     it("shows both once the user turns descriptions on", async () => {
         const getConfiguration = vscode.workspace.getConfiguration as unknown as jest.Mock;
         const original = getConfiguration.getMockImplementation();

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -44,9 +44,8 @@ describe("ImportCodeActionProvider quick fix titles", () => {
 
     // The writer reads behavior.importSyntax scoped to the document's folder,
     // so a labeller reading it window-scoped offers a title in one syntax and
-    // inserts the other. Driven through a real ImportHandler: a stubbed
-    // extractor hands the provider a statement someone else formatted, which
-    // is the one thing this cannot assert.
+    // inserts the other. The extractor must not be stubbed here: a stub would
+    // supply the very statement under test.
     it("titles the action in the syntax the document's folder sets", async () => {
         const getConfiguration = vscode.workspace.getConfiguration as unknown as jest.Mock;
         const original = getConfiguration.getMockImplementation();
@@ -76,6 +75,10 @@ describe("ImportCodeActionProvider quick fix titles", () => {
             );
 
             expect((actions ?? []).map((action) => action.title)).toEqual(["Add import: using. /Verse.org/Simulation"]);
+            // The other half of the criterion: the statement handed to
+            // addSingleImport is what gets written, so the title describes the
+            // insertion only while these two agree.
+            expect((actions ?? []).map((action) => action.command?.arguments?.[1])).toEqual(["using. /Verse.org/Simulation"]);
         } finally {
             getConfiguration.mockReset();
             if (original) {


### PR DESCRIPTION
`behavior.importSyntax` is declared `"scope": "resource"`, but `ImportSuggestionExtractor` read it from an unscoped configuration at both of its sites, while `ImportDocumentEditor` reads it scoped to the document. In a multi-root workspace, a folder that overrode the setting got a quick-fix title in the window's syntax and an insertion in the folder's: the lightbulb offered `Add import: using { /Verse.org/Simulation }` and inserted `using. /Verse.org/Simulation`. The file ended up correct; the menu did not describe it.

`ImportHandler.extractImportSuggestions` now takes an optional trailing `resource?: vscode.Uri` and forwards it to both `settingsFor()` calls. Optional and trailing keeps it source-compatible with every existing caller, so nothing else had to move; `ImportCodeActionProvider` and `DiagnosticsHandler` each pass the `document.uri` they already hold.

The alternative — rendering the title inside `ImportCodeActionProvider` from its own scoped config — would put an `ImportFormatter` in a caller, which `CLAUDE.md` rules out in favour of the `ImportHandler` facade.

## Changed

- `src/imports/ImportSuggestionExtractor.ts` — `extractImportSuggestions` and `lookupIdentifierInDigest` take the optional resource and read settings scoped to it.
- `src/imports/ImportHandler.ts` — forwards it through the facade.
- `src/imports/ImportCodeActionProvider.ts`, `src/diagnostics/DiagnosticsHandler.ts` — pass `document.uri`.
- `src/imports/__tests__/ImportCodeActionProvider.test.ts` — regression test at the code-action entry point, driven through a real `ImportHandler`.

No pattern in the extractor was added, moved or broadened: `PATTERNS` and `classifyMessage` are untouched, so the load-bearing precedence is unchanged.

## Verification

The regression test was checked against the unfixed code — with the four source files reverted to `origin/main` it fails with exactly the reported symptom:

```
● ImportCodeActionProvider quick fix titles › titles the action in the syntax the document's folder sets

    - Expected  - 1
    + Received  + 1

      Array [
    -   "Add import: using. /Verse.org/Simulation",
    +   "Add import: using { /Verse.org/Simulation }",
      ]
```

`npm run compile`

```
> verse-auto-imports@0.11.1 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 50 passed, 50 total
Tests:       1506 passed, 1506 total
Snapshots:   0 total
Time:        14.142 s
Ran all test suites.
```

`npx jest src/imports/__tests__` — run in full because extractor precedence is load-bearing, and a shadowing change surfaces as an unrelated case changing shape:

```
Test Suites: 10 passed, 10 total
Tests:       858 passed, 858 total
```

`npm run format:check`

```
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Closes #433
