### PR TITLE
fix(visibility): report a re-declared ancestor instead of writing it

### DIFF
--- a/changelog.d/449.fixed.md
+++ b/changelog.d/449.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: the make-module-public quick fix now refuses, naming the module, where the declaration chain would re-declare an ancestor your project already declares, instead of writing a duplicate definition that can stop the project compiling.

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -543,13 +543,20 @@ export class ModuleVisibilityWriter {
  * remedy before it is read.
  */
 function refusalForConflicts(moduleName: string, conflicts: readonly VisibilityConflict[]): string {
+    // Bracketed rather than trailing a comma, and the list punctuated: one
+    // conflict per declared ancestor is ordinary, and a reader given
+    // `A and B, declared internal and C` cannot tell where a path ends.
+    const joined = (items: readonly string[]) => (items.length <= 2 ? items.join(" and ") : `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`);
+
     const listed = (reason: VisibilityConflict["reason"]) =>
-        conflicts
-            .filter((conflict) => conflict.reason === reason)
-            // A repeat of a declaration carrying no specifier has no keyword to
-            // name, and `declared undefined` would read as one it does carry.
-            .map((conflict) => (conflict.keyword ? `${conflict.path}, declared ${conflict.keyword}` : conflict.path))
-            .join(" and ");
+        joined(
+            conflicts
+                .filter((conflict) => conflict.reason === reason)
+                // A repeat of a declaration carrying no specifier has no
+                // keyword to name, and `declared undefined` would read as one
+                // it does carry.
+                .map((conflict) => (conflict.keyword ? `${conflict.path} (declared ${conflict.keyword})` : conflict.path)),
+        );
 
     const widen = listed("widen");
     const nest = listed("nest");

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -67,12 +67,14 @@ export class ModuleVisibilityWriter {
      * Puts the `<public>` declarations that make the requested module
      * reachable through the refactor preview, and reports what came back.
      *
-     * Refuses rather than half-applying: a module declared anything but
+     * Refuses rather than half-applying, and everything else the same request
+     * would have changed goes with it. A module declared anything but
      * `<public>` or `<internal>` is left alone, whether it is the one to
-     * publicize or one a new declaration would sit inside, and so is everything
-     * else the same request would have changed. That governs what is offered,
-     * not what lands - the preview lets the user apply a subset, so what is
-     * reported afterwards is intent rather than outcome.
+     * publicize or one a new declaration would sit inside; so is one the chain
+     * would have to declare a second time, since the block is appended whole
+     * and cannot join a declaration the project already carries. That governs
+     * what is offered, not what lands - the preview lets the user apply a
+     * subset, so what is reported afterwards is intent rather than outcome.
      *
      * @param sourceUri the document whose diagnostic asked for this, which is
      * what picks the workspace folder in a multi-root workspace. The first
@@ -536,20 +538,23 @@ export class ModuleVisibilityWriter {
 
 /**
  * Why a request was refused, naming what each conflicting module would have
- * needed. The two kinds are phrased apart because they ask different things of
- * the user, and one sentence carries both so a notification does not clip the
- * second remedy before it is read.
+ * needed. The kinds are phrased apart because they ask different things of the
+ * user, and one sentence carries them all so a notification does not clip a
+ * remedy before it is read.
  */
 function refusalForConflicts(moduleName: string, conflicts: readonly VisibilityConflict[]): string {
     const listed = (reason: VisibilityConflict["reason"]) =>
         conflicts
             .filter((conflict) => conflict.reason === reason)
-            .map((conflict) => `${conflict.path}, declared ${conflict.keyword}`)
+            // A repeat of a declaration carrying no specifier has no keyword to
+            // name, and `declared undefined` would read as one it does carry.
+            .map((conflict) => (conflict.keyword ? `${conflict.path}, declared ${conflict.keyword}` : conflict.path))
             .join(" and ");
 
     const widen = listed("widen");
     const nest = listed("nest");
-    const clauses = [widen && `widening ${widen}`, nest && `declaring a module inside ${nest}`].filter(Boolean);
+    const repeat = listed("repeat");
+    const clauses = [widen && `widening ${widen}`, nest && `declaring a module inside ${nest}`, repeat && `re-declaring ${repeat}`].filter(Boolean);
 
     return `making '${moduleName}' reachable would mean ${clauses.join(", and ")}. Make the change by hand if that is intended.`;
 }

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -563,7 +563,10 @@ function refusalForConflicts(moduleName: string, conflicts: readonly VisibilityC
     const repeat = listed("repeat");
     const clauses = [widen && `widening ${widen}`, nest && `declaring a module inside ${nest}`, repeat && `re-declaring ${repeat}`].filter(Boolean);
 
-    return `making '${moduleName}' reachable would mean ${clauses.join(", and ")}. Make the change by hand if that is intended.`;
+    // Semicolons between clauses, because the lists inside them already spend
+    // ", and": one separator doing both jobs leaves the gerund as the only mark
+    // of where a clause starts.
+    return `making '${moduleName}' reachable would mean ${clauses.join("; ")}. Make the change by hand if that is intended.`;
 }
 
 /** The text with every specifier rewrite applied, taken last-first so earlier offsets stay valid. */

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -198,9 +198,10 @@ describe("ModuleVisibilityWriter", () => {
         expect(replace.text).toBe("Other<public> := module {}\n\nGadgets := module:\n    Tools<public> := module {}\n");
     });
 
-    it("folds a specifier edit inside the definitions file into the same replacement", async () => {
-        // Two operations on one file would overlap, which VS Code rejects, and
-        // half-applying would leave two parts of Deep disagreeing.
+    it("refuses to append a second definition of a module the definitions file already declares", async () => {
+        // The file the fix wrote on an earlier run. Appending a block through
+        // Gadgets and Deep would leave that one file defining each of them
+        // twice, which the second run has no way to make compile.
         givenProject({ "Content/_definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
 
         await writer().makeModulePublic({
@@ -209,10 +210,17 @@ describe("ModuleVisibilityWriter", () => {
             moduleName: "Tools",
         });
 
-        const operations = appliedOperations();
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("replace");
-        expect(operations[0].text).toBe("Gadgets := module:\n    Deep<public> := module {}\n\nGadgets := module:\n    Deep<public> := module:\n        Tools<public> := module {}\n");
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("re-declaring Gadgets and Gadgets/Deep"));
+    });
+
+    it("refuses when an ancestor is declared in a user file, naming the declaration the chain would repeat", async () => {
+        givenProject({ "Content/gadgets.verse": "Gadgets<internal> := module:\n    X:int = 1\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("re-declaring Gadgets, declared internal"));
     });
 
     it("edits an existing declaration instead of writing a second part", async () => {
@@ -485,13 +493,13 @@ describe("ModuleVisibilityWriter", () => {
         // entry the writer emits, so an unpreviewed one is the worst version
         // of the defect this ticket exists to close.
         it("marks a whole-file rewrite of an existing definitions file as needing confirmation", async () => {
-            givenProject({ "Content/_definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
+            // The file has to exist to be replaced rather than created, and to
+            // declare nothing on the target's own path: a declaration there
+            // would be one the appended block re-declares, and the request
+            // would be refused before any operation was built.
+            givenProject({ "Content/_definitions.verse": "Other<public> := module {}\n" });
 
-            await writer().makeModulePublic({
-                targetPath: `${PROJECT}/Gadgets/Deep/Tools`,
-                importerPath: `${PROJECT}/Scripts`,
-                moduleName: "Tools",
-            });
+            await writer().makeModulePublic(REQUEST);
 
             expect(appliedOperations()[0]).toMatchObject({
                 kind: "replace",

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -214,13 +214,29 @@ describe("ModuleVisibilityWriter", () => {
         expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("re-declaring Gadgets and Gadgets/Deep"));
     });
 
+    it("punctuates a list of repeats so a path carrying a keyword cannot be read as two", async () => {
+        // One conflict per declared ancestor, so three is ordinary rather than
+        // exotic. Joined with bare "and" throughout, the keyword clause fuses
+        // with the path after it and the reader cannot tell them apart.
+        givenProject({ "Content/_definitions.verse": "Gadgets := module:\n    Deep := module:\n        Tools<internal> := module {}\n" });
+
+        await writer().makeModulePublic({
+            targetPath: `${PROJECT}/Gadgets/Deep/Tools/More`,
+            importerPath: `${PROJECT}/Scripts`,
+            moduleName: "More",
+        });
+
+        const [warning] = (vscode.window.showWarningMessage as jest.Mock).mock.calls[0];
+        expect(warning).toContain("re-declaring Gadgets, Gadgets/Deep, and Gadgets/Deep/Tools (declared internal)");
+    });
+
     it("refuses when an ancestor is declared in a user file, naming the declaration the chain would repeat", async () => {
         givenProject({ "Content/gadgets.verse": "Gadgets<internal> := module:\n    X:int = 1\n" });
 
         await writer().makeModulePublic(REQUEST);
 
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("re-declaring Gadgets, declared internal"));
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("re-declaring Gadgets (declared internal)"));
     });
 
     it("edits an existing declaration instead of writing a second part", async () => {
@@ -261,7 +277,7 @@ describe("ModuleVisibilityWriter", () => {
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
         // "widening" is what separates this refusal from the nesting one below;
         // the module name alone appears in both.
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("widening Gadgets/Tools, declared private"));
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("widening Gadgets/Tools (declared private)"));
     });
 
     it("refuses to declare a module inside a scoped one, without quoting it as a specifier it is not", async () => {
@@ -271,7 +287,7 @@ describe("ModuleVisibilityWriter", () => {
 
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
         const [warning] = (vscode.window.showWarningMessage as jest.Mock).mock.calls[0];
-        expect(warning).toContain("declaring a module inside Gadgets, declared scoped");
+        expect(warning).toContain("declaring a module inside Gadgets (declared scoped)");
         // The declaration reads `<scoped{Scripts}>`; printing `<scoped>` would
         // quote the file as saying something that does not compile.
         expect(warning).not.toContain("<scoped>");

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -94,15 +94,40 @@ describe("resolveVisibility", () => {
         expect(resolved.chain).toEqual([]);
     });
 
-    it("repeats an existing parent specifier in the written chain, so the parts cannot disagree", () => {
+    it("reports a parent the chain would have to repeat, rather than writing a second definition of it", () => {
         const found = declarationsIn("file://a", "", "Gadgets<internal> := module:\n    X:int = 1\n");
 
         const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
 
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets", keyword: "internal", reason: "repeat" }]);
+        // The chain still carries what a write would have put in the file, as
+        // the narrowed path does. The conflict is what stops it.
         expect(resolved.chain).toEqual([
             { name: "Gadgets", specifier: "internal" },
             { name: "Tools", specifier: "public" },
         ]);
+    });
+
+    it("reports a repeat of a bare declaration, which carries no keyword to name", () => {
+        const found = declarationsIn("file://a", "", "Gadgets := module:\n    X:int = 1\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        // The compiler's duplicate-definition check turns on the existing
+        // declaration being explicit, not on either part's specifier, so a bare
+        // repeat is a second definition exactly as an attributed one is.
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets", reason: "repeat" }]);
+        expect(resolved.conflicts[0].keyword).toBeUndefined();
+    });
+
+    it("says nothing about a repeat the trim drops, since an unwritten part defines nothing", () => {
+        const found = declarationsIn("file://a", "", "Gadgets := module:\n    Tools := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.chain).toEqual([]);
+        expect(resolved.conflicts).toEqual([]);
+        expect(resolved.edits.map((edit) => edit.path)).toEqual(["Gadgets/Tools"]);
     });
 
     it("reports a deliberate narrowing as a conflict rather than widening it", () => {
@@ -194,11 +219,14 @@ describe("resolveVisibility", () => {
         ]);
     });
 
-    it("repeats a prefix module's declared specifier, so the nesting part cannot disagree", () => {
+    it("reports a repeat of a prefix module, which a written part defines a second time whether or not it is reachable", () => {
         const found = declarationsIn("file://a", "", "Systems<public> := module:\n    X:int = 1\n");
 
         const resolved = resolveVisibility(["Systems"], segments(["Gadgets", false], ["Tools", true]), found);
 
+        expect(resolved.conflicts).toEqual([{ path: "Systems", keyword: "public", reason: "repeat" }]);
+        // The specifier is still repeated in the chain the conflict describes:
+        // a part that disagreed would be a second defect, not a remedy.
         expect(resolved.chain[0]).toEqual({ name: "Systems", specifier: "public" });
         // The prefix is reachable already, so nothing about it is rewritten.
         expect(resolved.edits).toEqual([]);

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -77,10 +77,9 @@ const PUBLIC_SPECIFIER = "<public>";
  * The edits and the declaration chain that make the planned segments reachable.
  *
  * A module's access level comes from its first explicit part, and every later
- * part must repeat the same specifier or the compiler raises
- * `ErrSemantic_MismatchedPartialAttributes` - so where a module is already
- * declared, EVERY part of it is rewritten rather than one, and the chain
- * repeats whatever specifier the project already declares.
+ * part must carry the same specifier or the compiler raises
+ * `ErrSemantic_MismatchedPartialAttributes`. That is why a module the project
+ * already declares has EVERY part of it rewritten rather than one.
  *
  * Three kinds of module are reported as conflicts rather than written. One
  * declared anything other than `<public>` or `<internal>` is a deliberate
@@ -96,9 +95,12 @@ const PUBLIC_SPECIFIER = "<public>";
  * carries is reported, and only a module with no declaration at all is safe to
  * write.
  *
- * A conflict does not empty the chain: it still describes what a write would
- * have put in the file, so the caller can report it. Refusing is the caller's
- * job.
+ * A conflict leaves the chain intact rather than emptying it, so the caller can
+ * name the nesting it refused. One consequence is worth knowing before editing
+ * either half: because every declared module the retained chain carries is a
+ * `repeat`, a specifier this function copies off an existing declaration only
+ * ever describes that nesting, and never reaches a file. Refusing is the
+ * caller's job.
  *
  * @param prefix Content-relative segments above the planned ones. They are
  * already reachable, but the chain is written at the Content root, so it has to
@@ -172,15 +174,21 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
             }
         }
 
-        // What the file says now, not what the edits above would make it say:
-        // this is reported to the user, who has to find the declaration.
-        declared.push({ chainIndex: chain.length, path: modulePath, keyword: declarations[0].declaration.visibility?.keyword });
+        // What the files say now, not what the edits above would make them say:
+        // this is reported to the user, who has to go and find the declaration.
+        // The part carrying a specifier is preferred over whichever the scan
+        // happened to reach first, since parts agree by construction and the
+        // one that names the access level is the one worth pointing at.
+        const declaredElsewhere = declarations.find((entry) => entry.declaration.visibility) ?? declarations[0];
+        declared.push({ chainIndex: chain.length, path: modulePath, keyword: declaredElsewhere.declaration.visibility?.keyword });
 
-        // Repeat what the project already declares, so a part written below
-        // this one cannot disagree with the parts that exist. Only `public` and
-        // `internal` reach here - every other keyword left through the branch
-        // above, which is what keeps a keyword-only repeat safe.
-        const declaredKeyword = segment.needsPublic ? "public" : declarations[0].declaration.visibility?.keyword;
+        // Carried so the chain describes the nesting exactly as a part of it
+        // would have had to be written - the specifier included, since one that
+        // disagreed with the existing parts would be a second defect rather
+        // than a remedy. Only `public` and `internal` reach here; every other
+        // keyword left through the branch above, which is what keeps naming a
+        // keyword here safe.
+        const declaredKeyword = segment.needsPublic ? "public" : declaredElsewhere.declaration.visibility?.keyword;
         chain.push({ name: segment.name, specifier: declaredKeyword });
         written.push(false);
     }

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -30,25 +30,30 @@ export interface SpecifierEdit {
     text: string;
 }
 
-/** A module whose declared access stops the request, and what about it stops it. */
+/** A module whose existing declaration stops the request, and what about it stops it. */
 export interface VisibilityConflict {
     /** Content-relative path of the module, for the report to the user. */
     path: string;
 
     /**
-     * The declared visibility keyword alone. `scoped` carries a module list the
-     * scanner does not capture, so this is not the specifier as written and
-     * must not be reported as if it were.
+     * The declared visibility keyword alone, absent where the declaration
+     * carries no specifier. `scoped` carries a module list the scanner does not
+     * capture, so this is not the specifier as written and must not be reported
+     * as if it were.
+     *
+     * Only `repeat` reaches here without one: a keyword being present and
+     * narrowed is what raises the other two.
      */
-    keyword: string;
+    keyword?: string;
 
     /**
      * `widen` where the module itself has to become public, `nest` where a new
-     * part would be written inside it. The remedies differ: one is a change to
-     * this module's specifier, the other a declaration the user must make
-     * inside it by hand.
+     * part would be written inside it, `repeat` where the chain would restate a
+     * declaration the project already carries. The remedies differ: the first
+     * is a change to this module's specifier, the other two a declaration the
+     * user must make by hand where the existing one lives.
      */
-    reason: "widen" | "nest";
+    reason: "widen" | "nest" | "repeat";
 }
 
 /** Everything that has to happen for the target to become reachable. */
@@ -71,20 +76,29 @@ const PUBLIC_SPECIFIER = "<public>";
 /**
  * The edits and the declaration chain that make the planned segments reachable.
  *
- * Two rules keep this from producing `ErrSemantic_MismatchedPartialAttributes`.
  * A module's access level comes from its first explicit part, and every later
- * part must repeat the same specifier - so where a module is already declared,
- * EVERY part of it is rewritten rather than one, and where a chain is written
- * into the definitions file, each of its modules repeats whatever specifier the
- * project already declares for that module.
+ * part must repeat the same specifier or the compiler raises
+ * `ErrSemantic_MismatchedPartialAttributes` - so where a module is already
+ * declared, EVERY part of it is rewritten rather than one, and the chain
+ * repeats whatever specifier the project already declares.
  *
- * A module declared anything other than `<public>` or `<internal>` is reported
- * as a conflict rather than rewritten, and so is one the chain would merely
- * nest a new part inside. Both are deliberate narrowings, and the second is a
- * conflict for a mechanical reason as well: a written part has to repeat the
- * declaration's specifier exactly, and `scoped`'s module list resolves against
- * the scope that declared it, so it cannot be copied into a file at the Content
- * root at all.
+ * Three kinds of module are reported as conflicts rather than written. One
+ * declared anything other than `<public>` or `<internal>` is a deliberate
+ * narrowing, whether it is the module to publicize (`widen`) or one the chain
+ * would nest a new part inside (`nest`); the second is mechanical as well,
+ * since `scoped`'s module list resolves against the scope that declared it and
+ * cannot be copied into a file at the Content root at all. One that already
+ * carries an explicit declaration anywhere in the project is a `repeat`: the
+ * chain restates it, and a restatement is a second explicit definition, which
+ * is `ErrSemantic_AmbiguousDefinition` in a user package unless that package
+ * sets `treatModulesAsImplicit`. The specifier is not what makes it one - a
+ * bare part counts the same - so every declared module the retained chain
+ * carries is reported, and only a module with no declaration at all is safe to
+ * write.
+ *
+ * A conflict does not empty the chain: it still describes what a write would
+ * have put in the file, so the caller can report it. Refusing is the caller's
+ * job.
  *
  * @param prefix Content-relative segments above the planned ones. They are
  * already reachable, but the chain is written at the Content root, so it has to
@@ -109,6 +123,11 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     // narrowed module matters depends on the trim below, which is not known
     // until the walk is over.
     const blocked: { chainIndex: number; path: string; keyword: string; needsPublic: boolean }[] = [];
+
+    // Every module the walk found a declaration for, collected for the same
+    // reason as `blocked`: whether the chain actually restates one depends on
+    // the trim below.
+    const declared: { chainIndex: number; path: string; keyword?: string }[] = [];
 
     // The prefix modules are reachable already, so they are walked purely as
     // the nesting the chain needs - never marked, but still matched against
@@ -153,6 +172,10 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
             }
         }
 
+        // What the file says now, not what the edits above would make it say:
+        // this is reported to the user, who has to find the declaration.
+        declared.push({ chainIndex: chain.length, path: modulePath, keyword: declarations[0].declaration.visibility?.keyword });
+
         // Repeat what the project already declares, so a part written below
         // this one cannot disagree with the parts that exist. Only `public` and
         // `internal` reach here - every other keyword left through the branch
@@ -172,6 +195,16 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     const conflicts: VisibilityConflict[] = blocked
         .filter((entry) => entry.needsPublic || entry.chainIndex <= deepestWritten)
         .map(({ path, keyword, needsPublic }) => ({ path, keyword, reason: needsPublic ? "widen" : "nest" }));
+
+    // Same trim, for the same reason: a declaration is only restated where the
+    // retained chain reaches it. A module publicized in place sits below the
+    // deepest written part whenever nothing new goes under it, and is edited
+    // rather than restated.
+    for (const entry of declared) {
+        if (entry.chainIndex <= deepestWritten) {
+            conflicts.push({ path: entry.path, keyword: entry.keyword, reason: "repeat" });
+        }
+    }
 
     return {
         edits,

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -36,8 +36,8 @@ export interface VisibilityConflict {
     path: string;
 
     /**
-     * The declared visibility keyword alone, absent where the declaration
-     * carries no specifier. `scoped` carries a module list the scanner does not
+     * The declared visibility keyword alone, absent where no part of the module
+     * carries a specifier. `scoped` carries a module list the scanner does not
      * capture, so this is not the specifier as written and must not be reported
      * as if it were.
      *
@@ -95,12 +95,12 @@ const PUBLIC_SPECIFIER = "<public>";
  * carries is reported, and only a module with no declaration at all is safe to
  * write.
  *
- * A conflict leaves the chain intact rather than emptying it, so the caller can
- * name the nesting it refused. One consequence is worth knowing before editing
- * either half: because every declared module the retained chain carries is a
- * `repeat`, a specifier this function copies off an existing declaration only
- * ever describes that nesting, and never reaches a file. Refusing is the
- * caller's job.
+ * Refusing is the caller's job, and a conflict leaves the chain as it is rather
+ * than emptying it. Nothing reads the chain on that path today, so the fact
+ * worth knowing before editing either half is the invariant rather than the
+ * consumer: the trim and the `repeat` test are the same predicate, so a chain
+ * entry whose specifier was copied off an existing declaration always coincides
+ * with a conflict, and that specifier never reaches a file.
  *
  * @param prefix Content-relative segments above the planned ones. They are
  * already reachable, but the chain is written at the Content root, so it has to
@@ -176,19 +176,16 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
 
         // What the files say now, not what the edits above would make them say:
         // this is reported to the user, who has to go and find the declaration.
-        // The part carrying a specifier is preferred over whichever the scan
-        // happened to reach first, since parts agree by construction and the
-        // one that names the access level is the one worth pointing at.
-        const declaredElsewhere = declarations.find((entry) => entry.declaration.visibility) ?? declarations[0];
-        declared.push({ chainIndex: chain.length, path: modulePath, keyword: declaredElsewhere.declaration.visibility?.keyword });
+        // Parts that disagree are already `ErrSemantic_MismatchedPartialAttributes`,
+        // so preferring the one carrying a specifier changes the answer only on
+        // a project that does not compile - where it buys a report that does not
+        // vary with scan order.
+        const reportedDeclaration = declarations.find((entry) => entry.declaration.visibility) ?? declarations[0];
+        declared.push({ chainIndex: chain.length, path: modulePath, keyword: reportedDeclaration.declaration.visibility?.keyword });
 
-        // Carried so the chain describes the nesting exactly as a part of it
-        // would have had to be written - the specifier included, since one that
-        // disagreed with the existing parts would be a second defect rather
-        // than a remedy. Only `public` and `internal` reach here; every other
-        // keyword left through the branch above, which is what keeps naming a
-        // keyword here safe.
-        const declaredKeyword = segment.needsPublic ? "public" : declaredElsewhere.declaration.visibility?.keyword;
+        // The specifier a part here would have had to carry, which is never
+        // written: a declared module in the retained chain is always a repeat.
+        const declaredKeyword = segment.needsPublic ? "public" : reportedDeclaration.declaration.visibility?.keyword;
         chain.push({ name: segment.name, specifier: declaredKeyword });
         written.push(false);
     }


### PR DESCRIPTION
Closes #449

## What was wrong

The declaration chain restated any ancestor that already carried an explicit declaration, and a restatement is a second explicit definition. `SemanticAnalyzer.cpp:4437-4447` rejects one in a `PublicUser` package with `ErrSemantic_AmbiguousDefinition` (3532, `Glitch.h:138`) unless `_bTreatModulesAsImplicit` is set on either package — so the edit that claimed to fix a visibility error could stop the project compiling, silently.

The most reachable form is not the one the ticket describes. The definitions file's own declarations feed back into the scan (`ModuleVisibilityWriter.ts:441-443`), so the **second** run of the quick fix in one subtree found the first run's output and appended a block defining the same modules again. That was pinned as intended behaviour by a checked-in test, whose expected value was:

```
Gadgets := module:
    Deep<public> := module {}

Gadgets := module:
    Deep<public> := module:
        Tools<public> := module {}
```

One file, `Gadgets` defined twice and `Deep` defined twice.

## The rule, and how it was settled

The gate does **not** depend on whether the new part carries attributes: `bTreatAsImplicit = !bHasAttributes && bPackageTreatsModulesAsImplicit` (`:4428`) feeds only `CreatePart` at `:4458`, never the gate. So bare repeats carry the same exposure as attributed ones, which is why all three shapes the ticket names are covered rather than just the keyword-carrying one.

The narrowing in the other direction holds and is respected: the gate needs the *existing* definition to be explicit (`:4437`), and `visibilityResolution.ts` already routes an undeclared module down the new-module branch. A chain nesting only through folder-only modules is not at risk and is **not** reported — the ordinary first-use quick fix is unchanged.

Checked against the shipped compiler, not only `ue5-main`: the diagnostic templates are byte-identical in `epicgames.verse-0.0.56430492/bin/Win64/verse-lsp.exe`.

## The decision the ticket deferred

#449 left it to the implementing session whether the new conflict refuses the write or is reported while the write proceeds. **Refuse**, because `conflicts` is a hard gate by construction — `ModuleVisibilityWriter.ts` returns a `Refusal` before any `WorkspaceEdit` is built — so routing through the channel the ticket names *is* refusing, and building a report-and-proceed channel would be the design change both #393 and #449 put out of scope. It is also the cheap direction to reverse if the `treatModulesAsImplicit` question later resolves favourably: lifting the refusal deletes one filter.

Accepted cost: a project with an explicitly-declared ancestor now gets a refusal where it previously got a write that may have been legal. The in-place specifier path — the common "just make this module public" case — is untouched.

## Changes

- `visibilityResolution.ts` — `VisibilityConflict.reason` gains `repeat`; `keyword` becomes optional, since a repeated ancestor may be declared bare. Declared modules are collected alongside the existing `blocked` and filtered by the same `chainIndex <= deepestWritten` trim, so a repeat that gets trimmed out of the retained chain is not reported.
- `ModuleVisibilityWriter.ts` — `refusalForConflicts` gains the `re-declaring` clause. The keyword is bracketed and lists take a serial comma, because one conflict per declared ancestor makes multi-entry lists ordinary and the old join fused a keyword clause with the path after it.

`definitionsContent.ts` is untouched, and so is where the writer puts a new module's declaration.

## Verification

```
$ npm run compile
> tsc -p ./
```

```
$ npm test
Test Suites: 52 passed, 52 total
Tests:       1589 passed, 1589 total
```

```
$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

## Review

Two rounds at `opus`, both `PASS_WITH_SUGGESTIONS`, no `Critical` in either.

Round 1 (3 Important) and round 2 (1 Important) were all acted on: the refusal message was unparseable at three or more entries; the reported keyword depended on arbitrary scan order for a module declared in several files; and two doc comments asserted rules the change had made dead.

Both reviewers independently confirmed the load-bearing claim that a specifier copied off an existing declaration never reaches a file — the trim and the `repeat` test are literally the same predicate — and that the ordinary folder-only quick fix still writes.

## Known consequence, left alone deliberately

The definitions-file specifier fold (`ModuleVisibilityWriter.ts`, the `inDefinitions` branch) is now unreachable: any specifier edit against that file implies its module's ancestors are declared there too, which makes the module itself a `repeat`. Both reviewers proved this independently and probed six shapes, all refusing.

I left the branch in place rather than deleting it — it is the guard that stops overlapping edits, and it goes live again the moment the refusal is relaxed. Worth a decision from you, not from me.

## Follow-up worth filing

Teaching the writer to nest a new declaration **inside** the block it already wrote, instead of appending a second one, would turn the most common refusal back into a working quick fix. That is the "where the writer puts things" redesign #393 and #449 both exclude, so it is not in this PR. I have not filed it — say the word and I will.
