### PR TITLE
feat(manifest): declare untrusted and virtual workspace capabilities

### DIFF
--- a/changelog.d/361.added.md
+++ b/changelog.d/361.added.md
@@ -1,0 +1,1 @@
+**Manifest**: declares workspace capabilities, keeping the extension enabled in Restricted Mode and marking virtual workspaces as unsupported instead of silently non-functional.

--- a/changelog.d/361.added.md
+++ b/changelog.d/361.added.md
@@ -1,1 +1,1 @@
-**Manifest**: declares workspace capabilities, keeping the extension enabled in Restricted Mode and marking virtual workspaces as unsupported instead of silently non-functional.
+**Workspace support**: declares workspace capabilities, keeping the extension enabled in Restricted Mode and marking virtual workspaces as unsupported instead of silently non-functional.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,15 @@
     "onLanguage:verse"
   ],
   "main": "./out/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    },
+    "virtualWorkspaces": {
+      "supported": false,
+      "description": "Verse Auto Imports relies on Verse compiler diagnostics and project file scanning, which are unavailable in virtual workspaces."
+    }
+  },
   "contributes": {
     "languages": [
       {

--- a/src/__tests__/manifestCapabilities.test.ts
+++ b/src/__tests__/manifestCapabilities.test.ts
@@ -1,0 +1,21 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * An undeclared `untrustedWorkspaces` disables the extension entirely in
+ * Restricted Mode, and an undeclared `virtualWorkspaces` defaults to enabled
+ * where the diagnostics-driven core cannot work. Both must stay declared.
+ */
+describe("manifest workspace capabilities", () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf8"));
+
+    it("supports untrusted workspaces", () => {
+        expect(manifest.capabilities.untrustedWorkspaces.supported).toBe(true);
+    });
+
+    it("declares virtual workspaces unsupported, with a reason", () => {
+        expect(manifest.capabilities.virtualWorkspaces.supported).toBe(false);
+        expect(typeof manifest.capabilities.virtualWorkspaces.description).toBe("string");
+        expect(manifest.capabilities.virtualWorkspaces.description.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Closes #361

## What

Adds the `capabilities` field to the manifest, declaring both workspace capabilities the issue found missing:

- `untrustedWorkspaces: { "supported": true }` — the extension only performs diagnostics-driven text edits on workspace `.verse` files. Audit of all 22 contributed settings found none interpreted as an executable path or loaded code; the only filesystem-reaching setting, `moduleVisibility.definitionsFileName`, is validated to a bare `.verse` filename before use, so a workspace value cannot escape the Content root.
- `virtualWorkspaces: { "supported": false, "description": ... }` — the core depends on Verse compiler diagnostics and project-file scanning, neither of which exists in a virtual workspace, so the extension now says so instead of appearing available and doing nothing.

A regression test (`src/__tests__/manifestCapabilities.test.ts`) pins both declarations, and a changelog fragment records the user-facing effect.

## Verification

`npm run compile` — clean.

`npm test`:

```
Test Suites: 58 passed, 58 total
Tests:       1642 passed, 1642 total
```

`npm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```

The new test was proven to detect the defect: with the manifest change stashed, both assertions fail; restored, they pass.

## Review

Fresh reviewer (opus), round 1: **PASS**, 0 Critical, 0 Important, 2 Suggestions (changelog wording — applied; a note that `untrustedWorkspaces` intentionally carries no `description`, which VS Code ignores when supported is true).
