### PR TITLE
chore: release v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Where an entry resolves a tracked issue, it ends with a `[#N]` reference linked 
 
 Pending changes are kept as one file per change under [changelog.d/](changelog.d/) and assembled here at release.
 
+## [0.11.3] - 2026-08-16
+
+### Fixed
+
+- **Settings**: `general.diagnosticDelay` now uses VS Code's own deprecation support, so the settings editor hides it and flags an existing value instead of listing it above its replacement. An explicitly set value is still honored ([#369])
+- **Import placement**: A newly added relative import no longer lands inside an indented module body or inside an unclosed block comment, where it broke the construct or was silently duplicated on every later compile ([#389])
+- **Import path conversion**: modules declared inside other modules now convert in both directions, and a project too large for the module search to read in full is told so once rather than offered a path the search cannot stand behind ([#395])
+- **Project path scan**: a string interpolation spanning lines no longer strands the brace depth, which reported every declaration below it under the wrong module path ([#414])
+- **Digest lookups**: With `experimental.useDigestFiles` on, an identifier declared in more than one module is now led by the live module, so the SpatialMath and input surfaces no longer suggest the deprecated `/UnrealEngine.com` paths first ([#416])
+- **Verse file scanning**: a `<#` block opened in a `<#>` marker's line, or a `#` comment continuing past the `#>` that closes one, now reads as commented out, so imports written there no longer count as present ([#419])
+- **Path conversion**: imports convert in both directions again for a project that nests its Verse under `Plugins/<Name>/Content`, the UEFN layout where every conversion was refused when the workspace was opened at the project root ([#429])
+- **Quick fixes**: In a multi-root workspace, the quick-fix menu now labels an import in the syntax the file's own folder sets, matching the text it inserts ([#433])
+- **Module visibility**: the make-module-public quick fix now writes the definitions file of the workspace folder holding the edited file, so a multi-root workspace no longer writes the first folder's file or ignores that folder's file name override ([#436])
+
 ## [0.11.2] - 2026-08-15
 
 ### Added
@@ -446,7 +460,8 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 
 <!-- Version comparisons. The chain starts at 0.6.0: no v0.4.x or v0.5.x tags exist. -->
 
-[Unreleased]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/vukefn/verse-auto-imports/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/vukefn/verse-auto-imports/compare/v0.10.0...v0.11.0
@@ -463,6 +478,15 @@ See [GitHub Releases](https://github.com/VukeFN/verse-auto-imports/releases) for
 
 <!-- Issue references -->
 
+[#369]: https://github.com/vukefn/verse-auto-imports/issues/369
+[#389]: https://github.com/vukefn/verse-auto-imports/issues/389
+[#395]: https://github.com/vukefn/verse-auto-imports/issues/395
+[#414]: https://github.com/vukefn/verse-auto-imports/issues/414
+[#416]: https://github.com/vukefn/verse-auto-imports/issues/416
+[#419]: https://github.com/vukefn/verse-auto-imports/issues/419
+[#429]: https://github.com/vukefn/verse-auto-imports/issues/429
+[#433]: https://github.com/vukefn/verse-auto-imports/issues/433
+[#436]: https://github.com/vukefn/verse-auto-imports/issues/436
 [#359]: https://github.com/vukefn/verse-auto-imports/issues/359
 [#360]: https://github.com/vukefn/verse-auto-imports/issues/360
 [#363]: https://github.com/vukefn/verse-auto-imports/issues/363

--- a/changelog.d/369.fixed.md
+++ b/changelog.d/369.fixed.md
@@ -1,1 +1,0 @@
-**Settings**: `general.diagnosticDelay` now uses VS Code's own deprecation support, so the settings editor hides it and flags an existing value instead of listing it above its replacement. An explicitly set value is still honored.

--- a/changelog.d/389.fixed.md
+++ b/changelog.d/389.fixed.md
@@ -1,1 +1,0 @@
-**Import placement**: A newly added relative import no longer lands inside an indented module body or inside an unclosed block comment, where it broke the construct or was silently duplicated on every later compile.

--- a/changelog.d/395.fixed.md
+++ b/changelog.d/395.fixed.md
@@ -1,1 +1,0 @@
-**Import path conversion**: modules declared inside other modules now convert in both directions, and a project too large for the module search to read in full is told so once rather than offered a path the search cannot stand behind.

--- a/changelog.d/414.fixed.md
+++ b/changelog.d/414.fixed.md
@@ -1,1 +1,0 @@
-**Project path scan**: a string interpolation spanning lines no longer strands the brace depth, which reported every declaration below it under the wrong module path.

--- a/changelog.d/416.fixed.md
+++ b/changelog.d/416.fixed.md
@@ -1,1 +1,0 @@
-**Digest lookups**: With `experimental.useDigestFiles` on, an identifier declared in more than one module is now led by the live module, so the SpatialMath and input surfaces no longer suggest the deprecated `/UnrealEngine.com` paths first.

--- a/changelog.d/419.fixed.md
+++ b/changelog.d/419.fixed.md
@@ -1,1 +1,0 @@
-**Verse file scanning**: a `<#` block opened in a `<#>` marker's line, or a `#` comment continuing past the `#>` that closes one, now reads as commented out, so imports written there no longer count as present

--- a/changelog.d/429.fixed.md
+++ b/changelog.d/429.fixed.md
@@ -1,1 +1,0 @@
-**Path conversion**: imports convert in both directions again for a project that nests its Verse under `Plugins/<Name>/Content`, the UEFN layout where every conversion was refused when the workspace was opened at the project root.

--- a/changelog.d/433.fixed.md
+++ b/changelog.d/433.fixed.md
@@ -1,1 +1,0 @@
-**Quick fixes**: In a multi-root workspace, the quick-fix menu now labels an import in the syntax the file's own folder sets, matching the text it inserts.

--- a/changelog.d/436.fixed.md
+++ b/changelog.d/436.fixed.md
@@ -1,1 +1,0 @@
-**Module visibility**: the make-module-public quick fix now writes the definitions file of the workspace folder holding the edited file, so a multi-root workspace no longer writes the first folder's file or ignores that folder's file name override.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verse-auto-imports",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verse-auto-imports",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "verse-auto-imports",
   "displayName": "Verse Auto Imports",
   "description": "Automatically adds missing using statements in Verse files",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Cuts `v0.11.3` from `origin/main` at `be839ab`. Nine `Fixed` fragments, no `Added` or breaking change, so a PATCH bump under the pre-1.0 rule.

Note: `#395`, `#414` and `#433` (PRs #438, #440, #441) were already merged when `v0.11.2` was tagged, but their fragments were still pending — the v0.11.2 assembly ran from an older base. Their entries ship here rather than being dropped, so the code is in the 0.11.2 build and the entry reads under 0.11.3.

## Changelog section as it will ship

```markdown
## [0.11.3] - 2026-08-16

### Fixed

- **Settings**: `general.diagnosticDelay` now uses VS Code's own deprecation support, so the settings editor hides it and flags an existing value instead of listing it above its replacement. An explicitly set value is still honored ([#369])
- **Import placement**: A newly added relative import no longer lands inside an indented module body or inside an unclosed block comment, where it broke the construct or was silently duplicated on every later compile ([#389])
- **Import path conversion**: modules declared inside other modules now convert in both directions, and a project too large for the module search to read in full is told so once rather than offered a path the search cannot stand behind ([#395])
- **Project path scan**: a string interpolation spanning lines no longer strands the brace depth, which reported every declaration below it under the wrong module path ([#414])
- **Digest lookups**: With `experimental.useDigestFiles` on, an identifier declared in more than one module is now led by the live module, so the SpatialMath and input surfaces no longer suggest the deprecated `/UnrealEngine.com` paths first ([#416])
- **Verse file scanning**: a `<#` block opened in a `<#>` marker's line, or a `#` comment continuing past the `#>` that closes one, now reads as commented out, so imports written there no longer count as present ([#419])
- **Path conversion**: imports convert in both directions again for a project that nests its Verse under `Plugins/<Name>/Content`, the UEFN layout where every conversion was refused when the workspace was opened at the project root ([#429])
- **Quick fixes**: In a multi-root workspace, the quick-fix menu now labels an import in the syntax the file's own folder sets, matching the text it inserts ([#433])
- **Module visibility**: the make-module-public quick fix now writes the definitions file of the workspace folder holding the edited file, so a multi-root workspace no longer writes the first folder's file or ignores that folder's file name override ([#436])
```

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.3 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.3 test
> jest --verbose

Test Suites: 52 passed, 52 total
Tests:       1585 passed, 1585 total
Snapshots:   0 total
Time:        13.553 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.3 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Files

- `package.json` / `package-lock.json` — `0.11.2` to `0.11.3`
- `CHANGELOG.md` — dated `[0.11.3]` section, compare link, `[Unreleased]` re-pointed
- `changelog.d/` — the nine consumed fragments removed
