### PR TITLE
fix(imports): carry a line comment past the block opened inside it

### DIFF
--- a/changelog.d/419.fixed.md
+++ b/changelog.d/419.fixed.md
@@ -1,0 +1,1 @@
+**Import scanning**: Imports written inside a comment no longer read as live when a block comment opens on a `<#>` marker's own line, or when a line comment runs on past the `#>` closing a block it opened.

--- a/changelog.d/419.fixed.md
+++ b/changelog.d/419.fixed.md
@@ -1,1 +1,1 @@
-**Import scanning**: Imports written inside a comment no longer read as live when a block comment opens on a `<#>` marker's own line, or when a line comment runs on past the `#>` closing a block it opened.
+**Verse file scanning**: a `<#` block opened in a `<#>` marker's line, or a `#` comment continuing past the `#>` that closes one, now reads as commented out, so imports written there no longer count as present

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -65,7 +65,7 @@ export class ImportFormatter {
      * so is kept whole rather than split at a `#` the lexer never resolved.
      */
     private static commentStartIndex(content: string): number {
-        return lexVerseLine(content, { depth: 0, markerIndent: null, openFrames: [] }).commentStart;
+        return lexVerseLine(content, { depth: 0, markerIndent: null, openFrames: [], lineComment: null }).commentStart;
     }
 
     /**

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -141,10 +141,17 @@ export interface LineClassification {
  */
 export function classifyLines(lines: string[]): LineClassification[] {
     const classifications: LineClassification[] = new Array(lines.length);
-    // Left empty and never carried, unlike the two beside it. An open
-    // interpolation is a state scanLine has just declined to read, since the
-    // line holding it is re-lexed with literal tracking off; carrying it would
-    // resume a literal on the next line that this line was never lexed as.
+    // openFrames is left empty and never carried, unlike the three beside it. An
+    // open interpolation is a state scanLine has just declined to read, since
+    // the line holding it is re-lexed with literal tracking off; carrying it
+    // would resume a literal on the next line that this line was never lexed as.
+    //
+    // lineComment carries despite coming out of that same re-lex, because it is
+    // comment structure rather than literal state: both lexing modes read it the
+    // same way, exactly as they do depth and markerIndent. On a line the
+    // fallback reached, the comment it reports may be one the tracked lex would
+    // not have opened - and that is the fallback's stated direction, to miss a
+    // `using` rather than invent one.
     const state: LexState = { depth: 0, markerIndent: null, openFrames: [], lineComment: null };
 
     for (let i = 0; i < lines.length; i++) {

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -145,7 +145,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
     // interpolation is a state scanLine has just declined to read, since the
     // line holding it is re-lexed with literal tracking off; carrying it would
     // resume a literal on the next line that this line was never lexed as.
-    const state: LexState = { depth: 0, markerIndent: null, openFrames: [] };
+    const state: LexState = { depth: 0, markerIndent: null, openFrames: [], lineComment: null };
 
     for (let i = 0; i < lines.length; i++) {
         const scan = scanLine(lines[i], state);
@@ -163,6 +163,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
 
         state.depth = scan.depth;
         state.markerIndent = scan.markerIndent;
+        state.lineComment = scan.lineComment;
     }
 
     return classifications;
@@ -423,11 +424,16 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
     //
     // A span always starts at depth 0: lines inside a block comment are skipped
     // below, and the `using:` opening an indented pair holds no `#` to open one
-    // on the path line. Only depth 0 yields opensIndentedComment, so a `<#>`
-    // inside a block comment on the same span cannot be mistaken for a marker.
+    // on the path line. The state starts fresh here, so a `<#>` inside a block
+    // comment on the same span cannot be mistaken for a marker: only a marker
+    // this span itself opened can yield opensIndentedComment.
+    //
+    // A marker whose tail opens a block defers its body to a line below, so it
+    // yields no opensIndentedComment on the span at all; the unclosed depth left
+    // at the end is what reports it, and reports it as the opener it also is.
     const anchorsCommentBelow = (startLine: number, endLine: number): boolean => {
         // Empty and never carried, for the reason classifyLines gives.
-        const state: LexState = { depth: 0, markerIndent: null, openFrames: [] };
+        const state: LexState = { depth: 0, markerIndent: null, openFrames: [], lineComment: null };
         for (let line = startLine; line <= endLine; line++) {
             const scan = scanLine(lines[line], state);
             if (scan.opensIndentedComment) {
@@ -435,6 +441,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             }
             state.depth = scan.depth;
             state.markerIndent = scan.markerIndent;
+            state.lineComment = scan.lineComment;
         }
         return state.depth > 0;
     };

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -107,6 +107,18 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["<# note #> using { Economy.Shop }", "using { /A }", "code()"])).toEqual(["Economy.Shop", "/A"]);
     });
 
+    // The mirror of the two above, and the reason neither of them generalises: a
+    // block opened at code scope hands the rest of the closing line back to
+    // code, where one opened inside a line comment hands it back to the comment,
+    // which runs to that line's end. Collecting the path there suppresses an
+    // import the file has not really made.
+    //
+    // Pinned here rather than on scanModuleImports, which never reads a line
+    // that opens inside a block comment and so cannot see this at all.
+    it("does not collect a using written after the #> that closes a block a line comment opened", () => {
+        expect(allUsingPaths(["# note <#", "using { Economy.Shop }", "#> using { /Dead }", "using { /A }", "code()"])).toEqual(["/A"]);
+    });
+
     it("does not read an identifier that merely starts with using", () => {
         expect(allUsingPaths(["usingFoo := 1", "usings := 3", "usingMap := map{Economy.Shop => 1}", "using { /A }", "code()"])).toEqual(["/A"]);
     });
@@ -1072,6 +1084,14 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
     });
 
+    it("treats a <# in an indented comment marker's own tail as the block opener it is", () => {
+        // The marker's tail is lexed at line-comment place, so the same rule
+        // reaches it and the `<#` opens a real block. Swallowing the tail
+        // instead leaves the block unopened and the import inside it live.
+        const lines = ["<#> disabled below <#", "using { /Old/Path }", "#>", "using { /Verse.org/Simulation }"];
+        expect(scanModuleImports(lines)).toEqual([{ path: "/Verse.org/Simulation", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" }]);
+    });
+
     it("returns entries in document order with correct spans across mixed styles", () => {
         const lines = ["using { /A }", "using:", "    /B", "using. /C"];
         expect(scanModuleImports(lines)).toEqual([
@@ -1284,6 +1304,20 @@ describe("classifyLines", () => {
 
     it("ends a line comment that opened and closed a block on its own line", () => {
         expect(kinds(["# see <# aside #> below", "code()"])).toEqual(["comment", "code"]);
+    });
+
+    it("reads a block opener in an indented comment marker's own tail as one", () => {
+        expect(kinds(["<#> see <# below", "code()", "#>", "code()"])).toEqual(["comment", "comment", "comment", "code"]);
+    });
+
+    it("keeps a line comment over the tail of the line its block closed on", () => {
+        expect(kinds(["# see <# below", "code()", "#> code()", "code()"])).toEqual(["comment", "comment", "comment", "code"]);
+    });
+
+    it("keeps a marker body over the tail of the line its block closed on", () => {
+        // The dedented line inside the block ends nothing, so the body is still
+        // open when the `#>` hands the rest of its line back to it.
+        expect(kinds(["<#> notes", "    body <# below", "code()", "    #> code()", "    still body", "code()"])).toEqual(["comment", "comment", "comment", "comment", "comment", "code"]);
     });
 
     it("keeps a # inside a string literal in the line's code", () => {

--- a/src/utils/__tests__/verseLexer.test.ts
+++ b/src/utils/__tests__/verseLexer.test.ts
@@ -1,7 +1,7 @@
 import { lexVerseLine } from "../verseLexer";
 
 /** The lexer's entry state for a line nothing above it left open. */
-const atCodeScope = { depth: 0, markerIndent: null, openFrames: [] };
+const atCodeScope = { depth: 0, markerIndent: null, openFrames: [], lineComment: null };
 
 describe("lexVerseLine commentStart", () => {
     it("reports -1 for a line holding no comment", () => {
@@ -42,14 +42,46 @@ describe("lexVerseLine commentStart", () => {
     it("reports 0 for a line whose opener is above it", () => {
         // 0 even where the line closes that comment and carries live code, which
         // is why only a depthBefore-0 line may be split on the offset.
-        expect(lexVerseLine("still comment text", { depth: 1, markerIndent: null, openFrames: [] }).commentStart).toBe(0);
+        expect(lexVerseLine("still comment text", { depth: 1, markerIndent: null, openFrames: [], lineComment: null }).commentStart).toBe(0);
 
-        const closes = lexVerseLine("#> using { /A }", { depth: 1, markerIndent: null, openFrames: [] });
+        const closes = lexVerseLine("#> using { /A }", { depth: 1, markerIndent: null, openFrames: [], lineComment: null });
         expect(closes.commentStart).toBe(0);
         expect(closes.hasCode).toBe(true);
     });
 
     it("reports 0 for a line inside the body of a `<#>` marker", () => {
-        expect(lexVerseLine("    body text", { depth: 0, markerIndent: 0, openFrames: [] }).commentStart).toBe(0);
+        expect(lexVerseLine("    body text", { depth: 0, markerIndent: 0, openFrames: [], lineComment: null }).commentStart).toBe(0);
+    });
+});
+
+describe("lexVerseLine, a block comment opened in a line comment's text", () => {
+    it("opens one from a `<#>` marker's own tail, and holds the body back until it closes", () => {
+        const marker = lexVerseLine("using { /A } <#> note <# opener", atCodeScope);
+
+        expect(marker.commentStart).toBe(13);
+        expect(marker.depth).toBe(1);
+        // The tail's `<#` opened a block, so the marker's body has not begun and
+        // there is no indentation to report for it yet.
+        expect(marker.opensIndentedComment).toBe(false);
+        expect(marker.markerIndent).toBeNull();
+    });
+
+    it("opens the body on the line that closes the block, at that line's indentation", () => {
+        const marker = lexVerseLine("<#> note <# opener", atCodeScope);
+        const closes = lexVerseLine("    #>", { depth: marker.depth, markerIndent: marker.markerIndent, openFrames: [], lineComment: marker.lineComment });
+
+        expect(closes.opensIndentedComment).toBe(true);
+        expect(closes.markerIndent).toBe(4);
+    });
+
+    it("keeps the tail of the line the block closed on as comment text", () => {
+        const opener = lexVerseLine("# open <# here", atCodeScope);
+        const closes = lexVerseLine("#> using { /A }", { depth: opener.depth, markerIndent: null, openFrames: [], lineComment: opener.lineComment });
+
+        expect(closes.hasCode).toBe(false);
+        expect(closes.codeOutsideLiterals).toBe("");
+        // And the comment ends with that line, so nothing carries below it.
+        expect(closes.lineComment).toBeNull();
+        expect(closes.depth).toBe(0);
     });
 });

--- a/src/utils/__tests__/verseLexerCorpus.test.ts
+++ b/src/utils/__tests__/verseLexerCorpus.test.ts
@@ -153,6 +153,32 @@ const probes: Probe[] = [
         live: ["L1"],
     },
     {
+        // The comment outlives the block rather than ending at it: `Text`
+        // resumes where `BlockCmt()` returned, so it runs to the `Ending` of the
+        // line the `#>` sits on. The tail of that line was being read as code.
+        name: "a line comment resumes after the block opened in it closes",
+        source: "# D1 <# D2\nD3 := 1\n#> D4\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // The marker's own tail is lexed at line-comment place, so the same rule
+        // reaches it: the `<#` opens a real block, and the body waits for it.
+        // The body's indentation comes from the line that closed the block, so
+        // `D4` indented past it is body text and `L1` back at its column is not.
+        name: "a `<#` inside a `<#>` marker's own tail outlives the marker's line",
+        source: "<#> D1 <# D2\nD3 := 1\n#>\n    D4\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
+        // The other direction of the same resume, at marker-body place. The
+        // dedented `D3` inside the block ends nothing - a body measures its
+        // lines through `Scan`, which a block comment never reaches - so `D5` is
+        // still body text and only `L1` is a statement.
+        name: "a marker body resumes after the block opened in it closes",
+        source: "<#>\n    D1 <# D2\nD3 := 1\n    #> D4\n    D5\nL1 := 1\n",
+        live: ["L1"],
+    },
+    {
         // The `<#>` arm falls to three characters of text at line-comment place,
         // so this opens neither a block nor a body. The lexer has to test it
         // before it tests `<#`, or the tail reads as an opener that never

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -21,8 +21,14 @@
  *   opener that never closes. At `Text`'s `case '<'` (:2115-2137) a `<#`
  *   dispatches `BlockCmt()` at every place, while a `<#>` dispatches `IndCmt()`
  *   only at trivia, code and marker-body place and is three characters of plain
- *   text inside a block comment or a literal. It advances block-comment depth
- *   nowhere.
+ *   text inside a block comment, a line comment or a literal. It advances
+ *   block-comment depth nowhere.
+ *
+ *   Its tail is a line comment, not a region holding nothing: `IndCmt` lexes it
+ *   with `Text<EPlace::LineCmt>` and reaches `Ind()` only once that returns
+ *   (:2040-2048), so a `<#` there opens a block and the body waits for it. The
+ *   body's indentation then comes from the line `Ind()` runs on (:1637), which
+ *   is the line that closed the block rather than the marker's own.
  *
  *   One written inside a marker body is left as text here rather than nested,
  *   which the grammar allows because the two cannot disagree: the body it would
@@ -37,6 +43,11 @@
  *   dispatches `BlockCmt()` at every place, so a `<#` written in a line comment
  *   opens a block that runs to its `#>` however many lines below. Failing to
  *   carry that reads the lines the compiler comments out as live imports.
+ *
+ *   The comment itself outlives that block rather than ending at it. `Text`
+ *   resumes where `BlockCmt()` returned, so the comment ends at the `Ending` of
+ *   whatever line the `#>` sits on and the tail of that line is comment too. A
+ *   marker body resumes the same way after a block opened inside it.
  * - A `"` string interpolates, and `Interp := '{' List '}'` (:2163) makes the
  *   interpolation body ordinary code: a `"` inside one opens a fresh string and
  *   a `#` opens a real comment. So literal state is a stack of frames, and an
@@ -88,6 +99,32 @@ export interface LexState {
      * code scope.
      */
     openFrames: LexFrame[];
+    /**
+     * The line comment still open where the line starts, or null. Non-null only
+     * while a block comment opened in that comment's text is unclosed, so a line
+     * carrying one always starts inside that block.
+     */
+    lineComment: OpenLineComment | null;
+}
+
+/**
+ * A `#` or `<#>` whose comment text a block comment opened inside it has
+ * interrupted.
+ *
+ * Both are lexed as `Text<EPlace::LineCmt>`, where `Text`'s `<` arm dispatches
+ * `BlockCmt()` and resumes after it returns (VerseGrammar.h:2116-2126), so the
+ * comment runs on below the line that opened it and ends at the `Ending` of
+ * whatever line closes the block.
+ */
+export interface OpenLineComment {
+    /** Block-comment depth the comment's text resumes at - the depth its opener sat at. */
+    depth: number;
+    /**
+     * Whether ending the comment opens a `<#>` marker body. `IndCmt` reaches
+     * `Ind()` only once the marker's tail returns (VerseGrammar.h:2040-2048), so
+     * a `<#` written in that tail defers the body rather than cancelling it.
+     */
+    opensMarker: boolean;
 }
 
 /** One literal or interpolation open at a point in a line. */
@@ -126,7 +163,15 @@ export interface LexedLine {
      * end and swallows what follows.
      */
     insideIndentedComment: boolean;
-    /** Whether the line holds a `<#>` marker, opening a body over the lines indented past it. */
+    /**
+     * Whether a `<#>` marker's body begins below this line, over the lines
+     * indented past this one.
+     *
+     * Not always the line the `<#>` sits on. A `<#` in the marker's tail defers
+     * the body until that block closes, and `Ind()` then takes the body's
+     * indentation from the line it runs on (VerseGrammar.h:1635-1644), which is
+     * the line the `#>` closed on.
+     */
     opensIndentedComment: boolean;
     /** Whether the line carries any text outside a comment. */
     hasCode: boolean;
@@ -153,6 +198,12 @@ export interface LexedLine {
      * an empty stack under a true `endedOpen` is the unterminated literal.
      */
     openFrames: LexFrame[];
+    /**
+     * The line comment the next line starts inside, or null. Seed
+     * {@link LexState.lineComment} from this, or the lines a comment reaches
+     * through a block opened in it read as code.
+     */
+    lineComment: OpenLineComment | null;
     /**
      * Index into the line of the first comment opener on it, or -1 when it
      * holds none. 0 when the line opens already inside a comment, whose opener
@@ -244,8 +295,16 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     // the two agree on any consistently indented file, and a line that mixes
     // tabs and spaces inside one body is error S89 rather than a case the
     // language admits.
+    //
+    // Only where the line begins at code scope. Inside a block comment the
+    // body's dedent bookkeeping does not run at all: a body measures its lines
+    // through `Scan := Space {Line}` (:1757-1772), reached only from
+    // `Text<EPlace::IndCmt>`'s newline case (:2088-2094), where
+    // `Text<EPlace::BlockCmt>` takes a newline with `NewLine` instead
+    // (:2096-2100). So a dedented line inside the block ends nothing, and
+    // clearing on it strands the body's remaining text as code.
     let markerIndent = state.markerIndent;
-    if (markerIndent !== null && !blank && indent <= markerIndent) {
+    if (markerIndent !== null && depthBefore === 0 && !blank && indent <= markerIndent) {
         markerIndent = null;
     }
     // A block comment opened above outranks a marker body: the body's text is
@@ -257,11 +316,10 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     let codeWithoutComments = "";
     let codeOutsideLiterals = "";
     let masked = "";
-    let opensIndentedComment = false;
-    // Whether a `#` opened a line comment earlier on this line. Per-line, since
-    // a line comment ends with its line - but what it opened need not, so this
-    // says only that the text left is trivia, never that it holds no opener.
-    let insideLineComment = false;
+    // The line comment open at this point: carried in from above, or opened by a
+    // `#` or `<#>` on this line. It says only that the text left is trivia,
+    // never that it holds no opener.
+    let lineComment = state.lineComment;
     // Already inside one when the line begins, so the opener is above it and
     // every character from the first is trivia.
     let commentStart = depthBefore > 0 || insideIndentedComment ? 0 : -1;
@@ -298,13 +356,21 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         }
     };
 
+    // Both of these resume the moment a block comment opened inside them closes,
+    // rather than surrendering the rest of the line to it: `Text` continues
+    // where it left off after `BlockCmt()` returns (:2116-2126), at line-comment
+    // place and marker-body place alike. So each is asked of the depth here, not
+    // of the depth the line began at.
+    const inLineComment = (): boolean => lineComment !== null && nesting === lineComment.depth;
+    const inMarkerBody = (): boolean => markerIndent !== null && nesting === 0;
+
     while (i < line.length) {
         // Comment text, whether from a block comment opened above, from the body
-        // of a `<#>`, or from a `#` earlier on this line. Scanned rather than
+        // of a `<#>`, or from a `#` or `<#>` still open here. Scanned rather than
         // skipped so a `<#` inside it still opens a block that outlives the
         // region, which is what the compiler does at every place
         // (VerseGrammar.h:2115-2137).
-        if (nesting > 0 || insideIndentedComment || insideLineComment) {
+        if (nesting > 0 || inMarkerBody() || inLineComment()) {
             if (line.startsWith("<#>", i)) {
                 // Already comment text, so this opens nothing. Tested before
                 // `<#` or its first two characters read as a block opener that
@@ -348,15 +414,19 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
                 continue;
             }
 
-            // The rest of the marker's own line is comment text, and holds no
-            // opener of its own: at `EPlace::IndCmt` a `<#>` nests another
-            // indented comment rather than a block.
-            opensIndentedComment = true;
+            // The rest of the marker's own line is comment text, but not text
+            // that holds nothing: `IndCmt` lexes that tail with
+            // `Text<EPlace::LineCmt>` (:2040-2047), the same place a `#` opens,
+            // so a `<#` there opens a block exactly as one in a line comment
+            // does. Lexed on below rather than swallowed here, and the body
+            // deferred until the tail ends, or the block's lines read as code.
+            lineComment = { depth: nesting, opensMarker: true };
             opensComment();
-            for (; i < line.length; i++) {
-                commentChar();
-            }
-            break;
+            commentChar();
+            commentChar();
+            commentChar();
+            i += 3;
+            continue;
         }
 
         // Inside an interpolation this is code scope again, so a `#` there ends
@@ -371,7 +441,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         // open a comment on one at all, and outside a block comment it is error
         // S05, so there is no depth for it to close.
         if (line[i] === "#" && innermost?.kind !== "literal") {
-            insideLineComment = true;
+            lineComment = { depth: nesting, opensMarker: false };
             opensComment();
             commentChar();
             i += 1;
@@ -460,6 +530,18 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         i += 1;
     }
 
+    // A line comment ends with its line - `LineCmt := '#' !'>' {Text} Ending`
+    // (:2016), and `Text` stops dead at a newline at that place (:2088-2105) -
+    // unless a block opened in its text is still open, which is the one thing
+    // that carries it below. It then ends at the `Ending` of the line the `#>`
+    // sits on, so the tail of that line is still the comment's.
+    const heldOpen = lineComment !== null && nesting > lineComment.depth;
+    // `IndCmt` reaches `Ind()` only once its tail returns (:2044-2048), and
+    // `Ind()` takes the body's indentation from the line it runs on
+    // (`Context.BlockInd = Cursor.LineStart`, :1637). With no block in the tail
+    // that is the marker's own line; with one it is the line that closed it.
+    const opensIndentedComment = lineComment !== null && lineComment.opensMarker && !heldOpen;
+
     return {
         depthBefore,
         depth: nesting,
@@ -469,6 +551,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         hasCode,
         endedOpen: open.length > 0,
         openFrames: open[open.length - 1]?.kind === "interpolation" ? open : [],
+        lineComment: heldOpen ? lineComment : null,
         commentStart,
         codeWithoutComments,
         codeOutsideLiterals,

--- a/src/utils/verseLexer.ts
+++ b/src/utils/verseLexer.ts
@@ -102,7 +102,8 @@ export interface LexState {
     /**
      * The line comment still open where the line starts, or null. Non-null only
      * while a block comment opened in that comment's text is unclosed, so a line
-     * carrying one always starts inside that block.
+     * carrying one always starts inside that block, and its text resumes exactly
+     * where the depth returns to 0.
      */
     lineComment: OpenLineComment | null;
 }
@@ -117,8 +118,6 @@ export interface LexState {
  * whatever line closes the block.
  */
 export interface OpenLineComment {
-    /** Block-comment depth the comment's text resumes at - the depth its opener sat at. */
-    depth: number;
     /**
      * Whether ending the comment opens a `<#>` marker body. `IndCmt` reaches
      * `Ind()` only once the marker's tail returns (VerseGrammar.h:2040-2048), so
@@ -361,7 +360,13 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     // where it left off after `BlockCmt()` returns (:2116-2126), at line-comment
     // place and marker-body place alike. So each is asked of the depth here, not
     // of the depth the line began at.
-    const inLineComment = (): boolean => lineComment !== null && nesting === lineComment.depth;
+    //
+    // Depth 0 is the whole of it because only code scope opens either: both
+    // openers sit past the branch below, which claims every character at a depth
+    // above 0. A `#` inside a block comment does open a line comment in the
+    // grammar, but its text and the block's are both trivia, so nothing here can
+    // tell the two apart and nothing needs to.
+    const inLineComment = (): boolean => lineComment !== null && nesting === 0;
     const inMarkerBody = (): boolean => markerIndent !== null && nesting === 0;
 
     while (i < line.length) {
@@ -420,7 +425,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
             // so a `<#` there opens a block exactly as one in a line comment
             // does. Lexed on below rather than swallowed here, and the body
             // deferred until the tail ends, or the block's lines read as code.
-            lineComment = { depth: nesting, opensMarker: true };
+            lineComment = { opensMarker: true };
             opensComment();
             commentChar();
             commentChar();
@@ -441,7 +446,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
         // open a comment on one at all, and outside a block comment it is error
         // S05, so there is no depth for it to close.
         if (line[i] === "#" && innermost?.kind !== "literal") {
-            lineComment = { depth: nesting, opensMarker: false };
+            lineComment = { opensMarker: false };
             opensComment();
             commentChar();
             i += 1;
@@ -535,7 +540,7 @@ export function lexVerseLine(line: string, state: LexState, trackLiterals: boole
     // unless a block opened in its text is still open, which is the one thing
     // that carries it below. It then ends at the `Ending` of the line the `#>`
     // sits on, so the tail of that line is still the comment's.
-    const heldOpen = lineComment !== null && nesting > lineComment.depth;
+    const heldOpen = lineComment !== null && nesting > 0;
     // `IndCmt` reaches `Ind()` only once its tail returns (:2044-2048), and
     // `Ind()` takes the body's indentation from the line it runs on
     // (`Context.BlockInd = Cursor.LineStart`, :1637). With no block in the tail

--- a/src/utils/verseText.ts
+++ b/src/utils/verseText.ts
@@ -36,7 +36,7 @@ export { indentOf };
  * `}`, `"` and `\` inside one.
  */
 export function maskCommentsAndStrings(content: string): string {
-    const state: LexState = { depth: 0, markerIndent: null, openFrames: [] };
+    const state: LexState = { depth: 0, markerIndent: null, openFrames: [], lineComment: null };
     // Split on "\n" alone so a CRLF line keeps its "\r" and the masked line is
     // exactly as long as the line it replaces; joining then rebuilds the file
     // byte for byte.
@@ -47,6 +47,7 @@ export function maskCommentsAndStrings(content: string): string {
             state.depth = lexed.depth;
             state.markerIndent = lexed.markerIndent;
             state.openFrames = lexed.openFrames;
+            state.lineComment = lexed.lineComment;
             return lexed.masked;
         })
         .join("\n");


### PR DESCRIPTION
Closes #419

Two sibling paths reach `EPlace::LineCmt` and were not covered by #418, so the extension read text the compiler comments out as live code.

## What was wrong

**A `<#>` marker's own tail.** `IndCmt` lexes it with `Text<EPlace::LineCmt>` and reaches `Ending()`/`Ind()` only once that returns (`VerseGrammar.h:2040-2048`), so a `<#` there opens a real block. The tail was swallowed whole, so the block never opened and its lines read as imports.

**A line comment after its block closes.** `Text` resumes where `BlockCmt()` returned (`:2116-2126`), so the comment runs to the `Ending` of the line the `#>` sits on (`:2014-2024`; `Ending()` at `:1616-1620` is lookahead only). `insideLineComment` was per-line, so that tail read as code.

**A marker body, in both directions.** The same resume applies at `EPlace::IndCmt`. And a body measures its lines through `Scan := Space {Line}` (`:1757-1772`), reached only from `Text<EPlace::IndCmt>`'s newline case — `Text<EPlace::BlockCmt>` takes a newline with `NewLine(); continue;` (`:2096-2100`) — so a dedented line *inside* a block comment ended a body the compiler had not left.

Reproduced against `origin/main` through both readers, with the `#` spelling as a control:

| Fixture | Before | After |
| --- | --- | --- |
| `<#> note <# opener` / `using { /Dead }` / `#>` | `/Dead` live | comment |
| `# open <# here` / `using { /Dead }` / `#> using { /AlsoDead }` | `/AlsoDead` live | comment |
| `<#> marker` / `    body <# opener` / `using { /Dead }` / `    #>` / `    still body` | `still body` live | marker body |

## What changed

`LexState` and `LexedLine` gain `lineComment: OpenLineComment | null` — the block depth the comment's text resumes at, and whether ending it opens a marker body. It is non-null only while a block opened in that text is unclosed.

- The `<#>` arm sets it instead of swallowing the tail, so the existing trivia branch lexes the tail and the body is deferred.
- Line-comment and marker-body text are asked of the depth *here*, not the depth the line began at, so both resume mid-line when their block closes.
- The `markerIndent` dedent check is gated on `depthBefore === 0`.
- A marker's body opens on the line where its tail ends, taking its indentation from that line — which for a tail that opened a block is the line the `#>` closed on, per `Ind()`'s `Context.BlockInd = Cursor.LineStart` (`:1635-1644`).

`opensIndentedComment` therefore means "a body begins below this line", which is not always the line holding the `<#>`. Its one consumer, `anchorsCommentBelow`, keeps its answer unchanged: a deferred body leaves an unclosed depth, which its existing `state.depth > 0` fallback already reports.

Every site that carries `LexState` across lines carries the new field: `classifyLines`, `anchorsCommentBelow`, `maskCommentsAndStrings`. `ImportFormatter.commentStartIndex` is single-line and passes `null`.

`ImportSuggestionExtractor` is untouched and no pattern anywhere in `src/imports/` was added, moved or broadened.

## Tests

Regression tests are pinned at the entry points the issue names, and each was run against the pre-fix build to prove it detects the defect:

- `verseLexerCorpus.test.ts` — three probes, each asserted twice by the existing harness (the readers agree; what they agree on is the language's answer). Pre-fix each leaves dead sentinels standing: `["D4","L1"]`, `["D3","D4","L1"]`, `["D4","D5","L1"]` against `["L1"]`.
- `ImportScanner.test.ts` — `scanModuleImports` on the ticket's case-1 fixture (pre-fix `["/Old/Path","/Verse.org/Simulation"]`), `allUsingPaths` on case 2 (pre-fix `["/Dead","/A"]`), and three `classifyLines` kind rows, each of which changes shape pre-fix.
- `verseLexer.test.ts` — `commentStart`, `depth`, `opensIndentedComment` and `markerIndent` directly on a marker whose tail opens a block.

Case 2 is pinned on `allUsingPaths` and `classifyLines` rather than `scanModuleImports`: that entry point never reads a line beginning inside a block comment, so the fixture passes against the unfixed code there and would have tested nothing.

## Verification

```
$ npm run compile
> verse-auto-imports@0.11.2 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 50 passed, 50 total
Tests:       1534 passed, 1534 total
Snapshots:   0 total
Time:        10.779 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!

$ npx jest src/imports/__tests__
Test Suites: 10 passed, 10 total
Tests:       871 passed, 871 total
Snapshots:   0 total
Time:        6.49 s, estimated 9 s
Ran all test suites matching src/imports/__tests__.
```

`ImportDocumentEditor.test.ts` carries 76 `<#>` fixtures and is the loudest place a marker-body rule change would ring; it is green.

## Review

One round, verdict `PASS_WITH_SUGGESTIONS` — no `Critical`, no `Important`. The reviewer re-derived every `VerseGrammar.h` citation from the source rather than taking it on trust, and probed 21 shapes including nesting, CRLF, tabs, unterminated literals, an interpolation spanning lines, `<#>` inside a line comment, an unclosed tail block at EOF, and whether `lexVerseLine` can mutate a carried `LexState` (it cannot — proxied write traps saw zero writes across a seven-line carry).

Three suggestions are applied in the second commit, all behaviour-neutral:

- `OpenLineComment.depth` could only ever hold `0`, since both openers sit past the branch that claims every character at a depth above 0. Dropped; the rule it stated moved to the predicate that reads it.
- `classifyLines` now records why it carries `lineComment` out of the literal-tracking-off re-lex where it deliberately does not carry `openFrames`.
- The changelog lead matches #374, the sibling fix this continues.

To show the simplification changed nothing, 28 sources — the ticket's fixtures, everything the reviewer probed, and the existing corpus shapes — were run through `classifyLines`, `scanModuleImports`, `allUsingPaths`, `scanModuleAliases` and `maskCommentsAndStrings` against builds either side of it: byte-identical.

Two suggestions are **not** applied, and are recorded here rather than silently dropped:

- *Shotgun Surgery*: one new `LexState` field forced identical edits at four construction sites, and a `freshLexState()` helper would make the next field a one-file change. Real, but it is a refactor of the state plumbing rather than part of this fix.
- The reviewer read a reader-agreement regression into `Msg := "a D1 # D2 <# D3"` / … / `#> L1 := 1`. Checked directly: the two readers already disagree there on `origin/main` (`["L1","L2"]` vs `["D1","L1","L2"]`), so nothing regressed — the input is an unterminated literal, which `verseLexerCorpus.test.ts` documents as the one case the readers are allowed to differ on, and the branch moves the scanner towards the compiler rather than away.
