### PR TITLE
fix(imports): resolve phase-2 module locations with the shared matcher

### DIFF
--- a/changelog.d/395.fixed.md
+++ b/changelog.d/395.fixed.md
@@ -1,0 +1,1 @@
+**Import path conversion**: converting a `using` to its absolute path now resolves modules declared inside other modules, and declines rather than guessing when the project is too large for the declaration scan to read in full.

--- a/changelog.d/395.fixed.md
+++ b/changelog.d/395.fixed.md
@@ -1,1 +1,1 @@
-**Import path conversion**: converting a `using` to its absolute path now resolves modules declared inside other modules, and declines rather than guessing when the project is too large for the declaration scan to read in full.
+**Import path conversion**: modules declared inside other modules now convert in both directions, and a project too large for the module search to read in full is told so once rather than offered a path the search cannot stand behind.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -1,10 +1,11 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { logger } from "../utils";
-import { maskCommentsAndStrings } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathCache } from "../services";
-import { resolveFolderModuleLocations, toContentRelativeDir } from "../services/moduleLocationLookup";
+import { buildProjectIndexes, resolveFolderModuleLocations, resolveModuleLocations, toContentRelativeDir } from "../services/moduleLocationLookup";
+import { ProjectPathNode } from "../types";
+import { findExplicitModuleDeclarations } from "../visibility/moduleDeclarations";
 import { ImportFormatter } from "./ImportFormatter";
 import { LINE_SPLIT, scanConvertibleImports } from "./ImportScanner";
 
@@ -32,13 +33,37 @@ interface ImportConversionResult {
     line?: number;
 }
 
+/**
+ * Where a module could be, and whether the search that answered was complete.
+ *
+ * `truncated` says the declaration scan stopped at its file cap, so `locations`
+ * holds whatever a sample of the project attested to. A location absent from it
+ * may still exist, and a single entry is no evidence that the name is
+ * unambiguous, so nothing may be written from a truncated answer.
+ */
+interface ModuleLocationSearch {
+    locations: string[];
+    truncated: boolean;
+}
+
 const CONTENT_FOLDER = "Content";
 
 /**
+ * How many `.verse` files the explicit-declaration scan reads. Two orders of
+ * magnitude below FOLDER_SCAN_FILE_LIMIT because this phase opens and lexes
+ * every file it scans, where the folder search reads none.
+ *
+ * It stays small because a project past it answers from the declaration cache
+ * instead: this scan runs only once the cache has missed, and above the limit it
+ * reports itself truncated rather than answering from a sample.
+ */
+const DECLARATION_SCAN_FILE_LIMIT = 100;
+
+/**
  * How many `.verse` files the project-wide folder search enumerates. Far above
- * the explicit-declaration scan's 100 because this one reads no file contents:
- * it derives folder modules from the paths alone, so a file costs a string
- * split rather than a read.
+ * DECLARATION_SCAN_FILE_LIMIT because this one reads no file contents: it
+ * derives folder modules from the paths alone, so a file costs a string split
+ * rather than a read.
  */
 const FOLDER_SCAN_FILE_LIMIT = 5000;
 
@@ -103,34 +128,6 @@ export class ImportPathConverter {
      */
     static buildFullVersePath(projectVersePath: string, location: string, modulePath: string): string {
         return location === "/" || location === "" ? `${projectVersePath}/${modulePath}` : `${projectVersePath}${location}/${modulePath}`;
-    }
-
-    /**
-     * A regex matching an explicit declaration of one named module, in any of
-     * the three styles Verse writes a macro body in: `module:`, `module { }`
-     * with the brace on either that line or the next, and the dotted
-     * `module. Inner := ...`. A `>` after the keyword is accepted alongside
-     * them.
-     *
-     * No visibility keyword list appears here: nothing reads which specifier
-     * was found, only whether this file declares the module, so any `<...>`
-     * entry is accepted - a `scoped{A, B}` list included, whose specifier does
-     * not end at its keyword.
-     *
-     * A specifier body must exclude `<` and newlines. A body free to span lines
-     * lets a `<` that opens nothing - a comparison operator, say - run on to
-     * the `>` of a LATER declaration's specifier, reporting a file that
-     * declares no such module. The narrowing holds whether or not the text is
-     * masked first, and nothing binds a caller of this builder to mask, so it
-     * cannot be widened to MODULE_DECLARATION's `[^>]`.
-     *
-     * Non-global on purpose: the pattern is reused with `.test()` across many
-     * files, and a global flag would carry `lastIndex` between calls and skip
-     * valid definitions depending on the order the files are read in.
-     */
-    static buildModuleDefinitionRegex(moduleName: string): RegExp {
-        const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return new RegExp(`\\b${escaped}(?:'[^']*')?(?:\\s*<[^<>\\n]+>)*\\s*:=\\s*module\\s*[:>{.]`, "m");
     }
 
     /**
@@ -343,71 +340,67 @@ export class ImportPathConverter {
 
     /**
      * Appends the locations of the `.verse` files explicitly declaring this
-     * name as a module, which is the other way a module comes to exist and the
-     * one no folder attests to.
+     * module, which is the other way a module comes to exist and the one no
+     * folder attests to.
      *
-     * Capped at 100 files scanned, so a project larger than that resolves from
-     * whichever of them the search returned.
+     * Each declaration is read with its enclosing module chain and matched by
+     * resolveModuleLocations, the same segment-aligned matching the cache path
+     * runs. A module declared inside another is an ordinary path scope, so
+     * `Outer.Inner` names the inner one and a file's directory alone cannot say
+     * which module a declaration is; deciding that here, from the directory
+     * string, is what reported a nested module as missing and answered a bare
+     * inner name with a path nothing declares.
+     *
+     * @returns whether the scan hit DECLARATION_SCAN_FILE_LIMIT, leaving the
+     * rest of the project unread
      */
-    private async searchExplicitModuleDefinitions(modulePath: string, moduleName: string, pathSegments: string[], locations: string[]): Promise<void> {
+    private async searchExplicitModuleDefinitions(modulePath: string, locations: string[]): Promise<boolean> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) return;
+        if (!workspaceFolders || workspaceFolders.length === 0) return false;
 
         const { searchPattern, workspaceIsContent } = ImportPathConverter.workspaceScanTargets(workspaceFolders[0]);
 
         // Scope the scan to the project folder. The UEFN-generated workspace is
         // multi-root (Content plus Epic's digest folders); a bare string glob
         // would also read every *.digest.verse on each fallback scan.
-        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", 100);
-        const modulePattern = ImportPathConverter.buildModuleDefinitionRegex(moduleName);
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", DECLARATION_SCAN_FILE_LIMIT);
 
+        const nodes: ProjectPathNode[] = [];
         for (const file of verseFiles) {
             const content = await vscode.workspace.fs.readFile(file).then(
                 (buffer) => Buffer.from(buffer).toString("utf8"),
                 () => null,
             );
+            if (!content) continue;
 
-            // Only a live declaration attests to a location. Matched against
-            // raw text, a commented-out declaration or one quoted in a string
-            // puts its directory into `locations`, which either makes the
-            // conversion ambiguous or writes a path to the wrong file. The two
-            // sibling scanners, moduleDeclarations and ProjectPathScanner, mask
-            // for the same reason.
-            if (!content || !modulePattern.test(maskCommentsAndStrings(content))) continue;
+            // Paths are taken against the folder the glob was rooted at, which
+            // is also the folder workspaceIsContent describes. Asking which
+            // folder each file sits in instead lets the two disagree, and the
+            // Content prefix is then read off one folder and stripped by the
+            // rule of another.
+            const sourceFile = path.relative(workspaceFolders[0].uri.fsPath, file.fsPath).replace(/\\/g, "/");
 
-            logger.debug("ImportPathConverter", `Found module definition in: ${file.fsPath}`);
-            const workspaceFolder = vscode.workspace.getWorkspaceFolder(file);
-            if (!workspaceFolder) continue;
-
-            let relativePath = path.relative(workspaceFolder.uri.fsPath, file.fsPath).replace(/\\/g, "/");
-            relativePath = path.dirname(relativePath).replace(/\\/g, "/");
-
-            if (workspaceIsContent) {
-                relativePath = relativePath === "" || relativePath === "." ? CONTENT_FOLDER : `${CONTENT_FOLDER}/${relativePath}`;
-            }
-
-            if (!relativePath.startsWith(CONTENT_FOLDER)) continue;
-
-            relativePath = relativePath.startsWith(`${CONTENT_FOLDER}/`) ? relativePath.substring(CONTENT_FOLDER.length + 1) : relativePath === CONTENT_FOLDER ? "" : relativePath;
-
-            // A dotted reference names the path to the module as well as the
-            // module, and only the last segment was searched for, so a
-            // declaration whose directory does not end in the rest of the
-            // reference declares a different module of the same name.
-            if (pathSegments.length > 1) {
-                const parentPath = pathSegments.slice(0, -1).join("/");
-                if (!relativePath.endsWith(parentPath)) continue;
-
-                relativePath = relativePath.substring(0, relativePath.length - parentPath.length);
-                if (relativePath.endsWith("/")) relativePath = relativePath.substring(0, relativePath.length - 1);
-            }
-
-            if (!relativePath.startsWith("/") && relativePath !== "") relativePath = "/" + relativePath;
-
-            if (!locations.includes(relativePath)) {
-                locations.push(relativePath);
+            // Only a live declaration attests to a location; a commented-out one
+            // or one quoted in a string names a module that does not exist.
+            // findExplicitModuleDeclarations masks both before matching.
+            for (const declaration of findExplicitModuleDeclarations(content)) {
+                nodes.push({
+                    name: declaration.name,
+                    fullPath: declaration.chain.join("."),
+                    type: "module",
+                    isPublic: declaration.visibility?.keyword === "public",
+                    sourceFile,
+                });
             }
         }
+
+        const { moduleNameIndex } = buildProjectIndexes(nodes);
+        for (const candidate of resolveModuleLocations(modulePath, moduleNameIndex, { workspaceIsContent })) {
+            logger.debug("ImportPathConverter", `Found module definition in: ${candidate.sourceFile}`);
+            if (!locations.includes(candidate.location)) locations.push(candidate.location);
+        }
+
+        return verseFiles.length >= DECLARATION_SCAN_FILE_LIMIT;
     }
 
     /**
@@ -469,14 +462,17 @@ export class ImportPathConverter {
      * scope walk resolves nothing, it searches every module in the program and
      * collects all the matches rather than the first, which is why an ambiguous
      * answer here is a result and not a fault.
+     *
+     * A truncated declaration scan is reported for the whole search, not for its
+     * own phase alone: reaching that phase means the ones before it found
+     * nothing, so its incomplete silence is also what let the phase after it
+     * answer.
      */
-    async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<string[]> {
+    async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<ModuleLocationSearch> {
         const locations: string[] = [];
+        let truncated = false;
         const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) return locations;
-
-        const pathSegments = modulePath.split("/").filter((s) => s);
-        const moduleName = pathSegments[pathSegments.length - 1];
+        if (!workspaceFolders || workspaceFolders.length === 0) return { locations, truncated };
 
         logger.debug("ImportPathConverter", `Searching for module '${modulePath}'`);
 
@@ -512,7 +508,10 @@ export class ImportPathConverter {
         if (locations.length === 0) {
             logger.debug("ImportPathConverter", `Phase 2: Searching explicit module definitions`);
             try {
-                await this.searchExplicitModuleDefinitions(modulePath, moduleName, pathSegments, locations);
+                truncated = await this.searchExplicitModuleDefinitions(modulePath, locations);
+                if (truncated) {
+                    logger.debug("ImportPathConverter", `Phase 2 stopped at ${DECLARATION_SCAN_FILE_LIMIT} files; the search is a sample of the project`);
+                }
             } catch (error) {
                 logger.debug("ImportPathConverter", `Error in Phase 2 (explicit modules): ${error}`);
             }
@@ -535,7 +534,7 @@ export class ImportPathConverter {
             logger.debug("ImportPathConverter", `  - No locations found!`);
         }
 
-        return locations;
+        return { locations, truncated };
     }
 
     /** Path segments with the leading slash and any empty segments dropped. */
@@ -655,7 +654,10 @@ export class ImportPathConverter {
      * shadows the target or clashes with it, and no relative spelling reaches
      * past it, so there is no conversion to offer rather than a longer one to
      * find. None means nothing here can place the module, which is exactly the
-     * position this check exists to stop a conversion being written from.
+     * position this check exists to stop a conversion being written from. A
+     * truncated search refuses ahead of the count, because the one location it
+     * returned is a sample's answer and a namesake in the unread remainder would
+     * have made it two.
      *
      * The check is only as good as the search under it, and that search has
      * blind spots this does not close - these among them, rather than these
@@ -678,7 +680,14 @@ export class ImportPathConverter {
         // segment written after it.
         const expectedPath = `/${fullSegments.slice(0, fullSegments.length - (referenceSegments.length - 1)).join("/")}`;
 
-        const locations = await this.findModuleLocations(firstSegment, documentUri);
+        const { locations, truncated } = await this.findModuleLocations(firstSegment, documentUri);
+        if (truncated) {
+            logger.debug(
+                "ImportPathConverter",
+                `Refusing '${reference}' for ${fullPath}: the declaration scan stopped at ${DECLARATION_SCAN_FILE_LIMIT} files, so '${firstSegment}' was resolved against part of the project`,
+            );
+            return false;
+        }
         if (locations.length !== 1) {
             logger.debug("ImportPathConverter", `Refusing '${reference}' for ${fullPath}: '${firstSegment}' resolves to ${locations.length} locations, not one`);
             return false;
@@ -870,9 +879,20 @@ export class ImportPathConverter {
 
         logger.debug("ImportPathConverter", `Project verse path: ${projectVersePath}`);
 
-        const possibleLocations = await this.findModuleLocations(modulePath, documentUri);
+        const { locations: possibleLocations, truncated } = await this.findModuleLocations(modulePath, documentUri);
         logger.debug("ImportPathConverter", `findModuleLocations returned ${possibleLocations.length} location(s)`);
         possibleLocations.forEach((loc, idx) => logger.debug("ImportPathConverter", `  Location ${idx}: '${loc}'`));
+
+        // Ahead of the count, because a sample cannot answer either question the
+        // count decides: a location it did not reach is missing from the list,
+        // and a namesake it did not reach is missing from the ambiguity.
+        if (truncated) {
+            logger.debug("ImportPathConverter", `Refusing ${modulePath}: the declaration scan stopped at ${DECLARATION_SCAN_FILE_LIMIT} files`);
+            vscode.window.showWarningMessage(
+                `Could not resolve '${moduleName}' with certainty: the module search stopped after ${DECLARATION_SCAN_FILE_LIMIT} files, so it read part of the project. Enable the project cache, or write the absolute path by hand.`,
+            );
+            return null;
+        }
 
         const usesCurlyBraces = ImportPathConverter.usesBracedStyle(importStatement);
 

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -46,6 +46,15 @@ interface ModuleLocationSearch {
     truncated: boolean;
 }
 
+/**
+ * A notification not yet spent. The condition it reports belongs to the project
+ * rather than to any one import, so a run over a whole document consumes one
+ * between all of them instead of repeating it per line.
+ */
+interface TruncationNotice {
+    pending: boolean;
+}
+
 const CONTENT_FOLDER = "Content";
 
 /**
@@ -53,9 +62,11 @@ const CONTENT_FOLDER = "Content";
  * magnitude below FOLDER_SCAN_FILE_LIMIT because this phase opens and lexes
  * every file it scans, where the folder search reads none.
  *
- * It stays small because a project past it answers from the declaration cache
- * instead: this scan runs only once the cache has missed, and above the limit it
- * reports itself truncated rather than answering from a sample.
+ * A project holding more than this gets no answer from the phase rather than a
+ * sample's answer, so the number is a bound on how large a project the scan
+ * serves, not only on how long it takes. The declaration cache covers the same
+ * ground without a cap, but only for modules a declaration names: a folder
+ * module has none, so it reaches this scan however large the project is.
  */
 const DECLARATION_SCAN_FILE_LIMIT = 100;
 
@@ -346,13 +357,11 @@ export class ImportPathConverter {
      * Each declaration is read with its enclosing module chain and matched by
      * resolveModuleLocations, the same segment-aligned matching the cache path
      * runs. A module declared inside another is an ordinary path scope, so
-     * `Outer.Inner` names the inner one and a file's directory alone cannot say
-     * which module a declaration is; deciding that here, from the directory
-     * string, is what reported a nested module as missing and answered a bare
-     * inner name with a path nothing declares.
+     * `Outer.Inner` names the inner one, and a file's directory alone cannot say
+     * which module a declaration is.
      *
-     * @returns whether the scan hit DECLARATION_SCAN_FILE_LIMIT, leaving the
-     * rest of the project unread
+     * @returns whether the project holds more `.verse` files than
+     * DECLARATION_SCAN_FILE_LIMIT, leaving the rest of it unread
      */
     private async searchExplicitModuleDefinitions(modulePath: string, locations: string[]): Promise<boolean> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -363,10 +372,16 @@ export class ImportPathConverter {
         // Scope the scan to the project folder. The UEFN-generated workspace is
         // multi-root (Content plus Epic's digest folders); a bare string glob
         // would also read every *.digest.verse on each fallback scan.
-        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", DECLARATION_SCAN_FILE_LIMIT);
+        //
+        // One file past the limit is asked for and never read, so that a project
+        // holding exactly the limit is told apart from one holding more. Asking
+        // for the limit itself makes those two answers identical, which is the
+        // conflation the truncation signal exists to end.
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", DECLARATION_SCAN_FILE_LIMIT + 1);
+        const readPartOnly = verseFiles.length > DECLARATION_SCAN_FILE_LIMIT;
 
         const nodes: ProjectPathNode[] = [];
-        for (const file of verseFiles) {
+        for (const file of verseFiles.slice(0, DECLARATION_SCAN_FILE_LIMIT)) {
             const content = await vscode.workspace.fs.readFile(file).then(
                 (buffer) => Buffer.from(buffer).toString("utf8"),
                 () => null,
@@ -400,7 +415,7 @@ export class ImportPathConverter {
             if (!locations.includes(candidate.location)) locations.push(candidate.location);
         }
 
-        return verseFiles.length >= DECLARATION_SCAN_FILE_LIMIT;
+        return readPartOnly;
     }
 
     /**
@@ -463,16 +478,15 @@ export class ImportPathConverter {
      * collects all the matches rather than the first, which is why an ambiguous
      * answer here is a result and not a fault.
      *
-     * A truncated declaration scan is reported for the whole search, not for its
-     * own phase alone: reaching that phase means the ones before it found
-     * nothing, so its incomplete silence is also what let the phase after it
-     * answer.
+     * `truncated` covers the declaration scan's own answer and an empty result,
+     * not an answer the folder search gave: that phase reads the project's
+     * directories for itself and is capped an order of magnitude higher, so a
+     * short declaration scan says nothing about it.
      */
     async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<ModuleLocationSearch> {
         const locations: string[] = [];
-        let truncated = false;
         const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) return { locations, truncated };
+        if (!workspaceFolders || workspaceFolders.length === 0) return { locations, truncated: false };
 
         logger.debug("ImportPathConverter", `Searching for module '${modulePath}'`);
 
@@ -505,15 +519,21 @@ export class ImportPathConverter {
             }
         }
 
+        let declarationScanReadPart = false;
+        let answeredByDeclarationScan = false;
         if (locations.length === 0) {
             logger.debug("ImportPathConverter", `Phase 2: Searching explicit module definitions`);
             try {
-                truncated = await this.searchExplicitModuleDefinitions(modulePath, locations);
-                if (truncated) {
-                    logger.debug("ImportPathConverter", `Phase 2 stopped at ${DECLARATION_SCAN_FILE_LIMIT} files; the search is a sample of the project`);
-                }
+                declarationScanReadPart = await this.searchExplicitModuleDefinitions(modulePath, locations);
             } catch (error) {
+                // A phase that threw read an unknown amount of the project,
+                // which is the position stopping at the cap leaves it in.
+                declarationScanReadPart = true;
                 logger.debug("ImportPathConverter", `Error in Phase 2 (explicit modules): ${error}`);
+            }
+            answeredByDeclarationScan = locations.length > 0;
+            if (declarationScanReadPart) {
+                logger.debug("ImportPathConverter", `Phase 2 read part of the project, so its answer is a sample`);
             }
         }
 
@@ -525,6 +545,13 @@ export class ImportPathConverter {
                 logger.debug("ImportPathConverter", `Error in Phase 3 (project folder modules): ${error}`);
             }
         }
+
+        // A partial declaration scan clouds its own answer, and clouds an empty
+        // result, where the module may be declared in the part left unread. It
+        // does not cloud the folder search's answer: that phase reads the
+        // project's directories for itself, and reaching it at all means the
+        // declaration scan found nothing to weigh against them.
+        const truncated = declarationScanReadPart && (answeredByDeclarationScan || locations.length === 0);
 
         logger.debug("ImportPathConverter", `Module search complete for '${modulePath}'`);
         logger.debug("ImportPathConverter", `Found ${locations.length} possible locations:`);
@@ -854,6 +881,17 @@ export class ImportPathConverter {
      * picks, then hands the choice to applyConversion.
      */
     async convertToFullPath(importStatement: string, documentUri: vscode.Uri, line?: number): Promise<ImportConversionResult | null> {
+        return this.resolveToFullPath(importStatement, documentUri, { pending: true }, line);
+    }
+
+    /**
+     * convertToFullPath's body, with the truncation notice hoisted so a caller
+     * converting a whole document reports the condition once.
+     *
+     * @param notice consumed by the first import the cap refuses; the condition
+     *   is the project's, so repeating it per import says nothing new
+     */
+    private async resolveToFullPath(importStatement: string, documentUri: vscode.Uri, notice: TruncationNotice, line?: number): Promise<ImportConversionResult | null> {
         if (this.isFullPathImport(importStatement)) {
             if (this.isBuiltinModule(importStatement)) {
                 logger.debug("ImportPathConverter", "Import is a built-in module and should not be converted");
@@ -887,10 +925,13 @@ export class ImportPathConverter {
         // count decides: a location it did not reach is missing from the list,
         // and a namesake it did not reach is missing from the ambiguity.
         if (truncated) {
-            logger.debug("ImportPathConverter", `Refusing ${modulePath}: the declaration scan stopped at ${DECLARATION_SCAN_FILE_LIMIT} files`);
-            vscode.window.showWarningMessage(
-                `Could not resolve '${moduleName}' with certainty: the module search stopped after ${DECLARATION_SCAN_FILE_LIMIT} files, so it read part of the project. Enable the project cache, or write the absolute path by hand.`,
-            );
+            logger.debug("ImportPathConverter", `Refusing ${modulePath}: the declaration scan read part of the project`);
+            if (notice.pending) {
+                notice.pending = false;
+                vscode.window.showWarningMessage(
+                    `The module search reads at most ${DECLARATION_SCAN_FILE_LIMIT} .verse files and this project holds more, so it read part of it. Imports it cannot place with certainty are left alone; write those absolute paths by hand.`,
+                );
+            }
             return null;
         }
 
@@ -940,8 +981,9 @@ export class ImportPathConverter {
         const text = document.getText();
         const lines = text.split(LINE_SPLIT);
 
+        const notice: TruncationNotice = { pending: true };
         for (const { statement, line } of scanConvertibleImports(lines)) {
-            const result = await this.convertToFullPath(statement, document.uri, line);
+            const result = await this.resolveToFullPath(statement, document.uri, notice, line);
             if (result) {
                 results.push(result);
             }

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -58,15 +58,13 @@ interface TruncationNotice {
 const CONTENT_FOLDER = "Content";
 
 /**
- * How many `.verse` files the explicit-declaration scan reads. Two orders of
- * magnitude below FOLDER_SCAN_FILE_LIMIT because this phase opens and lexes
- * every file it scans, where the folder search reads none.
+ * How many `.verse` files the explicit-declaration scan reads. Far below
+ * FOLDER_SCAN_FILE_LIMIT because this phase opens and lexes every file it
+ * scans, where the folder search reads none.
  *
  * A project holding more than this gets no answer from the phase rather than a
- * sample's answer, so the number is a bound on how large a project the scan
- * serves, not only on how long it takes. The declaration cache covers the same
- * ground without a cap, but only for modules a declaration names: a folder
- * module has none, so it reaches this scan however large the project is.
+ * sample's answer, so the number bounds how large a project the phase serves,
+ * not only how long it takes.
  */
 const DECLARATION_SCAN_FILE_LIMIT = 100;
 
@@ -479,9 +477,8 @@ export class ImportPathConverter {
      * answer here is a result and not a fault.
      *
      * `truncated` covers the declaration scan's own answer and an empty result,
-     * not an answer the folder search gave: that phase reads the project's
-     * directories for itself and is capped an order of magnitude higher, so a
-     * short declaration scan says nothing about it.
+     * not an answer the folder search gave. The reasoning for that boundary,
+     * and what it knowingly leaves exposed, is at the assignment itself.
      */
     async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<ModuleLocationSearch> {
         const locations: string[] = [];
@@ -547,10 +544,17 @@ export class ImportPathConverter {
         }
 
         // A partial declaration scan clouds its own answer, and clouds an empty
-        // result, where the module may be declared in the part left unread. It
-        // does not cloud the folder search's answer: that phase reads the
-        // project's directories for itself, and reaching it at all means the
-        // declaration scan found nothing to weigh against them.
+        // result, where the module may be declared in the part left unread.
+        //
+        // It is deliberately not extended to the folder search's answer, and
+        // that is a trade rather than a proof. A declaration outranks a distant
+        // folder, so a declaration in the unread remainder would have answered
+        // instead of the folder chain, and trusting the folder chain can still
+        // put out the wrong location silently. Distrusting it costs more: a
+        // folder module has no declaration anywhere for this phase or the cache
+        // to hold, so the veto would refuse every folder module in a project
+        // past the cap - the commonest thing that reaches this search at all.
+        // Raising the cap is what shrinks the exposure; the rule cannot.
         const truncated = declarationScanReadPart && (answeredByDeclarationScan || locations.length === 0);
 
         logger.debug("ImportPathConverter", `Module search complete for '${modulePath}'`);
@@ -929,7 +933,7 @@ export class ImportPathConverter {
             if (notice.pending) {
                 notice.pending = false;
                 vscode.window.showWarningMessage(
-                    `The module search reads at most ${DECLARATION_SCAN_FILE_LIMIT} .verse files and this project holds more, so it read part of it. Imports it cannot place with certainty are left alone; write those absolute paths by hand.`,
+                    `This project holds more than ${DECLARATION_SCAN_FILE_LIMIT} .verse files, which is as many as the search for a declared module reads. Imports that need one are left alone rather than pointed at a module found in part of the project; write those absolute paths by hand.`,
                 );
             }
             return null;

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -732,10 +732,23 @@ describe("ImportPathConverter.findModuleLocations explicit declaration scan", ()
         expect(await locationsFor(source, "Helpers")).toEqual(["/Systems"]);
     });
 
+    it("does not let a stray < in a comment reach a later specifier", async () => {
+        const source = "# Inventory <-- rename before ship\nHelpers<internal> := module:\n";
+
+        expect(await locationsFor(source)).toEqual([]);
+        expect(await locationsFor(source, "Helpers")).toEqual(["/Systems"]);
+    });
+
+    it("reads a stacked specifier block on the declaration it belongs to", async () => {
+        const source = "Count := Inventory < 3\nOther<final><public> := module {}\n";
+
+        expect(await locationsFor(source)).toEqual([]);
+        expect(await locationsFor(source, "Other")).toEqual(["/Systems"]);
+    });
+
     // A module declared inside another is an ordinary path scope, so the inner
-    // one is named through the outer. Deciding the location from the directory
-    // string alone reported this as missing, and answered the bare inner name
-    // with a location that builds a path nothing declares.
+    // one is named through the outer, and a file's directory alone cannot say
+    // which module a declaration is.
     it("places a nested declaration under its enclosing module", async () => {
         const source = "Outer := module:\n    Inner := module:\n        Count<public>:int = 0\n";
 
@@ -751,9 +764,8 @@ describe("ImportPathConverter.findModuleLocations explicit declaration scan", ()
         expect(await locationsFor("Inventory := module:\n", "XSystems/Inventory")).toEqual([]);
     });
 
-    // What the two above cost the user: the import the project compiles with is
-    // reported missing, and the one it does not compile with is written out as
-    // a path no module answers to.
+    // The same rule at the entry point: only the chain a declaration sits in
+    // decides which import it answers.
     it("converts a nested reference, and offers nothing for the bare inner name", async () => {
         const projectVersePath = "/mygame@fortnite.com/mygame";
         (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([vscode.Uri.file(declaringFile)]);
@@ -776,13 +788,15 @@ describe("ImportPathConverter declaration scan file cap", () => {
     };
 
     /**
-     * A project of `fileCount` files, each declaring `Inventory`, none of which
-     * the folder phases can place. The scan's own cap is what the glob would
-     * apply in production, so the count standing in for it here is the count
-     * that reaches the phase.
+     * A project of `fileCount` `.verse` files, each declaring `Inventory`. The
+     * glob honours its maxResults in production, so the mock caps its own answer
+     * the same way rather than handing back more than was asked for.
      */
-    const scanReturning = (fileCount: number): void => {
-        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(Array.from({ length: fileCount }, (_, index) => vscode.Uri.file(`${workspaceRoot}/Content/Systems/File${index}.verse`)));
+    const projectOf = (fileCount: number): void => {
+        const files = Array.from({ length: fileCount }, (_, index) => vscode.Uri.file(`${workspaceRoot}/Content/Systems/File${index}.verse`));
+        (vscode.workspace.findFiles as jest.Mock).mockImplementation(async (_pattern: unknown, _exclude: unknown, maxResults?: number) =>
+            maxResults === undefined ? files : files.slice(0, maxResults),
+        );
         (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Inventory := module:\n", "utf8"));
     };
 
@@ -792,6 +806,7 @@ describe("ImportPathConverter declaration scan file cap", () => {
 
     afterEach(() => {
         setWorkspaceFolders(undefined);
+        (vscode.workspace.findFiles as jest.Mock).mockReset();
         (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
         (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
         (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
@@ -799,31 +814,75 @@ describe("ImportPathConverter declaration scan file cap", () => {
 
     const convert = (statement: string) => converterWithProjectPath(projectVersePath).convertToFullPath(statement, vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`), 0);
 
-    it("reports a scan that stopped short, so a caller can tell it from a completed one", async () => {
-        scanReturning(100);
+    it("reports a scan that read only part of the project, so a caller can tell it from a complete one", async () => {
+        projectOf(101);
 
         expect((await converterWithProjectPath(projectVersePath).findModuleLocations("Inventory")).truncated).toBe(true);
     });
 
-    it("reports a scan that read the whole project as complete", async () => {
-        scanReturning(99);
+    // The boundary is the whole point of the signal: a project of exactly the
+    // limit is read end to end, and calling that truncated is the same
+    // conflation of complete and partial that the signal exists to end.
+    it("reports a project of exactly the limit as read in full", async () => {
+        projectOf(100);
 
         expect((await converterWithProjectPath(projectVersePath).findModuleLocations("Inventory")).truncated).toBe(false);
     });
 
-    // The one location a truncated scan returns is a sample's answer: a namesake
+    // The one location a partial scan returns is a sample's answer: a namesake
     // in the part it never read would have made the conversion ambiguous, so
     // writing this path unambiguously is the silent wrong module the cap hides.
     it("refuses the conversion rather than writing a sample's answer", async () => {
-        scanReturning(100);
+        projectOf(101);
 
         expect(await convert("using { Inventory }")).toBeNull();
     });
 
-    it("converts as before when the scan read the whole project", async () => {
-        scanReturning(99);
+    it("converts when the scan read the whole project", async () => {
+        projectOf(100);
 
         expect((await convert("using { Inventory }"))?.convertedImport).toBe(`using { ${projectVersePath}/Systems/Inventory }`);
+    });
+
+    // The declaration scan's reach says nothing about the folder search's: that
+    // phase reads the project's directories for itself, under a cap two orders
+    // of magnitude higher. Vetoing its answer turned the feature off for every
+    // folder module in a project past 100 files - and a folder module has no
+    // declaration, so it is exactly the case the cache can never answer either.
+    it("keeps an answer the folder search reached on its own", async () => {
+        const files = Array.from({ length: 101 }, (_, index) => `Content/Systems/File${index}.verse`).concat("Content/Zone/Deep/Target/Thing.verse");
+        (vscode.workspace.findFiles as jest.Mock).mockImplementation(async (_pattern: unknown, _exclude: unknown, maxResults?: number) => {
+            const uris = files.map((file) => vscode.Uri.file(`${workspaceRoot}/${file}`));
+            return maxResults === undefined ? uris : uris.slice(0, maxResults);
+        });
+        // Nothing declares `Target`, so the declaration scan reads all it is
+        // allowed to and still finds nothing; only the folder search places it.
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Helper := class:\n", "utf8"));
+
+        expect((await convert("using { Deep.Target }"))?.convertedImport).toBe(`using { ${projectVersePath}/Zone/Deep/Target }`);
+    });
+
+    // An empty result is the other half the scan's reach clouds: the module may
+    // be declared in the part it never read, so "not found" is not a finding.
+    it("refuses rather than reporting a module missing on a partial scan", async () => {
+        projectOf(101);
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Helper := class:\n", "utf8"));
+
+        expect(await convert("using { Nowhere }")).toBeNull();
+    });
+
+    // The condition belongs to the project, not to any one import, so a
+    // document-wide run states it once instead of once per line.
+    it("reports the cap once for a whole document", async () => {
+        projectOf(101);
+        const document = fakeDocument(["using { Inventory }", "using { Economy }", "using { Weapons }", "", "code()"]);
+        const warn = vscode.window.showWarningMessage as jest.Mock;
+        warn.mockClear();
+
+        const results = await converterWithProjectPath(projectVersePath).convertAllImportsToFullPath(document);
+
+        expect(results).toEqual([]);
+        expect(warn).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -21,99 +21,6 @@ describe("ImportPathConverter.buildFullVersePath", () => {
     });
 });
 
-describe("ImportPathConverter.buildModuleDefinitionRegex", () => {
-    it("matches a module declaration with and without a visibility specifier", () => {
-        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
-        expect(re.test("Inventory := module:")).toBe(true);
-        expect(re.test("Inventory<public> := module:")).toBe(true);
-        expect(re.test("Inventory := module>")).toBe(true);
-    });
-
-    it("matches the brace form, with the brace on the declaration line or the next", () => {
-        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
-        expect(re.test("Inventory := module{}")).toBe(true);
-        expect(re.test("Inventory<public> := module { }")).toBe(true);
-        expect(re.test("Inventory := module\n{\n    Count<public>:int = 0\n}")).toBe(true);
-    });
-
-    it("matches the dotted form, for either name declared on the line", () => {
-        const source = "Inventory := module. Item := module{}";
-
-        expect(ImportPathConverter.buildModuleDefinitionRegex("Inventory").test(source)).toBe(true);
-        expect(ImportPathConverter.buildModuleDefinitionRegex("Item").test(source)).toBe(true);
-    });
-
-    it("matches any specifier the language allows, not a fixed keyword list", () => {
-        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
-
-        // A scope list holds module references, so the specifier does not end
-        // at the keyword.
-        expect(re.test("Inventory<scoped{ModuleA, ModuleB}> := module:")).toBe(true);
-        expect(re.test("Inventory<epic_internal> := module:")).toBe(true);
-
-        // A named scope is an arbitrary identifier, qualified or not, which no
-        // keyword list could cover.
-        expect(re.test("Inventory<scoped_X> := module:")).toBe(true);
-        expect(re.test("Inventory<Systems.scoped_to_A> := module:")).toBe(true);
-    });
-
-    it("matches a stacked specifier block, not one specifier", () => {
-        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
-        expect(re.test("Inventory<internal><final> := module:")).toBe(true);
-        expect(re.test("Inventory<public><scoped{ModuleA}> := module { }")).toBe(true);
-    });
-
-    it("does not let a stray < reach the specifier of a later declaration", () => {
-        // A `<` that opens nothing - a comparison, say - sits between the name
-        // and the next declaration's specifier. A specifier body free to span
-        // that far would report this file as declaring Inventory, and masking
-        // the text first does not take a live comparison away.
-        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
-
-        expect(re.test("if (Inventory < MaxSlots):\n\nHelpers<public> := module:")).toBe(false);
-        expect(re.test("# Inventory <-- rename before ship\nHelpers<internal> := module:")).toBe(false);
-        expect(re.test("Count := Inventory < 3\nOther<final><public> := module {}")).toBe(false);
-    });
-
-    it("does not match a different module or a non-module declaration", () => {
-        const re = ImportPathConverter.buildModuleDefinitionRegex("Inventory");
-        expect(re.test("MyInventory := module:")).toBe(false);
-        expect(re.test("Inventory := class:")).toBe(false);
-        expect(re.test("InventoryItem := module:")).toBe(false);
-
-        // A specifier block is not what makes a declaration a module, so one
-        // must not carry a non-module declaration into a match.
-        expect(re.test("Inventory<public> := class:")).toBe(false);
-
-        // What follows `module` is a character class, so a keyword that merely
-        // starts with it is not a declaration. Written as a bare `.` instead,
-        // the dotted style would accept any character and match this.
-        expect(re.test("Inventory := modulex")).toBe(false);
-    });
-
-    it("is not global, so repeated .test() calls are order-independent", () => {
-        // A global regex would retain lastIndex between calls and could skip a
-        // match in a later string depending on where the previous match ended.
-        const re = ImportPathConverter.buildModuleDefinitionRegex("Foo");
-        expect(re.flags).not.toContain("g");
-
-        const withLateMatch = "some preamble text here\n\n\nFoo := module:";
-        const withEarlyMatch = "Foo := module:";
-
-        // Call against a string whose match is far into the text, then against a
-        // string whose match is at the very start. Both must return true.
-        expect(re.test(withLateMatch)).toBe(true);
-        expect(re.test(withEarlyMatch)).toBe(true);
-        expect(re.test(withLateMatch)).toBe(true);
-    });
-
-    it("escapes regex metacharacters in the module name", () => {
-        const re = ImportPathConverter.buildModuleDefinitionRegex("a.b");
-        expect(re.test("a.b := module:")).toBe(true);
-        expect(re.test("axb := module:")).toBe(false);
-    });
-});
-
 interface RecordedOperation {
     kind: "insert" | "delete" | "replace";
     range?: { start: { line: number; character: number }; end: { line: number; character: number } };
@@ -725,7 +632,7 @@ describe("ImportPathConverter.convertToFullPath", () => {
     /** A converter that resolves every module to one fixed location, so conversion is pure string work. */
     function converterWithLocation(location: string): ImportPathConverter {
         const converter = converterWithProjectPath(projectVersePath);
-        converter.findModuleLocations = async () => [location];
+        converter.findModuleLocations = async () => ({ locations: [location], truncated: false });
         return converter;
     }
 
@@ -768,16 +675,16 @@ describe("ImportPathConverter.findModuleLocations explicit declaration scan", ()
     };
 
     /**
-     * The locations the scan finds for "Inventory" in a project whose one
+     * The locations the scan finds for `modulePath` in a project whose one
      * `.verse` file holds `source`. No current file is passed, so the folder
      * search is skipped and the declaration scan is the only phase that runs.
      */
-    async function locationsFor(source: string): Promise<string[]> {
+    async function locationsFor(source: string, modulePath = "Inventory"): Promise<string[]> {
         (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([vscode.Uri.file(declaringFile)]);
         (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from(source, "utf8"));
 
         const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
-        return converter.findModuleLocations("Inventory");
+        return (await converter.findModuleLocations(modulePath)).locations;
     }
 
     beforeEach(() => {
@@ -811,6 +718,112 @@ describe("ImportPathConverter.findModuleLocations explicit declaration scan", ()
 
     it("ignores declaration text quoted in a string literal", async () => {
         expect(await locationsFor('Doc := "Inventory := module:"\n')).toEqual([]);
+    });
+
+    // A `<` that opens nothing - a comparison, say - sits between an ordinary
+    // identifier and a later declaration's specifier. A specifier body free to
+    // reach that far reads the comparison's left operand as the declared name
+    // and swallows the real declaration behind it, so the file answers for a
+    // module it does not declare and stops answering for the one it does.
+    it("does not read a comparison operand as the declared name", async () => {
+        const source = "if (Inventory < MaxSlots):\n    Log()\n\nHelpers<public> := module:\n";
+
+        expect(await locationsFor(source)).toEqual([]);
+        expect(await locationsFor(source, "Helpers")).toEqual(["/Systems"]);
+    });
+
+    // A module declared inside another is an ordinary path scope, so the inner
+    // one is named through the outer. Deciding the location from the directory
+    // string alone reported this as missing, and answered the bare inner name
+    // with a location that builds a path nothing declares.
+    it("places a nested declaration under its enclosing module", async () => {
+        const source = "Outer := module:\n    Inner := module:\n        Count<public>:int = 0\n";
+
+        expect(await locationsFor(source, "Outer/Inner")).toEqual(["/Systems"]);
+        expect(await locationsFor(source, "Outer")).toEqual(["/Systems"]);
+    });
+
+    it("refuses a nested module named without its enclosing one", async () => {
+        expect(await locationsFor("Outer := module:\n    Inner := module:\n", "Inner")).toEqual([]);
+    });
+
+    it("matches whole segments, not a directory name that merely ends in one", async () => {
+        expect(await locationsFor("Inventory := module:\n", "XSystems/Inventory")).toEqual([]);
+    });
+
+    // What the two above cost the user: the import the project compiles with is
+    // reported missing, and the one it does not compile with is written out as
+    // a path no module answers to.
+    it("converts a nested reference, and offers nothing for the bare inner name", async () => {
+        const projectVersePath = "/mygame@fortnite.com/mygame";
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([vscode.Uri.file(declaringFile)]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Outer := module:\n    Inner := module:\n", "utf8"));
+
+        const convert = (statement: string) => converterWithProjectPath(projectVersePath).convertToFullPath(statement, vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`), 0);
+
+        expect((await convert("using { Outer.Inner }"))?.convertedImport).toBe(`using { ${projectVersePath}/Systems/Outer/Inner }`);
+        expect(await convert("using { Inner }")).toBeNull();
+    });
+});
+
+describe("ImportPathConverter declaration scan file cap", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    /**
+     * A project of `fileCount` files, each declaring `Inventory`, none of which
+     * the folder phases can place. The scan's own cap is what the glob would
+     * apply in production, so the count standing in for it here is the count
+     * that reaches the phase.
+     */
+    const scanReturning = (fileCount: number): void => {
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(Array.from({ length: fileCount }, (_, index) => vscode.Uri.file(`${workspaceRoot}/Content/Systems/File${index}.verse`)));
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Inventory := module:\n", "utf8"));
+    };
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    const convert = (statement: string) => converterWithProjectPath(projectVersePath).convertToFullPath(statement, vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`), 0);
+
+    it("reports a scan that stopped short, so a caller can tell it from a completed one", async () => {
+        scanReturning(100);
+
+        expect((await converterWithProjectPath(projectVersePath).findModuleLocations("Inventory")).truncated).toBe(true);
+    });
+
+    it("reports a scan that read the whole project as complete", async () => {
+        scanReturning(99);
+
+        expect((await converterWithProjectPath(projectVersePath).findModuleLocations("Inventory")).truncated).toBe(false);
+    });
+
+    // The one location a truncated scan returns is a sample's answer: a namesake
+    // in the part it never read would have made the conversion ambiguous, so
+    // writing this path unambiguously is the silent wrong module the cap hides.
+    it("refuses the conversion rather than writing a sample's answer", async () => {
+        scanReturning(100);
+
+        expect(await convert("using { Inventory }")).toBeNull();
+    });
+
+    it("converts as before when the scan read the whole project", async () => {
+        scanReturning(99);
+
+        expect((await convert("using { Inventory }"))?.convertedImport).toBe(`using { ${projectVersePath}/Systems/Inventory }`);
     });
 });
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -844,11 +844,10 @@ describe("ImportPathConverter declaration scan file cap", () => {
         expect((await convert("using { Inventory }"))?.convertedImport).toBe(`using { ${projectVersePath}/Systems/Inventory }`);
     });
 
-    // The declaration scan's reach says nothing about the folder search's: that
-    // phase reads the project's directories for itself, under a cap two orders
-    // of magnitude higher. Vetoing its answer turned the feature off for every
-    // folder module in a project past 100 files - and a folder module has no
-    // declaration, so it is exactly the case the cache can never answer either.
+    // The declaration scan's reach does not govern the folder search's answer.
+    // A folder module has no declaration for that scan or the cache to hold, so
+    // extending the refusal to it would refuse every folder module in a project
+    // past the cap.
     it("keeps an answer the folder search reached on its own", async () => {
         const files = Array.from({ length: 101 }, (_, index) => `Content/Systems/File${index}.verse`).concat("Content/Zone/Deep/Target/Thing.verse");
         (vscode.workspace.findFiles as jest.Mock).mockImplementation(async (_pattern: unknown, _exclude: unknown, maxResults?: number) => {
@@ -883,6 +882,44 @@ describe("ImportPathConverter declaration scan file cap", () => {
 
         expect(results).toEqual([]);
         expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    // The file past the limit is asked for to be counted, never to be read.
+    // Reading it would make the scan's reach one more than the limit says.
+    it("never reads the file it asks for past the limit", async () => {
+        projectOf(101);
+        (vscode.workspace.fs.readFile as jest.Mock).mockClear();
+
+        await converterWithProjectPath(projectVersePath).findModuleLocations("Inventory");
+
+        const read = (vscode.workspace.fs.readFile as jest.Mock).mock.calls.map((call) => (call[0] as { fsPath: string }).fsPath.replace(/\\/g, "/"));
+        expect(read).toHaveLength(100);
+        expect(read).not.toContain(`${workspaceRoot}/Content/Systems/File100.verse`);
+    });
+
+    // A phase that threw read an unknown amount of the project, which leaves the
+    // caller where stopping at the cap leaves it. Reporting a complete read is
+    // the one direction the signal exists to rule out.
+    it("treats a scan that threw as a partial read", async () => {
+        (vscode.workspace.findFiles as jest.Mock).mockRejectedValue(new Error("scan failed"));
+
+        expect((await converterWithProjectPath(projectVersePath).findModuleLocations("Inventory")).truncated).toBe(true);
+    });
+
+    // The cap belongs to the declaration scan, which runs only when the phases
+    // before it found nothing. An answer from one of those is not a sample's.
+    it("leaves an answer found before the declaration scan untouched by the cap", async () => {
+        projectOf(101);
+        (vscode.workspace.fs.readFile as jest.Mock).mockClear();
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            if (uri.fsPath.replace(/\\/g, "/") === `${workspaceRoot}/Content/Scripts/Inventory`) return { type: vscode.FileType.Directory };
+            throw new Error("ENOENT");
+        });
+
+        const search = await converterWithProjectPath(projectVersePath).findModuleLocations("Inventory", vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`));
+
+        expect(search).toEqual({ locations: ["/Scripts"], truncated: false });
+        expect(vscode.workspace.fs.readFile as jest.Mock).not.toHaveBeenCalled();
     });
 });
 

--- a/src/utils/verseDeclarationHead.ts
+++ b/src/utils/verseDeclarationHead.ts
@@ -54,12 +54,11 @@ export type DeclarationKeyword = (typeof DECLARATION_KEYWORDS)[number];
 /**
  * What may end a declaration keyword. `:`, `{` and `.` are the three body
  * styles; `>` is not Verse and matches only the literal `M := module>`, kept
- * because two further spellings of the module grammar outside this file -
- * `ImportPathConverter.buildModuleDefinitionRegex` and `moduleDeclarations`'
- * `MODULE_DECLARATION` - accept it, and dropping it here alone would put this
- * matcher out of step with them. Parity with those two is partial either way:
- * both end at `module\s*[:>{.]`, so neither admits the keyword specifiers this
- * does.
+ * because the other spelling of the module grammar outside this file -
+ * `moduleDeclarations`' `MODULE_DECLARATION` - accepts it, and dropping it here
+ * alone would put this matcher out of step with it. Parity is partial either
+ * way: that one ends at `module\s*[:>{.]`, so it does not admit the keyword
+ * specifiers this does.
  */
 const BODY_TERMINATORS = new Set([":", "{", ".", ">"]);
 

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -3,9 +3,9 @@
  * in-file module chain and located precisely enough to edit their access
  * specifier in place. No VS Code dependencies.
  *
- * This overlaps ImportPathConverter's declaration regexes, which answer only
- * "does this file declare a module of this name", and ProjectPathScanner's,
- * which records a position but matches one line at a time and reads no
+ * ImportPathConverter's module search reads declarations through this, so the
+ * two cannot disagree about what one is. It still overlaps ProjectPathScanner's
+ * own scan, which records a position but matches one line at a time and reads no
  * quoted suffix.
  */
 
@@ -15,12 +15,20 @@ import { countBraces, indentOf, maskCommentsAndStrings } from "../utils/verseTex
  * A declaration in any of the three styles a macro body is written in:
  * `module:`, `module { }` with the brace on that line or the next, and the
  * dotted `module. Inner := ...`. `>` is accepted after the keyword alongside
- * them, matching ImportPathConverter.
+ * them, matching verseDeclarationHead.
  *
  * Group 1 is the declared name with any quoted suffix; group 2 is the whole
  * stacked specifier block, of which at most one entry is a visibility.
+ *
+ * A specifier body excludes `<` as well as `>`. No specifier nests, so nothing
+ * legitimate is lost, and a body free to reach past one runs a `<` that opens
+ * nothing - a comparison operator, say - all the way to the `>` of a LATER
+ * declaration's specifier. That misreports the comparison's left operand as the
+ * declared name and swallows the real declaration on the way, so the caller both
+ * edits a name that declares nothing and misses the module it was looking for.
+ * The body still spans lines, because a `scoped{...}` list may be wrapped.
  */
-const MODULE_DECLARATION = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)((?:\s*<[^>]+>)*)\s*:=\s*module\s*[:>{.]/g;
+const MODULE_DECLARATION = /\b([A-Za-z_][A-Za-z0-9_]*(?:'[^']*')?)((?:\s*<[^<>]+>)*)\s*:=\s*module\s*[:>{.]/g;
 
 /** One entry of a stacked specifier block, spelled as MODULE_DECLARATION's group 2 spells it. */
 const SPECIFIER_ENTRY = /<[^>]+>/g;


### PR DESCRIPTION
Closes #395

Phase 2 of the module search decided where a module lived by testing whether the declaring file's directory string ended with the rest of the reference. That model cannot see nesting, and the correct one — segment-aligned, chain-aware, unit-tested — already existed in `resolveModuleLocations`, which is what the cache path uses.

## What changed

**One matcher, imported twice.** `searchExplicitModuleDefinitions` now reads each declaration with its enclosing module chain through `findExplicitModuleDeclarations` and matches through `resolveModuleLocations`. The directory-suffix rule, the Content-prefix arithmetic and the `startsWith`/`endsWith` string work are gone; `toContentRelativeDir`, exported for this, does that job inside the shared matcher.

A module declared inside another is an ordinary path scope (`SemanticAnalyzer.cpp:4416-4420` allows a module definition at module scope; resolution walks the segments through those scopes at `:6238-6260`). So `Outer.Inner` names the inner module and resolves to the declaring file's directory — where before it was reported missing, because directory `X` does not end with `Outer`. The bare name `Inner`, reachable only through `Outer`, now resolves to nothing instead of emitting the declaring file's directory and building `/proj/X/Inner`, a path nothing declares, written with `isAmbiguous: false`.

**`MODULE_DECLARATION`'s specifier body is narrowed to `[^<>]+`.** This is required by the reuse rather than adjacent: the deleted `buildModuleDefinitionRegex` carried this narrowing and the shared reader did not. With `[^>]+` a `<` that opens nothing — a comparison operator — runs to the `>` of a later declaration's specifier, so `if (Inventory < MaxSlots): ... Helpers<public> := module:` reported a module named `Inventory` and missed `Helpers` entirely. No specifier nests, so nothing legitimate is lost; the body still spans lines, because a `scoped{...}` list may be wrapped. The visibility writer shares this pattern and gains the same correction — for it a misread name means editing a declaration that does not exist.

**The scan's file cap is named and reported.** `DECLARATION_SCAN_FILE_LIMIT` stays at 100. The glob asks for one file past it and never reads that one, so a project holding exactly the limit is told apart from one holding more — asking for the limit itself makes those two answers identical, which is the conflation the signal exists to end. `findModuleLocations` returns `{ locations, truncated }`.

Both entry points fail closed on `truncated`, following the direction PR #427 set: `convertToFullPath` declines with a message naming the cap rather than the existing "Could not find module", and `referenceResolvesTo` refuses ahead of its location count, which makes explicit the limit its doc comment already recorded.

**Distrust is scoped to the phase that hit the cap.** `truncated` covers the declaration scan's own answer and an empty result — where the module may be declared in the part left unread — but not an answer the folder search reached on its own. That phase reads the project's directories for itself under a cap fifty times higher, and a folder module has no declaration for the cache to hold either, so vetoing it would have switched conversion off for the commonest case that reaches this code at all.

The cap is reported once per run rather than once per import, since the condition belongs to the project: converting a whole document raised one notification per line.

## Behaviour this removes

A project holding more than 100 `.verse` files no longer gets a conversion for a module only the declaration scan could place. It got one before, resolved from whichever files the glob happened to return — the silent wrong module the ticket describes. Everything the folder phases place is unaffected at any project size.

## What this knowingly leaves open

The cap cannot be made both safe and useful by a rule, and the review established both horns of that. Distrusting the folder search after a partial declaration scan refuses every folder module in a project past 100 files. Trusting it leaves one narrow route to the ticket's own harm: a module declared in the unread remainder, where a folder namesake answers instead and is written unambiguously. The same project one file smaller answers differently.

The rule takes the second, because a folder module has no declaration anywhere for the scan or the cache to hold, so the first turns the feature off for the commonest thing that reaches this search at all. The comment at the assignment states this as a trade rather than asserting the gap away. **Raising the cap is what shrinks the exposure; no rule at 100 can.** That is the ticket's own deferred "the number itself should scale or page", and it now has evidence behind it.

## Not fixed here

- **A quoted identifier whose suffix contains a dot** (`Inv'a.b'`) no longer resolves. `ProjectPathNode.fullPath` encodes the chain as a dotted string and `resolveModuleLocations` recovers it with `split(".")`. This is a regression this branch ships, not only a shared gap: the deleted `buildModuleDefinitionRegex` escaped the name and matched it. The cache path builds `fullPath` the same way (`ProjectPathScanner.ts:414`, `:457`), so the fix belongs in the node contract for both producers. Filed separately.
- **After a cap refusal the command layer still adds a generic line** — "No relative imports found to convert." for a document that holds three. The converter reports the cap once per run, but `CommandsHandler` cannot tell "refused for the cap" from "nothing to convert" without a decline reason on the result. The reverse direction gets only the generic line. The pattern predates this branch; this refusal path makes it common.
- **`FOLDER_SCAN_FILE_LIMIT` (5000) has no truncation signal at all** — the same shape this ticket closed for phase 2, one phase over.
- The ticket's "the number itself should scale or page" — deliberately out of this diff; the number is unchanged.

## Review

Two rounds, fresh context each, at `models.review`.

**Round 1 — FAIL** on a real Critical I had reasoned my way into: I scoped the truncation veto to the whole search, and the reviewer measured what that costs. Folder modules never hit the declaration cache, so conversion switched off for them in any project past 100 files, including answers phase 3 reached completely on its own. Fixed in `b17715a`, which also dropped advice to enable a setting that defaults to on, collapsed one notification per import into one per run, made the cap boundary exact, and marked a throwing scan as a partial read.

**Round 2 — FAIL** with no Critical, on the comment I wrote justifying the narrowed rule: it claimed the residual gap could not happen, and the reviewer built the project that reproduces it. Fixed in `5c5da32` — the rule stands, the comment now states the trade and names raising the cap as the only thing that shrinks it. Its remaining `Important` on the command layer's generic line is listed above and filed rather than fixed, since it needs a decline reason threaded to `CommandsHandler`.

## Verification

```
$ npm run compile
> verse-auto-imports@0.11.1 compile
> tsc -p ./

$ npm test
Test Suites: 50 passed, 50 total
Tests:       1513 passed, 1513 total

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

Every new test was proven to detect its defect by taking the fix away and watching it fail: `fullPath: chain.join(".")` reduced to `declaration.name` (the nested reference misses, the bare inner name fabricates a location, the entry point returns null), the specifier body widened back to `[^>]+` (the comparison operand is read as the declared module), the truncation signal forced to `false` (a 101-file project writes a sample's answer with `isAmbiguous: false`), and the scoping rule reduced to `declarationScanReadPart` (the folder search's own answer is vetoed).
