### PR TITLE
test(config): guard the snooze against a write at any settings level

### DIFF
--- a/src/test-integration/suite/commands.itest.ts
+++ b/src/test-integration/suite/commands.itest.ts
@@ -1,10 +1,8 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { openFixture, sleep } from "./helpers";
+import { openFixture, restoreSetting, sleep, snapshotSetting } from "./helpers";
 
-function globalAutoImport(): boolean | undefined {
-    return vscode.workspace.getConfiguration("verseAutoImports").inspect<boolean>("general.autoImport")?.globalValue;
-}
+const AUTO_IMPORT = "general.autoImport";
 
 describe("commands and snooze (playbook T7/T8)", () => {
     before(async () => {
@@ -50,26 +48,33 @@ describe("commands and snooze (playbook T7/T8)", () => {
     // into global user settings, so a reload during the snooze left auto-import
     // off permanently. Snooze state is now in-memory and settings stay clean.
     it("T8: snooze leaves user settings untouched; re-snoozing stays coherent; cancel is clean", async () => {
-        const before = globalAutoImport();
+        // Read about the open file: general.autoImport is resource-scoped, and
+        // the write path picks its level from whichever already holds an
+        // override, so no single level is the one to watch.
+        const resource = vscode.window.activeTextEditor?.document.uri;
+        const before = snapshotSetting(AUTO_IMPORT, resource);
+        const assertUnchanged = (message: string): void => {
+            assert.deepStrictEqual(snapshotSetting(AUTO_IMPORT, resource), before, message);
+        };
         try {
             await vscode.commands.executeCommand("verseAutoImports.snoozeAutoImport");
             await sleep(300);
-            assert.strictEqual(globalAutoImport(), before, "snooze must not write general.autoImport to user settings");
+            assertUnchanged("snooze must not write general.autoImport at any level");
 
             // Re-invoking while already snoozed must not corrupt the state
             // (single timer per the 0.6.x snooze fix).
             await vscode.commands.executeCommand("verseAutoImports.snoozeAutoImport");
             await sleep(300);
-            assert.strictEqual(globalAutoImport(), before, "re-snoozing must not write general.autoImport either");
+            assertUnchanged("re-snoozing must not write general.autoImport either");
 
             await vscode.commands.executeCommand("verseAutoImports.cancelSnooze");
             await sleep(300);
-            assert.strictEqual(globalAutoImport(), before, "cancelling must not write general.autoImport either");
+            assertUnchanged("cancelling must not write general.autoImport either");
         } finally {
-            // Never leak a snoozed state into later suites: cancel again and
-            // clear the global override so the default (true) applies.
+            // Never leak a snoozed state, or a stray override at any level,
+            // into later suites: the fixture workspace is reused across the run.
             await vscode.commands.executeCommand("verseAutoImports.cancelSnooze");
-            await vscode.workspace.getConfiguration("verseAutoImports").update("general.autoImport", undefined, vscode.ConfigurationTarget.Global);
+            await restoreSetting(AUTO_IMPORT, before, resource);
         }
     });
 });

--- a/src/test-integration/suite/helpers.ts
+++ b/src/test-integration/suite/helpers.ts
@@ -237,9 +237,13 @@ export interface SettingSnapshot {
 }
 
 /**
- * Every override level of a setting at once. A guard that only reads one level
- * passes for the wrong reason as soon as the write path picks a different one,
- * and writeTargetFor picks by which level already holds an override.
+ * Reads every override level of a setting at once, plus the value that wins. A
+ * guard that only reads one level passes for the wrong reason as soon as the
+ * write path picks a different one, and writeTargetFor picks by which level
+ * already holds an override.
+ *
+ * Language-block levels ("[verse]") are deliberately absent: reaching one needs
+ * update({ overrideInLanguage: true }), and no write path here passes it.
  *
  * @param resource The file the setting is read about. Required for
  * workspaceFolderValue to resolve at all; without one, inspect answers for the
@@ -260,6 +264,13 @@ export function snapshotSetting(key: string, resource?: vscode.Uri): SettingSnap
  * Puts every override level of a setting back to what `baseline` recorded,
  * writing only the levels that actually moved. Clearing a level that was
  * already clear would rewrite the fixture's own .code-workspace file.
+ *
+ * Levels are compared with `!==`, so `key` must hold a primitive; an object
+ * value would look changed on every call and defeat that.
+ *
+ * @param resource Must be supplied, and `key` must be resource-scoped, if a
+ * workspaceFolder-level override may need restoring - `update` rejects that
+ * target otherwise.
  */
 export async function restoreSetting(key: string, baseline: SettingSnapshot, resource?: vscode.Uri): Promise<void> {
     const config = vscode.workspace.getConfiguration("verseAutoImports", resource);

--- a/src/test-integration/suite/helpers.ts
+++ b/src/test-integration/suite/helpers.ts
@@ -228,6 +228,54 @@ export class WorkspaceSettings {
     }
 }
 
+/** Every level a setting can be overridden at, plus the value that currently wins. */
+export interface SettingSnapshot {
+    effective: unknown;
+    global: unknown;
+    workspace: unknown;
+    workspaceFolder: unknown;
+}
+
+/**
+ * Every override level of a setting at once. A guard that only reads one level
+ * passes for the wrong reason as soon as the write path picks a different one,
+ * and writeTargetFor picks by which level already holds an override.
+ *
+ * @param resource The file the setting is read about. Required for
+ * workspaceFolderValue to resolve at all; without one, inspect answers for the
+ * window and a folder override is invisible.
+ */
+export function snapshotSetting(key: string, resource?: vscode.Uri): SettingSnapshot {
+    const config = vscode.workspace.getConfiguration("verseAutoImports", resource);
+    const info = config.inspect(key);
+    return {
+        effective: config.get(key),
+        global: info?.globalValue,
+        workspace: info?.workspaceValue,
+        workspaceFolder: info?.workspaceFolderValue,
+    };
+}
+
+/**
+ * Puts every override level of a setting back to what `baseline` recorded,
+ * writing only the levels that actually moved. Clearing a level that was
+ * already clear would rewrite the fixture's own .code-workspace file.
+ */
+export async function restoreSetting(key: string, baseline: SettingSnapshot, resource?: vscode.Uri): Promise<void> {
+    const config = vscode.workspace.getConfiguration("verseAutoImports", resource);
+    const current = snapshotSetting(key, resource);
+    const levels: Array<[keyof SettingSnapshot, vscode.ConfigurationTarget]> = [
+        ["global", vscode.ConfigurationTarget.Global],
+        ["workspace", vscode.ConfigurationTarget.Workspace],
+        ["workspaceFolder", vscode.ConfigurationTarget.WorkspaceFolder],
+    ];
+    for (const [level, target] of levels) {
+        if (current[level] !== baseline[level]) {
+            await config.update(key, baseline[level], target);
+        }
+    }
+}
+
 /**
  * Runs Optimize Imports on the document (which must become the active editor)
  * and waits out the async on-save spacing pass before returning the text.


### PR DESCRIPTION
Closes #434

## What

The T8 snooze regression guard read `inspect("general.autoImport")?.globalValue`. Since #359 the write path picks its level from whichever already holds an override (`writeTargetFor`, `src/utils/settings.ts:64-75`), so `Global` is no longer the level a stray write would land on — a snooze writing at `Workspace` kept the guard green, and the teardown, which cleared `Global` only, left that write in the fixture workspace for every later suite.

The guard now compares a snapshot of all three override levels plus the effective value, and the teardown restores each level to its recorded baseline, writing only the levels that actually moved.

## Changes

- `src/test-integration/suite/helpers.ts` — adds `SettingSnapshot`, `snapshotSetting(key, resource)` and `restoreSetting(key, baseline, resource)`. The read passes a resource so `workspaceFolderValue` resolves at all; `general.autoImport` is resource-scoped (`RESOURCE_SCOPED`, `settings.ts:26`). Restore writes only changed levels, so the clean path never rewrites the checked-in `.code-workspace`.
- `src/test-integration/suite/commands.itest.ts` — T8 asserts `deepStrictEqual` on the whole snapshot after snooze, re-snooze and cancel, and restores through the new helper in `finally`.

Test-only; no production code changed, so no changelog fragment.

## Acceptance criterion, executed

The ticket asks: "Making a snooze command write `general.autoImport` at `ConfigurationTarget.Workspace` fails `commands.itest.ts`."

A `config.update("general.autoImport", false, ConfigurationTarget.Workspace)` line was injected into `CommandsHandler.snoozeAutoImport` and the integration suite rerun:

```
  commands and snooze (playbook T7/T8)
    ✔ T7/T8: every contributed command is registered
    1) T8: snooze leaves user settings untouched; re-snoozing stays coherent; cancel is clean
  29 passing
  1 failing
  1) commands and snooze (playbook T7/T8)
       T8: snooze leaves user settings untouched; re-snoozing stays coherent; cancel is clean:
      AssertionError [ERR_ASSERTION]: snooze must not write general.autoImport at any level
Exit code:   1
```

The injection was then reverted; it is not in this branch.

## Verification

`npm run compile` — clean.

```
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 50 passed, 50 total
Tests:       1505 passed, 1505 total
Snapshots:   0 total
Time:        23.771 s
```

`npm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```

`npm run test:integration` on the branch, unmodified: `30 passing (1m)`, exit code 0.

## Review

One round, opus, verdict `PASS_WITH_SUGGESTIONS` — no Critical or Important findings. The suggestions were doc-contract ones and are applied: `restoreSetting` now states that it compares with `!==` so the key must hold a primitive, and that a workspaceFolder-level restore needs a resource and a resource-scoped key; `snapshotSetting` states that language-block levels are out of scope because no write path passes `overrideInLanguage`. One suggestion is left as a note rather than a change: `WorkspaceSettings` in the same file remains a second, older save-and-restore mechanism, which is out of this ticket's scope.
