### PR TITLE
fix(imports): place a file under a Content root at any depth

### DIFF
--- a/changelog.d/429.fixed.md
+++ b/changelog.d/429.fixed.md
@@ -1,1 +1,1 @@
-**Path conversion**: "Use relative path" now works in the UEFN project layout that nests Verse under `Plugins/<Name>/Content`, where every conversion in such a file was refused.
+**Path conversion**: imports convert in both directions again for a project that nests its Verse under `Plugins/<Name>/Content`, the UEFN layout where every conversion was refused when the workspace was opened at the project root.

--- a/changelog.d/429.fixed.md
+++ b/changelog.d/429.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: "Use relative path" now works in the UEFN project layout that nests Verse under `Plugins/<Name>/Content`, where every conversion in such a file was refused.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -249,6 +249,46 @@ export class ImportPathConverter {
     }
 
     /**
+     * Where the project's Content root sits inside the workspace folder and
+     * where the file sits under that root, both as forward-slash paths with
+     * `""` for the enclosing directory itself, or null when no directory on
+     * the way down to the file is a Content root.
+     *
+     * The root is looked for along that whole path rather than read at a fixed
+     * depth, because UEFN's shipped layout puts Verse under
+     * `<project>/Plugins/<Name>/Content`: a workspace opened at the project
+     * root reaches Content three levels down, and a boundary that only admits
+     * depth zero places no file in such a project at all.
+     *
+     * The shallowest Content wins rather than the nearest. A Content below the
+     * root is an ordinary folder module, and taking that one as the root would
+     * address every file under it one scope too low.
+     */
+    private static placeUnderContentRoot(workspaceFolderPath: string, documentPath: string): { contentRootRelative: string; fileDirRelative: string } | null {
+        const relativeFilePath = path.relative(workspaceFolderPath, documentPath).replace(/\\/g, "/");
+
+        // path.relative climbs out with `..` for a file the folder does not
+        // hold, and a Content segment past that point belongs to some other
+        // tree - the placement has to be inside the folder to mean anything.
+        if (relativeFilePath.startsWith("../")) return null;
+
+        const fileDir = path.dirname(relativeFilePath).replace(/\\/g, "/");
+        const dirSegments = fileDir === "" || fileDir === "." ? [] : fileDir.split("/");
+
+        if (path.basename(workspaceFolderPath) === CONTENT_FOLDER) {
+            return { contentRootRelative: "", fileDirRelative: dirSegments.join("/") };
+        }
+
+        const rootIndex = dirSegments.indexOf(CONTENT_FOLDER);
+        if (rootIndex < 0) return null;
+
+        return {
+            contentRootRelative: dirSegments.slice(0, rootIndex + 1).join("/"),
+            fileDirRelative: dirSegments.slice(rootIndex + 1).join("/"),
+        };
+    }
+
+    /**
      * Appends the locations where a folder of this name sits, searched outwards
      * from the current file: siblings first, then each ancestor directory, then
      * the Content root. A folder is an implicit module, so its presence is the
@@ -261,31 +301,24 @@ export class ImportPathConverter {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(currentFileUri);
         if (!workspaceFolder) return;
 
-        const currentFilePath = path.relative(workspaceFolder.uri.fsPath, currentFileUri.fsPath).replace(/\\/g, "/");
-        let currentFileDir = path.dirname(currentFilePath).replace(/\\/g, "/");
+        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, currentFileUri.fsPath);
+        if (!placement) return;
 
-        const workspaceFolderName = path.basename(workspaceFolder.uri.fsPath);
-        const workspaceFolderIsContent = workspaceFolderName === CONTENT_FOLDER;
-
-        // Every path below is reasoned about with a leading Content/, so a
-        // workspace opened at Content itself has that segment put back on.
-        if (workspaceFolderIsContent) {
-            currentFileDir = currentFileDir === "" || currentFileDir === "." ? CONTENT_FOLDER : `${CONTENT_FOLDER}/${currentFileDir}`;
-        }
-
-        if (!currentFileDir.startsWith(`${CONTENT_FOLDER}/`) && currentFileDir !== CONTENT_FOLDER) {
-            return;
-        }
+        // Every path below is reasoned about with a leading Content/, whatever
+        // depth the root really sits at, so the logical and on-disk spellings
+        // of one directory differ by that prefix alone.
+        const currentFileDir = placement.fileDirRelative ? `${CONTENT_FOLDER}/${placement.fileDirRelative}` : CONTENT_FOLDER;
 
         const dirSegments = currentFileDir.split("/");
 
         // The inverse of that: a filesystem check is made against the
-        // workspace, which in this layout is already inside Content.
+        // workspace, so the logical prefix is swapped back for wherever the
+        // Content root actually sits under it.
         const getFsCheckPath = (logicalPath: string): string => {
-            if (workspaceFolderIsContent && logicalPath.startsWith(`${CONTENT_FOLDER}/`)) {
-                return logicalPath.substring(CONTENT_FOLDER.length + 1);
-            }
-            return logicalPath;
+            if (logicalPath === CONTENT_FOLDER) return placement.contentRootRelative;
+
+            const belowRoot = logicalPath.substring(CONTENT_FOLDER.length + 1);
+            return placement.contentRootRelative ? `${placement.contentRootRelative}/${belowRoot}` : belowRoot;
         };
 
         // The file's own directory first, and nearest of all: a folder beside
@@ -653,20 +686,10 @@ export class ImportPathConverter {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri);
         if (!workspaceFolder) return null;
 
-        const relativeFilePath = path.relative(workspaceFolder.uri.fsPath, documentUri.fsPath).replace(/\\/g, "/");
-        let fileDir = path.dirname(relativeFilePath).replace(/\\/g, "/");
+        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, documentUri.fsPath);
+        if (!placement) return null;
 
-        // Every path below is reasoned about with a leading Content/, so a
-        // workspace opened at Content itself has that segment put back on -
-        // the same correction searchImplicitModules makes.
-        if (path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER) {
-            fileDir = fileDir === "" || fileDir === "." ? CONTENT_FOLDER : `${CONTENT_FOLDER}/${fileDir}`;
-        }
-
-        if (fileDir === CONTENT_FOLDER) return projectVersePath;
-        if (!fileDir.startsWith(`${CONTENT_FOLDER}/`)) return null;
-
-        return `${projectVersePath}/${fileDir.substring(CONTENT_FOLDER.length + 1)}`;
+        return placement.fileDirRelative ? `${projectVersePath}/${placement.fileDirRelative}` : projectVersePath;
     }
 
     /**

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -55,7 +55,24 @@ interface TruncationNotice {
     pending: boolean;
 }
 
+/**
+ * Where a file sits relative to the project's Content root: the root as a path
+ * relative to the workspace folder, and the file's directory as a path relative
+ * to that root. Either is `""` for the directory it is measured from.
+ *
+ * The pair travels together because the two spellings of one directory - the
+ * logical `Content/...` the module search reasons in, and the on-disk path a
+ * filesystem check needs - differ by exactly this prefix.
+ */
+interface ContentPlacement {
+    contentRootRelative: string;
+    fileDirRelative: string;
+}
+
 const CONTENT_FOLDER = "Content";
+
+/** The directory UEFN nests a project's plugins under, `<project>/Plugins/<Name>/Content`. */
+const PLUGINS_FOLDER = "Plugins";
 
 /**
  * How many `.verse` files the explicit-declaration scan reads. Far below
@@ -249,13 +266,37 @@ export class ImportPathConverter {
     }
 
     /**
+     * Whether a Content root found below the workspace folder's own top level
+     * is the one `bindings.projectVersePath` addresses - the root plugin's.
+     *
+     * UEFN gives a second plugin a Verse path of its own, so addressing a file
+     * under `Plugins/<Other>/Content` with the project's path would name
+     * modules in the wrong package. Nothing downstream can catch that: the
+     * round-trip check re-derives the scope from the same project path, so it
+     * confirms the reference it was handed.
+     *
+     * The plugin segment is folded rather than compared byte-exact, for the
+     * reason the project prefix is: it is a package name read from the project
+     * file and matched against a directory, not a module name the compiler
+     * resolves.
+     */
+    private static isRootPluginContent(contentRootAbsolute: string, rootPluginName: string | null): boolean {
+        if (!rootPluginName) return false;
+
+        const fold = (segment: string): string => segment.replace(/[a-z]/g, (character) => character.toUpperCase());
+        const pluginDirectory = path.dirname(contentRootAbsolute);
+
+        return fold(path.basename(pluginDirectory)) === fold(rootPluginName) && fold(path.basename(path.dirname(pluginDirectory))) === fold(PLUGINS_FOLDER);
+    }
+
+    /**
      * Where the project's Content root sits inside the workspace folder and
      * where the file sits under that root, both as forward-slash paths with
-     * `""` for the enclosing directory itself, or null when no directory on
-     * the way down to the file is a Content root.
+     * `""` for the enclosing directory itself, or null when the file is under
+     * no Content root this project's Verse path can address.
      *
-     * The root is looked for along that whole path rather than read at a fixed
-     * depth, because UEFN's shipped layout puts Verse under
+     * The root is looked for along the whole path down to the file rather than
+     * read at a fixed depth, because UEFN's shipped layout puts Verse under
      * `<project>/Plugins/<Name>/Content`: a workspace opened at the project
      * root reaches Content three levels down, and a boundary that only admits
      * depth zero places no file in such a project at all.
@@ -263,14 +304,20 @@ export class ImportPathConverter {
      * The shallowest Content wins rather than the nearest. A Content below the
      * root is an ordinary folder module, and taking that one as the root would
      * address every file under it one scope too low.
+     *
+     * A root found below the workspace folder's top level has to be the root
+     * plugin's, since only that one answers to the project's Verse path. A
+     * Content directly under the workspace folder is taken as before, without
+     * that evidence: the workspace is then opened at the thing holding it, and
+     * refusing there would drop the layout that already worked.
      */
-    private static placeUnderContentRoot(workspaceFolderPath: string, documentPath: string): { contentRootRelative: string; fileDirRelative: string } | null {
+    private static placeUnderContentRoot(workspaceFolderPath: string, documentPath: string, rootPluginName: string | null): ContentPlacement | null {
         const relativeFilePath = path.relative(workspaceFolderPath, documentPath).replace(/\\/g, "/");
 
         // path.relative climbs out with `..` for a file the folder does not
         // hold, and a Content segment past that point belongs to some other
         // tree - the placement has to be inside the folder to mean anything.
-        if (relativeFilePath.startsWith("../")) return null;
+        if (relativeFilePath === ".." || relativeFilePath.startsWith("../")) return null;
 
         const fileDir = path.dirname(relativeFilePath).replace(/\\/g, "/");
         const dirSegments = fileDir === "" || fileDir === "." ? [] : fileDir.split("/");
@@ -282,10 +329,12 @@ export class ImportPathConverter {
         const rootIndex = dirSegments.indexOf(CONTENT_FOLDER);
         if (rootIndex < 0) return null;
 
-        return {
-            contentRootRelative: dirSegments.slice(0, rootIndex + 1).join("/"),
-            fileDirRelative: dirSegments.slice(rootIndex + 1).join("/"),
-        };
+        const contentRootRelative = dirSegments.slice(0, rootIndex + 1).join("/");
+        if (rootIndex > 0 && !ImportPathConverter.isRootPluginContent(path.join(workspaceFolderPath, contentRootRelative), rootPluginName)) {
+            return null;
+        }
+
+        return { contentRootRelative, fileDirRelative: dirSegments.slice(rootIndex + 1).join("/") };
     }
 
     /**
@@ -301,7 +350,7 @@ export class ImportPathConverter {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(currentFileUri);
         if (!workspaceFolder) return;
 
-        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, currentFileUri.fsPath);
+        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, currentFileUri.fsPath, await this.projectPathHandler.getRootPluginName());
         if (!placement) return;
 
         // Every path below is reasoned about with a leading Content/, whatever
@@ -315,6 +364,9 @@ export class ImportPathConverter {
         // workspace, so the logical prefix is swapped back for wherever the
         // Content root actually sits under it.
         const getFsCheckPath = (logicalPath: string): string => {
+            // The root itself, held so the substring below is never handed a
+            // string shorter than the prefix it drops. Every caller appends a
+            // module name, so nothing reaches this today.
             if (logicalPath === CONTENT_FOLDER) return placement.contentRootRelative;
 
             const belowRoot = logicalPath.substring(CONTENT_FOLDER.length + 1);
@@ -682,11 +734,11 @@ export class ImportPathConverter {
      * name, and one that still resolves, since resolution walks the parent
      * chain outward.
      */
-    private enclosingModulePath(documentUri: vscode.Uri, projectVersePath: string): string | null {
+    private async enclosingModulePath(documentUri: vscode.Uri, projectVersePath: string): Promise<string | null> {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri);
         if (!workspaceFolder) return null;
 
-        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, documentUri.fsPath);
+        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, documentUri.fsPath, await this.projectPathHandler.getRootPluginName());
         if (!placement) return null;
 
         return placement.fileDirRelative ? `${projectVersePath}/${placement.fileDirRelative}` : projectVersePath;
@@ -829,7 +881,7 @@ export class ImportPathConverter {
         // from the document, and the phases behind it scan the workspace, so
         // they answer the same for any file that asks. They would confirm a
         // reference written into a scope nothing here can name.
-        const scopePath = this.enclosingModulePath(documentUri, projectVersePath);
+        const scopePath = await this.enclosingModulePath(documentUri, projectVersePath);
         if (!scopePath) {
             logger.debug("ImportPathConverter", `Cannot place the importing file under the project's Content root: ${documentUri.fsPath}`);
             return null;

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -283,7 +283,7 @@ export class ImportPathConverter {
     private static isRootPluginContent(contentRootAbsolute: string, rootPluginName: string | null): boolean {
         if (!rootPluginName) return false;
 
-        const fold = (segment: string): string => segment.replace(/[a-z]/g, (character) => character.toUpperCase());
+        const fold = ImportPathConverter.foldAscii;
         const pluginDirectory = path.dirname(contentRootAbsolute);
 
         return fold(path.basename(pluginDirectory)) === fold(rootPluginName) && fold(path.basename(path.dirname(pluginDirectory))) === fold(PLUGINS_FOLDER);
@@ -314,10 +314,12 @@ export class ImportPathConverter {
     private static placeUnderContentRoot(workspaceFolderPath: string, documentPath: string, rootPluginName: string | null): ContentPlacement | null {
         const relativeFilePath = path.relative(workspaceFolderPath, documentPath).replace(/\\/g, "/");
 
-        // path.relative climbs out with `..` for a file the folder does not
-        // hold, and a Content segment past that point belongs to some other
-        // tree - the placement has to be inside the folder to mean anything.
-        if (relativeFilePath === ".." || relativeFilePath.startsWith("../")) return null;
+        // A Content segment outside the workspace folder belongs to some other
+        // tree, and the placement has to be inside the folder to mean anything.
+        // path.relative says "outside" two ways: it climbs out with `..`, and
+        // on Windows it hands back the target whole when the two are on
+        // different drives, where no `..` could express the step.
+        if (relativeFilePath === ".." || relativeFilePath.startsWith("../") || path.isAbsolute(relativeFilePath)) return null;
 
         const fileDir = path.dirname(relativeFilePath).replace(/\\/g, "/");
         const dirSegments = fileDir === "" || fileDir === "." ? [] : fileDir.split("/");
@@ -653,6 +655,16 @@ export class ImportPathConverter {
         return { locations, truncated };
     }
 
+    /**
+     * A segment upper-cased over ASCII only, for the two comparisons that match
+     * a name against a spelling of it from another source rather than resolving
+     * it: the project prefix, and a plugin directory against the project file.
+     * Anything the compiler resolves is compared byte-exact instead.
+     */
+    private static foldAscii(segment: string): string {
+        return segment.replace(/[a-z]/g, (character) => character.toUpperCase());
+    }
+
     /** Path segments with the leading slash and any empty segments dropped. */
     private static splitPath(versePath: string): string[] {
         return versePath.split("/").filter((segment) => segment);
@@ -681,7 +693,7 @@ export class ImportPathConverter {
      * `/proj/Econ` yields `omy.Shop` there.
      */
     private static sharedSegmentCount(pathSegments: string[], baseSegments: string[], foldSegments: number): number {
-        const foldAscii = (segment: string): string => segment.replace(/[a-z]/g, (character) => character.toUpperCase());
+        const foldAscii = ImportPathConverter.foldAscii;
 
         let common = 0;
         while (common < pathSegments.length && common < baseSegments.length) {

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -252,10 +252,20 @@ function stubFolderTree(workspaceRoot: string, folders: string[]): void {
     });
 }
 
-/** A converter with project path resolution pinned, so conversion is pure string work. */
-function converterWithProjectPath(projectVersePath: string): ImportPathConverter {
+/**
+ * A converter with project path resolution pinned, so conversion is pure string
+ * work.
+ *
+ * @param rootPluginName What the project file declares as its root plugin, which
+ *   is what admits a Content root nested under `Plugins/<name>`. Left unset, the
+ *   project declares none and only a Content directly under the workspace folder
+ *   places a file.
+ */
+function converterWithProjectPath(projectVersePath: string, rootPluginName: string | null = null): ImportPathConverter {
     const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
-    (converter as unknown as { projectPathHandler: { getProjectVersePath: () => Promise<string> } }).projectPathHandler.getProjectVersePath = async () => projectVersePath;
+    const handler = (converter as unknown as { projectPathHandler: { getProjectVersePath: () => Promise<string>; getRootPluginName: () => Promise<string | null> } }).projectPathHandler;
+    handler.getProjectVersePath = async () => projectVersePath;
+    handler.getRootPluginName = async () => rootPluginName;
     return converter;
 }
 
@@ -537,7 +547,8 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
 describe("ImportPathConverter.convertFromFullPath under a nested plugin Content root", () => {
     const projectVersePath = "/mygame@fortnite.com/mygame";
     const workspaceRoot = "C:/Project";
-    const contentRoot = `${workspaceRoot}/Plugins/MyGame/Content`;
+    const rootPluginName = "MyGame";
+    const contentRoot = `${workspaceRoot}/Plugins/${rootPluginName}/Content`;
 
     /** Answers `fs.stat` from directories named relative to the nested Content root. */
     function stubNestedFolderTree(folders: string[]): void {
@@ -551,7 +562,7 @@ describe("ImportPathConverter.convertFromFullPath under a nested plugin Content 
     const fileAt = (contentRelativeDir: string): vscode.Uri => vscode.Uri.file(`${contentRoot}/${contentRelativeDir}/Feature.verse`);
 
     async function relativeFormOf(fullPath: string, fileUri: vscode.Uri): Promise<string | undefined> {
-        const converter = converterWithProjectPath(projectVersePath);
+        const converter = converterWithProjectPath(projectVersePath, rootPluginName);
         return (await converter.convertFromFullPath(`using. ${fullPath}`, fileUri, 0))?.convertedImport;
     }
 
@@ -578,7 +589,7 @@ describe("ImportPathConverter.convertFromFullPath under a nested plugin Content 
     });
 
     it("restores the absolute path the relative form was shortened from", async () => {
-        const converter = converterWithProjectPath(projectVersePath);
+        const converter = converterWithProjectPath(projectVersePath, rootPluginName);
         const fileUri = fileAt("Systems");
         const absolute = `using. ${projectVersePath}/Systems/Gadgets`;
 
@@ -598,6 +609,66 @@ describe("ImportPathConverter.convertFromFullPath under a nested plugin Content 
 
     it("offers no conversion for a file no Content root in the project holds", async () => {
         expect(await relativeFormOf(`${projectVersePath}/Systems/Gadgets`, vscode.Uri.file(`${workspaceRoot}/Plugins/MyGame/Feature.verse`))).toBeUndefined();
+    });
+
+    // Only the root plugin's Content answers to bindings.projectVersePath. A
+    // second plugin carries a Verse path of its own, so placing its files under
+    // the project's path names modules in the wrong package - and the
+    // round-trip check cannot catch it, because it re-derives the scope from
+    // that same project path and so confirms what it was handed.
+    describe("a Content root that is not the root plugin's", () => {
+        const otherPluginContent = `${workspaceRoot}/Plugins/Extra/Content`;
+
+        function stubOtherPluginTree(folders: string[]): void {
+            (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+                const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${otherPluginContent}/`, "");
+                if (!folders.includes(contentRelative)) throw new Error("ENOENT");
+                return { type: vscode.FileType.Directory };
+            });
+        }
+
+        it("offers no relative form for a file in it", async () => {
+            stubOtherPluginTree(["Systems", "Systems/Gadgets"]);
+
+            expect(await relativeFormOf(`${projectVersePath}/Systems/Gadgets`, vscode.Uri.file(`${otherPluginContent}/Systems/Feature.verse`))).toBeUndefined();
+        });
+
+        it("finds no module location for a file in it, so no absolute form either", async () => {
+            stubOtherPluginTree(["Systems", "Systems/Gadgets"]);
+            const converter = converterWithProjectPath(projectVersePath, rootPluginName);
+
+            expect(await converter.convertToFullPath("using. Gadgets", vscode.Uri.file(`${otherPluginContent}/Systems/Feature.verse`), 0)).toBeNull();
+        });
+
+        it("offers no relative form when the project declares no root plugin at all", async () => {
+            const converter = converterWithProjectPath(projectVersePath, null);
+
+            expect(await converter.convertFromFullPath(`using. ${projectVersePath}/Systems/Gadgets`, fileAt("Systems"), 0)).toBeNull();
+        });
+    });
+
+    it("reads the plugin's Content root, not an unrelated Content beside Plugins", async () => {
+        // A project may hold assets under a Content at its own top level while
+        // the Verse lives in the plugin. The file's own path is what picks the
+        // root, so the two do not compete.
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Gadgets`, fileAt("Systems"))).toBe("using. Gadgets");
+    });
+
+    it("takes the workspace folder itself when it is Content, over a Content nested below it", async () => {
+        // The shallowest root is the workspace folder here, so the nested
+        // Plugins/... path below it is an ordinary chain of folder modules.
+        setWorkspaceFolders([{ uri: { fsPath: `${workspaceRoot}/Content` }, name: "Content", index: 0 }]);
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            const relative = uri.fsPath.replace(/\\/g, "/").replace(`${workspaceRoot}/Content/`, "");
+            if (!["Plugins", "Plugins/Extra", "Plugins/Extra/Content", "Plugins/Extra/Content/Gadgets"].includes(relative)) throw new Error("ENOENT");
+            return { type: vscode.FileType.Directory };
+        });
+
+        const fileUri = vscode.Uri.file(`${workspaceRoot}/Content/Plugins/Extra/Content/Feature.verse`);
+
+        expect(await relativeFormOf(`${projectVersePath}/Plugins/Extra/Content/Gadgets`, fileUri)).toBe("using. Gadgets");
     });
 });
 

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -645,6 +645,28 @@ describe("ImportPathConverter.convertFromFullPath under a nested plugin Content 
 
             expect(await converter.convertFromFullPath(`using. ${projectVersePath}/Systems/Gadgets`, fileAt("Systems"), 0)).toBeNull();
         });
+
+        it("offers no relative form for a Content root nested under something other than Plugins", async () => {
+            // The plugin name alone is not the evidence - `Modules/MyGame` is
+            // not where UEFN binds a project's Verse, so a Content under it
+            // answers to no path this project can write.
+            const strayContent = `${workspaceRoot}/Modules/${rootPluginName}/Content`;
+            (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+                const relative = uri.fsPath.replace(/\\/g, "/").replace(`${strayContent}/`, "");
+                if (!["Systems", "Systems/Gadgets"].includes(relative)) throw new Error("ENOENT");
+                return { type: vscode.FileType.Directory };
+            });
+
+            expect(await relativeFormOf(`${projectVersePath}/Systems/Gadgets`, vscode.Uri.file(`${strayContent}/Systems/Feature.verse`))).toBeUndefined();
+        });
+    });
+
+    it("admits the root plugin's Content when the declared name differs from the directory only in case", async () => {
+        // The declared name is matched against a directory rather than
+        // resolved, so it folds - the same rule the project prefix follows.
+        const converter = converterWithProjectPath(projectVersePath, rootPluginName.toLowerCase());
+
+        expect((await converter.convertFromFullPath(`using. ${projectVersePath}/Systems/Gadgets`, fileAt("Systems"), 0))?.convertedImport).toBe("using. Gadgets");
     });
 
     it("reads the plugin's Content root, not an unrelated Content beside Plugins", async () => {

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -529,6 +529,78 @@ describe("ImportPathConverter.convertFromFullPath scope-relative shortening", ()
     });
 });
 
+// UEFN's shipped project layout puts Verse under
+// <project>/Plugins/<Name>/Content, so a workspace opened at the project root
+// reaches Content three levels down. While the boundary was read at one fixed
+// depth, no file in such a project could be placed, and the placeability guard
+// turned that into a refusal of every conversion the layout offered.
+describe("ImportPathConverter.convertFromFullPath under a nested plugin Content root", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+    const contentRoot = `${workspaceRoot}/Plugins/MyGame/Content`;
+
+    /** Answers `fs.stat` from directories named relative to the nested Content root. */
+    function stubNestedFolderTree(folders: string[]): void {
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${contentRoot}/`, "");
+            if (!folders.includes(contentRelative)) throw new Error("ENOENT");
+            return { type: vscode.FileType.Directory };
+        });
+    }
+
+    const fileAt = (contentRelativeDir: string): vscode.Uri => vscode.Uri.file(`${contentRoot}/${contentRelativeDir}/Feature.verse`);
+
+    async function relativeFormOf(fullPath: string, fileUri: vscode.Uri): Promise<string | undefined> {
+        const converter = converterWithProjectPath(projectVersePath);
+        return (await converter.convertFromFullPath(`using. ${fullPath}`, fileUri, 0))?.convertedImport;
+    }
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubNestedFolderTree(["Systems", "Systems/Gadgets", "Systems/Economy", "UI", "UI/HUD"]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("names a module in the importing file's own module by its bare name", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Gadgets`, fileAt("Systems"))).toBe("using. Gadgets");
+    });
+
+    it("keeps every segment below the root when the two branches part at the Content root", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/UI/HUD`, fileAt("Systems/Economy"))).toBe("using. UI.HUD");
+    });
+
+    it("shortens against the project root for a file at the nested Content root itself", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Gadgets`, vscode.Uri.file(`${contentRoot}/Feature.verse`))).toBe("using. Systems.Gadgets");
+    });
+
+    it("restores the absolute path the relative form was shortened from", async () => {
+        const converter = converterWithProjectPath(projectVersePath);
+        const fileUri = fileAt("Systems");
+        const absolute = `using. ${projectVersePath}/Systems/Gadgets`;
+
+        const relative = await converter.convertFromFullPath(absolute, fileUri, 0);
+
+        expect((await converter.convertToFullPath(relative!.convertedImport, fileUri, 0))?.convertedImport).toBe(absolute);
+    });
+
+    it("takes the shallowest Content as the root, not a folder module named Content below it", async () => {
+        // A Content under the root is an ordinary folder module. Reading the
+        // nearest one as the root instead would address this file at the
+        // project root and name the target Content.Widgets from inside it.
+        stubNestedFolderTree(["Content", "Content/Widgets"]);
+
+        expect(await relativeFormOf(`${projectVersePath}/Content/Widgets`, fileAt("Content"))).toBe("using. Widgets");
+    });
+
+    it("offers no conversion for a file no Content root in the project holds", async () => {
+        expect(await relativeFormOf(`${projectVersePath}/Systems/Gadgets`, vscode.Uri.file(`${workspaceRoot}/Plugins/MyGame/Feature.verse`))).toBeUndefined();
+    });
+});
+
 // The relative form is a proposal until the module search confirms it names
 // the module the absolute path named. Before that check, going relative was
 // string arithmetic that consulted nothing, so every case below wrote a

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -164,6 +164,20 @@ export class ProjectPathHandler {
     }
 
     /**
+     * The name of the plugin `bindings.projectVersePath` addresses, or null
+     * when the project file declares no root plugin.
+     *
+     * UEFN nests a project's Verse under `<project>/Plugins/<name>/Content`,
+     * and only the root plugin's Content answers to that path - a second
+     * plugin carries a Verse path of its own. So this is what separates a
+     * Content root the project's path can address from one it cannot.
+     */
+    async getRootPluginName(): Promise<string | null> {
+        const projectFile = await this.findAndParseProjectFile();
+        return projectFile?.plugins?.find((plugin) => plugin.bIsRoot)?.name || null;
+    }
+
+    /**
      * The project's `bindings.modules` map, verbatim. Nothing in `src/` calls
      * this, so what the keys and values mean is UEFN's to define.
      */


### PR DESCRIPTION
Closes #429

`enclosingModulePath` and `searchImplicitModules` both read the `Content` boundary against a path relative to the workspace folder root, so a `Content` directory anywhere below depth zero placed no file at all. With the workspace opened at the project root and a file at `Plugins/MyGame/Content/Systems/Feature.verse`, phase 1 of the module search returned before walking, the scope came back null, and the placeability guard from #392 turned both into the refusal the issue reports.

One private helper now locates the root along the whole path from the workspace folder down to the file, and the two sites read it. The **shallowest** `Content` wins rather than the nearest, so a folder module named `Content` below the root is not mistaken for the root and its files are not addressed one scope too low.

## The layout is the current one, not a legacy one

`ProjectPathHandler`'s doc comment calls the nested layout "UEFN's older project layout". A live check against 40 real `.uefnproject` projects says otherwise: **25 are nested `Plugins/<Name>/Content`, 15 are flat `Content`, and none carry both**. A current project file (`fileVersion 15`, `compatibilityVersion 35.10`) puts `.uefnproject` at the project root with Verse under `Plugins/<Name>/Content` and a single root plugin. So this was not a fringe layout: it is the majority shape, and "Use relative path" was refused in all of it whenever the workspace was opened at the project root.

Every one of the 40 projects declares exactly one plugin, always `bIsRoot`. The multi-plugin case is bounded anyway by the existing outside-the-project guard in `convertFromFullPath`, which refuses any import whose prefix does not match `projectVersePath`, so a second plugin's imports cannot be silently re-addressed under this project's path.

## Only the root plugin's Content root is admitted

Placing a file under whatever `Content` sits on its path would have gone too far, and the first review round caught it: only the root plugin's Content answers to `bindings.projectVersePath`, so a file under `Plugins/<Other>/Content` would have been scoped and addressed under the wrong package — a refusal traded for a silent wrong write, which is the failure class #392 exists to prevent. `referenceResolvesTo` cannot catch that, because it re-derives the scope from the same project path and so confirms the reference it was handed.

A Content root **below** the workspace folder's top level is therefore admitted only when its parent is the root plugin's declared name and its grandparent is `Plugins`, read from the project file's `plugins` array — which was parsed already and had no readers. A Content **directly under** the workspace folder is taken as before, without that evidence: the workspace is then opened at the thing holding it, and requiring evidence there would drop the flat layout that already worked. In the sample, all 15 flat projects have no plugin directory at all, and 24 of the 25 nested ones have exactly one plugin Content directory whose name equals the declared root plugin's.

## Known residual, owned by no ticket yet

`workspaceScanTargets` still globs `Content/**/*.verse` from the workspace folder, so module-search phases 2 and 3 stay blind to a nested project; `ProjectPathCache.workspaceIsContent()` and `toContentRelativeDir` read the same fixed depth, and `ModuleVisibilityWriter.findContentRoot` reads it for a different feature. `findModuleLocations` runs phase 1 first and falls through only when it found nothing, so fixing phase 1 restores the reported behaviour — but "Use full path" on a module only the project-wide scan could reach still fails in this layout, fail-closed rather than wrong.

This is **not** covered by #396: its H-08 is the byte-exact *case* rule and H-14 is `workspaceFolders[0]`, and neither is the *depth* rule. A follow-up issue should own it rather than this PR widening into it.

## Review

Two rounds at opus, both probed rather than read. Round 1 returned FAIL on one Critical, which is what produced the root-plugin gate above: the first attempt placed a file under whatever `Content` sat on its path, which would have addressed a non-root plugin's files under the wrong package — a refusal traded for a silent wrong write. Round 2 verified that closed against `origin/main`, confirmed both directions and the round trip, and returned PASS_WITH_SUGGESTIONS.

The remaining suggestions were taken except one: moving the plugin check onto the path segments the caller already holds, instead of building an absolute path and taking it apart. Declined because it would narrow real behaviour — reading the absolute path is what lets a workspace opened at `<project>/Plugins` or at `<project>/Plugins/<Name>` still place its files, where segments relative to the workspace folder cannot see the `Plugins` level at all.

## Tests

Thirteen cases in a new `under a nested plugin Content root` block, pinned at `convertFromFullPath` — the entry point `CommandsHandler.convertToRelativePath` calls and the one that returned null. They cover the bare-name and multi-segment forms, a file at the nested root itself, the round trip back through `convertToFullPath`, the shallowest-Content rule, a file no Content root holds, a non-root plugin's Content refused in both directions, a project declaring no root plugin, a Content nested under something other than `Plugins`, a declared plugin name differing from the directory only in case, an unrelated `Content` beside `Plugins`, and workspace-at-`Content` winning over a `Content` nested below it.

Every assertion was proven to detect its defect by taking the code away rather than by passing: five of the six original cases fail against the unfixed source (the sixth is a negative case, which correctly refuses either way); all three gate cases fail with the root-plugin check disabled; and the two halves of the gate's own rule were mutation-tested separately — dropping the `Plugins` grandparent check fails one case, replacing the case fold with the identity fails three.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.2 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 50 passed, 50 total
Tests:       1533 passed, 1533 total
Snapshots:   0 total
Time:        7.967 s, estimated 11 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
