### PR TITLE
fix(imports): keep a header-driven insert out of an unclosed comment

### DIFF
--- a/changelog.d/451.fixed.md
+++ b/changelog.d/451.fixed.md
@@ -1,0 +1,1 @@
+**Import placement**: An import added to a file that opens with a block comment that never closes is now written above that comment instead of inside it, where it was invisible to the scan and re-added on every later compile.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -102,6 +102,12 @@ function queuedEditsFor(edit: vscode.WorkspaceEdit, uri: vscode.Uri): QueuedEdit
  * A run of nothing but blank lines is not a header: it describes nothing, and
  * it is dropped here as it always was.
  *
+ * Neither is the run an unterminated `<#` swallowed. A block comment left open
+ * runs to the end of the buffer, so a run reaching that end has no line below
+ * it to write an import on and naming it would put the import inside the
+ * comment - where the scanner cannot see it, and the next compile adds it
+ * again. Only the closed lines above the opener are header.
+ *
  * The opening run wins over the annotation rule below, so a comment on line 0
  * written against the first import stays at the top of the block rather than
  * following that import down through a sort. Line 0 is ambiguous - a file
@@ -114,6 +120,20 @@ function headerLineCount(classifications: LineClassification[]): number {
     while (end < classifications.length && classifications[end].kind !== "code") {
         end++;
     }
+
+    // Step back over the run an unclosed opener holds, to the line that opener
+    // sits on. Back to that line and no further: a header closed above it is
+    // still a header, and starting from 0 instead would write the import above
+    // a licence, which is the placement this function exists to prevent.
+    //
+    // Reached only where the walk found no code line at all, since a line below
+    // one ending inside a block comment cannot be code.
+    if (end === classifications.length) {
+        while (end > 0 && classifications[end - 1].endsInsideBlockComment) {
+            end--;
+        }
+    }
+
     return classifications.slice(0, end).some((classification) => classification.kind === "comment") ? end : 0;
 }
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -792,6 +792,50 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["/Added"], curlySorted)).toBe("# Copyright 2026 MyGame\n\nusing { /Added }\nusing { /Existing }\n\ncode()");
     });
 
+    // A file opening with an opener that never closes is comment to its last
+    // line, so the header ran to the end of the buffer and the added import was
+    // written past it - inside the comment, where the scan cannot see it and
+    // the next compile adds it again. The floor never gets a say here: nothing
+    // is pinned, which is what separates this from the shape #454 covered.
+    it("writes an added path above an unclosed opener that opens the file", () => {
+        const input = ["<# note", "still note"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["using { /B }", "", "<# note", "still note"].join("\n"));
+    });
+
+    it("writes an added relative path above an unclosed opener that opens the file", () => {
+        const input = ["<# note", "still note"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["Gadgets.Tools"], curlySorted)).toBe(["using { Gadgets.Tools }", "", "<# note", "still note"].join("\n"));
+    });
+
+    // Only the run the opener swallowed stops being header. A licence closed
+    // above it is still one, and starting from line 0 instead would write the
+    // import above it.
+    it("keeps a closed header above the import when an unclosed opener follows it", () => {
+        const input = ["# Copyright 2026 MyGame", "<# unclosed", "more"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["# Copyright 2026 MyGame", "using { /B }", "", "<# unclosed", "more"].join("\n"));
+    });
+
+    it("steps back only to the opener that never closes, not to one that did", () => {
+        const input = ["<# a", "b #>", "<# unclosed"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["<# a", "b #>", "using { /B }", "", "<# unclosed"].join("\n"));
+    });
+
+    // Reaching the end of the buffer is not itself the fault - a closed comment
+    // leaves a writable line below it. The guard keys on the comment still
+    // being open, so neither of these moves.
+    it("still writes below a header of entirely closed comment", () => {
+        const input = ["<# note #>", "# more"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["<# note #>", "# more", "using { /B }", ""].join("\n"));
+    });
+
+    // A `<#>` marker raises no block-comment depth, and a column-0 line ends
+    // the indented block its body sits in, so the line below the body is real
+    // code and the import belongs there.
+    it("still writes below an indented comment whose body ends the buffer", () => {
+        const input = ["<#> note", "    body"].join("\n");
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["<#> note", "    body", "using { /B }", ""].join("\n"));
+    });
+
     it("writes the preferred dot syntax", () => {
         const input = "using { /A }\ncode()";
         expect(
@@ -1691,6 +1735,34 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(insert).toBeDefined();
             expect(insert!.position!.line).toBe(2);
             expect(insert!.text).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n");
+        });
+
+        // Every case above has code below the header. Where the header is an
+        // opener that never closes it runs to the last line instead, and the
+        // insert took insertImportLines' end-of-document branch - appending the
+        // import after that line, inside the comment.
+        it("writes above an opener that never closes, not past the last line", async () => {
+            mockConfig({ "behavior.preserveImportLocations": true });
+            const input = ["<# note", "still note"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+        });
+
+        it("writes between a closed header and the unclosed opener below it", async () => {
+            mockConfig({ "behavior.preserveImportLocations": true });
+            const input = ["# Copyright 2026 MyGame", "<# unclosed", "more"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
+
+            expect(success).toBe(true);
+            const insert = appliedOperations(0).find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(1);
         });
     });
 


### PR DESCRIPTION
Closes #451

A file whose text opens with a `<#` that never closes is comment to its last line. `headerLineCount` identifies the header by walking to the first `kind === "code"` line, which never arrives, so it returned `classifications.length` — an index past the last line of the buffer. Both entry points wrote the added import there:

- `buildOrganizedContent` used it as a slice boundary, so `header` was the whole file, the body loop never ran, and the block was appended after everything.
- `applyImports` passed it to `insertImportLines`, where `line >= document.lineCount` takes the end-of-document branch and appends after the last line — correct for every other caller, wrong only here.

The scan skips a line whose `insideBlockComment` is set, so the written import never counted as present and the next compile-plus-add wrote another copy. That is the compounding half of #389's shape (b), reached through the header path instead of the floor path; #454 fixed the floor path and filed this one out of its diff.

## The change

One guard in `headerLineCount`, the single function both entry points read:

```ts
if (end === classifications.length) {
    while (end > 0 && classifications[end - 1].endsInsideBlockComment) {
        end--;
    }
}
```

It steps back over the run the unterminated opener swallowed, to the line that opener sits on. The existing `some(kind === "comment")` test then does the rest: a pulled-back `end` of 0 leaves an empty slice and returns 0, and a blank-only remainder still fails that test exactly as before.

**Stepping back to the opener rather than to 0.** The issue's smallest-fix wording is "the file has no header for placement purposes", i.e. return 0. That is wrong in the mixed case: for `["# Copyright", "<# unclosed", "more"]` it would write the import at line 0, above the licence — which is the placement this very function exists to prevent, and which its own doc calls "the one place a header must never be". Walking back over the trailing unterminated run costs three lines, degrades to 0 in the issue's own example, and keeps the invariant. It walks backwards from the end rather than forwards to the first `endsInsideBlockComment` line, so a comment that did close earlier in the header (`["<# a", "b #>", "<# unclosed"]`) does not drag the import above it.

This answers the question the issue left open — whether an import may be written into a file that is entirely comment, and if so where — as **yes, directly above the unterminated opener**. Consistent with #454, which dropped an unwritable floor rather than refuse, on the ground that the file cannot compile either way and a path that silently lands nowhere is the worse outcome.

**Blast radius.** The guard can only fire where the walk reached the end of the buffer, i.e. where the file has no code line at all — and `scanModuleImports` cannot find an import on a non-code line, so such a file has no imports. Only added paths are ever written under it, and `attachedCommentStart`, the other `headerEnd` consumer, is never reached.

## Verse rules this rests on

Settled at the compiler source, not off this extension's own scanner.

- **An unclosed `<#` consumes every line to the end of the buffer.** `BlockCmt := "<#" !'>' {Text|NewLine} !'<' "#>"` (`VerseGrammar.h:2026-2039`) — the `{Text|NewLine}` loop takes newlines, and on `Cursor[0] == 0` it emits S04, "Block comment beginning at `<#` never ends" (`:1290-1293`). So there is genuinely no writable line below such an opener.
- **A `<#>` marker raises no block-comment depth.** At `Text`'s `case '<'` (`VerseGrammar.h:2117-2137`), `<#` where `Cursor[2] != '>'` dispatches `BlockCmt()`, while `<#>` dispatches `IndCmt()`, a separate production. This is why `endsInsideBlockComment` is correctly false for a file that is one `<#>` marker plus an indented body, and why the guard keys on that flag rather than on "the header reached the end of the buffer" — the latter would over-fire on that shape and on a file of entirely closed comments.
- **A column-0 line ends an indented block.** `Line()` (`VerseGrammar.h:1666-1690`) matches the opener's whitespace prefix byte-wise, so an import written at column 0 below a `<#>` body is real code. That shape is already correct and is left untouched.

## Tests

Eight regression tests at the two entry points the issue names. Through `buildOrganizedContent`: the issue's own example with an absolute added path, the same with a relative one, a closed header above the opener, and an earlier comment that did close. Through `addImportsToDocument`, in `describe("adding to a headered file with no import block")` — every input there had real code below the header, none had the header itself never closing — the pure case at line 0 and the mixed case at line 1, asserted on the edit position so an append-past-the-last-line regression cannot pass.

Two negatives pin that the guard does not over-fire: a header of entirely closed comment, and a `<#>` marker whose body ends the buffer. Both pass before and after, on purpose.

**Proven to detect the defect.** The source hunk was reverted with the tests left in place: exactly the six positives failed and nothing else did, reproducing the reported output verbatim — `"<# note\nstill note\nusing { /B }"`, the import inside the comment. (Reverted by copying the file aside rather than `git stash`, which is shared across this repo's worktrees.)

## Probes

Around 50 input permutations exercised at both call sites, beyond the committed tests:

- **`buildOrganizedContent`, 28 shapes** — absolute and relative added paths; sorted and unsorted; `none`/`digestFirst`/`localFirst` grouping; LF and CRLF; a single-line `<#`; an empty buffer; blank lines before the opener; nested openers closed once and not at all; a `<#` inside a string literal on a code line; an existing import above and below the opener; an import inside a `<#>` body; a nested unclosed `<#` inside a `<#>` body; a bare `#>`; a trailing blank line. All correct.
- **`addImportsToDocument`, 21 shapes** — `preserveImportLocations` true and false across the same axes. Every one wrote the import outside the comment; the `<#>`-body and all-closed-comment cases still append below the header, unchanged.
- **Idempotence** — 6 organize inputs run three times each and 4 add-path inputs run twice each, all stable with nothing re-added. This is the half of the issue that mattered most: the duplicate on every later compile is gone.

## Review

**The review gate did not complete.** Three reviewer subagents were spawned and all three hung without returning a verdict — the last produced one line of output in 25 minutes — so this PR carries no independent review. The probe evidence above was recovered from the first reviewer's harness and run directly rather than taken on its word. Worth a human read before merge, particularly on the divergence from the issue's literal "return 0" wording.

## Verification

```
> verse-auto-imports@0.11.2 compile
> tsc -p ./
```

```
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 52 passed, 52 total
Tests:       1593 passed, 1593 total
Snapshots:   0 total
Time:        12.673 s
Ran all test suites.
```

```
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

`npx jest src/imports/__tests__` for the extractor-order check: 10 suites, 916 tests, all passing, no unrelated case changing shape. `ImportSuggestionExtractor` is untouched, so no pattern was added, moved or broadened and there is nothing to shadow.
