### PR TITLE
fix(config): deprecate general.diagnosticDelay via deprecationMessage

### DIFF
--- a/changelog.d/369.fixed.md
+++ b/changelog.d/369.fixed.md
@@ -1,0 +1,1 @@
+**Settings**: `general.diagnosticDelay` now uses VS Code's own deprecation support, so the settings editor hides it and flags an existing value instead of listing it above its replacement. An explicitly set value is still honored.

--- a/package.json
+++ b/package.json
@@ -192,7 +192,8 @@
           "scope": "window",
           "type": "number",
           "default": 1000,
-          "description": "[DEPRECATED - Use autoImportDebounceDelay instead] Delay in milliseconds before processing diagnostics",
+          "description": "Delay in milliseconds before processing diagnostics",
+          "deprecationMessage": "Deprecated: use verseAutoImports.general.autoImportDebounceDelay instead. An explicitly set value here is still honored while the replacement is unset.",
           "order": 2
         },
         "verseAutoImports.general.autoImportDebounceDelay": {

--- a/src/__tests__/configurationDeprecation.test.ts
+++ b/src/__tests__/configurationDeprecation.test.ts
@@ -1,0 +1,29 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Only `deprecationMessage` makes VS Code hide a setting from the settings
+ * editor and flag an existing value; a deprecation written into `description`
+ * leaves the key listed as a live setting.
+ */
+describe("deprecated configuration properties", () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf8"));
+    const registered: Record<string, { description?: string; deprecationMessage?: string }> = manifest.contributes.configuration.properties;
+
+    /** Keys the manifest still contributes for backward compatibility only. */
+    const DEPRECATED = ["verseAutoImports.general.diagnosticDelay"];
+
+    it.each(DEPRECATED)("declares %s deprecated through deprecationMessage", (key) => {
+        expect(registered[key]?.deprecationMessage).toEqual(expect.stringContaining("autoImportDebounceDelay"));
+    });
+
+    // The marker shape rather than the word: a description may legitimately
+    // mention a deprecation it is not itself carrying.
+    it("carries no prose deprecation marker in any description", () => {
+        const inProse = Object.entries(registered)
+            .filter(([, property]) => /^\s*\[deprecated/i.test(property.description ?? ""))
+            .map(([key]) => key);
+
+        expect(inProse).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #369

`verseAutoImports.general.diagnosticDelay` carried its deprecation as a `[DEPRECATED - Use autoImportDebounceDelay instead]` prefix inside `description`. VS Code reads only `deprecationMessage` for this, so the settings editor listed the key as a first-class setting at `order` 2, directly above the replacement it told the reader to prefer. It now hides the entry unless a value is set, and flags an existing one.

## Changes

- `package.json` — the legacy property drops the prose marker from `description` and gains a `deprecationMessage` naming the replacement and stating that an explicit value here is still honored.
- `src/__tests__/configurationDeprecation.test.ts` (new) — pins the manifest: the deprecated key must declare `deprecationMessage` naming `autoImportDebounceDelay`, and no property's `description` may open with a `[DEPRECATED` marker. Both assertions were checked against the unfixed manifest and fail there.
- `changelog.d/369.fixed.md` — fragment.

`order: 2` is deliberately left alone. A property with a `deprecationMessage` is hidden from the settings editor unless the user has a value set, so the ordering no longer puts it in front of the replacement; renumbering would churn every property below it for no visible effect.

Runtime behaviour is unchanged. `getConfiguredDebounceDelay` (`src/extension.ts:26`) resolves through `config.inspect()`, which reports explicitly set values only — `deprecationMessage` is UI metadata and the registered `default` of 1000 is untouched, so the precedence explicit new > explicit legacy > registered 3000 is exactly as before. The issue #76 integration regressions cover that path and depend on nothing this diff touches.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.2 compile
> tsc -p ./
```

`npm test`

```
Test Suites: 51 passed, 51 total
Tests:       1522 passed, 1522 total
Snapshots:   0 total
Time:        15.305 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round at opus: `PASS_WITH_SUGGESTIONS`, 0 Critical, 1 Important, 4 Suggestions. The Important finding was the missing changelog fragment, now written. Two suggestions applied: the description scan was narrowed from any occurrence of "deprecat" to the `[DEPRECATED` marker shape, so a description legitimately mentioning a deprecation cannot fail the guard; and the test's doc comment was trimmed to the load-bearing clause. Left unapplied: `markdownDeprecationMessage` would render the replacement key as a clickable jump, which is an enhancement beyond what the ticket asks for.
