### PR TITLE
fix(project): resolve the project file from the folder its file sits in

### DIFF
--- a/changelog.d/450.fixed.md
+++ b/changelog.d/450.fixed.md
@@ -1,1 +1,1 @@
-**Project detection**: the project's Verse path, name and root plugin now come from the .uefnproject owning the file being worked on, so a multi-root workspace holding two UEFN projects no longer answers every file from the first project.
+**Project detection**: the Verse path and root plugin now come from the .uefnproject owning the file being worked on, so a multi-root workspace with two UEFN projects no longer answers every file from the first.

--- a/changelog.d/450.fixed.md
+++ b/changelog.d/450.fixed.md
@@ -1,0 +1,1 @@
+**Project detection**: the project's Verse path, name and root plugin now come from the .uefnproject owning the file being worked on, so a multi-root workspace holding two UEFN projects no longer answers every file from the first project.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -352,7 +352,7 @@ export class ImportPathConverter {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(currentFileUri);
         if (!workspaceFolder) return;
 
-        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, currentFileUri.fsPath, await this.projectPathHandler.getRootPluginName());
+        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, currentFileUri.fsPath, await this.projectPathHandler.getRootPluginName(currentFileUri));
         if (!placement) return;
 
         // Every path below is reasoned about with a leading Content/, whatever
@@ -750,7 +750,7 @@ export class ImportPathConverter {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri);
         if (!workspaceFolder) return null;
 
-        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, documentUri.fsPath, await this.projectPathHandler.getRootPluginName());
+        const placement = ImportPathConverter.placeUnderContentRoot(workspaceFolder.uri.fsPath, documentUri.fsPath, await this.projectPathHandler.getRootPluginName(documentUri));
         if (!placement) return null;
 
         return placement.fileDirRelative ? `${projectVersePath}/${placement.fileDirRelative}` : projectVersePath;

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -868,7 +868,7 @@ export class ImportPathConverter {
             return null;
         }
 
-        const projectVersePath = await this.projectPathHandler.getProjectVersePath();
+        const projectVersePath = await this.projectPathHandler.getProjectVersePath(documentUri);
         if (!projectVersePath) {
             return null;
         }
@@ -1000,7 +1000,7 @@ export class ImportPathConverter {
 
         const { fullPath: modulePath, moduleName } = moduleInfo;
 
-        const projectVersePath = await this.projectPathHandler.getProjectVersePath();
+        const projectVersePath = await this.projectPathHandler.getProjectVersePath(documentUri);
         if (!projectVersePath) {
             vscode.window.showWarningMessage("Could not find .uefnproject file in workspace. Please ensure you have a valid UEFN project.");
             return null;

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -26,77 +26,150 @@ interface UEFNProjectFile {
 }
 
 /**
+ * The cache key for a lookup that named no workspace folder. A folder's URI
+ * never stringifies to empty, so this cannot collide with one.
+ */
+const WORKSPACE_SCOPE = "";
+
+/** How far above a folder the search looks for the project file. */
+const MAX_PARENT_LEVELS = 5;
+
+/**
  * Resolves the project's Verse path, name and module list from its
  * `.uefnproject` file.
  *
- * All three cached fields come from a single parse and are cleared together by
- * `clearCache`; leaving one behind would answer from a project file that is no
- * longer on disk.
+ * A multi-root workspace can hold two UEFN projects, so an answer is only
+ * meaningful about a particular file: every accessor takes the resource being
+ * worked on and answers for the project that owns it, caching per workspace
+ * folder rather than per handler. A caller that names no resource gets the
+ * whole-workspace search instead, which is what the activation-time readers
+ * need - they identify the workspace, not a file in it.
  */
 export class ProjectPathHandler {
-    private projectVersePath: string | null = null;
-    private projectName: string | null = null;
-    private cachedProjectFile: UEFNProjectFile | null = null;
+    /**
+     * The parsed project file per workspace folder, keyed by folder URI.
+     *
+     * Keyed by the folder searched from rather than the project file found,
+     * because the key has to be known before the search that would reveal the
+     * file. Two folders under one project therefore hold equal entries, which
+     * costs a second parse and never a wrong answer.
+     */
+    private readonly projectFilesByScope = new Map<string, UEFNProjectFile>();
 
     constructor(private outputChannel: vscode.OutputChannel) {}
 
     /**
-     * The parsed `.uefnproject`, searched for in each workspace folder and then
-     * up to five directories above the first one: UEFN's older project layout
-     * nests the Verse code under `<project>/Plugins/<ProjectName>/Content`, so
-     * the folder the user opens is often below the project file rather than at
-     * it.
+     * The parsed `.uefnproject` that owns `resource`, or the first one in the
+     * workspace when nothing names a folder.
      *
      * Only a success is cached, so in a workspace with no `.uefnproject` every
      * call redoes the folder scan and the parent walk from scratch.
+     *
+     * @param resource a file in the project being asked about. A resource
+     * outside every workspace folder falls back to the whole-workspace search
+     * rather than answering nothing.
      */
-    async findAndParseProjectFile(): Promise<UEFNProjectFile | null> {
-        if (this.cachedProjectFile) {
-            return this.cachedProjectFile;
+    async findAndParseProjectFile(resource?: vscode.Uri): Promise<UEFNProjectFile | null> {
+        const scope = resource ? vscode.workspace.getWorkspaceFolder(resource) : undefined;
+        const key = scope ? scope.uri.toString() : WORKSPACE_SCOPE;
+
+        const cached = this.projectFilesByScope.get(key);
+        if (cached) {
+            return cached;
         }
 
+        const projectFile = await this.searchForProjectFile(scope);
+        if (projectFile) {
+            this.projectFilesByScope.set(key, projectFile);
+        }
+
+        return projectFile;
+    }
+
+    /**
+     * The project file for `scope`, falling back to the whole workspace.
+     *
+     * The scoped half is what makes a second project in the workspace
+     * reachable; the fallback is what keeps a workspace whose first folder
+     * holds no project working, since the project can sit in any folder.
+     */
+    private async searchForProjectFile(scope: vscode.WorkspaceFolder | undefined): Promise<UEFNProjectFile | null> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) {
             logger.debug("ProjectPathHandler", "No workspace folders found");
             return null;
         }
 
-        for (const folder of workspaceFolders) {
-            const files = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, "*.uefnproject"), null, 1);
+        if (scope) {
+            const own = await this.readProjectFileIn(scope);
+            if (own !== undefined) {
+                return own;
+            }
 
-            if (files.length > 0) {
-                const projectFilePath = files[0].fsPath;
-                logger.debug("ProjectPathHandler", `Found .uefnproject file at: ${projectFilePath}`);
-
-                try {
-                    const content = fs.readFileSync(projectFilePath, "utf8");
-                    this.cachedProjectFile = JSON.parse(content) as UEFNProjectFile;
-
-                    if (this.cachedProjectFile.bindings?.projectVersePath) {
-                        this.projectVersePath = this.cachedProjectFile.bindings.projectVersePath;
-                        logger.debug("ProjectPathHandler", `Project Verse path: ${this.projectVersePath}`);
-                    }
-
-                    if (this.cachedProjectFile.title) {
-                        this.projectName = this.cachedProjectFile.title;
-                    }
-
-                    return this.cachedProjectFile;
-                } catch (error) {
-                    // A project file that exists but will not parse ends the
-                    // search. Walking on would answer from some parent
-                    // project's paths, which is worse than answering nothing.
-                    logger.debug("ProjectPathHandler", `Error parsing .uefnproject file: ${error}`);
-                    return null;
-                }
+            const above = await this.walkUpFrom(scope.uri);
+            if (above) {
+                return above;
             }
         }
 
-        const firstWorkspace = workspaceFolders[0];
-        let currentDir = firstWorkspace.uri.fsPath;
-        const maxLevels = 5;
+        for (const folder of workspaceFolders) {
+            const found = await this.readProjectFileIn(folder);
+            if (found !== undefined) {
+                return found;
+            }
+        }
 
-        for (let level = 0; level < maxLevels; level++) {
+        const above = await this.walkUpFrom(workspaceFolders[0].uri);
+        if (!above) {
+            logger.debug("ProjectPathHandler", `No .uefnproject file found in workspace or parent directories (checked up to ${MAX_PARENT_LEVELS} levels)`);
+        }
+
+        return above;
+    }
+
+    /**
+     * The project file directly in `base`.
+     *
+     * Undefined when the directory holds none, which means the search goes on.
+     * Null when it holds one that will not parse, which ends the search:
+     * walking on would answer from some parent project's paths, which is worse
+     * than answering nothing.
+     */
+    private async readProjectFileIn(base: vscode.WorkspaceFolder | vscode.Uri): Promise<UEFNProjectFile | null | undefined> {
+        const files = await vscode.workspace.findFiles(new vscode.RelativePattern(base, "*.uefnproject"), null, 1);
+
+        if (files.length === 0) {
+            return undefined;
+        }
+
+        const projectFilePath = files[0].fsPath;
+        logger.debug("ProjectPathHandler", `Found .uefnproject file at: ${projectFilePath}`);
+
+        try {
+            return ProjectPathHandler.parseProjectFile(projectFilePath);
+        } catch (error) {
+            logger.debug("ProjectPathHandler", `Error parsing .uefnproject file: ${error}`);
+            return null;
+        }
+    }
+
+    /**
+     * The project file in the nearest of up to five directories above `start`,
+     * or null when none of them holds one.
+     *
+     * UEFN's older project layout nests the Verse code under
+     * `<project>/Plugins/<ProjectName>/Content`, so the folder the user opens
+     * is often below the project file rather than at it.
+     *
+     * A file that will not parse only ends its own level here, where it ends
+     * the whole search in readProjectFileIn: a directory closer to the file
+     * has the better claim to answer, so an unreadable one there is decisive,
+     * while one found part-way up should not hide a project above it.
+     */
+    private async walkUpFrom(start: vscode.Uri): Promise<UEFNProjectFile | null> {
+        let currentDir = start.fsPath;
+
+        for (let level = 0; level < MAX_PARENT_LEVELS; level++) {
             const parentDir = path.dirname(currentDir);
 
             if (parentDir === currentDir) {
@@ -111,19 +184,7 @@ export class ProjectPathHandler {
                     const projectFilePath = files[0].fsPath;
                     logger.debug("ProjectPathHandler", `Found .uefnproject file in parent directory (${level + 1} level(s) up): ${projectFilePath}`);
 
-                    const content = fs.readFileSync(projectFilePath, "utf8");
-                    this.cachedProjectFile = JSON.parse(content) as UEFNProjectFile;
-
-                    if (this.cachedProjectFile.bindings?.projectVersePath) {
-                        this.projectVersePath = this.cachedProjectFile.bindings.projectVersePath;
-                        logger.debug("ProjectPathHandler", `Project Verse path: ${this.projectVersePath}`);
-                    }
-
-                    if (this.cachedProjectFile.title) {
-                        this.projectName = this.cachedProjectFile.title;
-                    }
-
-                    return this.cachedProjectFile;
+                    return ProjectPathHandler.parseProjectFile(projectFilePath);
                 }
             } catch (error) {
                 logger.debug("ProjectPathHandler", `Error searching parent directory at level ${level + 1}: ${error}`);
@@ -132,34 +193,36 @@ export class ProjectPathHandler {
             currentDir = parentDir;
         }
 
-        logger.debug("ProjectPathHandler", "No .uefnproject file found in workspace or parent directories (checked up to 5 levels)");
         return null;
+    }
+
+    /** Raises on an unreadable file and on one that is not JSON alike. */
+    private static parseProjectFile(projectFilePath: string): UEFNProjectFile {
+        return JSON.parse(fs.readFileSync(projectFilePath, "utf8")) as UEFNProjectFile;
     }
 
     /**
      * The project's Verse path, the prefix every module in it is addressed
      * under: `/vukefn@fortnite.com/MyGame`. Passed through exactly as UEFN
      * wrote it - callers that join onto it add their own separator.
+     *
+     * @param resource the file the path is wanted for, which is what picks the
+     * project in a multi-root workspace.
      */
-    async getProjectVersePath(): Promise<string | null> {
-        if (this.projectVersePath) {
-            return this.projectVersePath;
-        }
-
-        const projectFile = await this.findAndParseProjectFile();
+    async getProjectVersePath(resource?: vscode.Uri): Promise<string | null> {
+        const projectFile = await this.findAndParseProjectFile(resource);
         return projectFile?.bindings?.projectVersePath || null;
     }
 
     /**
      * The project's display title, which is not necessarily the name of the
      * directory holding it.
+     *
+     * @param resource the file the title is wanted for, which is what picks
+     * the project in a multi-root workspace.
      */
-    async getProjectName(): Promise<string | null> {
-        if (this.projectName) {
-            return this.projectName;
-        }
-
-        const projectFile = await this.findAndParseProjectFile();
+    async getProjectName(resource?: vscode.Uri): Promise<string | null> {
+        const projectFile = await this.findAndParseProjectFile(resource);
         return projectFile?.title || null;
     }
 
@@ -171,29 +234,34 @@ export class ProjectPathHandler {
      * and only the root plugin's Content answers to that path - a second
      * plugin carries a Verse path of its own. So this is what separates a
      * Content root the project's path can address from one it cannot.
+     *
+     * @param resource the file the plugin is wanted for, which is what picks
+     * the project in a multi-root workspace.
      */
-    async getRootPluginName(): Promise<string | null> {
-        const projectFile = await this.findAndParseProjectFile();
+    async getRootPluginName(resource?: vscode.Uri): Promise<string | null> {
+        const projectFile = await this.findAndParseProjectFile(resource);
         return projectFile?.plugins?.find((plugin) => plugin.bIsRoot)?.name || null;
     }
 
     /**
      * The project's `bindings.modules` map, verbatim. Nothing in `src/` calls
      * this, so what the keys and values mean is UEFN's to define.
+     *
+     * @param resource the file the map is wanted for, which is what picks the
+     * project in a multi-root workspace.
      */
-    async getProjectModules(): Promise<Record<string, string> | null> {
-        const projectFile = await this.findAndParseProjectFile();
+    async getProjectModules(resource?: vscode.Uri): Promise<Record<string, string> | null> {
+        const projectFile = await this.findAndParseProjectFile(resource);
         return projectFile?.bindings?.modules || null;
     }
 
     /**
-     * Drops the parsed project file and everything derived from it, so the
-     * next read re-runs the search.
+     * Drops every folder's parsed project file, so the next read re-runs the
+     * search. Clearing one folder would leave the others answering from a file
+     * that is no longer on disk.
      */
     clearCache(): void {
-        this.cachedProjectFile = null;
-        this.projectVersePath = null;
-        this.projectName = null;
+        this.projectFilesByScope.clear();
         logger.debug("ProjectPathHandler", "Cleared project path cache");
     }
 

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -113,6 +113,13 @@ export class ProjectPathHandler {
         }
 
         for (const folder of workspaceFolders) {
+            // Already searched above, and the answer for a directory does not
+            // change within one call, so asking again would only repeat a
+            // workspace search that has already come back empty.
+            if (scope && folder.uri.toString() === scope.uri.toString()) {
+                continue;
+            }
+
             const found = await this.readProjectFileIn(folder);
             if (found !== undefined) {
                 return found;
@@ -128,15 +135,15 @@ export class ProjectPathHandler {
     }
 
     /**
-     * The project file directly in `base`.
+     * The project file directly in `folder`.
      *
-     * Undefined when the directory holds none, which means the search goes on.
+     * Undefined when the folder holds none, which means the search goes on.
      * Null when it holds one that will not parse, which ends the search:
      * walking on would answer from some parent project's paths, which is worse
      * than answering nothing.
      */
-    private async readProjectFileIn(base: vscode.WorkspaceFolder | vscode.Uri): Promise<UEFNProjectFile | null | undefined> {
-        const files = await vscode.workspace.findFiles(new vscode.RelativePattern(base, "*.uefnproject"), null, 1);
+    private async readProjectFileIn(folder: vscode.WorkspaceFolder): Promise<UEFNProjectFile | null | undefined> {
+        const files = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, "*.uefnproject"), null, 1);
 
         if (files.length === 0) {
             return undefined;

--- a/src/project/__tests__/ProjectPathHandler.test.ts
+++ b/src/project/__tests__/ProjectPathHandler.test.ts
@@ -1,0 +1,170 @@
+import * as fs from "fs";
+import * as vscode from "vscode";
+import { ProjectPathHandler } from "../ProjectPathHandler";
+
+/**
+ * Regression tests for issue #450: the handler searched every workspace folder
+ * for a `.uefnproject` but returned on the first one it found and cached it on
+ * the instance, so in a multi-root workspace holding two UEFN projects every
+ * answer described whichever project sat in the lowest-indexed folder.
+ *
+ * These drive the real folder search through the vscode mock rather than a
+ * stubbed resolver, because the defect was in which directory was searched.
+ */
+describe("ProjectPathHandler", () => {
+    const FIRST_ROOT = "/workspace/first";
+    const SECOND_ROOT = "/workspace/second";
+    const NOTES_ROOT = "/workspace/notes";
+
+    const projectFor = (name: string) => ({
+        title: name,
+        bindings: {
+            projectVersePath: `/mygame@fortnite.com/${name.toLowerCase()}`,
+            modules: { [name]: `${name}.versemodule` },
+        },
+        plugins: [{ name, bIsRoot: true }],
+    });
+
+    const FIRST = projectFor("FirstGame");
+    const SECOND = projectFor("SecondGame");
+
+    /** Directory holding a `.uefnproject` -> its content, parsed or raw text. */
+    let projectsByDirectory: Map<string, unknown>;
+    /** Project files read, in order, so a cache hit can be told from a miss. */
+    let reads: string[];
+    let handler: ProjectPathHandler;
+
+    const forwardSlashed = (fsPath: string) => fsPath.replace(/\\/g, "/").replace(/\/+$/, "");
+    const projectPathIn = (directory: string) => `${directory}/Project.uefnproject`;
+
+    /** Registers the workspace folders in the order VS Code would index them. */
+    const givenWorkspaceFolders = (...roots: string[]): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = roots.map((root, index) => ({
+            uri: vscode.Uri.file(root),
+            name: root.split("/").pop() ?? root,
+            index,
+        }));
+    };
+
+    /** Puts a `.uefnproject` in each named directory and nowhere else. */
+    const givenProjectsIn = (byDirectory: Record<string, unknown>): void => {
+        projectsByDirectory = new Map(Object.entries(byDirectory));
+    };
+
+    const fileIn = (root: string) => vscode.Uri.file(`${root}/Content/main.verse`);
+
+    beforeEach(() => {
+        reads = [];
+        projectsByDirectory = new Map();
+
+        // findFiles is a bare mockResolvedValue([]) on the shared mock, so the
+        // per-directory answer has to be supplied here. The pattern's base is a
+        // WorkspaceFolder when the handler searches a folder and a Uri when it
+        // walks up from one, so both shapes have to be unwrapped.
+        (vscode.workspace.findFiles as jest.Mock).mockImplementation(async (pattern: { base: { uri?: { fsPath: string }; fsPath?: string } }) => {
+            const base = pattern.base.uri ?? (pattern.base as { fsPath: string });
+            const directory = forwardSlashed(base.fsPath);
+
+            return projectsByDirectory.has(directory) ? [vscode.Uri.file(projectPathIn(directory))] : [];
+        });
+
+        jest.spyOn(fs, "readFileSync").mockImplementation(((target: string): string => {
+            const requested = forwardSlashed(String(target));
+            reads.push(requested);
+
+            const project = projectsByDirectory.get(requested.replace(/\/Project\.uefnproject$/, ""));
+            if (project === undefined) {
+                throw new Error(`ENOENT: ${requested}`);
+            }
+
+            return typeof project === "string" ? project : JSON.stringify(project);
+        }) as unknown as typeof fs.readFileSync);
+
+        handler = new ProjectPathHandler(vscode.window.createOutputChannel("test"));
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        (vscode.workspace.findFiles as jest.Mock).mockReset().mockResolvedValue([]);
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = undefined;
+    });
+
+    it("answers for the project in the folder the file belongs to", async () => {
+        givenWorkspaceFolders(FIRST_ROOT, SECOND_ROOT);
+        givenProjectsIn({ [FIRST_ROOT]: FIRST, [SECOND_ROOT]: SECOND });
+
+        // The first folder is asked first on purpose: the defect was that the
+        // first answer became every later answer.
+        const first = await handler.getProjectVersePath(fileIn(FIRST_ROOT));
+        const second = await handler.getProjectVersePath(fileIn(SECOND_ROOT));
+
+        expect(first).toBe("/mygame@fortnite.com/firstgame");
+        expect(second).toBe("/mygame@fortnite.com/secondgame");
+    });
+
+    it("scopes the name, the root plugin and the module map to the same folder", async () => {
+        givenWorkspaceFolders(FIRST_ROOT, SECOND_ROOT);
+        givenProjectsIn({ [FIRST_ROOT]: FIRST, [SECOND_ROOT]: SECOND });
+        await handler.getProjectName(fileIn(FIRST_ROOT));
+
+        const second = fileIn(SECOND_ROOT);
+
+        expect(await handler.getProjectName(second)).toBe("SecondGame");
+        expect(await handler.getRootPluginName(second)).toBe("SecondGame");
+        expect(await handler.getProjectModules(second)).toEqual({ SecondGame: "SecondGame.versemodule" });
+    });
+
+    it("walks up from the file's own folder rather than the first one", async () => {
+        const deepRoot = `${SECOND_ROOT}/Plugins/SecondGame/Content`;
+        givenWorkspaceFolders(FIRST_ROOT, deepRoot);
+        givenProjectsIn({ [FIRST_ROOT]: FIRST, [SECOND_ROOT]: SECOND });
+
+        expect(await handler.getProjectVersePath(vscode.Uri.file(`${deepRoot}/main.verse`))).toBe("/mygame@fortnite.com/secondgame");
+    });
+
+    it("searches every folder when nothing names one", async () => {
+        givenWorkspaceFolders(NOTES_ROOT, SECOND_ROOT);
+        givenProjectsIn({ [SECOND_ROOT]: SECOND });
+
+        expect(await handler.getProjectVersePath()).toBe("/mygame@fortnite.com/secondgame");
+    });
+
+    it("falls back to the workspace for a file under no folder", async () => {
+        givenWorkspaceFolders(NOTES_ROOT, SECOND_ROOT);
+        givenProjectsIn({ [SECOND_ROOT]: SECOND });
+
+        expect(await handler.getProjectVersePath(vscode.Uri.file("/elsewhere/scratch.verse"))).toBe("/mygame@fortnite.com/secondgame");
+    });
+
+    it("answers nothing rather than another project when the file will not parse", async () => {
+        givenWorkspaceFolders(FIRST_ROOT, SECOND_ROOT);
+        givenProjectsIn({ [FIRST_ROOT]: FIRST, [SECOND_ROOT]: "{ not json" });
+
+        expect(await handler.getProjectVersePath(fileIn(SECOND_ROOT))).toBeNull();
+    });
+
+    it("parses a folder's project file once", async () => {
+        givenWorkspaceFolders(FIRST_ROOT, SECOND_ROOT);
+        givenProjectsIn({ [FIRST_ROOT]: FIRST, [SECOND_ROOT]: SECOND });
+        const second = fileIn(SECOND_ROOT);
+
+        await handler.getProjectVersePath(second);
+        await handler.getProjectName(second);
+
+        expect(reads).toEqual([projectPathIn(SECOND_ROOT)]);
+    });
+
+    it("clears every folder's entry, not only one", async () => {
+        givenWorkspaceFolders(FIRST_ROOT, SECOND_ROOT);
+        givenProjectsIn({ [FIRST_ROOT]: FIRST, [SECOND_ROOT]: SECOND });
+        await handler.getProjectVersePath(fileIn(FIRST_ROOT));
+        await handler.getProjectVersePath(fileIn(SECOND_ROOT));
+        reads = [];
+
+        handler.clearCache();
+        await handler.getProjectVersePath(fileIn(FIRST_ROOT));
+        await handler.getProjectVersePath(fileIn(SECOND_ROOT));
+
+        expect(reads).toEqual([projectPathIn(FIRST_ROOT), projectPathIn(SECOND_ROOT)]);
+    });
+});

--- a/src/services/ProjectPathScanner.ts
+++ b/src/services/ProjectPathScanner.ts
@@ -148,8 +148,8 @@ export class ProjectPathScanner {
         logger.info("ProjectPathScanner", `Scanning project ${workspaceFolder.name}...`);
 
         try {
-            const projectVersePath = await this.projectPathHandler.getProjectVersePath();
-            const projectName = await this.projectPathHandler.getProjectName();
+            const projectVersePath = await this.projectPathHandler.getProjectVersePath(workspaceFolder.uri);
+            const projectName = await this.projectPathHandler.getProjectName(workspaceFolder.uri);
 
             if (!projectName) {
                 logger.warn("ProjectPathScanner", "No UEFN project found in workspace");

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -125,10 +125,11 @@ export class ModuleVisibilityWriter {
      * The single edit that satisfies a request, with what every file it was
      * computed from looked like at read time, or why there is none.
      *
-     * The folder this resolves decides all three of the Content root written
-     * to, the scope `moduleVisibility.definitionsFileName` is read at, and the
-     * subtree the declaration scan sweeps, so a wrong one rules on
-     * declarations it never read rather than merely writing the wrong file.
+     * The folder this resolves decides all four of the Content root written
+     * to, the project Verse path every module path is measured against, the
+     * scope `moduleVisibility.definitionsFileName` is read at, and the subtree
+     * the declaration scan sweeps, so a wrong one rules on declarations it
+     * never read rather than merely writing the wrong file.
      */
     private async buildEdit(request: ModuleVisibilityRequest, sourceUri?: vscode.Uri): Promise<{ edit: vscode.WorkspaceEdit; summary: string; snapshots: Snapshot[] } | Refusal> {
         // The target module cannot be resolved to a folder directly: its path
@@ -142,7 +143,22 @@ export class ModuleVisibilityWriter {
             return { reason: "no workspace folder is open." };
         }
 
-        const projectVersePath = await this.projectPathHandler.getProjectVersePath();
+        // A folder holding no Content root cannot host the declaration, and a
+        // workspace can carry one legitimately - notes or art opened alongside
+        // the project. A document in such a folder falls back rather than
+        // refusing, since the project's own folder can still serve it.
+        const located = (await this.locateContentRoot(requestedFolder)) ?? (await this.locateContentRoot(firstFolder));
+        if (!located) {
+            return { reason: `no '${CONTENT_FOLDER}' folder was found in the workspace, so there is nowhere to declare the module.` };
+        }
+        const { workspaceFolder, contentRoot } = located;
+
+        // Read for the folder that won above rather than for the requesting
+        // document, because the fallback can settle on a different one. A path
+        // taken from the document's folder would then name a project this edit
+        // is not being written into, and every segment below is measured
+        // against it.
+        const projectVersePath = await this.projectPathHandler.getProjectVersePath(workspaceFolder.uri);
         if (!projectVersePath) {
             return { reason: "no .uefnproject file was found, so module paths cannot be resolved." };
         }
@@ -157,16 +173,6 @@ export class ModuleVisibilityWriter {
         if (segments.length === 0) {
             return { reason: `'${request.moduleName}' is already reachable from the importing module.` };
         }
-
-        // A folder holding no Content root cannot host the declaration, and a
-        // workspace can carry one legitimately - notes or art opened alongside
-        // the project. A document in such a folder falls back rather than
-        // refusing, since the project's own folder can still serve it.
-        const located = (await this.locateContentRoot(requestedFolder)) ?? (await this.locateContentRoot(firstFolder));
-        if (!located) {
-            return { reason: `no '${CONTENT_FOLDER}' folder was found in the workspace, so there is nowhere to declare the module.` };
-        }
-        const { workspaceFolder, contentRoot } = located;
 
         const definitionsUri = this.definitionsUri(contentRoot);
         if (!definitionsUri) {


### PR DESCRIPTION
Closes #450

## What was wrong

`ProjectPathHandler` searched every workspace folder for a `.uefnproject` but returned on the first hit and cached it on the instance, so `getProjectVersePath`, `getProjectName`, `getRootPluginName` and `getProjectModules` answered for whichever project sat in the lowest-indexed folder for the life of the handler. In a multi-root workspace holding two UEFN projects, a file in the second project resolved against the first project's Verse path, and `ModuleVisibilityWriter` then refused with `'<path>' is outside the project '<other project>'` — a message naming the wrong project.

This is the remaining half of #436 (PR #452), which made the content root, the settings scope and the declaration-scan subtree follow the requesting document but left the project path those segments are measured against coming from folder 0.

## What changed

**`src/project/ProjectPathHandler.ts`** — every accessor takes an optional resource and answers for the project that owns it, caching per workspace folder instead of per handler. The cache is keyed on the folder searched from rather than the project file found, because the key has to be known before the search that would reveal the file; two folders under one project therefore hold equal entries, which costs a second parse and never a wrong answer. `clearCache()` empties the whole map. A call naming no resource keeps the whole-workspace search, which is what the activation-time readers need.

**`src/imports/ImportPathConverter.ts`** — the two `getProjectVersePath` reads and the two `getRootPluginName` reads pass the document being converted, so the path and the plugin name always describe one project where they meet in `placeUnderContentRoot`.

**`src/services/ProjectPathScanner.ts`** — `scanProject` passes the folder it was handed.

**`src/visibility/ModuleVisibilityWriter.ts`** — the content-root block moved above the project-path read, and the path is read for the folder that won rather than for `sourceUri`. `locateContentRoot(requestedFolder) ?? locateContentRoot(firstFolder)` can settle on a folder other than the requesting document's, and scoping the path to `sourceUri` alone would then name a project the edit is not being written into.

**`src/project/__tests__/ProjectPathHandler.test.ts`** — new; the class had no suite.

## Behaviour changes beyond the fix

Three, all deliberate, none pinned by an existing test:

1. A `.uefnproject` in the file's own folder that will not parse now answers nothing, where the old code fell through to the first folder's project. Answering some other project's paths is the bug this ticket is about, so refusing is the correct answer here. Pinned by a test.
2. Where a resource's own folder holds no project but an ancestor directory does, that ancestor now outranks an unrelated sibling workspace folder that has one. The old code preferred the sibling. The file is genuinely inside its ancestor's project, so this is the better answer — but it is a change rather than a preservation, and the plan claimed preservation until review caught it.
3. Refusal ordering in `ModuleVisibilityWriter`: when no `Content` folder is present, "no 'Content' folder was found" now wins over "no .uefnproject file was found", over "is outside the project" and over "already reachable". No refusal was lost and no success became a refusal — only which message wins when several conditions hold at once.

## Verification

`npm run compile`

```
> verse-auto-imports@0.11.2 compile
> tsc -p ./
```

`npm test`

```
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 53 passed, 53 total
Tests:       1593 passed, 1593 total
Snapshots:   0 total
Time:        11.972 s
Ran all test suites.
```

`npm run format:check`

```
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```

The regression test was proved to detect the defect: with the resolution neutered but the signature intact, 6 of the 8 new tests fail with exactly the reported symptom (asked about the second project, answering `/mygame@fortnite.com/firstgame`). The 2 that still pass are the workspace-wide cases, which correctly do not depend on scoping.

`npx jest src/imports/__tests__` was also run in full and read whole, per the repo's extractor-order check: 10 suites, 908 tests, nothing changed shape.

## Review

One round at opus: `PASS_WITH_SUGGESTIONS`, 0 Critical, 3 Important, 4 Suggestions. Fixed in the second commit:

- `getRootPluginName` had gained the resource parameter but kept two callers passing nothing, leaving a folder-scoped Verse path meeting a workspace-scoped plugin name.
- The changelog fragment claimed the project *name* was folder-scoped; its only scoped caller is reachable only through a code path this change leaves on folder 0. Trimmed to what the change actually reaches.
- The claim that the new search "preserves every answer the old code gave" was falsifiable; it is now recorded as behaviour change 2 above.

Also taken: narrowed `readProjectFileIn` to the `WorkspaceFolder` it is actually called with, and stopped the all-folders loop re-searching the folder already searched as the scope.

Left as reported, not fixed: the extension has no `onDidChangeWorkspaceFolders` invalidation (pre-existing, and the per-folder map is no more exposed to it than the single cached file was), and a workspace with no project file still costs a repeated search because misses are not cached.

## Not in this change

- `AssetsDigestParser.getAssetsDigestPath` and `ProjectPathCache.loadFromStorage` are activation-time and workspace-global, with no resource anywhere in their call chains, as is `ProjectPathCache.rebuildCache`'s hardcoded `workspaceFolders[0]`. Giving those a project identity is #376's job.
- `ImportPathConverter` constructs its own second `ProjectPathHandler` that never gets a file watcher, so its cache outlives a project-file edit. Pre-existing and separate; worth its own ticket, and this change raises the stakes since that instance is now the main consumer of the folder-scoped path.
