### PR TITLE
fix(visibility): resolve the content root from the requesting document

### DIFF
--- a/changelog.d/436.fixed.md
+++ b/changelog.d/436.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: the make-module-public quick fix now writes to the workspace folder holding the module, so a multi-root workspace no longer edits the first folder's definitions file or ignores its per-folder file name override.

--- a/changelog.d/436.fixed.md
+++ b/changelog.d/436.fixed.md
@@ -1,1 +1,1 @@
-**Module visibility**: the make-module-public quick fix now works in the workspace folder holding the edited file, so a multi-root workspace no longer writes the first folder's definitions file or ignores that folder's file name override.
+**Module visibility**: the make-module-public quick fix now writes the definitions file of the workspace folder holding the edited file, so a multi-root workspace no longer writes the first folder's file or ignores that folder's file name override.

--- a/changelog.d/436.fixed.md
+++ b/changelog.d/436.fixed.md
@@ -1,1 +1,1 @@
-**Module visibility**: the make-module-public quick fix now writes to the workspace folder holding the module, so a multi-root workspace no longer edits the first folder's definitions file or ignores its per-folder file name override.
+**Module visibility**: the make-module-public quick fix now works in the workspace folder holding the edited file, so a multi-root workspace no longer writes the first folder's definitions file or ignores that folder's file name override.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -309,16 +309,22 @@ const workspace = {
      *
      * The innermost containing folder wins and a URI equal to a folder root
      * answers that folder, both as the real API documents. Nesting is compared
-     * by path length, which orders folders correctly precisely because a
-     * containing path is a prefix of what it contains.
+     * by the length of the NORMALIZED root, which orders folders correctly
+     * precisely because a containing path is a prefix of what it contains -
+     * comparing raw fsPath lengths instead would let a root's own separators
+     * outweigh the nesting.
+     *
+     * Still case-sensitive, where real VS Code compares case-insensitively on
+     * win32, so a test differing only in drive-letter case gets no folder.
      */
     getWorkspaceFolder: jest.fn().mockImplementation((target: { fsPath: string }) => {
-        const normalized = target.fsPath.replace(/\\/g, "/").replace(/\/+$/, "");
-        const containing = workspace.workspaceFolders?.filter((folder) => {
-            const root = folder.uri.fsPath.replace(/\\/g, "/").replace(/\/+$/, "");
-            return normalized === root || normalized.startsWith(`${root}/`);
-        });
-        return containing?.sort((a, b) => b.uri.fsPath.length - a.uri.fsPath.length)[0];
+        const normalize = (fsPath: string) => fsPath.replace(/\\/g, "/").replace(/\/+$/, "");
+        const normalized = normalize(target.fsPath);
+
+        return workspace.workspaceFolders
+            ?.map((folder) => ({ folder, root: normalize(folder.uri.fsPath) }))
+            .filter(({ root }) => normalized === root || normalized.startsWith(`${root}/`))
+            .sort((a, b) => b.root.length - a.root.length)[0]?.folder;
     }),
     // Rejecting is the "no such file" answer, which is what production code
     // reads a missing file as. A resolving default would make an absent

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -307,14 +307,18 @@ const workspace = {
      * outside the project - so a test wanting a folder must register it in
      * workspaceFolders rather than rely on a fallback.
      *
-     * The first containing folder wins, where real VS Code returns the
-     * innermost, and a URI equal to a folder root answers undefined rather than
-     * that folder. A test covering the multi-root UEFN workspace, or nested
-     * folders, needs more than this.
+     * The innermost containing folder wins and a URI equal to a folder root
+     * answers that folder, both as the real API documents. Nesting is compared
+     * by path length, which orders folders correctly precisely because a
+     * containing path is a prefix of what it contains.
      */
     getWorkspaceFolder: jest.fn().mockImplementation((target: { fsPath: string }) => {
-        const normalized = target.fsPath.replace(/\\/g, "/");
-        return workspace.workspaceFolders?.find((folder) => normalized.startsWith(`${folder.uri.fsPath.replace(/\\/g, "/").replace(/\/+$/, "")}/`));
+        const normalized = target.fsPath.replace(/\\/g, "/").replace(/\/+$/, "");
+        const containing = workspace.workspaceFolders?.filter((folder) => {
+            const root = folder.uri.fsPath.replace(/\\/g, "/").replace(/\/+$/, "");
+            return normalized === root || normalized.startsWith(`${root}/`);
+        });
+        return containing?.sort((a, b) => b.uri.fsPath.length - a.uri.fsPath.length)[0];
     }),
     // Rejecting is the "no such file" answer, which is what production code
     // reads a missing file as. A resolving default would make an absent

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -98,12 +98,17 @@ export class CommandsHandler {
      * Declares the module an import could not reach `<public>`, so the import
      * compiles.
      *
-     * The argument comes from the quick fix that parsed it out of the compiler
-     * diagnostic, which is why the command is hidden from the Command Palette.
+     * The arguments come from the quick fix that parsed the request out of the
+     * compiler diagnostic, which is why the command is hidden from the Command
+     * Palette.
+     *
+     * @param sourceUri the document the diagnostic was reported on, which picks
+     * the workspace folder. Optional so an invocation that cannot name one
+     * still reaches the writer's fallback.
      */
-    async makeModulePublic(request: ModuleVisibilityRequest): Promise<void> {
+    async makeModulePublic(request: ModuleVisibilityRequest, sourceUri?: vscode.Uri): Promise<void> {
         logger.info("CommandsHandler", `Make module public command triggered for ${request.targetPath}`);
-        await this.deps.moduleVisibilityWriter.makeModulePublic(request);
+        await this.deps.moduleVisibilityWriter.makeModulePublic(request, sourceUri);
     }
 
     /**

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -656,4 +656,27 @@ describe("CommandsHandler failure logging", () => {
             expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("Project path cache rebuilt: 12 identifiers from 3 files");
         });
     });
+
+    describe("makeModulePublic", () => {
+        const REQUEST = {
+            targetPath: "/mygame@fortnite.com/mygame/Gadgets/Tools",
+            importerPath: "/mygame@fortnite.com/mygame/Scripts",
+            moduleName: "Tools",
+        };
+
+        /**
+         * The document is the middle hop of provider - command - writer, and
+         * dropping it here reverts to the first workspace folder silently:
+         * every other test in the chain still passes.
+         */
+        it("forwards the document the quick fix named to the writer", async () => {
+            const makeModulePublic = jest.fn().mockResolvedValue(undefined);
+            const handler = new CommandsHandler({ moduleVisibilityWriter: { makeModulePublic } } as unknown as CommandsDependencies);
+            const source = vscode.Uri.file("/second/Content/Scripts/main.verse");
+
+            await handler.makeModulePublic(REQUEST, source);
+
+            expect(makeModulePublic).toHaveBeenCalledWith(REQUEST, source);
+        });
+    });
 });

--- a/src/visibility/ModuleVisibilityCodeActionProvider.ts
+++ b/src/visibility/ModuleVisibilityCodeActionProvider.ts
@@ -30,10 +30,13 @@ export class ModuleVisibilityCodeActionProvider implements vscode.CodeActionProv
             const action = new vscode.CodeAction(`Make module '${request.moduleName}' public`, vscode.CodeActionKind.QuickFix);
             action.kind = vscode.CodeActionKind.QuickFix.append("verse.moduleVisibility");
             action.diagnostics = [diagnostic];
+            // The document rides along because the request carries Verse paths
+            // only, and the writer needs a URI to pick the workspace folder in
+            // a multi-root workspace.
             action.command = {
                 title: "Make Module Public",
                 command: "verseAutoImports.makeModulePublic",
-                arguments: [request],
+                arguments: [request, document.uri],
             };
 
             actions.push(action);

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -75,9 +75,11 @@ export class ModuleVisibilityWriter {
      * reported afterwards is intent rather than outcome.
      *
      * @param sourceUri the document whose diagnostic asked for this, which is
-     * what picks the workspace folder in a multi-root workspace. Optional, and
-     * falling back to the first folder, because a caller outside the quick fix
-     * has no document to name.
+     * what picks the workspace folder in a multi-root workspace. The first
+     * folder is used instead whenever this names nothing usable - it is
+     * absent, it sits outside every folder, or its folder holds no Content
+     * root - so a caller that cannot name a document still gets the
+     * single-root behaviour rather than a refusal.
      */
     async makeModulePublic(request: ModuleVisibilityRequest, sourceUri?: vscode.Uri): Promise<void> {
         const outcome = await this.buildEdit(request, sourceUri);
@@ -134,8 +136,9 @@ export class ModuleVisibilityWriter {
         // this is on the way to finding. The requesting document is in the
         // right folder already, and the target shares it - the compiler
         // resolved both under one projectVersePath.
-        const workspaceFolder = (sourceUri ? vscode.workspace.getWorkspaceFolder(sourceUri) : undefined) ?? vscode.workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
+        const requestedFolder = sourceUri ? vscode.workspace.getWorkspaceFolder(sourceUri) : undefined;
+        const firstFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!requestedFolder && !firstFolder) {
             return { reason: "no workspace folder is open." };
         }
 
@@ -155,10 +158,16 @@ export class ModuleVisibilityWriter {
             return { reason: `'${request.moduleName}' is already reachable from the importing module.` };
         }
 
-        const contentRoot = await this.findContentRoot(workspaceFolder);
-        if (!contentRoot) {
+        // A folder holding no Content root cannot host the declaration, and a
+        // workspace can carry one legitimately - notes or art opened alongside
+        // the project. Falling back there rather than refusing keeps the fix
+        // working for a document in such a folder, as it did before the
+        // requesting folder was consulted at all.
+        const located = (await this.locateContentRoot(requestedFolder)) ?? (await this.locateContentRoot(firstFolder));
+        if (!located) {
             return { reason: `no '${CONTENT_FOLDER}' folder was found in the workspace, so there is nowhere to declare the module.` };
         }
+        const { workspaceFolder, contentRoot } = located;
 
         const definitionsUri = this.definitionsUri(contentRoot);
         if (!definitionsUri) {
@@ -314,6 +323,16 @@ export class ModuleVisibilityWriter {
                 edit.replace(file.uri, new vscode.Range(positionAt(file.text, start), positionAt(file.text, end)), specifierEdit.text, metadata);
             }
         }
+    }
+
+    /** A folder paired with its Content root, or null when there is no folder or it holds none. */
+    private async locateContentRoot(folder: vscode.WorkspaceFolder | undefined): Promise<{ workspaceFolder: vscode.WorkspaceFolder; contentRoot: vscode.Uri } | null> {
+        if (!folder) {
+            return null;
+        }
+
+        const contentRoot = await this.findContentRoot(folder);
+        return contentRoot ? { workspaceFolder: folder, contentRoot } : null;
     }
 
     /** The Content folder the project's modules hang off, or null when the workspace has none. */

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -160,9 +160,8 @@ export class ModuleVisibilityWriter {
 
         // A folder holding no Content root cannot host the declaration, and a
         // workspace can carry one legitimately - notes or art opened alongside
-        // the project. Falling back there rather than refusing keeps the fix
-        // working for a document in such a folder, as it did before the
-        // requesting folder was consulted at all.
+        // the project. A document in such a folder falls back rather than
+        // refusing, since the project's own folder can still serve it.
         const located = (await this.locateContentRoot(requestedFolder)) ?? (await this.locateContentRoot(firstFolder));
         if (!located) {
             return { reason: `no '${CONTENT_FOLDER}' folder was found in the workspace, so there is nowhere to declare the module.` };

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -73,9 +73,14 @@ export class ModuleVisibilityWriter {
      * else the same request would have changed. That governs what is offered,
      * not what lands - the preview lets the user apply a subset, so what is
      * reported afterwards is intent rather than outcome.
+     *
+     * @param sourceUri the document whose diagnostic asked for this, which is
+     * what picks the workspace folder in a multi-root workspace. Optional, and
+     * falling back to the first folder, because a caller outside the quick fix
+     * has no document to name.
      */
-    async makeModulePublic(request: ModuleVisibilityRequest): Promise<void> {
-        const outcome = await this.buildEdit(request);
+    async makeModulePublic(request: ModuleVisibilityRequest, sourceUri?: vscode.Uri): Promise<void> {
+        const outcome = await this.buildEdit(request, sourceUri);
 
         if ("reason" in outcome) {
             logger.warn("ModuleVisibilityWriter", `Cannot publicize ${request.targetPath}: ${outcome.reason}`);
@@ -117,9 +122,19 @@ export class ModuleVisibilityWriter {
     /**
      * The single edit that satisfies a request, with what every file it was
      * computed from looked like at read time, or why there is none.
+     *
+     * The folder this resolves decides all three of the Content root written
+     * to, the scope `moduleVisibility.definitionsFileName` is read at, and the
+     * subtree the declaration scan sweeps, so a wrong one rules on
+     * declarations it never read rather than merely writing the wrong file.
      */
-    private async buildEdit(request: ModuleVisibilityRequest): Promise<{ edit: vscode.WorkspaceEdit; summary: string; snapshots: Snapshot[] } | Refusal> {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    private async buildEdit(request: ModuleVisibilityRequest, sourceUri?: vscode.Uri): Promise<{ edit: vscode.WorkspaceEdit; summary: string; snapshots: Snapshot[] } | Refusal> {
+        // The target module cannot be resolved to a folder directly: its path
+        // is a Verse path, and turning one into a URI needs the Content root
+        // this is on the way to finding. The requesting document is in the
+        // right folder already, and the target shares it - the compiler
+        // resolved both under one projectVersePath.
+        const workspaceFolder = (sourceUri ? vscode.workspace.getWorkspaceFolder(sourceUri) : undefined) ?? vscode.workspace.workspaceFolders?.[0];
         if (!workspaceFolder) {
             return { reason: "no workspace folder is open." };
         }

--- a/src/visibility/__tests__/ModuleVisibilityCodeActionProvider.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityCodeActionProvider.test.ts
@@ -6,10 +6,13 @@ const INACCESSIBLE =
 
 const diagnostic = (message: string) => ({ message }) as vscode.Diagnostic;
 
+/** The file the diagnostic was reported on, which is what picks the workspace folder. */
+const SOURCE = vscode.Uri.file("/second/Content/Scripts/main.verse");
+
 const provide = (...messages: string[]) => {
     const provider = new ModuleVisibilityCodeActionProvider();
     const context = { diagnostics: messages.map(diagnostic) } as unknown as vscode.CodeActionContext;
-    return provider.provideCodeActions({} as vscode.TextDocument, {} as vscode.Range, context);
+    return provider.provideCodeActions({ uri: SOURCE } as vscode.TextDocument, {} as vscode.Range, context);
 };
 
 describe("ModuleVisibilityCodeActionProvider", () => {
@@ -32,8 +35,15 @@ describe("ModuleVisibilityCodeActionProvider", () => {
                     importerPath: "/mygame@fortnite.com/mygame/Scripts",
                     moduleName: "Tools",
                 },
+                SOURCE,
             ],
         });
+    });
+
+    it("sends the document alongside it, since the request names no file the folder can be read from", () => {
+        const actions = provide(INACCESSIBLE);
+
+        expect(actions![0].command?.arguments?.[1]).toBe(SOURCE);
     });
 
     it("attaches the diagnostic it answers", () => {

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -9,6 +9,9 @@ const ROOT = "/repo";
 /** The second root of a multi-root workspace, which the quick fix is invoked under. */
 const OTHER_ROOT = "/second";
 
+/** A root holding no Content folder, as an art or notes folder opened alongside a project. */
+const NOTES_ROOT = "/notes";
+
 const REQUEST = {
     targetPath: `${PROJECT}/Gadgets/Tools`,
     importerPath: `${PROJECT}/Scripts`,
@@ -92,8 +95,8 @@ const alsoListsUnreadable = (listed: readonly vscode.Uri[], relative: string): v
 /**
  * Stands the same project up under the second of two workspace folders, and
  * returns the document URI the quick fix would pass. The first folder is
- * registered and empty, which is the shape that hid the folder-0 pin: every
- * single-root test passes either way.
+ * registered and holds nothing, so a writer resolving to it fails here rather
+ * than passing by coincidence.
  */
 const givenSecondFolderProject = (files: Record<string, string>): vscode.Uri => {
     givenProject(files, OTHER_ROOT);
@@ -567,6 +570,29 @@ describe("ModuleVisibilityWriter", () => {
             givenSecondFolderProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
 
             await writer().makeModulePublic(REQUEST);
+
+            expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${ROOT}/Content/_definitions.verse`);
+        });
+
+        it("falls back to the first folder for a document under no folder at all", async () => {
+            givenSecondFolderProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+            await writer().makeModulePublic(REQUEST, vscode.Uri.file("/elsewhere/scratch.verse"));
+
+            expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${ROOT}/Content/_definitions.verse`);
+        });
+
+        it("falls back to the first folder when the document's own folder holds no Content root", async () => {
+            givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+            (vscode.workspace as any).workspaceFolders = [
+                { uri: vscode.Uri.file(ROOT), name: "repo", index: 0 },
+                { uri: vscode.Uri.file(NOTES_ROOT), name: "notes", index: 1 },
+            ];
+            const stat = vscode.workspace.fs.stat as jest.Mock;
+            const base = stat.getMockImplementation()!;
+            stat.mockImplementation((uri: vscode.Uri) => (forwardSlashed(uri) === `${NOTES_ROOT}/Content` ? Promise.reject(new Error("ENOENT")) : base(uri)));
+
+            await writer().makeModulePublic(REQUEST, vscode.Uri.file(`${NOTES_ROOT}/scratch.verse`));
 
             expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${ROOT}/Content/_definitions.verse`);
         });

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -6,6 +6,9 @@ import { ModuleVisibilityWriter } from "../ModuleVisibilityWriter";
 const PROJECT = "/mygame@fortnite.com/mygame";
 const ROOT = "/repo";
 
+/** The second root of a multi-root workspace, which the quick fix is invoked under. */
+const OTHER_ROOT = "/second";
+
 const REQUEST = {
     targetPath: `${PROJECT}/Gadgets/Tools`,
     importerPath: `${PROJECT}/Scripts`,
@@ -84,6 +87,33 @@ const alsoListsUnreadable = (listed: readonly vscode.Uri[], relative: string): v
     const uri = vscode.Uri.file(`${ROOT}/${relative}`);
     (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([...listed, uri]);
     return uri;
+};
+
+/**
+ * Stands the same project up under the second of two workspace folders, and
+ * returns the document URI the quick fix would pass. The first folder is
+ * registered and empty, which is the shape that hid the folder-0 pin: every
+ * single-root test passes either way.
+ */
+const givenSecondFolderProject = (files: Record<string, string>): vscode.Uri => {
+    givenProject(files, OTHER_ROOT);
+    (vscode.workspace as any).workspaceFolders = [
+        { uri: vscode.Uri.file(ROOT), name: "repo", index: 0 },
+        { uri: vscode.Uri.file(OTHER_ROOT), name: "second", index: 1 },
+    ];
+
+    return vscode.Uri.file(`${OTHER_ROOT}/Content/Scripts/main.verse`);
+};
+
+/** A definitionsFileName override that answers differently per workspace folder. */
+const givenPerFolderDefinitionsName = (byRoot: Record<string, string>): void => {
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation((_section: string, resource?: { fsPath: string }) => {
+        const root = resource && Object.keys(byRoot).find((candidate) => forwardSlashed(resource).startsWith(`${candidate}/`));
+        return {
+            get: jest.fn().mockImplementation((key: string, fallback?: unknown) => (key === "moduleVisibility.definitionsFileName" && root ? byRoot[root] : fallback)),
+            update: jest.fn(),
+        };
+    });
 };
 
 const writer = (): ModuleVisibilityWriter => {
@@ -503,6 +533,42 @@ describe("ModuleVisibilityWriter", () => {
             const [message] = (vscode.window.showInformationMessage as jest.Mock).mock.calls[0];
             expect(message).toContain("previewed");
             expect(message).not.toContain("declaring");
+        });
+    });
+
+    describe("multi-root workspace", () => {
+        it("writes under the folder holding the document the fix was invoked from", async () => {
+            const source = givenSecondFolderProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+            await writer().makeModulePublic(REQUEST, source);
+
+            expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${OTHER_ROOT}/Content/_definitions.verse`);
+        });
+
+        it("honours that folder's definitionsFileName rather than the first folder's", async () => {
+            const source = givenSecondFolderProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+            givenPerFolderDefinitionsName({ [ROOT]: "first.verse", [OTHER_ROOT]: "second.verse" });
+
+            await writer().makeModulePublic(REQUEST, source);
+
+            expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${OTHER_ROOT}/Content/second.verse`);
+        });
+
+        it("scans that folder for existing declarations, not the first", async () => {
+            const source = givenSecondFolderProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+            await writer().makeModulePublic(REQUEST, source);
+
+            const [pattern] = (vscode.workspace.findFiles as jest.Mock).mock.calls[0];
+            expect(forwardSlashed(pattern.base.uri)).toBe(OTHER_ROOT);
+        });
+
+        it("falls back to the first folder when the caller names no document", async () => {
+            givenSecondFolderProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+            await writer().makeModulePublic(REQUEST);
+
+            expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${ROOT}/Content/_definitions.verse`);
         });
     });
 });


### PR DESCRIPTION
Closes #436

## What was wrong

`ModuleVisibilityWriter.buildEdit` opened with `vscode.workspace.workspaceFolders?.[0]`, and that one local decides three things, not the one the issue names:

- the Content root the definitions file is written to
- the scope `moduleVisibility.definitionsFileName` — a `"scope": "resource"` setting — is read at
- the subtree `findDeclarations` sweeps, via `new vscode.RelativePattern(workspaceFolder, …)` and the Content-relative paths computed from it

The third is the worst of them: in a multi-root workspace `resolveVisibility` ruled on declarations it had never read, because the scan swept a folder the module was not in.

## Where the issue's proposed mechanism did not survive

The issue suggested `getWorkspaceFolder(uri)` on the resolved target path. That is circular — `request.targetPath` is an absolute *Verse* path, and resolving one to a filesystem URI needs the Content root being computed.

The URI that is actually available is the document whose diagnostic raised the quick fix. `ModuleVisibilityCodeActionProvider` had it as `document` and dropped it. It is in the right folder by construction, and the target module shares that folder: the compiler resolved both paths under one `projectVersePath`, and `toContentSegments` refuses anything outside it. `ImportPathConverter.ts:261,653` already resolves its folder this way, so this follows the existing pattern rather than inventing one.

## The change

The provider passes `document.uri` as a second command argument, `CommandsHandler` forwards it, and `buildEdit` resolves the folder from it. Both parameters are optional the whole way down, so any caller that cannot name a document still gets the previous single-root behaviour.

The fallback to the first folder covers three cases, not one: no URI supplied, a URI outside every folder, and a URI whose folder holds no `Content` root — the last being a workspace root legitimately opened alongside a project for notes or art. Without that third case this change would have turned a working quick fix into a refusal, which is what review round 1 caught.

`src/__mocks__/vscode.ts` needed work before any of this was testable, as the issue predicted: `getWorkspaceFolder` returned the *first* containing folder where real VS Code returns the innermost, and answered `undefined` for a URI equal to a folder root. Both now match the documented API (`@types/vscode` 1.85.0, `index.d.ts:13076-13083`). It remains case-sensitive where real VS Code is case-insensitive on win32, which its doc comment now states.

## Known limit, tracked separately

`ProjectPathHandler.findAndParseProjectFile` walks every workspace folder but caches the **first** `.uefnproject` it finds, so `getProjectVersePath()` is pinned to folder 0 in the same way. Where two workspace folders are two genuinely different UEFN projects, a request for the second is refused at `toContentSegments` before the folder resolution here is ever consulted. Filed as #450 and deliberately not folded into this diff; the issue's acceptance case — one project, several folders — is fully served.

## Tests

The regression is pinned at the entry point, with three new cases asserting all three consequences of the pin (definitions file, per-folder file name override, scan root), and three more covering the fallbacks. Each was verified to fail against the unfixed code and pass against the fix:

- reverting the resolution line alone fails the three multi-root cases with `/repo/...` for `/second/...`, `first.verse` for `second.verse`, and a scan base of `/repo`
- reverting the Content-root fallback alone fails the notes-folder case

`CommandsHandler` gained a test pinning the middle hop of provider → command → writer, which was the one link no test covered.

## Verification

```
$ npm run compile
> verse-auto-imports@0.11.2 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 50 passed, 50 total
Tests:       1528 passed, 1528 total
Snapshots:   0 total
Time:        9.744 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

Two rounds at opus, both `PASS_WITH_SUGGESTIONS`, no `Critical` in either.

Round 1 raised two `Important` findings, both fixed here: the Content-root fallback regression above, and a changelog entry that promised multi-root correctness the code delivers only for the same-project case. Round 2 returned no `Important` findings; its two actionable suggestions (a refactor-history clause in a comment, and the changelog's lead clause) are also applied.

One suggestion was declined in both rounds and the second reviewer agreed with declining it: folding the source URI into `ModuleVisibilityRequest` would remove an optional parameter from two signatures, but `ModuleVisibilityMessage.ts` states in its header that it has no VS Code dependencies, and a `vscode.Uri` field would break that.
