### PR TITLE
fix(imports): resolve the Content root at any depth for project-wide scans

### DIFF
--- a/changelog.d/448.fixed.md
+++ b/changelog.d/448.fixed.md
@@ -1,1 +1,1 @@
-**Module search and visibility**: project-wide module lookups and "Make module public" now find the project's Content folder wherever UEFN nests it, so a workspace opened at the project root works the same as one opened at Content.
+**Module search and visibility**: project-wide module lookups and "Make module public" now find a Content folder nested under `Plugins/<Name>`, so a workspace opened at the project root works the same as one opened at Content.

--- a/changelog.d/448.fixed.md
+++ b/changelog.d/448.fixed.md
@@ -1,0 +1,1 @@
+**Module search and visibility**: project-wide module lookups and "Make module public" now find the project's Content folder wherever UEFN nests it, so a workspace opened at the project root works the same as one opened at Content.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { logger } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathCache } from "../services";
+import { findContentRoot } from "../services/contentRoot";
 import { buildProjectIndexes, resolveFolderModuleLocations, resolveModuleLocations, toContentRelativeDir } from "../services/moduleLocationLookup";
 import { ProjectPathNode } from "../types";
 import { findExplicitModuleDeclarations } from "../visibility/moduleDeclarations";
@@ -418,20 +419,17 @@ export class ImportPathConverter {
     }
 
     /**
-     * Where a workspace-wide `.verse` scan has to look, and whether the
-     * workspace folder is itself the Content folder - which decides both the
-     * glob and how a found path maps back to a Content-relative one.
+     * The Content root a workspace-wide `.verse` scan has to look under, or
+     * null when the project has none there.
      *
-     * Shared by the two scanning phases so they cannot disagree about the
-     * layout: a phase reading one rule and a phase reading the other would
-     * resolve the same project differently.
+     * Neither scanning phase has a document to walk out from, so the root is
+     * resolved from the workspace folder and the project's root plugin instead
+     * of read at a fixed depth. Shared by both phases so they cannot disagree
+     * about the layout: a phase reading one rule and a phase reading the other
+     * would resolve the same project differently.
      */
-    private static workspaceScanTargets(workspaceFolder: { uri: vscode.Uri }): { searchPattern: string; workspaceIsContent: boolean } {
-        const workspaceIsContent = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER;
-        return {
-            searchPattern: workspaceIsContent ? "**/*.verse" : `${CONTENT_FOLDER}/**/*.verse`,
-            workspaceIsContent,
-        };
+    private async scanContentRoot(workspaceFolder: { uri: vscode.Uri }): Promise<vscode.Uri | null> {
+        return findContentRoot(workspaceFolder, await this.projectPathHandler.getRootPluginName());
     }
 
     /**
@@ -452,17 +450,19 @@ export class ImportPathConverter {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) return false;
 
-        const { searchPattern, workspaceIsContent } = ImportPathConverter.workspaceScanTargets(workspaceFolders[0]);
+        const contentRoot = await this.scanContentRoot(workspaceFolders[0]);
+        if (!contentRoot) return false;
 
-        // Scope the scan to the project folder. The UEFN-generated workspace is
-        // multi-root (Content plus Epic's digest folders); a bare string glob
-        // would also read every *.digest.verse on each fallback scan.
+        // Scope the scan to the project's Content root. The UEFN-generated
+        // workspace is multi-root (Content plus Epic's digest folders); a bare
+        // string glob would also read every *.digest.verse on each fallback
+        // scan.
         //
         // One file past the limit is asked for and never read, so that a project
         // holding exactly the limit is told apart from one holding more. Asking
         // for the limit itself makes those two answers identical, which is the
         // conflation the truncation signal exists to end.
-        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", DECLARATION_SCAN_FILE_LIMIT + 1);
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(contentRoot, "**/*.verse"), "**/*.digest.verse", DECLARATION_SCAN_FILE_LIMIT + 1);
         const readPartOnly = verseFiles.length > DECLARATION_SCAN_FILE_LIMIT;
 
         const nodes: ProjectPathNode[] = [];
@@ -473,11 +473,12 @@ export class ImportPathConverter {
             );
             if (!content) continue;
 
-            // Paths are taken against the folder the glob was rooted at, which
-            // is also the folder workspaceIsContent describes. Asking which
-            // folder each file sits in instead lets the two disagree, and the
-            // Content prefix is then read off one folder and stripped by the
-            // rule of another.
+            // Workspace-relative, which is the sourceFile shape the cache also
+            // produces - resolveModuleLocations places both against the same
+            // pair of anchors, so a candidate reads the same whichever of the
+            // two found it. Taking the path against the folder passed below
+            // rather than asking which folder the file sits in is what keeps
+            // the anchor and the path from being read off different folders.
             const sourceFile = path.relative(workspaceFolders[0].uri.fsPath, file.fsPath).replace(/\\/g, "/");
 
             // Only a live declaration attests to a location; a commented-out one
@@ -495,7 +496,7 @@ export class ImportPathConverter {
         }
 
         const { moduleNameIndex } = buildProjectIndexes(nodes);
-        for (const candidate of resolveModuleLocations(modulePath, moduleNameIndex, { workspaceIsContent })) {
+        for (const candidate of resolveModuleLocations(modulePath, moduleNameIndex, { workspaceFolderPath: workspaceFolders[0].uri.fsPath, contentRootPath: contentRoot.fsPath })) {
             logger.debug("ImportPathConverter", `Found module definition in: ${candidate.sourceFile}`);
             if (!locations.includes(candidate.location)) locations.push(candidate.location);
         }
@@ -521,13 +522,14 @@ export class ImportPathConverter {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) return;
 
-        const { searchPattern, workspaceIsContent } = ImportPathConverter.workspaceScanTargets(workspaceFolders[0]);
-        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolders[0], searchPattern), "**/*.digest.verse", FOLDER_SCAN_FILE_LIMIT);
+        const contentRoot = await this.scanContentRoot(workspaceFolders[0]);
+        if (!contentRoot) return;
+
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(contentRoot, "**/*.verse"), "**/*.digest.verse", FOLDER_SCAN_FILE_LIMIT);
 
         const contentRelativeDirs = new Set<string>();
         for (const file of verseFiles) {
-            const workspaceRelative = path.relative(workspaceFolders[0].uri.fsPath, file.fsPath).replace(/\\/g, "/");
-            const directory = toContentRelativeDir(workspaceRelative, workspaceIsContent);
+            const directory = toContentRelativeDir(file.fsPath, contentRoot.fsPath);
 
             // null is a file outside Content, which contributes no importable
             // module.
@@ -587,7 +589,7 @@ export class ImportPathConverter {
         // the full scan below still runs whenever the cache yields nothing
         // valid - empty, stale, or never set.
         if (locations.length === 0 && this.projectPathCache) {
-            const candidates = this.projectPathCache.lookupModuleLocations(modulePath);
+            const candidates = await this.projectPathCache.lookupModuleLocations(modulePath);
             for (const candidate of candidates) {
                 if (locations.includes(candidate.location)) {
                     continue;

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -245,8 +245,23 @@ function setWorkspaceFolders(folders: unknown): void {
  * them would hide the very drift under test.
  */
 function stubFolderTree(workspaceRoot: string, folders: string[]): void {
+    stubTreeUnder(`${workspaceRoot}/Content`, folders);
+}
+
+/**
+ * Answers `fs.stat` as a directory for a Content root and for the folders named
+ * relative to it.
+ *
+ * The root itself is always there, whatever the tree holds: a project-wide scan
+ * resolves the root before it globs, so a tree that omits it leaves the scan
+ * with nowhere to look and no phase past the first can run.
+ */
+function stubTreeUnder(contentRoot: string, folders: string[]): void {
     (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
-        const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${workspaceRoot}/Content/`, "");
+        const fsPath = uri.fsPath.replace(/\\/g, "/");
+        if (fsPath === contentRoot) return { type: vscode.FileType.Directory };
+
+        const contentRelative = fsPath.replace(`${contentRoot}/`, "");
         if (!folders.includes(contentRelative)) throw new Error("ENOENT");
         return { type: vscode.FileType.Directory };
     });
@@ -552,11 +567,7 @@ describe("ImportPathConverter.convertFromFullPath under a nested plugin Content 
 
     /** Answers `fs.stat` from directories named relative to the nested Content root. */
     function stubNestedFolderTree(folders: string[]): void {
-        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
-            const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${contentRoot}/`, "");
-            if (!folders.includes(contentRelative)) throw new Error("ENOENT");
-            return { type: vscode.FileType.Directory };
-        });
+        stubTreeUnder(contentRoot, folders);
     }
 
     const fileAt = (contentRelativeDir: string): vscode.Uri => vscode.Uri.file(`${contentRoot}/${contentRelativeDir}/Feature.verse`);
@@ -691,6 +702,71 @@ describe("ImportPathConverter.convertFromFullPath under a nested plugin Content 
         const fileUri = vscode.Uri.file(`${workspaceRoot}/Content/Plugins/Extra/Content/Feature.verse`);
 
         expect(await relativeFormOf(`${projectVersePath}/Plugins/Extra/Content/Gadgets`, fileUri)).toBe("using. Gadgets");
+    });
+});
+
+// Neither project-wide phase has a document to walk out from, so each resolved
+// the Content root off the workspace folder at one fixed depth. In the layout
+// above that glob matched nothing, and a module only these phases could reach
+// was reported missing however plainly it was declared.
+describe("ImportPathConverter.findModuleLocations project-wide phases under a nested plugin Content root", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+    const rootPluginName = "MyGame";
+    const contentRoot = `${workspaceRoot}/Plugins/${rootPluginName}/Content`;
+
+    /** The project's `.verse` files, named relative to the nested Content root. */
+    const givenVerseFiles = (contentRelativePaths: string[], source: string): void => {
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(contentRelativePaths.map((file) => vscode.Uri.file(`${contentRoot}/${file}`)));
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from(source, "utf8"));
+    };
+
+    const locationsFor = async (modulePath: string, declaredRootPlugin: string | null = rootPluginName): Promise<string[]> =>
+        (await converterWithProjectPath(projectVersePath, declaredRootPlugin).findModuleLocations(modulePath)).locations;
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubTreeUnder(contentRoot, []);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("reports the directory of a declaration the declaration scan reaches", async () => {
+        givenVerseFiles(["Systems/Inventory.verse"], "Inventory := module:\n    Count<public>:int = 0\n");
+
+        expect(await locationsFor("Inventory")).toEqual(["/Systems"]);
+    });
+
+    // A folder module has no declaration anywhere to read, so the phase before
+    // this one cannot see it and only the project-wide folder search places it.
+    it("reports the directory of a folder chain the folder search reaches", async () => {
+        givenVerseFiles(["Zone/Deep/Target/Thing.verse"], "Helper := class:\n");
+
+        expect(await locationsFor("Deep/Target")).toEqual(["/Zone"]);
+    });
+
+    it("roots the scan at the plugin's Content rather than at the workspace folder", async () => {
+        givenVerseFiles(["Systems/Inventory.verse"], "Inventory := module:\n");
+
+        await locationsFor("Inventory");
+
+        const [pattern] = (vscode.workspace.findFiles as jest.Mock).mock.calls[0];
+        expect(pattern.base.fsPath.replace(/\\/g, "/")).toBe(contentRoot);
+        expect(pattern.pattern).toBe("**/*.verse");
+    });
+
+    // Only the root plugin's Content answers to bindings.projectVersePath, so
+    // without a declared root plugin there is no evidence for a nested root and
+    // the scan has nowhere to look. Failing closed here is what it did before.
+    it("finds nothing when the project declares no root plugin", async () => {
+        givenVerseFiles(["Systems/Inventory.verse"], "Inventory := module:\n");
+
+        expect(await locationsFor("Inventory", null)).toEqual([]);
     });
 });
 
@@ -854,12 +930,14 @@ describe("ImportPathConverter.findModuleLocations explicit declaration scan", ()
 
     beforeEach(() => {
         setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubTreeUnder(`${workspaceRoot}/Content`, []);
     });
 
     afterEach(() => {
         setWorkspaceFolders(undefined);
         (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
         (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
     });
 
     it("reports the directory of a live declaration", async () => {
@@ -967,6 +1045,7 @@ describe("ImportPathConverter declaration scan file cap", () => {
 
     beforeEach(() => {
         setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubTreeUnder(`${workspaceRoot}/Content`, []);
     });
 
     afterEach(() => {
@@ -1106,11 +1185,7 @@ describe("ImportPathConverter.convertToFullPath project-wide folder module searc
     beforeEach(() => {
         setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
         (vscode.workspace.findFiles as jest.Mock).mockResolvedValue(verseFiles.map((file) => vscode.Uri.file(`${workspaceRoot}/${file}`)));
-        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
-            const contentRelative = uri.fsPath.replace(/\\/g, "/").replace(`${workspaceRoot}/Content/`, "");
-            if (!folders.includes(contentRelative)) throw new Error("ENOENT");
-            return { type: vscode.FileType.Directory };
-        });
+        stubTreeUnder(`${workspaceRoot}/Content`, folders);
     });
 
     afterEach(() => {

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -768,6 +768,20 @@ describe("ImportPathConverter.findModuleLocations project-wide phases under a ne
 
         expect(await locationsFor("Inventory", null)).toEqual([]);
     });
+
+    // FileStat.type is a bitmask, so the disk provider reports a linked
+    // directory as Directory|SymbolicLink. These phases globbed without stating
+    // at all before, and findFiles follows links by default, so reading the
+    // type as a value would drop a root reached through a junction.
+    it("takes a Content root reached through a symlink or a junction", async () => {
+        givenVerseFiles(["Systems/Inventory.verse"], "Inventory := module:\n");
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            if (uri.fsPath.replace(/\\/g, "/") !== contentRoot) throw new Error("ENOENT");
+            return { type: vscode.FileType.Directory | vscode.FileType.SymbolicLink };
+        });
+
+        expect(await locationsFor("Inventory")).toEqual(["/Systems"]);
+    });
 });
 
 // The relative form is a proposal until the module search confirms it names

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -4,6 +4,7 @@ import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathScanner } from "./ProjectPathScanner";
 import { PROJECT_CACHE_VERSION, ProjectPathData, ProjectPathNode, SerializedProjectPathCache } from "../types";
+import { findContentRoot } from "./contentRoot";
 import { buildProjectIndexes, resolveModuleLocations, ModuleLocationCandidate, ProjectIndexes } from "./moduleLocationLookup";
 
 /**
@@ -103,7 +104,8 @@ export class ProjectPathCache {
 
     /**
      * The possible locations of a module import path, empty when nothing is
-     * cached.
+     * cached and empty again when the workspace holds no Content root to place
+     * a cached declaration under.
      *
      * Candidates use the same location contract the converter's
      * filesystem scan produces ("" or "/Dir/Sub", Content-relative), each
@@ -112,13 +114,24 @@ export class ProjectPathCache {
      * Only explicit module declarations are known to the cache; implicit
      * folder modules are the filesystem scan's job.
      */
-    lookupModuleLocations(modulePath: string): ModuleLocationCandidate[] {
+    async lookupModuleLocations(modulePath: string): Promise<ModuleLocationCandidate[]> {
         if (!this.data) {
             return [];
         }
 
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return [];
+        }
+
+        const contentRoot = await findContentRoot(workspaceFolder, await this.projectPathHandler.getRootPluginName());
+        if (!contentRoot) {
+            return [];
+        }
+
         return resolveModuleLocations(modulePath, this.indexes.moduleNameIndex, {
-            workspaceIsContent: this.workspaceIsContent(),
+            workspaceFolderPath: workspaceFolder.uri.fsPath,
+            contentRootPath: contentRoot.fsPath,
         });
     }
 
@@ -418,18 +431,6 @@ export class ProjectPathCache {
     /** Must follow every mutation of `data.nodes`, or lookups serve the old set. */
     private rebuildIndexes(): void {
         this.indexes = buildProjectIndexes(this.data ? this.data.nodes : []);
-    }
-
-    /**
-     * Whether the workspace folder itself is the Content folder (affects how
-     * source file paths map to Content-relative locations).
-     */
-    private workspaceIsContent(): boolean {
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) {
-            return false;
-        }
-        return path.basename(workspaceFolders[0].uri.fsPath) === "Content";
     }
 
     /**

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import * as path from "path";
 import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathScanner } from "./ProjectPathScanner";

--- a/src/services/__tests__/ProjectPathCache.moduleLookup.test.ts
+++ b/src/services/__tests__/ProjectPathCache.moduleLookup.test.ts
@@ -1,0 +1,118 @@
+import * as vscode from "vscode";
+import { ProjectPathCache } from "../ProjectPathCache";
+import { PROJECT_CACHE_VERSION, ProjectPathNode, SerializedProjectPathCache } from "../../types";
+
+/**
+ * The cache serves lookups against source paths its scanner recorded relative
+ * to the workspace folder, so it has to place them under the project's Content
+ * root itself. While that root was read at one fixed depth, a project whose
+ * Verse sits under `Plugins/<Name>/Content` had every cached candidate
+ * discarded as outside Content, and the converter fell through to a scan that
+ * was blind to the same layout.
+ */
+describe("ProjectPathCache.lookupModuleLocations under a nested plugin Content root", () => {
+    const WORKSPACE_ROOT = "C:/Project";
+    const ROOT_PLUGIN = "MyGame";
+    const CONTENT_ROOT = `${WORKSPACE_ROOT}/Plugins/${ROOT_PLUGIN}/Content`;
+
+    /** Minimal in-memory stand-in for vscode.Memento (workspaceState). */
+    class FakeMemento {
+        private readonly store: Map<string, unknown> = new Map();
+
+        get<T>(key: string): T | undefined {
+            return this.store.get(key) as T | undefined;
+        }
+
+        async update(key: string, value: unknown): Promise<void> {
+            this.store.set(key, value);
+        }
+    }
+
+    type CacheParams = ConstructorParameters<typeof ProjectPathCache>;
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    /** Answers `fs.stat` as a directory for exactly these paths. */
+    const stubDirectories = (paths: string[]): void => {
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            if (!paths.includes(uri.fsPath.replace(/\\/g, "/"))) throw new Error("ENOENT");
+            return { type: vscode.FileType.Directory };
+        });
+    };
+
+    /**
+     * A cache holding one module declaration, restored from storage so no scan
+     * runs. `rootPluginName` is what the project file declares, which is what
+     * admits a Content root nested under `Plugins/<name>`.
+     */
+    const cacheHolding = async (node: ProjectPathNode, rootPluginName: string | null): Promise<ProjectPathCache> => {
+        const workspaceState = new FakeMemento();
+        const stored: SerializedProjectPathCache = {
+            version: PROJECT_CACHE_VERSION,
+            projectVersePath: "/mygame@fortnite.com/mygame",
+            projectName: "mygame",
+            generatedAt: 0,
+            nodes: [node],
+        };
+        await workspaceState.update("projectPathTree", stored);
+
+        const handler = {
+            getProjectName: async () => "mygame",
+            getProjectVersePath: async () => "/mygame@fortnite.com/mygame",
+            getRootPluginName: async () => rootPluginName,
+        };
+
+        const cache = new ProjectPathCache(
+            { workspaceState } as unknown as CacheParams[0],
+            vscode.window.createOutputChannel("test") as unknown as CacheParams[1],
+            handler as unknown as CacheParams[2],
+        );
+        await cache.initialize();
+        return cache;
+    };
+
+    const declaration = (sourceFile: string): ProjectPathNode => ({
+        name: "Inventory",
+        fullPath: "Inventory",
+        type: "module",
+        isPublic: true,
+        sourceFile,
+    });
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: WORKSPACE_ROOT }, name: "Project", index: 0 }]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.fs.stat as jest.Mock).mockReset();
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("places a cached declaration under a Content root nested below the workspace folder", async () => {
+        stubDirectories([CONTENT_ROOT]);
+        const cache = await cacheHolding(declaration(`Plugins/${ROOT_PLUGIN}/Content/Systems/Inventory.verse`), ROOT_PLUGIN);
+
+        expect(await cache.lookupModuleLocations("Inventory")).toEqual([{ location: "/Systems", sourceFile: `Plugins/${ROOT_PLUGIN}/Content/Systems/Inventory.verse` }]);
+    });
+
+    it("still places a declaration under a Content directly below the workspace folder", async () => {
+        stubDirectories([`${WORKSPACE_ROOT}/Content`]);
+        const cache = await cacheHolding(declaration("Content/Systems/Inventory.verse"), ROOT_PLUGIN);
+
+        expect(await cache.lookupModuleLocations("Inventory")).toEqual([{ location: "/Systems", sourceFile: "Content/Systems/Inventory.verse" }]);
+    });
+
+    // Only the root plugin's Content answers to bindings.projectVersePath, so a
+    // project declaring none has no evidence for a nested root and a
+    // declaration under one is not at any location this project can address.
+    it("finds no location for a nested declaration when the project declares no root plugin", async () => {
+        stubDirectories([CONTENT_ROOT]);
+        const cache = await cacheHolding(declaration(`Plugins/${ROOT_PLUGIN}/Content/Systems/Inventory.verse`), null);
+
+        expect(await cache.lookupModuleLocations("Inventory")).toEqual([]);
+    });
+});

--- a/src/services/__tests__/contentRoot.test.ts
+++ b/src/services/__tests__/contentRoot.test.ts
@@ -1,0 +1,35 @@
+import { contentRootCandidates } from "../contentRoot";
+
+/**
+ * The candidate list is the whole of the depth rule, so it is pinned here
+ * rather than only through the scans that consume it: order decides which root
+ * a project with more than one wins, and what is left out decides what the
+ * scans refuse to look under at all.
+ */
+describe("contentRootCandidates", () => {
+    const WORKSPACE_ROOT = "C:/Project";
+
+    it("offers the workspace folder itself when that is the Content folder", () => {
+        // UEFN's generated workspace opens here, so this is the common case and
+        // the one that must cost no filesystem check.
+        expect(contentRootCandidates(`${WORKSPACE_ROOT}/Plugins/MyGame/Content`, "MyGame")).toEqual([""]);
+    });
+
+    it("offers the shallowest root first, so a Content below it stays a folder module", () => {
+        expect(contentRootCandidates(WORKSPACE_ROOT, "MyGame")).toEqual(["Content", "Plugins/MyGame/Content"]);
+    });
+
+    // Only the root plugin's Content answers to bindings.projectVersePath, so a
+    // project declaring none offers no evidence for a nested root.
+    it("offers no nested root when the project declares no root plugin", () => {
+        expect(contentRootCandidates(WORKSPACE_ROOT, null)).toEqual(["Content"]);
+    });
+
+    // UEFN writes the name and creates the directory from one value, so these
+    // are malformed project files rather than layouts. Joining one anyway would
+    // resolve its segments and put the root outside the workspace folder, where
+    // the visibility writer would go on to create its definitions file.
+    it.each(["../../Elsewhere", "..", ".", "Nested/Plugin", "Nested\\Plugin", "C:/Elsewhere"])("offers no nested root for the plugin name %p", (rootPluginName) => {
+        expect(contentRootCandidates(WORKSPACE_ROOT, rootPluginName)).toEqual(["Content"]);
+    });
+});

--- a/src/services/__tests__/moduleLocationLookup.test.ts
+++ b/src/services/__tests__/moduleLocationLookup.test.ts
@@ -9,10 +9,18 @@ function classNode(name: string, fullPath: string, sourceFile: string): ProjectP
     return { name, fullPath, type: "class", isPublic: true, sourceFile };
 }
 
-function resolve(modulePath: string, nodes: ProjectPathNode[], workspaceIsContent = false) {
+const WORKSPACE_ROOT = "C:/Project";
+
+/**
+ * @param contentRootRelative where the project's Content root sits under the
+ *   workspace folder. "" is a workspace folder that is itself the Content root,
+ *   which is what UEFN's generated workspace opens.
+ */
+function resolve(modulePath: string, nodes: ProjectPathNode[], contentRootRelative = "Content") {
     const { moduleNameIndex } = buildProjectIndexes(nodes);
     return resolveModuleLocations(modulePath, moduleNameIndex, {
-        workspaceIsContent,
+        workspaceFolderPath: WORKSPACE_ROOT,
+        contentRootPath: contentRootRelative ? `${WORKSPACE_ROOT}/${contentRootRelative}` : WORKSPACE_ROOT,
     });
 }
 
@@ -120,14 +128,32 @@ describe("resolveModuleLocations", () => {
     it("treats source paths as Content-relative when the workspace is the Content folder", () => {
         const nodes = [moduleNode("Inventory", "Inventory", "Systems/Main.verse")];
 
-        expect(resolve("Inventory", nodes, true)).toEqual([{ location: "/Systems", sourceFile: "Systems/Main.verse" }]);
-        expect(resolve("Inventory", nodes, false)).toEqual([]);
+        expect(resolve("Inventory", nodes, "")).toEqual([{ location: "/Systems", sourceFile: "Systems/Main.verse" }]);
+        expect(resolve("Inventory", nodes, "Content")).toEqual([]);
     });
 
     it("resolves files directly at the workspace root when the workspace is Content", () => {
         const nodes = [moduleNode("Inventory", "Inventory", "Main.verse")];
 
-        expect(resolve("Inventory", nodes, true)).toEqual([{ location: "", sourceFile: "Main.verse" }]);
+        expect(resolve("Inventory", nodes, "")).toEqual([{ location: "", sourceFile: "Main.verse" }]);
+    });
+
+    // UEFN nests a project's Verse under <project>/Plugins/<Name>/Content, so a
+    // workspace opened at the project root reaches the root three levels down.
+    // While the boundary was read at one fixed depth, every cached declaration
+    // in such a project was dropped here as sitting outside Content.
+    it("resolves a declaration under a Content root nested below the workspace folder", () => {
+        const nodes = [moduleNode("Inventory", "Inventory", "Plugins/MyGame/Content/Systems/Main.verse")];
+
+        expect(resolve("Inventory", nodes, "Plugins/MyGame/Content")).toEqual([{ location: "/Systems", sourceFile: "Plugins/MyGame/Content/Systems/Main.verse" }]);
+    });
+
+    it("excludes a declaration under a Content root the project does not answer for", () => {
+        // A second plugin's Content carries a Verse path of its own, so a
+        // declaration in it is not at some location under this project's.
+        const nodes = [moduleNode("Inventory", "Inventory", "Plugins/Extra/Content/Systems/Main.verse")];
+
+        expect(resolve("Inventory", nodes, "Plugins/MyGame/Content")).toEqual([]);
     });
 
     it("deduplicates candidates that resolve to the same location", () => {

--- a/src/services/contentRoot.ts
+++ b/src/services/contentRoot.ts
@@ -1,0 +1,75 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { logger } from "../utils";
+
+/** The Content folder that anchors every importable module location. */
+const CONTENT_FOLDER = "Content";
+
+/** The directory UEFN nests a project's plugins under. */
+const PLUGINS_FOLDER = "Plugins";
+
+/**
+ * Where the project's Content root can sit inside a workspace folder,
+ * shallowest first, as workspace-relative forward-slash paths with "" for the
+ * folder itself.
+ *
+ * UEFN's shipped layout puts Verse under `<project>/Plugins/<Name>/Content` and
+ * the workspace it generates opens at that Content folder, so a workspace
+ * opened at the project root instead reaches it three levels down. A boundary
+ * that only admits depth zero finds nothing in such a project.
+ *
+ * Shallowest first, and only the root plugin's Content below the top level:
+ * both rules come from ImportPathConverter.placeUnderContentRoot, which is what
+ * a caller holding a document uses. A Content below the root is an ordinary
+ * folder module, and a second plugin's Content answers to a Verse path of its
+ * own rather than to this project's.
+ *
+ * @param rootPluginName `plugins[bIsRoot].name` from the project file; without
+ * one there is no evidence for a nested root, so only the top two are offered.
+ */
+export function contentRootCandidates(workspaceFolderPath: string, rootPluginName: string | null): string[] {
+    if (path.basename(workspaceFolderPath) === CONTENT_FOLDER) {
+        return [""];
+    }
+
+    const candidates = [CONTENT_FOLDER];
+    if (rootPluginName) {
+        candidates.push(`${PLUGINS_FOLDER}/${rootPluginName}/${CONTENT_FOLDER}`);
+    }
+
+    return candidates;
+}
+
+/**
+ * The project's Content root inside a workspace folder, or null when the folder
+ * holds none.
+ *
+ * Returned absolute, so a caller maps a file back through
+ * `path.relative(contentRoot, file)` rather than by stripping a prefix it
+ * spelled itself. That matters because the nested candidate is composed from
+ * the plugin name the project file declares, which is matched against a
+ * directory rather than resolved and so need not match its case: the relative
+ * step then folds exactly as far as the stat that found the root did.
+ */
+export async function findContentRoot(workspaceFolder: { uri: vscode.Uri }, rootPluginName: string | null): Promise<vscode.Uri | null> {
+    for (const candidate of contentRootCandidates(workspaceFolder.uri.fsPath, rootPluginName)) {
+        // The workspace folder is the Content folder itself, which is what it
+        // is named rather than what is under it - nothing to stat.
+        if (candidate === "") {
+            return workspaceFolder.uri;
+        }
+
+        const uri = vscode.Uri.joinPath(workspaceFolder.uri, candidate);
+        try {
+            const stat = await vscode.workspace.fs.stat(uri);
+            if (stat.type === vscode.FileType.Directory) {
+                return uri;
+            }
+        } catch {
+            // Absent, which is the ordinary answer for every candidate but one.
+        }
+    }
+
+    logger.debug("contentRoot", `No Content root under ${workspaceFolder.uri.fsPath} (root plugin: ${rootPluginName ?? "none"})`);
+    return null;
+}

--- a/src/services/contentRoot.ts
+++ b/src/services/contentRoot.ts
@@ -26,6 +26,10 @@ const PLUGINS_FOLDER = "Plugins";
  *
  * @param rootPluginName `plugins[bIsRoot].name` from the project file; without
  * one there is no evidence for a nested root, so only the top two are offered.
+ * A name carrying a path separator or a relative segment is refused rather than
+ * joined: `Uri.joinPath` would resolve it, and a `..` in the project file would
+ * put the root outside the workspace folder, where the visibility writer would
+ * then create its definitions file.
  */
 export function contentRootCandidates(workspaceFolderPath: string, rootPluginName: string | null): string[] {
     if (path.basename(workspaceFolderPath) === CONTENT_FOLDER) {
@@ -33,7 +37,7 @@ export function contentRootCandidates(workspaceFolderPath: string, rootPluginNam
     }
 
     const candidates = [CONTENT_FOLDER];
-    if (rootPluginName) {
+    if (rootPluginName && /^[^\\/:*?"<>|]+$/.test(rootPluginName) && rootPluginName !== "." && rootPluginName !== "..") {
         candidates.push(`${PLUGINS_FOLDER}/${rootPluginName}/${CONTENT_FOLDER}`);
     }
 
@@ -46,10 +50,11 @@ export function contentRootCandidates(workspaceFolderPath: string, rootPluginNam
  *
  * Returned absolute, so a caller maps a file back through
  * `path.relative(contentRoot, file)` rather than by stripping a prefix it
- * spelled itself. That matters because the nested candidate is composed from
- * the plugin name the project file declares, which is matched against a
- * directory rather than resolved and so need not match its case: the relative
- * step then folds exactly as far as the stat that found the root did.
+ * spelled itself. The nested candidate carries the plugin name as the project
+ * file spells it, which is matched against a directory rather than resolved,
+ * so it need not match the directory's case; relating two absolute paths folds
+ * as far as the platform does, which on Windows - where UEFN runs - is as far
+ * as the stat that found the root did.
  */
 export async function findContentRoot(workspaceFolder: { uri: vscode.Uri }, rootPluginName: string | null): Promise<vscode.Uri | null> {
     for (const candidate of contentRootCandidates(workspaceFolder.uri.fsPath, rootPluginName)) {
@@ -62,7 +67,13 @@ export async function findContentRoot(workspaceFolder: { uri: vscode.Uri }, root
         const uri = vscode.Uri.joinPath(workspaceFolder.uri, candidate);
         try {
             const stat = await vscode.workspace.fs.stat(uri);
-            if (stat.type === vscode.FileType.Directory) {
+
+            // A bitmask, not a value: the disk provider ORs SymbolicLink onto
+            // the target's type, so an equality test rejects a Content root
+            // reached through a symlink or a junction. The scans this feeds
+            // used to glob without stating at all, and findFiles follows links
+            // by default, so such a root has to keep working.
+            if ((stat.type & vscode.FileType.Directory) !== 0) {
                 return uri;
             }
         } catch {

--- a/src/services/moduleLocationLookup.ts
+++ b/src/services/moduleLocationLookup.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import { ProjectPathNode } from "../types";
 
 /**
@@ -10,9 +11,6 @@ import { ProjectPathNode } from "../types";
  * otherwise. The converter builds the final Verse path as
  * `${projectVersePath}${location}/${modulePath}`.
  */
-
-/** The Content folder that anchors importable module locations. */
-const CONTENT_FOLDER = "Content";
 
 /**
  * A resolved module location plus the file that proves it, so callers can
@@ -90,10 +88,15 @@ export function buildProjectIndexes(nodes: readonly ProjectPathNode[]): ProjectI
  * tail of the file's Content-relative directory (folders are implicit
  * modules). Non-module declarations are never considered.
  *
- * @param workspaceIsContent whether the workspace folder itself is the
- * Content folder (source file paths then have no "Content/" prefix).
+ * @param options the two anchors a node's workspace-relative `sourceFile` is
+ * placed against: the folder it is relative to, and the project's Content root
+ * wherever that sits under it.
  */
-export function resolveModuleLocations(modulePath: string, moduleNameIndex: ReadonlyMap<string, ProjectPathNode[]>, options: { workspaceIsContent: boolean }): ModuleLocationCandidate[] {
+export function resolveModuleLocations(
+    modulePath: string,
+    moduleNameIndex: ReadonlyMap<string, ProjectPathNode[]>,
+    options: { workspaceFolderPath: string; contentRootPath: string },
+): ModuleLocationCandidate[] {
     const requested = modulePath
         .replace(/^\//, "")
         .split("/")
@@ -130,7 +133,7 @@ export function resolveModuleLocations(modulePath: string, moduleNameIndex: Read
             continue;
         }
 
-        const contentRelativeDir = toContentRelativeDir(node.sourceFile, options.workspaceIsContent);
+        const contentRelativeDir = toContentRelativeDir(path.join(options.workspaceFolderPath, node.sourceFile), options.contentRootPath);
         if (contentRelativeDir === null) {
             continue;
         }
@@ -222,30 +225,31 @@ export function resolveFolderModuleLocations(modulePath: string, contentRelative
 }
 
 /**
- * The Content-relative directory of a workspace-relative source file, or null
- * when the file sits outside the Content folder and so cannot provide an
- * importable module location.
+ * The directory of a source file relative to the Content root, "" at the root
+ * itself, or null when the file sits outside it and so provides no importable
+ * module location.
  *
  * Exported so the converter's filesystem scan maps paths through this rather
  * than through a second copy of the rule: the two must agree on where Content
  * starts, or the same project resolves differently depending on which of them
  * asked.
  *
- * @param sourceFile workspace-relative, separated by "/"
+ * Both paths are absolute, so the root is subtracted by `path.relative` rather
+ * than by stripping a prefix the caller spelled. The root is found by a stat,
+ * and a caller cannot reproduce the on-disk spelling of what that stat matched:
+ * a plugin name read from the project file need not match its directory's case.
+ * Relating the two absolute paths folds exactly as far as the filesystem does.
  */
-export function toContentRelativeDir(sourceFile: string, workspaceIsContent: boolean): string | null {
-    const lastSlash = sourceFile.lastIndexOf("/");
-    const dir = lastSlash === -1 ? "" : sourceFile.slice(0, lastSlash);
+export function toContentRelativeDir(sourceFileAbsolute: string, contentRootAbsolute: string): string | null {
+    const belowRoot = path.relative(contentRootAbsolute, sourceFileAbsolute).replace(/\\/g, "/");
 
-    if (workspaceIsContent) {
-        return dir === "." ? "" : dir;
+    // `path.relative` says "outside the root" two ways: it climbs out with
+    // `..`, and on Windows it hands back the target whole when the two are on
+    // different drives, where no `..` could express the step.
+    if (belowRoot === ".." || belowRoot.startsWith("../") || path.isAbsolute(belowRoot)) {
+        return null;
     }
 
-    if (dir === CONTENT_FOLDER) {
-        return "";
-    }
-    if (dir.startsWith(`${CONTENT_FOLDER}/`)) {
-        return dir.slice(CONTENT_FOLDER.length + 1);
-    }
-    return null;
+    const lastSlash = belowRoot.lastIndexOf("/");
+    return lastSlash === -1 ? "" : belowRoot.slice(0, lastSlash);
 }

--- a/src/services/moduleLocationLookup.ts
+++ b/src/services/moduleLocationLookup.ts
@@ -238,7 +238,9 @@ export function resolveFolderModuleLocations(modulePath: string, contentRelative
  * than by stripping a prefix the caller spelled. The root is found by a stat,
  * and a caller cannot reproduce the on-disk spelling of what that stat matched:
  * a plugin name read from the project file need not match its directory's case.
- * Relating the two absolute paths folds exactly as far as the filesystem does.
+ * `path.relative` folds on Windows, where UEFN runs, so the two agree there; on
+ * a case-sensitive platform a root whose spelling differs from its directory
+ * places no file, which is the fail-closed direction.
  */
 export function toContentRelativeDir(sourceFileAbsolute: string, contentRootAbsolute: string): string | null {
     const belowRoot = path.relative(contentRootAbsolute, sourceFileAbsolute).replace(/\\/g, "/");

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -2,6 +2,8 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
+import { findContentRoot } from "../services/contentRoot";
+import { toContentRelativeDir } from "../services/moduleLocationLookup";
 import { appendDeclarationBlock, buildDeclarationBlock } from "./definitionsContent";
 import { findExplicitModuleDeclarations } from "./moduleDeclarations";
 import { ModuleVisibilityRequest } from "./ModuleVisibilityMessage";
@@ -166,7 +168,7 @@ export class ModuleVisibilityWriter {
         if (!located) {
             return { reason: `no '${CONTENT_FOLDER}' folder was found in the workspace, so there is nowhere to declare the module.` };
         }
-        const { workspaceFolder, contentRoot } = located;
+        const { contentRoot } = located;
 
         const definitionsUri = this.definitionsUri(contentRoot);
         if (!definitionsUri) {
@@ -177,7 +179,7 @@ export class ModuleVisibilityWriter {
         // Every module on the path is looked up, the reachable prefix included:
         // the chain written into the definitions file has to nest through them,
         // and a part it writes must repeat whatever they already declare.
-        const scan = await this.findDeclarations(workspaceFolder, [...prefix, ...segments.map((segment) => segment.name)], definitionsKey);
+        const scan = await this.findDeclarations(contentRoot, [...prefix, ...segments.map((segment) => segment.name)], definitionsKey);
         if ("unreadable" in scan) {
             return { reason: `'${vscode.workspace.asRelativePath(scan.unreadable, false)}' could not be read, so whether it declares part of '${request.moduleName}' is unknown.` };
         }
@@ -324,29 +326,21 @@ export class ModuleVisibilityWriter {
         }
     }
 
-    /** A folder paired with its Content root, or null when there is no folder or it holds none. */
+    /**
+     * A folder paired with its Content root, or null when there is no folder or
+     * it holds none.
+     *
+     * The root is resolved at whatever depth it sits, since UEFN nests it under
+     * `Plugins/<Name>` and a workspace opened at the project root holds no
+     * Content at its own top level.
+     */
     private async locateContentRoot(folder: vscode.WorkspaceFolder | undefined): Promise<{ workspaceFolder: vscode.WorkspaceFolder; contentRoot: vscode.Uri } | null> {
         if (!folder) {
             return null;
         }
 
-        const contentRoot = await this.findContentRoot(folder);
+        const contentRoot = await findContentRoot(folder, await this.projectPathHandler.getRootPluginName());
         return contentRoot ? { workspaceFolder: folder, contentRoot } : null;
-    }
-
-    /** The Content folder the project's modules hang off, or null when the workspace has none. */
-    private async findContentRoot(workspaceFolder: vscode.WorkspaceFolder): Promise<vscode.Uri | null> {
-        if (path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER) {
-            return workspaceFolder.uri;
-        }
-
-        const candidate = vscode.Uri.joinPath(workspaceFolder.uri, CONTENT_FOLDER);
-        try {
-            const stat = await vscode.workspace.fs.stat(candidate);
-            return stat.type === vscode.FileType.Directory ? candidate : null;
-        } catch {
-            return null;
-        }
     }
 
     /**
@@ -408,25 +402,26 @@ export class ModuleVisibilityWriter {
      * ProjectPathScanner's does, so an offset addresses the buffer the edit will
      * be applied to rather than what is currently on disk.
      *
+     * @param contentRoot the root the scan sweeps and every path is taken
+     * against, resolved once by the caller: deriving it a second time here
+     * would let the folder written to and the folder read from disagree.
      * @param definitionsKey the definitions file, whose text is kept even when
      * it declares none of these modules, because the caller appends to it. A
      * file holding no module declaration at all is skipped before that, and
      * reaches the caller through readDefinitions instead.
      */
     private async findDeclarations(
-        workspaceFolder: vscode.WorkspaceFolder,
+        contentRoot: vscode.Uri,
         names: readonly string[],
         definitionsKey: string,
     ): Promise<{ declarations: FoundDeclaration[]; scanned: Map<string, ScannedFile> } | UnreadableFile> {
-        const workspaceIsContent = path.basename(workspaceFolder.uri.fsPath) === CONTENT_FOLDER;
-        const searchPattern = workspaceIsContent ? "**/*.verse" : `${CONTENT_FOLDER}/**/*.verse`;
-        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, searchPattern), "**/*.digest.verse");
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(contentRoot, "**/*.verse"), "**/*.digest.verse");
         const wanted = new Set(names);
         const declarations: FoundDeclaration[] = [];
         const scanned = new Map<string, ScannedFile>();
 
         for (let i = 0; i < verseFiles.length; i += SCAN_CONCURRENCY) {
-            const batch = await Promise.all(verseFiles.slice(i, i + SCAN_CONCURRENCY).map((file) => this.readDeclarations(file, workspaceFolder, workspaceIsContent, wanted)));
+            const batch = await Promise.all(verseFiles.slice(i, i + SCAN_CONCURRENCY).map((file) => this.readDeclarations(file, contentRoot, wanted)));
             for (const result of batch) {
                 if (!result) {
                     continue;
@@ -458,13 +453,8 @@ export class ModuleVisibilityWriter {
      * deliberately - a file there is skipped without ever being opened, so an
      * unreadable one cannot refuse the request.
      */
-    private async readDeclarations(
-        uri: vscode.Uri,
-        workspaceFolder: vscode.WorkspaceFolder,
-        workspaceIsContent: boolean,
-        wanted: ReadonlySet<string>,
-    ): Promise<{ file: ScannedFile; declarations: FoundDeclaration[] } | UnreadableFile | null> {
-        const directory = this.contentRelativeDirectory(uri, workspaceFolder, workspaceIsContent);
+    private async readDeclarations(uri: vscode.Uri, contentRoot: vscode.Uri, wanted: ReadonlySet<string>): Promise<{ file: ScannedFile; declarations: FoundDeclaration[] } | UnreadableFile | null> {
+        const directory = toContentRelativeDir(uri.fsPath, contentRoot.fsPath);
         if (directory === null) {
             return null;
         }
@@ -493,27 +483,6 @@ export class ModuleVisibilityWriter {
             }));
 
         return { file: { uri, text, version: read.version }, declarations };
-    }
-
-    /**
-     * A file's directory relative to the Content root, "" at the root itself,
-     * or null when the file sits outside Content. Mirrors the normalization in
-     * ImportPathConverter's declaration scan.
-     */
-    private contentRelativeDirectory(file: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, workspaceIsContent: boolean): string | null {
-        const directory = path.dirname(path.relative(workspaceFolder.uri.fsPath, file.fsPath)).replace(/\\/g, "/");
-
-        if (workspaceIsContent) {
-            return directory === "" || directory === "." ? "" : directory;
-        }
-
-        if (directory === CONTENT_FOLDER) {
-            return "";
-        }
-        if (directory.startsWith(`${CONTENT_FOLDER}/`)) {
-            return directory.substring(CONTENT_FOLDER.length + 1);
-        }
-        return null;
     }
 
     /**

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -1,4 +1,3 @@
-import * as path from "path";
 import * as vscode from "vscode";
 import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
@@ -164,11 +163,10 @@ export class ModuleVisibilityWriter {
         // workspace can carry one legitimately - notes or art opened alongside
         // the project. A document in such a folder falls back rather than
         // refusing, since the project's own folder can still serve it.
-        const located = (await this.locateContentRoot(requestedFolder)) ?? (await this.locateContentRoot(firstFolder));
-        if (!located) {
+        const contentRoot = (await this.locateContentRoot(requestedFolder)) ?? (await this.locateContentRoot(firstFolder));
+        if (!contentRoot) {
             return { reason: `no '${CONTENT_FOLDER}' folder was found in the workspace, so there is nowhere to declare the module.` };
         }
-        const { contentRoot } = located;
 
         const definitionsUri = this.definitionsUri(contentRoot);
         if (!definitionsUri) {
@@ -327,20 +325,20 @@ export class ModuleVisibilityWriter {
     }
 
     /**
-     * A folder paired with its Content root, or null when there is no folder or
-     * it holds none.
+     * A folder's Content root, or null when there is no folder or it holds
+     * none. Nullable on both counts so the caller can fall back from the
+     * document's own folder to the first with one `??`.
      *
      * The root is resolved at whatever depth it sits, since UEFN nests it under
      * `Plugins/<Name>` and a workspace opened at the project root holds no
      * Content at its own top level.
      */
-    private async locateContentRoot(folder: vscode.WorkspaceFolder | undefined): Promise<{ workspaceFolder: vscode.WorkspaceFolder; contentRoot: vscode.Uri } | null> {
+    private async locateContentRoot(folder: vscode.WorkspaceFolder | undefined): Promise<vscode.Uri | null> {
         if (!folder) {
             return null;
         }
 
-        const contentRoot = await findContentRoot(folder, await this.projectPathHandler.getRootPluginName());
-        return contentRoot ? { workspaceFolder: folder, contentRoot } : null;
+        return findContentRoot(folder, await this.projectPathHandler.getRootPluginName());
     }
 
     /**

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -119,8 +119,17 @@ const givenPerFolderDefinitionsName = (byRoot: Record<string, string>): void => 
     });
 };
 
-const writer = (): ModuleVisibilityWriter => {
-    const handler = { getProjectVersePath: jest.fn().mockResolvedValue(PROJECT) } as unknown as ProjectPathHandler;
+/**
+ * @param rootPluginName what the project file declares as its root plugin, which
+ *   is what admits a Content root nested under `Plugins/<name>`. Left unset, the
+ *   project declares none and only a Content directly under a workspace folder
+ *   is found.
+ */
+const writer = (rootPluginName: string | null = null): ModuleVisibilityWriter => {
+    const handler = {
+        getProjectVersePath: jest.fn().mockResolvedValue(PROJECT),
+        getRootPluginName: jest.fn().mockResolvedValue(rootPluginName),
+    } as unknown as ProjectPathHandler;
     return new ModuleVisibilityWriter({} as vscode.OutputChannel, handler);
 };
 
@@ -375,7 +384,10 @@ describe("ModuleVisibilityWriter", () => {
 
     it("refuses when no project file resolves the module paths", async () => {
         givenProject({ "Content/Scripts/main.verse": "" });
-        const handler = { getProjectVersePath: jest.fn().mockResolvedValue(null) } as unknown as ProjectPathHandler;
+        const handler = {
+            getProjectVersePath: jest.fn().mockResolvedValue(null),
+            getRootPluginName: jest.fn().mockResolvedValue(null),
+        } as unknown as ProjectPathHandler;
 
         await new ModuleVisibilityWriter({} as vscode.OutputChannel, handler).makeModulePublic(REQUEST);
 
@@ -562,8 +574,10 @@ describe("ModuleVisibilityWriter", () => {
 
             await writer().makeModulePublic(REQUEST, source);
 
+            // The scan is rooted at the Content root the write goes to, so the
+            // folder written and the folder read cannot come apart.
             const [pattern] = (vscode.workspace.findFiles as jest.Mock).mock.calls[0];
-            expect(forwardSlashed(pattern.base.uri)).toBe(OTHER_ROOT);
+            expect(forwardSlashed(pattern.base)).toBe(`${OTHER_ROOT}/Content`);
         });
 
         it("falls back to the first folder when the caller names no document", async () => {
@@ -596,5 +610,84 @@ describe("ModuleVisibilityWriter", () => {
 
             expect(forwardSlashed(appliedOperations()[0].uri)).toBe(`${ROOT}/Content/_definitions.verse`);
         });
+    });
+});
+
+// UEFN nests a project's Verse under <project>/Plugins/<Name>/Content, so a
+// workspace opened at the project root holds no Content at its own top level.
+// While the root was read at one fixed depth, the quick fix refused every such
+// project with "no 'Content' folder was found in the workspace" - the one layout
+// import conversion had already been taught to handle.
+describe("ModuleVisibilityWriter under a nested plugin Content root", () => {
+    const ROOT_PLUGIN = "MyGame";
+    const CONTENT_ROOT = `${ROOT}/Plugins/${ROOT_PLUGIN}/Content`;
+
+    /**
+     * Stands the project up under the nested Content root, from one map of
+     * root-relative path to file text. Nothing but that root stats as a
+     * directory, so a writer still reading the boundary at depth zero finds no
+     * Content folder here rather than passing by coincidence.
+     */
+    const givenNestedProject = (files: Record<string, string>): void => {
+        (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file(ROOT), name: "repo", index: 0 }];
+
+        const byUri = new Map(Object.entries(files).map(([relative, text]) => [vscode.Uri.file(`${CONTENT_ROOT}/${relative}`).toString(), text]));
+
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([...byUri.keys()].map((key) => vscode.Uri.file(key.replace(/^file:\/\//, ""))));
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation((uri: vscode.Uri) => {
+            if (forwardSlashed(uri) === CONTENT_ROOT) return Promise.resolve({ type: vscode.FileType.Directory });
+            return byUri.has(uri.toString()) ? Promise.resolve({ type: vscode.FileType.File }) : Promise.reject(new Error("ENOENT"));
+        });
+        (vscode.workspace.openTextDocument as jest.Mock).mockImplementation((uri: vscode.Uri) => {
+            const text = byUri.get(uri.toString());
+            return text === undefined ? Promise.reject(new Error("ENOENT")) : Promise.resolve({ getText: () => text, version: 1 });
+        });
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (vscode.workspace.applyEdit as jest.Mock).mockResolvedValue(true);
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn().mockImplementation((_key: string, fallback?: unknown) => fallback),
+            update: jest.fn(),
+        });
+    });
+
+    afterEach(() => {
+        (vscode.workspace as any).workspaceFolders = undefined;
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("writes the definitions file at the nested Content root", async () => {
+        givenNestedProject({ "Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+        await writer(ROOT_PLUGIN).makeModulePublic(REQUEST);
+
+        const operations = appliedOperations();
+        expect(forwardSlashed(operations[0].uri)).toBe(`${CONTENT_ROOT}/_definitions.verse`);
+        expect(operations[1]).toMatchObject({ kind: "insert", text: "Gadgets := module:\n    Tools<public> := module {}\n" });
+    });
+
+    // The scan has to sweep the same root the write goes to: a declaration it
+    // never reached becomes a second, conflicting part in the definitions file.
+    it("rewrites a declaration the scan finds under the nested root, rather than repeating it", async () => {
+        givenNestedProject({ "Gadgets/tools.verse": "Tools := module {}\n" });
+
+        await writer(ROOT_PLUGIN).makeModulePublic(REQUEST);
+
+        const operations = appliedOperations();
+        expect(operations).toHaveLength(1);
+        expect(operations[0]).toMatchObject({ kind: "insert", text: "<public>" });
+        expect(forwardSlashed(operations[0].uri)).toBe(`${CONTENT_ROOT}/Gadgets/tools.verse`);
+    });
+
+    it("refuses when the project declares no root plugin, so no nested root is addressable", async () => {
+        givenNestedProject({ "Scripts/main.verse": "using { Gadgets.Tools }\n" });
+
+        await writer(null).makeModulePublic(REQUEST);
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("no 'Content' folder"));
     });
 });


### PR DESCRIPTION
Closes #448

## What

#429 taught the two document-relative sites to find a Content root nested under `Plugins/<Name>`. The four sites with no document to walk from still read the boundary at a fixed depth off the workspace folder, so a workspace opened at the project root was invisible to the declaration scan, the folder scan and the cache lookup, and "Make module public" refused it with `no 'Content' folder was found in the workspace`.

The root is now resolved once per operation, as an absolute URI, and threaded through the glob, the cache lookup and the map-back.

## How

**`src/services/contentRoot.ts`** (new) states the boundary once, in the same terms `ImportPathConverter.placeUnderContentRoot` uses:

- `contentRootCandidates` — pure, shallowest first: `""` when the workspace folder is itself named `Content`, otherwise `Content`, then `Plugins/<rootPluginName>/Content` when the project file declares a root plugin.
- `findContentRoot` — the first candidate that stats as a directory.

**`moduleLocationLookup`** — `toContentRelativeDir(sourceFileAbsolute, contentRootAbsolute)` replaces the `workspaceIsContent` boolean, and `resolveModuleLocations` takes `{ workspaceFolderPath, contentRootPath }`. Absolute paths let `path.relative` subtract the root instead of a caller stripping a prefix it spelled itself, which matters because the nested candidate is composed from the plugin name the project file declares and that name is matched against a directory rather than resolved, so it need not match its case. Relating two absolute paths folds exactly as far as the `stat` that found the root did.

**`ImportPathConverter`** — `workspaceScanTargets` is gone; both scan phases resolve the root once and glob `RelativePattern(contentRoot, "**/*.verse")`.

**`ProjectPathCache.lookupModuleLocations`** — async, and resolves the root before placing a cached `sourceFile`.

**`ModuleVisibilityWriter`** — `findContentRoot` and `contentRelativeDirectory` are gone. `buildEdit` passes the located root into `findDeclarations`, so the folder written to and the folder read from can no longer come apart: the rule was previously derived three times inside one operation.

## Why this shape

Settled against real UEFN output rather than off this extension's own scanner:

- A UEFN project root holds only `<Project>.uefnproject` and `Plugins/`. There is no project-level `Content` — checked across every project under a local UEFN project directory at depth 2, zero hits. So shallowest-first candidate ordering never competes with the root plugin's Content on a real layout, and this introduces no divergence from #429's rule.
- UEFN's generated `.code-workspace` opens folder 0 *at* `Plugins/<Name>/Content`. That is the depth-0 case the fixed-depth rule was written for, and why the defect only surfaces for someone who opens the project root instead.

## Out of scope

Which workspace folder is chosen (#396 H-14, #450) and the byte-exact `Content` comparison (#396 H-08) are untouched, as the ticket asks.

## From the review gate

Two findings were fixed rather than only reported, both pinned by tests that fail without them:

- **`FileStat.type` is a bitmask.** The disk provider ORs `SymbolicLink` onto the target's type, so `stat.type === FileType.Directory` rejects a Content root reached through a symlink or a junction. These phases globbed with no stat at all before and `search.followSymlinks` defaults to true, so a junctioned root worked and would have stopped working. The pre-existing `ImportPathConverter.folderExists` carries the same equality test; left alone as out of scope.
- **The root plugin name is joined into a path.** A project file carrying a separator or a relative segment in it could root the scan outside the workspace folder, where the visibility writer would then create its definitions file. Refused the way `definitionsUri` already refuses a file name carrying a path.

One finding is reported and not fixed, deliberately:

- **The nested candidate is composed against the workspace folder, not the `.uefnproject` directory.** The ticket's "Smallest fix" names the project-file location as the anchor; only `getRootPluginName()` was used. The gap is a workspace opened at `<project>/Plugins`, where `placeUnderContentRoot` still places a document but the scans find no root — a layout UEFN does not generate. Closing it means anchoring on `path.dirname(projectFilePath)`, which needs `ProjectPathHandler.findAndParseProjectFile` to retain the path it currently discards — the same method #450 is restructuring. Worth a follow-up once #450 lands rather than a conflicting edit now.

Also noted, not acted on: `CONTENT_FOLDER` is declared in three files and `PLUGINS_FOLDER` in two; `placeUnderContentRoot` still encodes the same two rules in its own shape (it walks a known file path where this probes a directory); and the root is resolved per call rather than memoized per operation.

## Tests

Regression tests at the entry points the issue names. Six pin the depth rule and were proved to detect it — disabling the nested candidate fails exactly those six and nothing else:

- `ImportPathConverter.findModuleLocations` through phase 2 (declaration scan) and phase 3 (folder scan) under a nested root, the glob's base, and the fail-closed case where no root plugin is declared.
- `ProjectPathCache.lookupModuleLocations` placing a nested `sourceFile`, the flat case still working, and the no-root-plugin case.
- `ModuleVisibilityWriter` writing at the nested root, rewriting a declaration the scan finds there, and still refusing when no root plugin is declared.

Two more pin the review fixes, each likewise proved to fail without them: a Content root reported as `Directory|SymbolicLink`, and `contentRootCandidates` refusing a plugin name that carries a separator or a relative segment. The candidate list is tested directly rather than through a scan because the mock's `Uri.joinPath` does not resolve `..`, which made the end-to-end version of that test pass for the wrong reason.

## Verification

```
> verse-auto-imports@0.11.2 compile
> tsc -p ./
```

```
> verse-auto-imports@0.11.2 test
> jest --verbose

Test Suites: 54 passed, 54 total
Tests:       1607 passed, 1607 total
Snapshots:   0 total
Time:        8.15 s
Ran all test suites.
```

```
> verse-auto-imports@0.11.2 format:check
> prettier --check "**/*.ts"

Checking formatting...
All matched files use Prettier code style!
```
