### PR TITLE
fix(lexer): carry an open interpolation across the line boundary

### DIFF
--- a/changelog.d/414.fixed.md
+++ b/changelog.d/414.fixed.md
@@ -1,1 +1,1 @@
-**Project path scan**: a string interpolation written across two lines no longer strands the brace depth, which reported every declaration below it under the wrong module path.
+**Project path scan**: a string interpolation spanning lines no longer strands the brace depth, which reported every declaration below it under the wrong module path.

--- a/changelog.d/414.fixed.md
+++ b/changelog.d/414.fixed.md
@@ -1,0 +1,1 @@
+**Project path scan**: a string interpolation written across two lines no longer strands the brace depth, which reported every declaration below it under the wrong module path.

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -65,7 +65,7 @@ export class ImportFormatter {
      * so is kept whole rather than split at a `#` the lexer never resolved.
      */
     private static commentStartIndex(content: string): number {
-        return lexVerseLine(content, { depth: 0, markerIndent: null }).commentStart;
+        return lexVerseLine(content, { depth: 0, markerIndent: null, openFrames: [] }).commentStart;
     }
 
     /**

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -141,7 +141,11 @@ export interface LineClassification {
  */
 export function classifyLines(lines: string[]): LineClassification[] {
     const classifications: LineClassification[] = new Array(lines.length);
-    const state: LexState = { depth: 0, markerIndent: null };
+    // Left empty and never carried, unlike the two beside it. An open
+    // interpolation is a state scanLine has just declined to read, since the
+    // line holding it is re-lexed with literal tracking off; carrying it would
+    // resume a literal on the next line that this line was never lexed as.
+    const state: LexState = { depth: 0, markerIndent: null, openFrames: [] };
 
     for (let i = 0; i < lines.length; i++) {
         const scan = scanLine(lines[i], state);
@@ -422,7 +426,8 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     // on the path line. Only depth 0 yields opensIndentedComment, so a `<#>`
     // inside a block comment on the same span cannot be mistaken for a marker.
     const anchorsCommentBelow = (startLine: number, endLine: number): boolean => {
-        const state: LexState = { depth: 0, markerIndent: null };
+        // Empty and never carried, for the reason classifyLines gives.
+        const state: LexState = { depth: 0, markerIndent: null, openFrames: [] };
         for (let line = startLine; line <= endLine; line++) {
             const scan = scanLine(lines[line], state);
             if (scan.opensIndentedComment) {

--- a/src/utils/__tests__/verseLexer.test.ts
+++ b/src/utils/__tests__/verseLexer.test.ts
@@ -1,7 +1,7 @@
 import { lexVerseLine } from "../verseLexer";
 
 /** The lexer's entry state for a line nothing above it left open. */
-const atCodeScope = { depth: 0, markerIndent: null };
+const atCodeScope = { depth: 0, markerIndent: null, openFrames: [] };
 
 describe("lexVerseLine commentStart", () => {
     it("reports -1 for a line holding no comment", () => {
@@ -42,14 +42,14 @@ describe("lexVerseLine commentStart", () => {
     it("reports 0 for a line whose opener is above it", () => {
         // 0 even where the line closes that comment and carries live code, which
         // is why only a depthBefore-0 line may be split on the offset.
-        expect(lexVerseLine("still comment text", { depth: 1, markerIndent: null }).commentStart).toBe(0);
+        expect(lexVerseLine("still comment text", { depth: 1, markerIndent: null, openFrames: [] }).commentStart).toBe(0);
 
-        const closes = lexVerseLine("#> using { /A }", { depth: 1, markerIndent: null });
+        const closes = lexVerseLine("#> using { /A }", { depth: 1, markerIndent: null, openFrames: [] });
         expect(closes.commentStart).toBe(0);
         expect(closes.hasCode).toBe(true);
     });
 
     it("reports 0 for a line inside the body of a `<#>` marker", () => {
-        expect(lexVerseLine("    body text", { depth: 0, markerIndent: 0 }).commentStart).toBe(0);
+        expect(lexVerseLine("    body text", { depth: 0, markerIndent: 0, openFrames: [] }).commentStart).toBe(0);
     });
 });

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -187,6 +187,15 @@ const probes: Probe[] = [
         source: 'Broken := "oops\nL1 := 1\n',
         live: ["L1"],
     },
+    {
+        // The interpolation opened and closed on the line, so the string alone
+        // is what is left open at its end - and a string cannot span a newline.
+        // Carrying on `endedOpen` rather than on which frame is innermost reads
+        // every line below this one as literal text.
+        name: "an unterminated string that held a closed interpolation does not carry either",
+        source: 'Broken := "a{B}c\nL1 := 1\n',
+        live: ["L1"],
+    },
 ];
 
 describe("verse lexer probe corpus", () => {
@@ -210,6 +219,11 @@ describe("verse lexer probe corpus, brace depth", () => {
     // countBraces reads masked text, so every brace reaching it is a body's.
     // Each source below balances, and a literal brace counted as real leaves the
     // depth stranded for the rest of the file.
+    //
+    // The three spanning cases are the masker's alone, not sentinel probes: the
+    // scanner reads a line that ends open with literal tracking off and so does
+    // not carry the interpolation, which is the second shape - after the
+    // unterminated string above - where the two readers are allowed to differ.
     it.each([
         ["a brace in a char literal", "Body := module:\n    Brace := '{'\n"],
         ["an escaped brace in a char literal", "Body := module:\n    Brace := '\\{'\n"],
@@ -217,6 +231,15 @@ describe("verse lexer probe corpus, brace depth", () => {
         ["a brace in a comment", "Body := module:\n    Note := 1 # {\n"],
         ["a balanced braced body", "Body := module {\n    Field := 1\n}\n"],
         ["an interpolation holding a map", 'Body := module:\n    Text := "a{map{1=>2}}b"\n'],
+        ["an interpolation spanning lines", 'Body := module:\n    Msg := "Score: {\n        Points}"\n'],
+        // The carried frame has to bring its brace count with it, or the first
+        // `}` below reads as the end of the interpolation and the `b"` after it
+        // is lexed as code.
+        ["a block brace inside an interpolation spanning lines", 'Body := module:\n    Msg := "a{map{1=>2\n    }}b"\n'],
+        // `"ab{<#blkcmt#>\n    }cd"` is a versetest the compiler validates, and
+        // it puts the two carried states on one construct: the block comment
+        // ends on the line below the interpolation it was opened inside.
+        ["a block comment inside an interpolation spanning lines", 'Body := module:\n    Msg := "ab{<# note\n    #>}cd"\n'],
     ])("returns to zero across %s", (_name, source) => {
         const masked = maskCommentsAndStrings(source);
 
@@ -262,6 +285,17 @@ describe("verse lexer probe corpus, the readers built on it", () => {
         expect(paths(source)).toEqual(["/Verse.org/Simulation"]);
         expect(declared(source)).toEqual(["Label", "Inner"]);
         expect(findExplicitModuleDeclarations(source).map((declaration) => declaration.name)).toEqual(["Inner"]);
+    });
+
+    it("keeps the enclosing module across an interpolation that spans lines", () => {
+        // The `{` sits inside the literal and is blanked, so leaving its `}` on
+        // the line below at code scope returned the depth to zero a line early
+        // and closed `Outer`. Every declaration after it was then reported at a
+        // path that does not exist, and collided with any real top-level Inner.
+        const source = 'Outer := module {\n    Msg := "Score: {\n        Points}"\n    Inner := module {\n        X := 1\n    }\n}\n';
+
+        expect(declared(source)).toEqual(["Outer", "Outer.Msg", "Outer.Inner", "Outer.Inner.X"]);
+        expect(findExplicitModuleDeclarations(source).map((declaration) => declaration.chain.join("."))).toEqual(["Outer", "Outer.Inner"]);
     });
 
     it("drops what a `<#>` marker body really does comment out", () => {

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -45,7 +45,7 @@
  *
  *   That body being ordinary code also lets it span lines, which is the one
  *   literal state a newline does not end: at String place `Text` stops dead at
- *   the newline (:2083-2099) and `Quote` then requires the closing `"` (:459),
+ *   the newline (:2083-2105) and `Quote` then requires the closing `"` (:3224),
  *   so an open `"` at a line end is error S32 while an open interpolation is
  *   just a list still being read. `openFrames` is that distinction.
  * - A `'` means one of two things, and which one is decided by the character
@@ -143,13 +143,14 @@ export interface LexedLine {
      *
      * Only an interpolation carries, because only an interpolation legally spans
      * a line: `Interp := '{' List '}'` (:2163) makes its body an ordinary list,
-     * while `Text` at String place stops at a newline (:2083-2099) and `Quote`
-     * then requires the closing `"` (:459), so a `"` still open where the line
+     * while `Text` at String place stops at a newline (:2083-2105) and `Quote`
+     * then requires the closing `"` (:3224), so a `"` still open where the line
      * ends is error S32 rather than a string continuing below. Carrying that one
      * would let a single stray quote blank the rest of the file.
      *
-     * `endedOpen` cannot tell the two apart and this can: an empty stack under a
-     * true `endedOpen` is the unterminated literal.
+     * Read this, not `endedOpen`, to decide what carries. `endedOpen` is true
+     * for a carried interpolation as well, so the two are not interchangeable:
+     * an empty stack under a true `endedOpen` is the unterminated literal.
      */
     openFrames: LexFrame[];
     /**
@@ -219,10 +220,13 @@ export interface LexedLine {
  * misses is read by its caller as permission to remove an import. Deciding it
  * here would silently impose one of those on the other.
  *
- * A line ending inside an interpolation is not that case and is settled here,
- * through `openFrames`: the language lets an interpolation span lines, so a
- * reader that carries it is reading the file the compiler reads rather than
- * guessing at a broken one.
+ * Which of those two a line ended inside is settled here, through `openFrames`,
+ * because the language answers it: an interpolation may span lines and a string
+ * may not. `endedOpen` does not carry that answer - it is true of both - so a
+ * reader deciding what to resume must read `openFrames` instead. The two are
+ * still separate signals: the scanner takes its fallback on `endedOpen`,
+ * declining to lex past a point it cannot classify, whether or not the state
+ * there was one it could have carried.
  *
  * @param line one line, with no line terminator. A trailing `\r` from a CRLF
  *   document is harmless and counts as trailing whitespace.
@@ -270,9 +274,12 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     // Kept across the `nesting > 0` branch, because a block comment written
     // inside a string does not end it: `"a<#c#>#b"` is the string `"a#b"`.
     //
-    // Copied frame by frame rather than aliased, because an interpolation's
-    // brace count advances in place and one state may lex a line twice -
-    // ImportScanner.scanLine does exactly that to take its fallback.
+    // Copied frame by frame rather than aliased, or this line's pushes and its
+    // interpolation brace counts would land in the caller's own state object.
+    // A caller that never reassigns `openFrames` is relying on it staying as it
+    // set it - both scanner states below hold an empty stack they never write
+    // back, and aliasing would leak every line's literals into the next through
+    // the array they thought was inert.
     //
     // Empty with tracking off, whatever the caller carried: that mode reads a
     // `#` as a comment opener wherever it sits, which is a caller saying it does

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -42,6 +42,12 @@
  *   a `#` opens a real comment. So literal state is a stack of frames, and an
  *   interpolation frame counts the plain `{ }` blocks written inside it or a
  *   map's `}` closes it early.
+ *
+ *   That body being ordinary code also lets it span lines, which is the one
+ *   literal state a newline does not end: at String place `Text` stops dead at
+ *   the newline (:2083-2099) and `Quote` then requires the closing `"` (:459),
+ *   so an open `"` at a line end is error S32 while an open interpolation is
+ *   just a list still being read. `openFrames` is that distinction.
  * - A `'` means one of two things, and which one is decided by the character
  *   before it. `Ident := Alpha {Alnum} !Alnum ["'" {…} "'"]` (:1954) opens the
  *   quoted segment suffix only directly after an identifier's alphanumeric run,
@@ -75,10 +81,17 @@ export interface LexState {
      * outside one.
      */
     markerIndent: number | null;
+    /**
+     * The literal and interpolation frames open where the line starts, innermost
+     * last, and empty at code scope. Seed it from the line above's
+     * {@link LexedLine.openFrames}, or leave it empty to read every line from
+     * code scope.
+     */
+    openFrames: LexFrame[];
 }
 
 /** One literal or interpolation open at a point in a line. */
-type LexFrame =
+export type LexFrame =
     /**
      * `suffix` is an identifier's quoted segment, `Economy.Shop'Loc'`, and is
      * kept in every output: masking it truncates the path to `Economy.Shop`, a
@@ -124,6 +137,21 @@ export interface LexedLine {
      * {@link lexVerseLine}.
      */
     endedOpen: boolean;
+    /**
+     * The frames the next line starts inside, innermost last, and empty where
+     * nothing carries.
+     *
+     * Only an interpolation carries, because only an interpolation legally spans
+     * a line: `Interp := '{' List '}'` (:2163) makes its body an ordinary list,
+     * while `Text` at String place stops at a newline (:2083-2099) and `Quote`
+     * then requires the closing `"` (:459), so a `"` still open where the line
+     * ends is error S32 rather than a string continuing below. Carrying that one
+     * would let a single stray quote blank the rest of the file.
+     *
+     * `endedOpen` cannot tell the two apart and this can: an empty stack under a
+     * true `endedOpen` is the unterminated literal.
+     */
+    openFrames: LexFrame[];
     /**
      * Index into the line of the first comment opener on it, or -1 when it
      * holds none. 0 when the line opens already inside a comment, whose opener
@@ -183,13 +211,18 @@ export interface LexedLine {
 /**
  * Reads one line, given what the lines above it left open.
  *
- * A line that ends inside a literal is reported through `endedOpen` rather than
- * resolved here, because the two readers built on this want opposite fallbacks
- * and both are right. A masker must fail towards blanking: text it wrongly
- * offers as code becomes a declaration its caller edits as if it were real. A
- * scanner must fail towards keeping: a `using` it misses is read by its caller
- * as permission to remove an import. Deciding it here would silently impose one
- * of those on the other.
+ * A line that ends inside an *unterminated* literal is reported through
+ * `endedOpen` rather than resolved here, because the two readers built on this
+ * want opposite fallbacks and both are right. A masker must fail towards
+ * blanking: text it wrongly offers as code becomes a declaration its caller
+ * edits as if it were real. A scanner must fail towards keeping: a `using` it
+ * misses is read by its caller as permission to remove an import. Deciding it
+ * here would silently impose one of those on the other.
+ *
+ * A line ending inside an interpolation is not that case and is settled here,
+ * through `openFrames`: the language lets an interpolation span lines, so a
+ * reader that carries it is reading the file the compiler reads rather than
+ * guessing at a broken one.
  *
  * @param line one line, with no line terminator. A trailing `\r` from a CRLF
  *   document is harmless and counts as trailing whitespace.
@@ -236,7 +269,15 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     //
     // Kept across the `nesting > 0` branch, because a block comment written
     // inside a string does not end it: `"a<#c#>#b"` is the string `"a#b"`.
-    const open: LexFrame[] = [];
+    //
+    // Copied frame by frame rather than aliased, because an interpolation's
+    // brace count advances in place and one state may lex a line twice -
+    // ImportScanner.scanLine does exactly that to take its fallback.
+    //
+    // Empty with tracking off, whatever the caller carried: that mode reads a
+    // `#` as a comment opener wherever it sits, which is a caller saying it does
+    // not believe the literal state here.
+    const open: LexFrame[] = trackLiterals ? state.openFrames.map((frame) => ({ ...frame })) : [];
 
     /** Records one character as comment text: blanked in `masked`, absent from both code strings. */
     const commentChar = (): void => {
@@ -420,6 +461,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         opensIndentedComment,
         hasCode,
         endedOpen: open.length > 0,
+        openFrames: open[open.length - 1]?.kind === "interpolation" ? open : [],
         commentStart,
         codeWithoutComments,
         codeOutsideLiterals,

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -18,19 +18,25 @@ export { indentOf };
  * The text with every comment, `"` string and char literal replaced by spaces,
  * so offsets still address the original.
  *
- * A line that ends inside an open literal is left masked from the point it
- * opened, rather than re-read with literal tracking off. This reader must fail
- * towards blanking: its callers match declarations against what it returns, and
- * text it wrongly offers as code becomes a declaration one of them edits as if
- * it were real. The import scanner takes the opposite fallback on the same
+ * A line that ends inside an unterminated literal is left masked from the point
+ * it opened, and the literal does not carry to the line below. This reader must
+ * fail towards blanking: its callers match declarations against what it returns,
+ * and text it wrongly offers as code becomes a declaration one of them edits as
+ * if it were real. The import scanner takes the opposite fallback on the same
  * lines, for the opposite reason; see lexVerseLine.
+ *
+ * An open interpolation is carried, because it is the one literal state a
+ * newline does not end and the file below it is being read wrong otherwise: the
+ * `{` of `"Score: {` is inside the literal and blanked, so leaving the matching
+ * `}` on the next line at code scope strands the brace depth for the rest of the
+ * file. Which states may carry is the lexer's to decide, not this reader's.
  *
  * A quoted segment suffix is left standing, since it is part of an identifier
  * rather than literal text. Nothing can hide there: the grammar forbids `{`,
  * `}`, `"` and `\` inside one.
  */
 export function maskCommentsAndStrings(content: string): string {
-    const state: LexState = { depth: 0, markerIndent: null };
+    const state: LexState = { depth: 0, markerIndent: null, openFrames: [] };
     // Split on "\n" alone so a CRLF line keeps its "\r" and the masked line is
     // exactly as long as the line it replaces; joining then rebuilds the file
     // byte for byte.
@@ -40,6 +46,7 @@ export function maskCommentsAndStrings(content: string): string {
             const lexed = lexVerseLine(line, state);
             state.depth = lexed.depth;
             state.markerIndent = lexed.markerIndent;
+            state.openFrames = lexed.openFrames;
             return lexed.masked;
         })
         .join("\n");
@@ -83,10 +90,11 @@ export function popClosedBlocks(openBlockIndents: number[], indent: number): voi
  * depth as proof that a brace was missed:
  *
  * - `maskCommentsAndStrings` balances every literal it closes, and cannot
- *   balance one it does not. Each line is masked from the point a literal opened
- *   to the line's end, so an interpolation spanning lines - `"Score: {` over
- *   `Points}"` - loses its `{` and keeps its `}`, and nothing downstream can
- *   recover the pair.
+ *   balance one the file never closes. An unterminated `"` is masked only to its
+ *   own line's end and does not carry, so a `}` the author wrote inside that
+ *   string on a later line arrives here as a real one. An interpolation does
+ *   carry - the language lets one span lines - so `"Score: {` over `Points}"`
+ *   balances.
  * - `codeOutsideLiterals` consults only the frame open before each character, so
  *   an interpolation's opening `{` is blanked while its closing `}` survives
  *   even on one line. Callers reading a single line accept that, since a clause

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -90,11 +90,16 @@ export function popClosedBlocks(openBlockIndents: number[], indent: number): voi
  * depth as proof that a brace was missed:
  *
  * - `maskCommentsAndStrings` balances every literal it closes, and cannot
- *   balance one the file never closes. An unterminated `"` is masked only to its
- *   own line's end and does not carry, so a `}` the author wrote inside that
- *   string on a later line arrives here as a real one. An interpolation does
- *   carry - the language lets one span lines - so `"Score: {` over `Points}"`
- *   balances.
+ *   balance one the file never closes. An interpolation does carry across lines
+ *   - the language lets one span them - so `"Score: {` over `Points}"` balances,
+ *   but the two unclosed cases strand the depth in opposite directions. An
+ *   unterminated `"` is masked only to its own line's end and does not carry, so
+ *   a `}` the author wrote inside that string on a later line arrives here as a
+ *   real one and drives the depth down. An interpolation left open at the end of
+ *   the file carries to the end of the file, so the `}` that finally pops it is
+ *   blanked and whatever `{` was open outside the string never gets its closer
+ *   back. Neither file compiles; a reader here has no way to tell either from a
+ *   brace the author really did leave out.
  * - `codeOutsideLiterals` consults only the frame open before each character, so
  *   an interpolation's opening `{` is blanked while its closing `}` survives
  *   even on one line. Callers reading a single line accept that, since a clause


### PR DESCRIPTION
Closes #414

## The defect

`maskCommentsAndStrings` carried only the block-comment depth and the `<#>` marker indent from one line to the next, so `lexVerseLine` rebuilt its literal frame stack from code scope on every line. An interpolation legally spans lines — `Interp := '{' List '}'` (`VerseGrammar.h:2163`) makes its body an ordinary `List` — so the opening `{` sat inside the literal and was blanked while the closing `}` on the line below survived at code scope.

Reproduced on this branch before the change:

```
source: Outer := module {
            Msg := "Score: {
                Points}"
            Inner := module {
                X := 1
            }
        }

countBraces over the masked file: -1   (expected 0)
extractDeclarations:  ["Outer", "Outer.Msg", "Inner", "Inner.X"]
```

The stray `}` returned `depthAtLineStart` to zero a line early, `outermostClosedBrace` popped `Outer`, and every declaration below it was reported at a path that does not exist — one that then collides with any genuine top-level `Inner`.

## The fix

`LexState` and `LexedLine` each gain `openFrames`, and the carry rule lives in `lexVerseLine` rather than in any reader:

- The line's frame stack is seeded from `state.openFrames`, **copied frame by frame** — an interpolation's brace count advances in place, and `ImportScanner.scanLine` lexes one line twice off a single state object.
- On return, `openFrames` is that stack **only where the innermost frame is an interpolation**, and `[]` otherwise. That gate is the whole rule: a `"` cannot cross a newline — at String place `Text` stops dead there (`VerseGrammar.h:2083-2099`, jump table at `:437-444`) and `Quote` then requires the closing quote (`:459`), so an open string at a line end is error S32. Carrying it would let one stray quote blank the rest of the file.
- With `trackLiterals: false` the seed is empty: that mode reads a `#` as a comment opener wherever it sits, which is a caller saying it does not believe the literal state.

`maskCommentsAndStrings` carries it. `ImportScanner` deliberately does not, and says so where its state is built — it re-lexes an `endedOpen` line with literal tracking off, so resuming a literal on the next line would resume one that line was never lexed as.

The rule is settled from the compiler source, not from this extension's own readers, and is compile-validated by the book's versetests: `Tests/Literals/String.versetest:216` (`"this is a multi-line{\n    }string literal{...}"`) and `Tests/AutoQualification.versetest:171` (`"The Message to {\n        Name}"`).

## Acceptance

| Criterion | Where |
| --- | --- |
| `countBraces` returns 0 for a balanced file with a multi-line interpolation | `verseLexerCorpus.test.ts`, brace-depth block |
| `extractDeclarations` reports `Outer.Inner` | `verseLexerCorpus.test.ts`, "keeps the enclosing module across an interpolation that spans lines" |
| An unterminated `"` still does not carry past its line | existing probe plus a new one for the sharper shape, `"a{B}c` — interpolation closed, string still open |
| Probes shown to fail before the change | below |

Detection was proven in both directions:

- Removing the carry (`state.openFrames = lexed.openFrames`) fails all four new tests, with the other 53 in the suite still passing.
- Removing the interpolation gate (carrying unconditionally) fails `moduleDeclarationsMasking.test.ts:56` and both unterminated-string probes — so the gate is load-bearing, not decoration.

Two brace-depth cases beyond the minimum pin the parts a naive carry would drop: the interpolation's own `{ }` block count crossing the boundary, and a block comment opened inside a multi-line interpolation (the shape of versetest `String.versetest:230`).

## Deliberately not changed

`ImportScanner`'s `trackLiterals: false` fallback. Probed on this branch: across a multi-line interpolation `scanModuleImports` and `allUsingPaths` both return `[]` for a `using` written inside the string, so there is no defect there, and changing the fallback would be a behaviour change outside this ticket. The masker now carries where the scanner does not — a second shape, after the unterminated string already in the corpus, where the two readers legitimately differ. The brace-depth block says so where the new cases sit.

## Verification

```
$ npm run compile
> verse-auto-imports@0.11.1 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.11.1 test
> jest --verbose

Test Suites: 50 passed, 50 total
Tests:       1511 passed, 1511 total
Snapshots:   0 total
Time:        19.105 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.11.1 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!

$ npx jest src/imports/__tests__
Test Suites: 10 passed, 10 total
Tests:       857 passed, 857 total
Snapshots:   0 total
Time:        18.582 s
```

## Review

One round, fresh context at opus: `PASS_WITH_SUGGESTIONS`, no Critical. It probed 20-odd shapes — CRLF, tabs, nested interpolations, `}` at interpolation-brace depth 0 vs >0 across the boundary, a block comment inside a multi-line interpolation, char literals and quoted suffixes open at a line end, offset integrity on eight inputs — and independently confirmed all four acceptance criteria fail on `origin/main`. It also settled the open design question against the alternative: **"innermost is an interpolation" is the right gate**, and "no unterminated literal anywhere in the stack" would be wrong, since it would refuse `"a{F("b{`, which the compiler accepts — the newline sits in the inner `Interp`'s `List`, not in either string's `Text`.

Three `Important` findings, all about things stated wrongly rather than done wrongly, all fixed in `2a3bcc7`:

- **A wrong compiler citation, twice.** `:459` is a jump-table entry in the `EPlace::UTF8` branch, not `Quote`; the real `Require(u8"\"", &CParser::S32)` is `:3224`. Verified directly against the clone before fixing — and the `Text` range was six lines short of the `return SNothing{}` that carries the claim. Load-bearing, since that cite is the entire justification for the gate.
- **The frame copy's stated reason could not hold.** It named `ImportScanner.scanLine` lexing one line twice, but that second lex passes `trackLiterals: false` and starts from an empty stack regardless. What the copy actually protects is a caller that never reassigns `openFrames` — both scanner states hold an empty stack they never write back, and aliasing would push each line's literals into the array they treat as inert.
- **`lexVerseLine`'s doc contradicted `openFrames`'s.** It read as though `endedOpen` distinguished an unterminated literal from a carried interpolation. It does not — it is true of both, and the scanner's fallback fires on it either way.

One behaviour note it surfaced, left as documented rather than changed: an interpolation left open at end of file now carries to end of file, so the `}` that pops it is blanked and an enclosing `{` never gets its closer — the depth strands *positive* where an unterminated string strands it negative. Such a file cannot compile, and no reader here can tell either case from a brace the author really did omit. `scanBraces`' doc block enumerates how its input can be unbalanced, so it now enumerates both directions.

Declined: a `codeScopeState()` factory or an optional `openFrames`, offered as possible Shotgun Surgery. An optional field fails open, and the reviewer's own note is that the explicit spelling is the better one here — each construction site now carries a comment saying whether it carries and why.

The full `src/imports/__tests__` run is the repo's extractor check: this touches `src/imports/`, and a shadowing change there surfaces as an unrelated existing case changing shape rather than as the failure you predicted. No pattern in `ImportSuggestionExtractor` was added, moved or broadened — the only `src/imports/` edits are two `LexState` literals gaining a field and one call site in `ImportFormatter`.
