### PR TITLE
fix(imports): keep a floor-driven insert out of a body and an unclosed comment

### DIFF
--- a/changelog.d/389.fixed.md
+++ b/changelog.d/389.fixed.md
@@ -1,0 +1,1 @@
+**Import placement**: A newly added relative import no longer lands inside an indented module body or inside an unclosed block comment, where it broke the construct or was silently duplicated on every later compile.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -3,7 +3,18 @@ import { logger, settingsFor } from "../utils";
 import { DiagnosticLinesByPath, DiagnosticLinesByStatement } from "../types";
 import { ImportFormatter } from "./ImportFormatter";
 import { QueuedEdit, verifyImportEdits, verifyOrganizedRewrite } from "./ImportRewriteGuard";
-import { allUsingPaths, classifyLines, indentedPairPathLine, LINE_SPLIT, LineClassification, pinnedImports, rewritableImports, scanModuleImports, ScannedImport } from "./ImportScanner";
+import {
+    allUsingPaths,
+    classifyLines,
+    indentedBodyLine,
+    indentedPairPathLine,
+    LINE_SPLIT,
+    LineClassification,
+    pinnedImports,
+    rewritableImports,
+    scanModuleImports,
+    ScannedImport,
+} from "./ImportScanner";
 
 /**
  * A run of import statements on consecutive lines. Any gap starts a new block,
@@ -158,14 +169,22 @@ function attachedCommentStart(importStartLine: number, classifications: LineClas
  * path line free, and a new import written there leaves the `using:` with no
  * body.
  *
- * The two rules alternate rather than run in turn, because either can extend a
- * span the other then extends again: a pair's path line may itself open a
- * comment over the lines below it.
+ * An indented body reaches past it for the third time, and is the general case
+ * of the pair: a pinned line sharing itself with any block opener - `M :=
+ * module:`, a clause continued below - owns the lines indented under it, and a
+ * new import written at column 0 there ends the block before its body. See
+ * indentedBodyLine.
+ *
+ * The rules alternate rather than run in turn, because any can extend a span
+ * another then extends again: a pair's path line may itself open a comment over
+ * the lines below it, and a body can hold a nested pair.
  *
  * The pair rule goes first, and that order is load-bearing. Each hop re-anchors
  * on the new end, and only the opener line carries the `using:` - so where the
  * opener also opens a comment, letting the comment rule run first steps the
- * anchor past the opener and the pair is never found at all.
+ * anchor past the opener and the pair is never found at all. The body rule goes
+ * last for no such reason: it reads the first line of code below the anchor,
+ * which the other two hops reach by their own routes and never step past.
  */
 function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]): number {
     let end = imp.endLine;
@@ -177,6 +196,11 @@ function pinnedSpanEnd(imp: ScannedImport, classifications: LineClassification[]
         }
         if (end + 1 < classifications.length && classifications[end + 1].continuesCommentAbove) {
             end++;
+            continue;
+        }
+        const bodyLine = indentedBodyLine(classifications, end);
+        if (bodyLine > end) {
+            end = bodyLine;
             continue;
         }
         return end;
@@ -522,6 +546,23 @@ export class ImportDocumentEditor {
             if (needsScopeAbove) {
                 floor = Math.max(floor, pinnedSpanEnd(imp, classifications));
             }
+        }
+
+        // A floor names the line a new import is written below, so a floor with
+        // no writable line below it bounds nothing. That is the buffer ending
+        // inside an unclosed `<#`: every line the comment covers is already in
+        // the span, and appending past the last one writes into the comment -
+        // where the scan, which skips a line opened inside a block comment,
+        // then reads the path as absent and adds it again on the next compile.
+        //
+        // Dropped rather than refused. The path falls back to the block at the
+        // top, which is where an absolute path in the same file already goes,
+        // and a file holding an unclosed opener does not compile either way.
+        // Declining to write it at all is the worse of the two: see the
+        // grounded extras in buildOrganizedContent for why an added path that
+        // silently lands nowhere is not an option.
+        if (floor !== -1 && floor === classifications.length - 1 && classifications[floor].endsInsideBlockComment) {
+            floor = -1;
         }
 
         return { floor, ceiling };
@@ -1011,9 +1052,11 @@ export class ImportDocumentEditor {
                         // placementLine returns one of two things, and a pinned
                         // import's span holds no block line either way: its own
                         // line breaks the contiguity a block is built from, and
-                        // wherever the span runs past that line the rest of it
-                        // is comment body, so no column-0 import the scanner
-                        // would collect can be in it.
+                        // past that line the span is comment body or the lines
+                        // indented under it, neither of which holds a column-0
+                        // import the scanner would collect - an indented body
+                        // ends at the first column-0 line of code, which is the
+                        // earliest a block could start.
                         //
                         // - A ceiling, which is a pinned import's own line.
                         // - floor + 1, reached only when every block was

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -543,26 +543,35 @@ export class ImportDocumentEditor {
                 ceiling = ceiling === -1 ? imp.startLine : Math.min(ceiling, imp.startLine);
                 continue;
             }
-            if (needsScopeAbove) {
-                floor = Math.max(floor, pinnedSpanEnd(imp, classifications));
+            if (!needsScopeAbove) {
+                continue;
             }
-        }
-
-        // A floor names the line a new import is written below, so a floor with
-        // no writable line below it bounds nothing. That is the buffer ending
-        // inside an unclosed `<#`: every line the comment covers is already in
-        // the span, and appending past the last one writes into the comment -
-        // where the scan, which skips a line opened inside a block comment,
-        // then reads the path as absent and adds it again on the next compile.
-        //
-        // Dropped rather than refused. The path falls back to the block at the
-        // top, which is where an absolute path in the same file already goes,
-        // and a file holding an unclosed opener does not compile either way.
-        // Declining to write it at all is the worse of the two: see the
-        // grounded extras in buildOrganizedContent for why an added path that
-        // silently lands nowhere is not an option.
-        if (floor !== -1 && floor === classifications.length - 1 && classifications[floor].endsInsideBlockComment) {
-            floor = -1;
+            // A floor names the line a new import is written below, so a span
+            // with no writable line below it bounds nothing. That is the buffer
+            // ending inside an unclosed `<#`: every line the comment covers is
+            // already in the span, and appending past the last one writes into
+            // the comment - where the scan, which skips a line opened inside a
+            // block comment, reads the path as absent and adds it again on the
+            // next compile.
+            //
+            // Skipped here rather than dropped from the result, because the
+            // floor is the maximum over every pinned import and only this one
+            // is unwritable. Zeroing the maximum would discard the floors
+            // raised by the pinned imports above it, and carry the new path
+            // over one that could be bringing its first segment into scope.
+            //
+            // Skipped rather than refused, too. Where it was the only floor the
+            // path falls back to the block at the top, which is where an
+            // absolute path in the same file already goes, and a file holding
+            // an unclosed opener does not compile either way. Declining to
+            // write it at all is the worse of the two: see the grounded extras
+            // in buildOrganizedContent for why an added path that silently
+            // lands nowhere is not an option.
+            const spanEnd = pinnedSpanEnd(imp, classifications);
+            if (spanEnd === classifications.length - 1 && classifications[spanEnd].endsInsideBlockComment) {
+                continue;
+            }
+            floor = Math.max(floor, spanEnd);
         }
 
         return { floor, ceiling };

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -196,6 +196,26 @@ function firstCodeLineBelow(classifications: LineClassification[], from: number)
 }
 
 /**
+ * The first line below `from` holding anything at all, or `-1` where there is
+ * none.
+ *
+ * Blank lines alone are passed over, for the half of firstCodeLineBelow's
+ * reason that survives when the answer may be a comment: a blank line ends
+ * nothing, so what follows a run of them is still inside whatever was open
+ * above it. A line inside a block comment is never blank - classifyLines reads
+ * one as comment - so this stops on the comment body rather than running past
+ * it.
+ */
+function firstContentLineBelow(classifications: LineClassification[], from: number): number {
+    for (let line = from + 1; line < classifications.length; line++) {
+        if (classifications[line].kind !== "blank") {
+            return line;
+        }
+    }
+    return -1;
+}
+
+/**
  * The line holding the path that the `using:` ending line `opener` opens, or
  * `-1` where that line opens no pair.
  *
@@ -264,6 +284,12 @@ export function indentedPairPathLine(classifications: LineClassification[], open
  * file scope. Writing below it instead keeps the comment inside the body it was
  * written in, which is where it reads correctly anyway.
  *
+ * Reached past blank lines for the same reason the code line is: a blank line
+ * ends no block, so a comment written below one is as far inside the body as a
+ * comment written directly under the last statement. A line at column 0 is what
+ * says the body is over, and that line answers `-1` whether it is code or a
+ * comment - a column-0 comment is prose about what follows, not the body's own.
+ *
  * Answers one line rather than the whole span, so a caller re-anchors and asks
  * again: a body can hold a nested opener, and each answer is the next question.
  */
@@ -282,9 +308,9 @@ export function indentedBodyLine(classifications: LineClassification[], opener: 
         return codeLine;
     }
 
-    const next = classifications[opener + 1];
-    if (next !== undefined && next.kind === "comment" && /^\s/.test(next.codeWithoutComments)) {
-        return opener + 1;
+    const contentLine = firstContentLineBelow(classifications, opener);
+    if (contentLine !== -1 && classifications[contentLine].kind === "comment" && /^\s/.test(classifications[contentLine].codeWithoutComments)) {
+        return contentLine;
     }
 
     return -1;

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -202,9 +202,11 @@ function firstCodeLineBelow(classifications: LineClassification[], from: number)
  * Blank lines alone are passed over, for the half of firstCodeLineBelow's
  * reason that survives when the answer may be a comment: a blank line ends
  * nothing, so what follows a run of them is still inside whatever was open
- * above it. A line inside a block comment is never blank - classifyLines reads
- * one as comment - so this stops on the comment body rather than running past
- * it.
+ * above it. A line inside a `<#` block comment is never blank - classifyLines
+ * reads one as comment - so this stops on the body of one rather than running
+ * past it. A blank line inside a `<#>` marker's body is blank, and is passed
+ * over like any other; the line it stops on is then further into the same
+ * comment, which is the same answer one line down.
  */
 function firstContentLineBelow(classifications: LineClassification[], from: number): number {
     for (let line = from + 1; line < classifications.length; line++) {
@@ -286,9 +288,12 @@ export function indentedPairPathLine(classifications: LineClassification[], open
  *
  * Reached past blank lines for the same reason the code line is: a blank line
  * ends no block, so a comment written below one is as far inside the body as a
- * comment written directly under the last statement. A line at column 0 is what
- * says the body is over, and that line answers `-1` whether it is code or a
- * comment - a column-0 comment is prose about what follows, not the body's own.
+ * comment written directly under the last statement. A comment at column 0
+ * answers `-1` all the same, and that is this rule declining to claim it rather
+ * than anything about where the block ends - a comment ends no block at any
+ * indentation, but one written back at column 0 reads as prose about what
+ * follows rather than as the body's own, and nothing is lost by writing above
+ * it.
  *
  * Answers one line rather than the whole span, so a caller re-anchors and asks
  * again: a body can hold a nested opener, and each answer is the next question.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -105,6 +105,16 @@ export interface LineClassification {
      */
     insideBlockComment: boolean;
     /**
+     * Whether a `<# ... #>` block comment is still open once this line ends.
+     *
+     * The dual of `insideBlockComment`, and equal to the next line's copy of it
+     * wherever there is a next line. The last line is the one that reaches for:
+     * a caller asking whether it may write below a line has no classification to
+     * read past the end of the buffer, and an opener written on the final line
+     * leaves everything appended after it inside the comment.
+     */
+    endsInsideBlockComment: boolean;
+    /**
      * Whether the comment this line belongs to was opened on an earlier line,
      * as a block-comment body or the indented body of a `<#>` marker. A caller
      * moving a run of comment lines has to know this: a run whose opener stays
@@ -156,6 +166,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
         classifications[i] = {
             kind,
             insideBlockComment,
+            endsInsideBlockComment: scan.depth > 0,
             continuesCommentAbove: insideBlockComment || scan.insideIndentedComment,
             codeWithoutComments: scan.codeWithoutComments,
             codeOutsideLiterals: scan.codeOutsideLiterals,
@@ -224,6 +235,56 @@ export function indentedPairPathLine(classifications: LineClassification[], open
         // directions: were that statement really at column 0, the opener
         // opened nothing and the file did not compile to begin with.
         return /^\s/.test(classifications[pathLine].codeWithoutComments) ? pathLine : -1;
+    }
+
+    return -1;
+}
+
+/**
+ * The next line below `opener` that a construct opened on it owns, or `-1`
+ * where it owns nothing further.
+ *
+ * A column-0 statement whose next line of code is indented opened whatever that
+ * indentation belongs to - a `module:` body, a braced clause continued below,
+ * an `if:` block - and a caller writing at column 0 between the two ends the
+ * block before its body, stranding the body as an expression at an indentation
+ * nothing opened. So the line belongs to the statement above it, and a caller
+ * placing a new statement has to clear it.
+ *
+ * The first line of code below the opener rather than the line directly below
+ * it, for the reason indentedPairPathLine gives: neither a blank line nor a
+ * comment ends an indented block, so the body can begin several lines down.
+ * Only code ends it, and code at column 0 ends it without ever having been the
+ * body - so there the opener owns nothing and this answers `-1`.
+ *
+ * A comment indented past column 0 is owned as well, once no further code is.
+ * The compiler consumes a line indented past the enclosing block into that
+ * block whether it holds code or only a comment, so a column-0 statement
+ * written directly above one leaves that comment opening an indented block at
+ * file scope. Writing below it instead keeps the comment inside the body it was
+ * written in, which is where it reads correctly anyway.
+ *
+ * Answers one line rather than the whole span, so a caller re-anchors and asks
+ * again: a body can hold a nested opener, and each answer is the next question.
+ */
+export function indentedBodyLine(classifications: LineClassification[], opener: number): number {
+    if (classifications[opener] === undefined) {
+        return -1;
+    }
+
+    // Indentation read from the code for the reason indentedPairPathLine reads
+    // it there, and with the same caveat about a line closing a block comment
+    // ahead of its statement. A comment-only line keeps its leading whitespace
+    // and nothing else, so the same test tells an indented comment from one at
+    // column 0.
+    const codeLine = firstCodeLineBelow(classifications, opener);
+    if (codeLine !== -1 && /^\s/.test(classifications[codeLine].codeWithoutComments)) {
+        return codeLine;
+    }
+
+    const next = classifications[opener + 1];
+    if (next !== undefined && next.kind === "comment" && /^\s/.test(next.codeWithoutComments)) {
+        return opener + 1;
     }
 
     return -1;

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1236,6 +1236,33 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(operations[0].position!.line).toBe(0);
     });
 
+    it("adds it below a comment trailing the body a blank line separates from it", async () => {
+        const input = ["using { /A }; M := module:", "    Body<public>():int = 1", "", "    # what the module is for", "code()"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Gadgets.Tools }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("insert");
+        expect(operations[0].position!.line).toBe(4);
+    });
+
+    it("keeps the floor a pinned import above an unclosed opener raises", async () => {
+        const input = ["using { Features }; X := 1", "code()", "using { /B } <# note"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features.Shop }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("insert");
+        // Below the provider that could be bringing `Features` into scope, not
+        // at the top of the file: the unwritable span above the comment is
+        // skipped on its own, and takes no other pinned import's floor with it.
+        expect(operations[0].position!.line).toBe(1);
+    });
+
     function mockConfig(overrides: Record<string, unknown>): void {
         (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
             get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -267,6 +267,47 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         );
     });
 
+    // The floor is the line a new import is written below, and a pinned line
+    // that also opens a block owns the lines indented under it. Writing at
+    // column 0 on the first of them ended the block before its body and left
+    // that body indented under nothing.
+    it("writes a new relative import below the body a pinned line opens, not into it", () => {
+        const input = ["using { /A }; M := module:", "    Body<public>():int = 1", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(["using { /A }; M := module:", "    Body<public>():int = 1", "using { Gadgets.Tools }", "code()"].join("\n"));
+    });
+
+    // The body's own trailing comment is part of it. A column-0 statement above
+    // an indented comment leaves that comment opening an indented block at file
+    // scope, which is not a shape the compiler is asked to accept anywhere.
+    it("writes it below a comment trailing that body rather than between the two", () => {
+        const input = ["using { /A }; M := module:", "    Body<public>():int = 1", "    # what the module is for", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(
+            ["using { /A }; M := module:", "    Body<public>():int = 1", "    # what the module is for", "using { Gadgets.Tools }", "code()"].join("\n"),
+        );
+    });
+
+    // Each hop re-anchors, so a pair inside the body is found from the body
+    // line the first hop reached rather than from the pinned line itself.
+    it("writes it below a body holding a pair of its own", () => {
+        const input = ["using { /A }; M := module:", "    using:", "        Features", "    Body<public>():int = 1", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(
+            ["using { /A }; M := module:", "    using:", "        Features", "    Body<public>():int = 1", "using { Gadgets.Tools }", "code()"].join("\n"),
+        );
+    });
+
+    // A relative path was floored to the last line and written after it, inside
+    // the comment - where the scan skips it, so the next compile added it
+    // again. The absolute case above it never reached this: it raises no floor.
+    it("does not write a newly added relative import into an unclosed opener that ends the buffer", () => {
+        const input = ["code()", "using { /A } <#"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlySorted)).toBe(["using { Gadgets.Tools }", "", "code()", "using { /A } <#"].join("\n"));
+    });
+
+    it("does not write it into the comment body an unclosed opener runs over", () => {
+        const input = ["code()", "using { /A } <# note", "more note"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlySorted)).toBe(["using { Gadgets.Tools }", "", "code()", "using { /A } <# note", "more note"].join("\n"));
+    });
+
     // A line writing two complete statements read as its first path alone, so
     // organizing rebuilt it as `using { /X }` and Economy.Shop was simply gone.
     // The output was a well-formed import block, which is what made the loss
@@ -1136,6 +1177,35 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(operations).toHaveLength(1);
         expect(operations[0].kind).toBe("insert");
         expect(operations[0].text).toBe("using { /B }\n\n");
+        expect(operations[0].position!.line).toBe(0);
+    });
+
+    // The same two shapes through the auto-import path, which reaches the floor
+    // by a different route: placementLine rather than the grounded-extras
+    // splice buildOrganizedContent uses.
+    it("does not add a relative import into the body a pinned line opens", async () => {
+        const input = ["using { /A }; M := module:", "    Body<public>():int = 1", "code()"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Gadgets.Tools }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("insert");
+        expect(operations[0].text).toBe("using { Gadgets.Tools }\n\n");
+        expect(operations[0].position!.line).toBe(2);
+    });
+
+    it("does not add a relative import under an unclosed opener that ends the buffer", async () => {
+        const input = ["hello := 1", "using { /A } <#"].join("\n");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Gadgets.Tools }"]);
+
+        expect(success).toBe(true);
+        const operations = appliedOperations(0);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("insert");
+        expect(operations[0].text).toBe("using { Gadgets.Tools }\n\n");
         expect(operations[0].position!.line).toBe(0);
     });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -303,9 +303,36 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlySorted)).toBe(["using { Gadgets.Tools }", "", "code()", "using { /A } <#"].join("\n"));
     });
 
+    // A blank line ends no block, so a comment written below one is as far
+    // inside the body as one written directly under the last statement.
+    it("writes it below a body's trailing comment even where a blank line separates the two", () => {
+        const input = ["using { /A }; M := module:", "    Body<public>():int = 1", "", "    # what the module is for", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(
+            ["using { /A }; M := module:", "    Body<public>():int = 1", "", "    # what the module is for", "using { Gadgets.Tools }", "code()"].join("\n"),
+        );
+    });
+
+    // A comment at column 0 is prose about what follows rather than the body's
+    // own, so the span stops above it and the import is written there.
+    it("stops the span at a column-0 comment below the body", () => {
+        const input = ["using { /A }; M := module:", "    Body<public>():int = 1", "# what the code below does", "code()"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlyNoSort)).toBe(
+            ["using { /A }; M := module:", "    Body<public>():int = 1", "using { Gadgets.Tools }", "# what the code below does", "code()"].join("\n"),
+        );
+    });
+
     it("does not write it into the comment body an unclosed opener runs over", () => {
         const input = ["code()", "using { /A } <# note", "more note"].join("\n");
         expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlySorted)).toBe(["using { Gadgets.Tools }", "", "code()", "using { /A } <# note", "more note"].join("\n"));
+    });
+
+    // The floor is the last line owned by the *lowest* pinned import, so an
+    // unwritable one has to be passed over rather than take the whole floor
+    // with it: dropping the maximum would carry the path above the provider
+    // pinned higher up, which is the order the floor exists to keep.
+    it("keeps the floor a pinned import above an unclosed opener raises", () => {
+        const input = ["using { Features }; X := 1", "code()", "using { /B } <# note"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Features.Shop"], curlySorted)).toBe(["using { Features }; X := 1", "using { Features.Shop }", "code()", "using { /B } <# note"].join("\n"));
     });
 
     // A line writing two complete statements read as its first path alone, so

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1,4 +1,4 @@
-import { allUsingPaths, classifyLines, indentedPairPathLine, rewritableImports, scanConvertibleImports, scanModuleAliases, scanModuleImports } from "../ImportScanner";
+import { allUsingPaths, classifyLines, indentedBodyLine, indentedPairPathLine, rewritableImports, scanConvertibleImports, scanModuleAliases, scanModuleImports } from "../ImportScanner";
 
 describe("allUsingPaths", () => {
     it("collects a file-scope import the same way scanModuleImports does", () => {
@@ -1422,5 +1422,49 @@ describe("indentedPairPathLine", () => {
 
     it("declines an opener followed only by blank lines", () => {
         expect(pathLine(["using:", "", ""])).toBe(-1);
+    });
+});
+
+describe("indentedBodyLine", () => {
+    const bodyLine = (lines: string[], opener = 0) => indentedBodyLine(classifyLines(lines), opener);
+
+    it("owns the indented line of code a statement opens over", () => {
+        expect(bodyLine(["using { /A }; M := module:", "    Body<public>():int = 1", "code()"])).toBe(1);
+    });
+
+    it("looks past blank lines and comments to find that body", () => {
+        expect(bodyLine(["using { /A }; M := module:", "", "    # note", "    Body<public>():int = 1"])).toBe(3);
+    });
+
+    it("owns a comment indented past the body once no code is", () => {
+        expect(bodyLine(["using { /A }; M := module:", "    Body<public>():int = 1"], 1)).toBe(-1);
+        expect(bodyLine(["using { /A }; M := module:", "    Body<public>():int = 1", "    # note", "code()"], 1)).toBe(2);
+    });
+
+    it("reaches that comment past a blank line, which ends no block", () => {
+        expect(bodyLine(["using { /A }; M := module:", "    Body<public>():int = 1", "", "    # note", "code()"], 1)).toBe(3);
+    });
+
+    it("declines a comment written back at column 0, which is prose about what follows", () => {
+        expect(bodyLine(["using { /A }; M := module:", "    Body<public>():int = 1", "# note", "code()"], 1)).toBe(-1);
+    });
+
+    it("declines where the first line of code sits at column 0", () => {
+        expect(bodyLine(["using { /A }", "code()"])).toBe(-1);
+    });
+
+    it("declines an opener on the last line of the file, and one past its end", () => {
+        expect(bodyLine(["using { /A }"])).toBe(-1);
+        expect(bodyLine(["using { /A }"], 5)).toBe(-1);
+        expect(bodyLine(["using { /A }"], -1)).toBe(-1);
+    });
+
+    // The indentation is read from the code, so a line closing a block comment
+    // ahead of its statement reads as indented and is owned. Harmless in both
+    // directions - the statement is real code either way, and a line the mask
+    // leaves indented was never one a rebuilt block could hold - but pinned so
+    // that reading the raw line instead reads as the change it would be.
+    it("reads a line closing a block comment ahead of its statement as indented", () => {
+        expect(bodyLine(["using { /A }; X := 1", "<# note", "#> Foo():int = 1", "code()"])).toBe(2);
     });
 });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -1311,6 +1311,23 @@ describe("classifyLines", () => {
         expect(classifyLines(["<#", "note", "#>", "code()"]).map((classification) => classification.insideBlockComment)).toEqual([false, true, true, false]);
     });
 
+    it("marks the lines a block comment is still open at the end of", () => {
+        expect(classifyLines(["<#", "note", "#>", "code()"]).map((classification) => classification.endsInsideBlockComment)).toEqual([true, true, false, false]);
+    });
+
+    // The two answer the same question a line apart, which is what makes the
+    // last line the one worth asking: nothing below it carries the answer.
+    it("answers endsInsideBlockComment as the next line's insideBlockComment", () => {
+        const classifications = classifyLines(["code()", "using { /A } <# note", "more note", "#> code()"]);
+        expect(classifications.slice(0, -1).map((classification) => classification.endsInsideBlockComment)).toEqual(
+            classifications.slice(1).map((classification) => classification.insideBlockComment),
+        );
+    });
+
+    it("marks an opener written on the last line as leaving the comment open", () => {
+        expect(classifyLines(["code()", "using { /A } <#"]).map((classification) => classification.endsInsideBlockComment)).toEqual([false, true]);
+    });
+
     // "Indented comments begin with a `<#>` on its own line; everything
     // indented by four spaces on subsequent lines becomes part of the comment."
     it("reads the indented body of a marker as part of its comment", () => {


### PR DESCRIPTION
Closes #389

A pinned import's span ended at its own statement, the body of any comment it opened, and its `using:` pair. Two shapes reach past all three, and `floor + 1` landed somewhere no `using` may be written.

**Shape (a) — a pinned line that also opens an indented block.** `using { /A }; M := module:` over an indented body. Nothing hopped past the statement line, so a new relative import was written at column 0 on the first body line, ending the block before its body and leaving that body indented under nothing.

```
using { /A }; M := module:
using { Gadgets.Tools }        <- written here
    Body<public>():int = 1
```

**Shape (b) — an unclosed `<#` running to the end of the buffer.** The floor reached the last line, so the import was appended after it, inside the comment. The scan skips a line opened inside a block comment, so the copy never counted as present and the next compile-plus-add wrote another one.

```
code()
using { /A } <#
using { Gadgets.Tools }        <- written here, inside the comment
```

Both reach `organizeImports` through the grounded-extras splice and `addImportsToDocument` through `placementLine`. The tests that already covered an unclosed opener used an **absolute** added path, which raises no floor at all and is written above it — so neither shape was ever exercised.

## The change

- `ImportScanner.ts` — `LineClassification` gains `endsInsideBlockComment`, the dual of `insideBlockComment` a line earlier. It exists for the last line of the buffer, which is the one a caller asking "may I write below this?" has nothing below to read.
- `ImportScanner.ts` — new `indentedBodyLine`, a sibling of `indentedPairPathLine` sharing its `firstCodeLineBelow` walk: the next line a construct opened on a line owns, or -1. It answers the first code line below when that line is indented, and otherwise an indented comment trailing the body.
- `ImportDocumentEditor.ts` — `pinnedSpanEnd` gains that hop, after the pair and comment hops so the documented pair-first order is untouched.
- `ImportDocumentEditor.ts` — `pinnedBounds` drops a floor that names the last line of the buffer when that line ends inside an open block comment. Nothing below it is writable, so it bounds nothing, and the path falls back to the block at the top — where an absolute path in the same file already goes. Dropped rather than refused: the file cannot compile either way, and an added path that silently lands nowhere is what the grounded-extras path exists to avoid.

One guard in `pinnedBounds` covers all three floor consumers, since `hoistFloor`, `groupByPlacementLine` and `blockIsWithin` all read it.

## Verse rules this rests on

- **A column-0 code line ends an indented block; blank and comment lines do not.** `VerseGrammar.h:1680-1684` consumes a whitespace-only line as `Gen.BlankLine` unconditionally, and `:1690-1755` sends a whitespace-or-comment line through a `Scan` lookahead rather than closing the block. Epic's compile-validated `Tests/Bugs/SOL-3662-LineCommentEndsIndentedBlock.versetest` carries seven `assert_valid` cases of comments at four different indentations. Already owned here by `firstCodeLineBelow`, which the new hop reuses.
- **A module-scope `using` is deferred, not positional**, so writing the new import below a module body still brings the module into scope for that body: `SemanticAnalyzer.cpp:6526-6532` enqueues one as a `Deferred_ModuleReferences` task "to allow importing of modules that will get defined only later". This is what makes re-anchoring below the body correct rather than merely tidier.
- **A line indented past the enclosing block is consumed into that block, comment or not** (`VerseGrammar.h:1666-1679`, branch 1, which runs `Gen.Indent` before `Ending()` is consulted). A column-0 statement written directly above an indented comment would leave that comment opening an indent at file scope, which is why the span covers a comment trailing the body instead of stopping at the last indented code line.

## Tests

Regression tests at the two entry points the issue names, not at the unit beneath them. Through `buildOrganizedContent`: a body, a body with a trailing comment, a trailing comment a blank line separates from its body, a column-0 comment below a body (which the span must *not* claim), a body holding a pair of its own, an unclosed opener on the last line, an unclosed opener with body lines below it, and a pinned provider above an unclosed opener. Through `addImportsToDocument`: the same shapes again, since it reaches the floor by `placementLine` rather than the grounded-extras splice. Plus three `classifyLines` tests pinning `endsInsideBlockComment` (including against the following line's `insideBlockComment`) and an `indentedBodyLine` describe block that pins the masking caveat inherited from `indentedPairPathLine`.

The first seven were proven to detect the defect by reversing the source hunks with the tests left in place: all seven failed, and nothing else did.

## Review

Two rounds at `models.review`, both `PASS_WITH_SUGGESTIONS`, no Critical at either.

Round 1 raised two Important findings, both real and both fixed in `eba3048`:

- the unwritable-span check zeroed the floor, which is a `Math.max` over every pinned import, so a pinned provider higher in the file lost its floor along with the unclosed opener at the end of the buffer — carrying the new path above the import bringing its first segment into scope. It now skips the one span inside the loop.
- `indentedBodyLine` read only the line directly below for a body's trailing indented comment, so one blank line between the two stranded that comment below the new import, while the doc above the function claimed the general rule. `firstContentLineBelow` scans past blanks.

Round 2 reviewed that fix, could not break either half, and independently confirmed all three Verse rules above against the compiler source. Its three Suggestions are taken in the third commit: both fixes gained their paired `addImportsToDocument` test, and two doc claims that overstated what the code holds were narrowed.

Of round 1's Suggestions, two are declined on purpose: extracting the walk `indentedBodyLine` shares with `indentedPairPathLine` would widen the diff into code this ticket does not need changed, and the indented-comment branch stays despite being beyond the ticket's literal wording, because a column-0 statement above an indented comment leaves that comment opening an indent at file scope.

## Not in this PR

A file that **opens** with an unclosed `<#` gets an added import appended inside that comment as well, for absolute and relative paths alike. That is the `headerEnd` path with no pinned import involved, so it is filed separately as #451 rather than widened into this diff.

## Verification

Run after merging current `main` (5fd0520) into the branch — #453 touched `classifyLines` in the same file, and the merge was conflict-free.

```
> verse-auto-imports@0.11.2 compile
> tsc -p ./
```

```
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 51 passed, 51 total
Tests:       1580 passed, 1580 total
Snapshots:   0 total
Time:        18.896 s
Ran all test suites.
```

```
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

`npx jest src/imports/__tests__` read in full for the extractor-order check: 10 suites, 907 tests, all passing, no unrelated case changing shape.
