### PR TITLE
fix(digest): lead a collision list with the live module

### DIFF
--- a/changelog.d/416.fixed.md
+++ b/changelog.d/416.fixed.md
@@ -1,1 +1,1 @@
-**Digest lookups**: An identifier declared in more than one module is now led by the live module rather than the superseded one, so the SpatialMath and input surfaces no longer recommend the deprecated `/UnrealEngine.com` paths.
+**Digest lookups**: With `experimental.useDigestFiles` on, an identifier declared in more than one module is now led by the live module, so the SpatialMath and input surfaces no longer suggest the deprecated `/UnrealEngine.com` paths first.

--- a/changelog.d/416.fixed.md
+++ b/changelog.d/416.fixed.md
@@ -1,0 +1,1 @@
+**Digest lookups**: An identifier declared in more than one module is now led by the live module rather than the superseded one, so the SpatialMath and input surfaces no longer recommend the deprecated `/UnrealEngine.com` paths.

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -4,6 +4,27 @@ import { ImportHandler } from "../ImportHandler";
 import { ImportSuggestion } from "../../types";
 
 /**
+ * Drives the provider over one diagnostic whose suggestions are given rather
+ * than extracted, and returns the actions it produced.
+ *
+ * @param message The diagnostic text. It only has to classify as an unknown
+ *   identifier - the stubbed handler, not the message, supplies the suggestions.
+ */
+const provideFor = async (suggestions: ImportSuggestion[], message = "Unknown identifier `button_device`"): Promise<vscode.CodeAction[]> => {
+    const importHandler = { extractImportSuggestions: jest.fn().mockResolvedValue(suggestions) } as unknown as ImportHandler;
+    const provider = new ImportCodeActionProvider({ appendLine: jest.fn() } as unknown as vscode.OutputChannel, importHandler);
+
+    const actions = await provider.provideCodeActions(
+        { uri: { toString: () => "file:///Project/Content/Scripts/device.verse" } } as unknown as vscode.TextDocument,
+        {} as unknown as vscode.Range,
+        { diagnostics: [{ message, range: { start: { line: 7 } } }] } as unknown as vscode.CodeActionContext,
+        {} as unknown as vscode.CancellationToken,
+    );
+
+    return actions ?? [];
+};
+
+/**
  * Regression for issue #135: the provider read quickFix.showDescriptions with a
  * fallback of true where package.json registers false. config.get returns the
  * registered default for a registered setting, so the fallback never reached
@@ -19,20 +40,7 @@ describe("ImportCodeActionProvider quick fix titles", () => {
         ...overrides,
     });
 
-    /** Drives the provider over one diagnostic and returns the action titles. */
-    const titlesFor = async (suggestions: ImportSuggestion[]): Promise<string[]> => {
-        const importHandler = { extractImportSuggestions: jest.fn().mockResolvedValue(suggestions) } as unknown as ImportHandler;
-        const provider = new ImportCodeActionProvider({ appendLine: jest.fn() } as unknown as vscode.OutputChannel, importHandler);
-
-        const actions = await provider.provideCodeActions(
-            { uri: { toString: () => "file:///Project/Content/Scripts/device.verse" } } as unknown as vscode.TextDocument,
-            {} as unknown as vscode.Range,
-            { diagnostics: [{ message: "Unknown identifier `button_device`", range: { start: { line: 7 } } }] } as unknown as vscode.CodeActionContext,
-            {} as unknown as vscode.CancellationToken,
-        );
-
-        return (actions ?? []).map((action) => action.title);
-    };
+    const titlesFor = async (suggestions: ImportSuggestion[]): Promise<string[]> => (await provideFor(suggestions)).map((action) => action.title);
 
     it("omits the description, matching the default package.json registers", async () => {
         expect(await titlesFor([suggestion()])).toEqual(["Add import: using { /Fortnite.com/Devices }"]);
@@ -107,10 +115,11 @@ describe("ImportCodeActionProvider quick fix titles", () => {
 });
 
 /**
- * `isPreferred` is what the editor applies on Ctrl+. Enter, so the mapping from
- * list position to preference is what carries the digest manifest's choice of
- * lead through to the user. Reordering the menu without carrying that choice
- * with it silently restores whichever module used to be first.
+ * `isPreferred` is what the editor applies on Ctrl+. Enter, so whichever
+ * suggestion leads the list is the one a user takes without reading the rest.
+ * The suggestions are stubbed here, so this pins only that the lead is what
+ * gets preferred - which module leads is settled upstream, in the digest
+ * manifest, and pinned by digestCollisionOrder.test.ts.
  */
 describe("ImportCodeActionProvider preferred action", () => {
     const suggestion = (importStatement: string): ImportSuggestion => ({
@@ -120,22 +129,8 @@ describe("ImportCodeActionProvider preferred action", () => {
         description: `class from ${importStatement}`,
     });
 
-    const actionsFor = async (suggestions: ImportSuggestion[]): Promise<vscode.CodeAction[]> => {
-        const importHandler = { extractImportSuggestions: jest.fn().mockResolvedValue(suggestions) } as unknown as ImportHandler;
-        const provider = new ImportCodeActionProvider({ appendLine: jest.fn() } as unknown as vscode.OutputChannel, importHandler);
-
-        const actions = await provider.provideCodeActions(
-            { uri: { toString: () => "file:///Project/Content/Scripts/device.verse" } } as unknown as vscode.TextDocument,
-            {} as unknown as vscode.Range,
-            { diagnostics: [{ message: "Unknown identifier `vector3`", range: { start: { line: 7 } } }] } as unknown as vscode.CodeActionContext,
-            {} as unknown as vscode.CancellationToken,
-        );
-
-        return actions ?? [];
-    };
-
     it("prefers the leading suggestion and no other", async () => {
-        const actions = await actionsFor([suggestion("using { /Verse.org/SpatialMath }"), suggestion("using { /UnrealEngine.com/Temporary/SpatialMath }")]);
+        const actions = await provideFor([suggestion("using { /Verse.org/SpatialMath }"), suggestion("using { /UnrealEngine.com/Temporary/SpatialMath }")], "Unknown identifier `vector3`");
 
         expect(actions.map((action) => action.isPreferred)).toEqual([true, false]);
         expect(actions[0].title).toBe("Add import: using { /Verse.org/SpatialMath }");

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -105,3 +105,39 @@ describe("ImportCodeActionProvider quick fix titles", () => {
         }
     });
 });
+
+/**
+ * `isPreferred` is what the editor applies on Ctrl+. Enter, so the mapping from
+ * list position to preference is what carries the digest manifest's choice of
+ * lead through to the user. Reordering the menu without carrying that choice
+ * with it silently restores whichever module used to be first.
+ */
+describe("ImportCodeActionProvider preferred action", () => {
+    const suggestion = (importStatement: string): ImportSuggestion => ({
+        importStatement,
+        source: "digest_lookup",
+        confidence: "high",
+        description: `class from ${importStatement}`,
+    });
+
+    const actionsFor = async (suggestions: ImportSuggestion[]): Promise<vscode.CodeAction[]> => {
+        const importHandler = { extractImportSuggestions: jest.fn().mockResolvedValue(suggestions) } as unknown as ImportHandler;
+        const provider = new ImportCodeActionProvider({ appendLine: jest.fn() } as unknown as vscode.OutputChannel, importHandler);
+
+        const actions = await provider.provideCodeActions(
+            { uri: { toString: () => "file:///Project/Content/Scripts/device.verse" } } as unknown as vscode.TextDocument,
+            {} as unknown as vscode.Range,
+            { diagnostics: [{ message: "Unknown identifier `vector3`", range: { start: { line: 7 } } }] } as unknown as vscode.CodeActionContext,
+            {} as unknown as vscode.CancellationToken,
+        );
+
+        return actions ?? [];
+    };
+
+    it("prefers the leading suggestion and no other", async () => {
+        const actions = await actionsFor([suggestion("using { /Verse.org/SpatialMath }"), suggestion("using { /UnrealEngine.com/Temporary/SpatialMath }")]);
+
+        expect(actions.map((action) => action.isPreferred)).toEqual([true, false]);
+        expect(actions[0].title).toBe("Add import: using { /Verse.org/SpatialMath }");
+    });
+});

--- a/src/services/__tests__/DigestParser.test.ts
+++ b/src/services/__tests__/DigestParser.test.ts
@@ -127,7 +127,7 @@ describe("DigestParser", () => {
         it("returns every declaring module, led by the one the manifest prefers", async () => {
             const results = await parser.lookupIdentifier("Distance");
 
-            expect(results.map((result) => result.modulePath)).toEqual(["/UnrealEngine.com/Temporary/SpatialMath", "/Verse.org/SpatialMath"]);
+            expect(results.map((result) => result.modulePath)).toEqual(["/Verse.org/SpatialMath", "/UnrealEngine.com/Temporary/SpatialMath"]);
         });
 
         it("keeps one entry per module path when a file repeats a declaration", async () => {
@@ -137,7 +137,7 @@ describe("DigestParser", () => {
 
             const results = await parser.lookupIdentifier("Distance");
 
-            expect(results.map((result) => result.modulePath)).toEqual(["/UnrealEngine.com/Temporary/SpatialMath", "/Verse.org/SpatialMath"]);
+            expect(results.map((result) => result.modulePath)).toEqual(["/Verse.org/SpatialMath", "/UnrealEngine.com/Temporary/SpatialMath"]);
         });
     });
 

--- a/src/services/__tests__/digestCollisionOrder.test.ts
+++ b/src/services/__tests__/digestCollisionOrder.test.ts
@@ -35,8 +35,10 @@ describe("collision lead in the bundled digest data", () => {
     });
 
     it("leaves a /Fortnite.com lead alone", async () => {
-        // Demoting UnrealEngine must not promote /Verse.org over /Fortnite.com:
-        // a creator writing UI or Assets in UEFN means the Fortnite module.
+        // Green under any manifest order, so this pins the alternative that was
+        // rejected rather than the change that was made: ranking /Verse.org
+        // above every domain would move these, and a creator writing UI or
+        // Assets in UEFN means the Fortnite module.
         expect(await leadFor("UI")).toBe("/Fortnite.com/UI");
         expect(await leadFor("Assets")).toBe("/Fortnite.com/Assets");
         expect(await leadFor("Itemization")).toBe("/Fortnite.com/Itemization");

--- a/src/services/__tests__/digestCollisionOrder.test.ts
+++ b/src/services/__tests__/digestCollisionOrder.test.ts
@@ -1,0 +1,50 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { DigestParser } from "../DigestParser";
+
+/**
+ * Which module leads a collision list, read from the checked-in digest data
+ * rather than from fixtures.
+ *
+ * Position 0 is not merely first: ImportCodeActionProvider marks it
+ * `isPreferred` and an `auto_first` strategy applies it with no prompt. Several
+ * identifiers are declared by both a live module and a superseded one, so the
+ * lead is a recommendation the extension makes on the user's behalf.
+ *
+ * These read the real `src/data` through the real loader, because a digest
+ * refresh can move a name between modules - which the synthetic fixtures in
+ * DigestParser.test.ts cannot catch.
+ */
+describe("collision lead in the bundled digest data", () => {
+    const EXTENSION_PATH = path.resolve(__dirname, "..", "..", "..");
+    const context = { extensionPath: EXTENSION_PATH } as unknown as vscode.ExtensionContext;
+    const parser = new DigestParser(vscode.window.createOutputChannel("test"), context);
+
+    const leadFor = async (identifier: string): Promise<string | undefined> => (await parser.lookupIdentifier(identifier))[0]?.modulePath;
+
+    it("leads the SpatialMath surface with /Verse.org, not the Temporary home", async () => {
+        for (const id of ["vector3", "rotation", "transform", "Distance"]) {
+            expect(await leadFor(id)).toBe("/Verse.org/SpatialMath");
+        }
+    });
+
+    it("leads the input surface with /Verse.org/Input, not /UnrealEngine.com/ControlInput", async () => {
+        for (const id of ["GetPlayerInput", "player_input", "input_events"]) {
+            expect(await leadFor(id)).toBe("/Verse.org/Input");
+        }
+    });
+
+    it("leaves a /Fortnite.com lead alone", async () => {
+        // Demoting UnrealEngine must not promote /Verse.org over /Fortnite.com:
+        // a creator writing UI or Assets in UEFN means the Fortnite module.
+        expect(await leadFor("UI")).toBe("/Fortnite.com/UI");
+        expect(await leadFor("Assets")).toBe("/Fortnite.com/Assets");
+        expect(await leadFor("Itemization")).toBe("/Fortnite.com/Itemization");
+    });
+
+    it("still offers every declaring module, led by the live one", async () => {
+        const candidates = await parser.lookupIdentifier("vector3");
+
+        expect(candidates.map((candidate) => candidate.modulePath)).toEqual(["/Verse.org/SpatialMath", "/UnrealEngine.com/Temporary/SpatialMath"]);
+    });
+});

--- a/src/services/digestManifest.ts
+++ b/src/services/digestManifest.ts
@@ -19,10 +19,15 @@
  * answers - it decides which one leads the list, and the lead is what the
  * quick-fix menu prefers and what an `auto_first` strategy applies unasked.
  *
- * UnrealEngine sits last because its colliding modules are the superseded
- * homes: `/UnrealEngine.com/Temporary/SpatialMath` re-exports
- * `/Verse.org/SpatialMath`, and `/UnrealEngine.com/ControlInput` predates
- * `/Verse.org/Input`. Moving it back up recommends the deprecated path again.
+ * UnrealEngine sits last because the modules it shares identifiers with are its
+ * superseded homes: `/UnrealEngine.com/Temporary/SpatialMath` binds its own
+ * `rotation` and `vector3` to `..._Deprecated` natives where
+ * `/Verse.org/SpatialMath` binds the live ones, and
+ * `/UnrealEngine.com/ControlInput` predates `/Verse.org/Input`. These are
+ * distinct types rather than aliases, so the lead decides which type the user
+ * gets, not merely which path spells it. `Progression` is the one shared name
+ * this does not describe - both homes are `@experimental` and unrelated, so
+ * either lead is arbitrary there.
  */
 export const BUNDLED_DIGEST_NAMES = ["Fortnite", "Verse", "UnrealEngine"] as const;
 

--- a/src/services/digestManifest.ts
+++ b/src/services/digestManifest.ts
@@ -18,8 +18,13 @@
  * that declares an identifier, so this order no longer decides which one
  * answers - it decides which one leads the list, and the lead is what the
  * quick-fix menu prefers and what an `auto_first` strategy applies unasked.
+ *
+ * UnrealEngine sits last because its colliding modules are the superseded
+ * homes: `/UnrealEngine.com/Temporary/SpatialMath` re-exports
+ * `/Verse.org/SpatialMath`, and `/UnrealEngine.com/ControlInput` predates
+ * `/Verse.org/Input`. Moving it back up recommends the deprecated path again.
  */
-export const BUNDLED_DIGEST_NAMES = ["Fortnite", "UnrealEngine", "Verse"] as const;
+export const BUNDLED_DIGEST_NAMES = ["Fortnite", "Verse", "UnrealEngine"] as const;
 
 /** The checked-in Verse source a digest is generated from. */
 export function digestSourceFile(digestName: string): string {


### PR DESCRIPTION
Closes #416

## What changed

`BUNDLED_DIGEST_NAMES` becomes `["Fortnite", "Verse", "UnrealEngine"]`.

Since #375 a colliding identifier returns every declaring module, which turned position 0 from an arbitrary tiebreak into a recommendation: `ImportCodeActionProvider.ts:50` marks it `isPreferred`, and `DiagnosticsHandler.ts:265` has `auto_first` apply it with no prompt. The manifest order still ran `Fortnite, UnrealEngine, Verse`, so the whole SpatialMath surface recommended the deprecated `/UnrealEngine.com/Temporary/SpatialMath` over `/Verse.org/SpatialMath`, and the input surface recommended `/UnrealEngine.com/ControlInput` over `/Verse.org/Input`.

The order has exactly one origin — `PrecompiledDigestLoader.loadFromDirectory` appends per file in manifest order, and no hop between there and either consumer reorders — so demoting `UnrealEngine` is the whole fix. No comparator, no new ranking concept to keep in step with the data.

## Why this shape and not the ticket's three

Measured against the checked-in 41.30 data, and independently reproduced at review:

| Shape | Leads changed | Problem |
| --- | --- | --- |
| Sort `Temporary` last (option 1) | 18 | Misses `input_events`, `GetPlayerInput`, `player_input` — `/UnrealEngine.com/ControlInput` has no `Temporary` segment, and the ticket names those three |
| Domain rank `/Verse.org` first (option 2) | 30 | Also moves eight `/Fortnite.com` leads: `UI`, `Input`, `Assets`, `Ease`, `EaseIn`, `EaseOut`, `EaseInOut`, `Linear` |
| Label only (option 3) | 0 | Leaves `auto_first` applying the deprecated path unasked |
| **Manifest order (this PR)** | **22** | — |

The 22 are 18 SpatialMath, 3 Input, and `Progression`. After the change, 0 of the 32 collisions lead with any `/UnrealEngine.com` path, and no `/Fortnite.com` lead moves — so a creator writing `UI` or `Assets` in UEFN still gets the Fortnite module.

`Progression` is the one lateral case: `/UnrealEngine.com/Progression` (entitlement and marketplace rewards) and `/Verse.org/Progression` (quest participant info) are both `@experimental` and cover different feature areas, so neither is the other's successor and either lead is arbitrary. It is called out in the manifest comment as the case the rationale does not cover.

## The domain claim, and what settles it

This encodes an API-surface claim, not a grammar rule — no parsing, syntax or scope behaviour is touched.

- `/Verse.org/SpatialMath` and `/Verse.org/Input` publicly declare the promoted identifiers, so leading with them yields an import that compiles: `src/utils/Verse.digest.verse:3038` declares `SpatialMath<public> := module:` holding `vector3` (`:3204`) and `rotation` (`:3043`); `:1597` declares `Input<public> := module:` holding `GetPlayerInput` (`:1629`). Epic's generated API surface, not this extension's model of it.
- The two homes hold **distinct types, not aliases**. `/UnrealEngine.com/Temporary/SpatialMath` imports `/Verse.org/SpatialMath` and then declares its own `rotation` and `vector3`, bound via `@import_as` to `.../FVerseRotation_Deprecated` where the `/Verse.org` ones bind `/*.FVRotation`. So the lead decides which type the user gets, not merely which path spells it. `/UnrealEngine.com/ControlInput` is `MinUploadedAtFNVersion := 3630` against `/Verse.org/Input`'s `4110`.
- Both paths stay valid and importable, which is why this reorders rather than filters. Counter-evidence, named because it cuts the other way: the Book of Verse still lists the `Temporary` modules and uses them in its own examples (`docs/16_modules.md:82-83`, `:403`).

## Tests

`src/services/__tests__/digestCollisionOrder.test.ts` is new and is the regression test for the reported symptom: it drives the real `DigestParser` against the real `src/data` with no `fs` mock, so it also guards the next digest refresh, which can move a name between modules. Proven to detect the defect — reverting `digestManifest.ts` alone fails 3 of its 4 tests. The fourth (`leaves a /Fortnite.com lead alone`) passes either way by design and says so in a comment: it pins the rejected alternative, not this change.

`ImportCodeActionProvider.test.ts` gains one test that the leading suggestion is the action marked `isPreferred` — first coverage of `isPreferred` in the repo. Its suggestions are stubbed, so it pins only that the lead is what gets preferred; which module leads is pinned upstream.

`DigestParser.test.ts:127-141` — two order assertions flipped. Same contract, new expected lead.

## Verification

```
$ npm run compile
> verse-auto-imports@0.11.2 compile
> tsc -p ./

$ npm test
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 51 passed, 51 total
Tests:       1525 passed, 1525 total
Snapshots:   0 total
Time:        12.446 s
Ran all test suites.

$ npm run format:check
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

Reviewed at `opus` in one round: `PASS_WITH_SUGGESTIONS`, 0 Critical, 3 Important, 5 Suggestions. The three Important findings were corrected in `681c4cd` — an inaccurate "re-exports" claim in the manifest comment, a changelog entry that promised a default-config effect, and two test doc comments claiming links they do not exercise — except the third, below. The rename of `BUNDLED_DIGEST_NAMES` to something naming its ordering role was left as a suggestion rather than folded in, since it touches three consumers for a naming gain.

## Known gap, and what is left for a follow-up

**`quickFix.sortAlphabetically: true` still re-promotes the deprecated path.** `localeCompare` puts `/UnrealEngine.com/...` before `/Verse.org/...` (−1 for both the SpatialMath and Input pairs), and `provideCodeActions` marks `index === 0` of the *sorted* list preferred. So for a user with that setting on, the `isPreferred` half of this fix is defeated; `auto_first` is unaffected, since `DiagnosticsHandler` does not apply that sort. Not fixed here because honouring an explicit "sort alphabetically" and then not sorting alphabetically is its own wrong answer — the real defect is below.

**`isPreferred` on a multi-candidate list.** Marking one of several mutually-exclusive, differently-typed candidates as preferred is a false claim that no ordering repairs. It applies equally to the compiler-message `multiOption` path, which is on by default, where this ticket's subject is gated behind `experimental.useDigestFiles`. That is the fix that also closes the `sortAlphabetically` gap, and it wants its own issue rather than this diff.

**`auto_first` coverage.** `selectBestSuggestion` is private and reached only through the debounce timer, so pinning it means driving `DiagnosticsHandler` end to end. Worth doing, not here.
