### PR TITLE
fix(imports): declare the code action kinds and honour the cancellation token

### DIFF
--- a/changelog.d/365.fixed.md
+++ b/changelog.d/365.fixed.md
@@ -1,0 +1,1 @@
+**Quick fixes**: The import and module visibility quick fixes no longer run for code-action requests they cannot serve, and the import provider now abandons a request the editor has already superseded.

--- a/src/__tests__/extension.codeActionKinds.test.ts
+++ b/src/__tests__/extension.codeActionKinds.test.ts
@@ -1,0 +1,71 @@
+import * as vscode from "vscode";
+import { activate } from "../extension";
+import { ImportCodeActionProvider } from "../imports/ImportCodeActionProvider";
+import { ImportOrganizeCodeActionProvider } from "../imports/ImportOrganizeCodeActionProvider";
+import { ModuleVisibilityCodeActionProvider } from "../visibility/ModuleVisibilityCodeActionProvider";
+
+/**
+ * Regression for #365: the quick fix providers were registered with no
+ * metadata, and VS Code runs a provider that declares no kinds for every
+ * code-action request of every kind - refactor menus, source-action menus,
+ * on-type. ImportCodeActionProvider paid an async extraction per diagnostic
+ * for requests it can never serve.
+ */
+
+/** The subset of ExtensionContext activate() touches. */
+function makeContext(): { subscriptions: { dispose(): unknown }[]; workspaceState: unknown } {
+    return {
+        subscriptions: [],
+        workspaceState: {
+            get: jest.fn().mockReturnValue(undefined),
+            update: jest.fn().mockResolvedValue(undefined),
+            keys: jest.fn().mockReturnValue([]),
+        },
+    };
+}
+
+/**
+ * The metadata activate() passed for the given provider class, or undefined
+ * where it passed none - which is the defect this file pins.
+ */
+function metadataFor(providerClass: new (...args: never[]) => vscode.CodeActionProvider): vscode.CodeActionProviderMetadata | undefined {
+    const calls = (vscode.languages.registerCodeActionsProvider as jest.Mock).mock.calls;
+    const call = calls.find(([, provider]) => provider instanceof providerClass);
+    if (!call) {
+        throw new Error(`activate() registered no ${providerClass.name}`);
+    }
+    return call[2];
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+        get: jest.fn().mockImplementation((_key: string, defaultValue?: unknown) => defaultValue),
+        inspect: jest.fn().mockReturnValue(undefined),
+        update: jest.fn().mockResolvedValue(undefined),
+    });
+    activate(makeContext() as unknown as vscode.ExtensionContext);
+});
+
+describe("code action registrations declare the kinds they provide", () => {
+    it("declares quick fixes for the import provider", () => {
+        expect(metadataFor(ImportCodeActionProvider)?.providedCodeActionKinds).toEqual([vscode.CodeActionKind.QuickFix]);
+    });
+
+    it("declares quick fixes for the module visibility provider", () => {
+        expect(metadataFor(ModuleVisibilityCodeActionProvider)?.providedCodeActionKinds).toEqual([vscode.CodeActionKind.QuickFix]);
+    });
+
+    // Already declared before #365, and the one registration where the
+    // metadata is what routes the request rather than only filtering it.
+    it("still declares the organize imports source action", () => {
+        expect(metadataFor(ImportOrganizeCodeActionProvider)?.providedCodeActionKinds).toEqual([vscode.CodeActionKind.SourceOrganizeImports]);
+    });
+
+    it("leaves no code action provider registered without metadata", () => {
+        const calls = (vscode.languages.registerCodeActionsProvider as jest.Mock).mock.calls;
+        expect(calls.length).toBeGreaterThan(0);
+        const undeclared = calls.filter(([, , metadata]) => metadata?.providedCodeActionKinds === undefined).map(([, provider]) => provider.constructor.name);
+        expect(undeclared).toEqual([]);
+    });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,9 +126,13 @@ export function activate(context: vscode.ExtensionContext) {
     // of it: registerCodeLensProvider disposes the registration only, leaving
     // the provider's own listeners and hide timers live after deactivation.
     context.subscriptions.push(
-        vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ImportCodeActionProvider(outputChannel, importHandler)),
-        vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ModuleVisibilityCodeActionProvider()),
-        // The metadata is not optional here as it is for the quick fixes above:
+        vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ImportCodeActionProvider(outputChannel, importHandler), {
+            providedCodeActionKinds: ImportCodeActionProvider.providedCodeActionKinds,
+        }),
+        vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ModuleVisibilityCodeActionProvider(), {
+            providedCodeActionKinds: ModuleVisibilityCodeActionProvider.providedCodeActionKinds,
+        }),
+        // The metadata does more here than spare the quick fixes above a call:
         // it is what tells VS Code this provider answers source.organizeImports,
         // and so what puts Shift+Alt+O and editor.codeActionsOnSave through it.
         vscode.languages.registerCodeActionsProvider({ language: "verse" }, new ImportOrganizeCodeActionProvider(), {

--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -10,6 +10,14 @@ import { ImportHandler } from "./ImportHandler";
  * naming no import produces no action.
  */
 export class ImportCodeActionProvider implements vscode.CodeActionProvider {
+    /**
+     * Declared to the registration so VS Code skips this provider whenever a
+     * kind outside quick fixes is requested. Without it a refactor or source
+     * action menu runs the async extraction below for a request this provider
+     * can never serve.
+     */
+    static readonly providedCodeActionKinds: readonly vscode.CodeActionKind[] = [vscode.CodeActionKind.QuickFix];
+
     constructor(
         private outputChannel: vscode.OutputChannel,
         private importHandler: ImportHandler,
@@ -32,6 +40,14 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
         const showDescriptions = config.get<boolean>("quickFix.showDescriptions", false);
 
         for (const diagnostic of context.diagnostics) {
+            // Every cursor move near a diagnostic re-requests code actions, so
+            // the extraction below - which can reach the digest lookup - runs
+            // once per diagnostic for requests already superseded. Stop before
+            // paying it for a result the editor will discard.
+            if (token.isCancellationRequested) {
+                return undefined;
+            }
+
             const suggestions = await this.importHandler.extractImportSuggestions(diagnostic.message, document.uri);
 
             if (suggestions.length === 0) {

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -136,3 +136,41 @@ describe("ImportCodeActionProvider preferred action", () => {
         expect(actions[0].title).toBe("Add import: using { /Verse.org/SpatialMath }");
     });
 });
+
+/**
+ * Regression for #365: the provider took a CancellationToken and never read
+ * it, so a request superseded by the next cursor move still ran the async
+ * extraction once per diagnostic - work whose result VS Code discards.
+ */
+describe("ImportCodeActionProvider cancellation", () => {
+    const driveWith = async (isCancellationRequested: boolean, diagnosticCount: number) => {
+        const extractImportSuggestions = jest.fn().mockResolvedValue([]);
+        const provider = new ImportCodeActionProvider({ appendLine: jest.fn() } as unknown as vscode.OutputChannel, { extractImportSuggestions } as unknown as ImportHandler);
+        const diagnostics = Array.from({ length: diagnosticCount }, () => ({
+            message: "Unknown identifier `button_device`",
+            range: { start: { line: 7 } },
+        }));
+
+        const actions = await provider.provideCodeActions(
+            { uri: { toString: () => "file:///Project/Content/Scripts/device.verse" } } as unknown as vscode.TextDocument,
+            {} as unknown as vscode.Range,
+            { diagnostics } as unknown as vscode.CodeActionContext,
+            { isCancellationRequested } as unknown as vscode.CancellationToken,
+        );
+
+        return { actions, extractImportSuggestions };
+    };
+
+    it("extracts nothing once the request is cancelled", async () => {
+        const { actions, extractImportSuggestions } = await driveWith(true, 3);
+
+        expect(extractImportSuggestions).not.toHaveBeenCalled();
+        expect(actions).toBeUndefined();
+    });
+
+    it("extracts for every diagnostic while the request is live", async () => {
+        const { extractImportSuggestions } = await driveWith(false, 3);
+
+        expect(extractImportSuggestions).toHaveBeenCalledTimes(3);
+    });
+});

--- a/src/visibility/ModuleVisibilityCodeActionProvider.ts
+++ b/src/visibility/ModuleVisibilityCodeActionProvider.ts
@@ -13,6 +13,12 @@ import { parseModuleVisibilityMessage } from "./ModuleVisibilityMessage";
  */
 export class ModuleVisibilityCodeActionProvider implements vscode.CodeActionProvider {
     /**
+     * Declared to the registration so VS Code skips this provider whenever a
+     * kind outside quick fixes is requested.
+     */
+    static readonly providedCodeActionKinds: readonly vscode.CodeActionKind[] = [vscode.CodeActionKind.QuickFix];
+
+    /**
      * One action per diagnostic that names an inaccessible internal module, or
      * undefined when none does.
      */


### PR DESCRIPTION
Closes #365

Both quick fix registrations passed only a selector and a provider, so VS Code invoked them for every code-action request of every kind — refactor menus, source-action menus, on-type — and `ImportCodeActionProvider` ran its async per-diagnostic extraction for requests it can never serve. It also accepted a `CancellationToken` it never read, so a request superseded by the next cursor move still paid that extraction to produce a result the editor discards.

## What changed

- `src/extension.ts` — both quick fix registrations now pass `providedCodeActionKinds`. The comment on the organize registration is reworded: its metadata is still the load-bearing one, but it is no longer the only registration that carries any.
- `src/imports/ImportCodeActionProvider.ts` — a `static readonly providedCodeActionKinds` of `[QuickFix]`, mirroring `ImportOrganizeCodeActionProvider`, and a cancellation check at the top of the diagnostics loop. Inside the loop rather than before it, so it re-checks after each `await`.
- `src/visibility/ModuleVisibilityCodeActionProvider.ts` — the same static declaration.
- Regression tests at both entry points: `activate()` for the registration metadata (including an assertion that no code action provider is registered without it), and `provideCodeActions` for the token.

The generic `QuickFix` kind is declared although the actions carry the sub-kinds `quickfix.verse.import` and `quickfix.verse.moduleVisibility`. `CodeActionProviderMetadata` in `@types/vscode` (`index.d.ts:2725-2728`) endorses a generic list explicitly, and matching is containment in both directions, so a plain `quickfix` request and a sub-kind-scoped request both still reach these providers.

## Verification

Both regression tests were confirmed to detect the defect: with the source reverted and the tests kept, 4 of the 6 new assertions fail; the two that still pass are the ones pinning pre-existing behaviour.

```
> npm run compile
> tsc -p ./
```

```
> npm test
> jest --verbose

Test Suites: 53 passed, 53 total
Tests:       1591 passed, 1591 total
Snapshots:   0 total
Time:        15.168 s
```

```
> npm run format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

## Review

One round at opus, fresh context: `PASS_WITH_SUGGESTIONS` — 0 Critical, 0 Important, 3 Suggestions. It probed the provider directly over zero diagnostics, several diagnostics, a token cancelled up front, and a token shaped as VS Code really passes it that flips to cancelled partway through the loop, plus the metadata reaching all three registrations. The suggestions are trade-offs recorded rather than changes asked for: the generic vs sub-kind declaration, the static field vs the ticket's inline literal, and a pre-existing duplication of the fake `ExtensionContext` across the three activate-driven spec files.
