### PR TITLE
fix(project): anchor the Content root on the .uefnproject directory

### DIFF
--- a/changelog.d/466.fixed.md
+++ b/changelog.d/466.fixed.md
@@ -1,0 +1,1 @@
+**Project scanning**: a workspace opened above the project root, such as at the Plugins folder, now resolves the Content root from the .uefnproject file's own directory, so project-wide scans and visibility edits work there.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -429,7 +429,7 @@ export class ImportPathConverter {
      * would resolve the same project differently.
      */
     private async scanContentRoot(workspaceFolder: { uri: vscode.Uri }): Promise<vscode.Uri | null> {
-        return findContentRoot(workspaceFolder, await this.projectPathHandler.getRootPluginName(workspaceFolder.uri));
+        return findContentRoot(workspaceFolder, await this.projectPathHandler.getRootPluginName(workspaceFolder.uri), await this.projectPathHandler.getProjectFileDirectory(workspaceFolder.uri));
     }
 
     /**

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -278,9 +278,14 @@ function stubTreeUnder(contentRoot: string, folders: string[]): void {
  */
 function converterWithProjectPath(projectVersePath: string, rootPluginName: string | null = null): ImportPathConverter {
     const converter = new ImportPathConverter(vscode.window.createOutputChannel("test"));
-    const handler = (converter as unknown as { projectPathHandler: { getProjectVersePath: () => Promise<string>; getRootPluginName: () => Promise<string | null> } }).projectPathHandler;
+    const handler = (
+        converter as unknown as {
+            projectPathHandler: { getProjectVersePath: () => Promise<string>; getRootPluginName: () => Promise<string | null>; getProjectFileDirectory: () => Promise<string | null> };
+        }
+    ).projectPathHandler;
     handler.getProjectVersePath = async () => projectVersePath;
     handler.getRootPluginName = async () => rootPluginName;
+    handler.getProjectFileDirectory = async () => null;
     return converter;
 }
 

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -26,6 +26,19 @@ interface UEFNProjectFile {
 }
 
 /**
+ * A parsed project file together with the directory it was read from.
+ *
+ * The directory is what anchors the project's on-disk layout - the Content
+ * root sits at `<directory>/Plugins/<root plugin>/Content` - so it has to
+ * survive the parse: the parsed JSON alone says where modules are addressed,
+ * not where they live.
+ */
+interface LocatedProjectFile {
+    file: UEFNProjectFile;
+    directory: string;
+}
+
+/**
  * The cache key for a lookup that named no workspace folder. A folder's URI
  * never stringifies to empty, so this cannot collide with one.
  */
@@ -54,7 +67,7 @@ export class ProjectPathHandler {
      * file. Two folders under one project therefore hold equal entries, which
      * costs a second parse and never a wrong answer.
      */
-    private readonly projectFilesByScope = new Map<string, UEFNProjectFile>();
+    private readonly projectFilesByScope = new Map<string, LocatedProjectFile>();
 
     constructor(private outputChannel: vscode.OutputChannel) {}
 
@@ -70,6 +83,24 @@ export class ProjectPathHandler {
      * rather than answering nothing.
      */
     async findAndParseProjectFile(resource?: vscode.Uri): Promise<UEFNProjectFile | null> {
+        return (await this.findAndLocateProjectFile(resource))?.file ?? null;
+    }
+
+    /**
+     * The directory holding the `.uefnproject` that owns `resource`, or null
+     * when no project file was found. This is the project root the on-disk
+     * layout hangs off, which is not necessarily inside any workspace folder -
+     * the parent walk can find the file above them all.
+     *
+     * @param resource a file in the project being asked about. A resource
+     * outside every workspace folder falls back to the whole-workspace search
+     * rather than answering nothing.
+     */
+    async getProjectFileDirectory(resource?: vscode.Uri): Promise<string | null> {
+        return (await this.findAndLocateProjectFile(resource))?.directory ?? null;
+    }
+
+    private async findAndLocateProjectFile(resource?: vscode.Uri): Promise<LocatedProjectFile | null> {
         const scope = resource ? vscode.workspace.getWorkspaceFolder(resource) : undefined;
         const key = scope ? scope.uri.toString() : WORKSPACE_SCOPE;
 
@@ -93,7 +124,7 @@ export class ProjectPathHandler {
      * reachable; the fallback is what keeps a workspace whose first folder
      * holds no project working, since the project can sit in any folder.
      */
-    private async searchForProjectFile(scope: vscode.WorkspaceFolder | undefined): Promise<UEFNProjectFile | null> {
+    private async searchForProjectFile(scope: vscode.WorkspaceFolder | undefined): Promise<LocatedProjectFile | null> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) {
             logger.debug("ProjectPathHandler", "No workspace folders found");
@@ -142,7 +173,7 @@ export class ProjectPathHandler {
      * walking on would answer from some parent project's paths, which is worse
      * than answering nothing.
      */
-    private async readProjectFileIn(folder: vscode.WorkspaceFolder): Promise<UEFNProjectFile | null | undefined> {
+    private async readProjectFileIn(folder: vscode.WorkspaceFolder): Promise<LocatedProjectFile | null | undefined> {
         const files = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, "*.uefnproject"), null, 1);
 
         if (files.length === 0) {
@@ -173,7 +204,7 @@ export class ProjectPathHandler {
      * has the better claim to answer, so an unreadable one there is decisive,
      * while one found part-way up should not hide a project above it.
      */
-    private async walkUpFrom(start: vscode.Uri): Promise<UEFNProjectFile | null> {
+    private async walkUpFrom(start: vscode.Uri): Promise<LocatedProjectFile | null> {
         let currentDir = start.fsPath;
 
         for (let level = 0; level < MAX_PARENT_LEVELS; level++) {
@@ -204,8 +235,11 @@ export class ProjectPathHandler {
     }
 
     /** Raises on an unreadable file and on one that is not JSON alike. */
-    private static parseProjectFile(projectFilePath: string): UEFNProjectFile {
-        return JSON.parse(fs.readFileSync(projectFilePath, "utf8")) as UEFNProjectFile;
+    private static parseProjectFile(projectFilePath: string): LocatedProjectFile {
+        return {
+            file: JSON.parse(fs.readFileSync(projectFilePath, "utf8")) as UEFNProjectFile,
+            directory: path.dirname(projectFilePath),
+        };
     }
 
     /**

--- a/src/project/__tests__/ProjectPathHandler.test.ts
+++ b/src/project/__tests__/ProjectPathHandler.test.ts
@@ -122,6 +122,23 @@ describe("ProjectPathHandler", () => {
         expect(await handler.getProjectVersePath(vscode.Uri.file(`${deepRoot}/main.verse`))).toBe("/mygame@fortnite.com/secondgame");
     });
 
+    // The directory is what anchors Plugins/<root>/Content on disk, so it has
+    // to name where the file was found, the parent-walk case included.
+    it("exposes the directory the project file was read from", async () => {
+        givenWorkspaceFolders(FIRST_ROOT);
+        givenProjectsIn({ [FIRST_ROOT]: FIRST });
+
+        expect(await handler.getProjectFileDirectory(fileIn(FIRST_ROOT))).toBe(FIRST_ROOT);
+    });
+
+    it("exposes the parent directory the walk found the project file in", async () => {
+        const pluginsRoot = `${SECOND_ROOT}/Plugins`;
+        givenWorkspaceFolders(pluginsRoot);
+        givenProjectsIn({ [SECOND_ROOT]: SECOND });
+
+        expect(await handler.getProjectFileDirectory(vscode.Uri.file(`${pluginsRoot}/SecondGame/Content/main.verse`))).toBe(SECOND_ROOT);
+    });
+
     it("searches every folder when nothing names one", async () => {
         givenWorkspaceFolders(NOTES_ROOT, SECOND_ROOT);
         givenProjectsIn({ [SECOND_ROOT]: SECOND });

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -123,7 +123,11 @@ export class ProjectPathCache {
             return [];
         }
 
-        const contentRoot = await findContentRoot(workspaceFolder, await this.projectPathHandler.getRootPluginName(workspaceFolder.uri));
+        const contentRoot = await findContentRoot(
+            workspaceFolder,
+            await this.projectPathHandler.getRootPluginName(workspaceFolder.uri),
+            await this.projectPathHandler.getProjectFileDirectory(workspaceFolder.uri),
+        );
         if (!contentRoot) {
             return [];
         }

--- a/src/services/__tests__/ProjectPathCache.moduleLookup.test.ts
+++ b/src/services/__tests__/ProjectPathCache.moduleLookup.test.ts
@@ -63,6 +63,7 @@ describe("ProjectPathCache.lookupModuleLocations under a nested plugin Content r
             getProjectName: async () => "mygame",
             getProjectVersePath: async () => "/mygame@fortnite.com/mygame",
             getRootPluginName: async () => rootPluginName,
+            getProjectFileDirectory: async () => null,
         };
 
         const cache = new ProjectPathCache(

--- a/src/services/__tests__/contentRoot.test.ts
+++ b/src/services/__tests__/contentRoot.test.ts
@@ -1,4 +1,5 @@
-import { contentRootCandidates } from "../contentRoot";
+import * as vscode from "vscode";
+import { contentRootCandidates, findContentRoot } from "../contentRoot";
 
 /**
  * The candidate list is the whole of the depth rule, so it is pinned here
@@ -31,5 +32,54 @@ describe("contentRootCandidates", () => {
     // the visibility writer would go on to create its definitions file.
     it.each(["../../Elsewhere", "..", ".", "Nested/Plugin", "Nested\\Plugin", "C:/Elsewhere"])("offers no nested root for the plugin name %p", (rootPluginName) => {
         expect(contentRootCandidates(WORKSPACE_ROOT, rootPluginName)).toEqual(["Content"]);
+    });
+
+    // The project file's own directory anchors Plugins/<root>/Content, so a
+    // workspace opened above the project root - at Plugins - still reaches it.
+    it("composes the nested root from the project file's directory", () => {
+        expect(contentRootCandidates(`${WORKSPACE_ROOT}/Plugins`, "MyGame", WORKSPACE_ROOT)).toEqual(["Content", "MyGame/Content", "Plugins/MyGame/Content"]);
+    });
+
+    it("offers the composed root once when the project sits at the workspace folder", () => {
+        expect(contentRootCandidates(WORKSPACE_ROOT, "MyGame", WORKSPACE_ROOT)).toEqual(["Content", "Plugins/MyGame/Content"]);
+    });
+
+    // The parent-walk case: the project file sits above the workspace folder
+    // and its Content root outside it, where no glob rooted in the folder
+    // would reach and the visibility writer must not create files.
+    it("drops a composed root that escapes the workspace folder", () => {
+        expect(contentRootCandidates(`${WORKSPACE_ROOT}/Plugins/MyGame/Verse`, "MyGame", WORKSPACE_ROOT)).toEqual(["Content", "Plugins/MyGame/Content"]);
+    });
+});
+
+/**
+ * Issue's entry point: with the workspace opened at `<project>/Plugins`, the
+ * document-relative placement accepted `<ws>/<Root>/Content` while this
+ * returned null, so the scan phases and the visibility writer never globbed.
+ */
+describe("findContentRoot", () => {
+    const statAcceptingDirectory = (fsPath: string) => async (uri: { fsPath: string }) => {
+        if (uri.fsPath.replace(/\\/g, "/") === fsPath) {
+            return { type: vscode.FileType.Directory };
+        }
+        throw new Error("ENOENT");
+    };
+
+    afterEach(() => {
+        (vscode.workspace.fs.stat as jest.Mock).mockReset().mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("finds the root plugin's Content from a workspace opened at Plugins", async () => {
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(statAcceptingDirectory("C:/Project/Plugins/MyGame/Content"));
+
+        const root = await findContentRoot({ uri: vscode.Uri.file("C:/Project/Plugins") }, "MyGame", "C:/Project");
+
+        expect(root?.fsPath.replace(/\\/g, "/")).toBe("C:/Project/Plugins/MyGame/Content");
+    });
+
+    it("still answers null when the composed root does not exist on disk", async () => {
+        const root = await findContentRoot({ uri: vscode.Uri.file("C:/Project/Plugins") }, "MyGame", "C:/Project");
+
+        expect(root).toBeNull();
     });
 });

--- a/src/services/contentRoot.ts
+++ b/src/services/contentRoot.ts
@@ -30,18 +30,34 @@ const PLUGINS_FOLDER = "Plugins";
  * joined: `Uri.joinPath` would resolve it, and a `..` in the project file would
  * put the root outside the workspace folder, where the visibility writer would
  * then create its definitions file.
+ * @param projectFileDirectory the directory holding the `.uefnproject`, which
+ * anchors `Plugins/<root>/Content` where the workspace folder is opened above
+ * or below the project root. A composition that escapes the workspace folder
+ * is dropped rather than offered: no glob rooted in the folder would reach it,
+ * and the visibility writer must not create files outside the workspace.
  */
-export function contentRootCandidates(workspaceFolderPath: string, rootPluginName: string | null): string[] {
+export function contentRootCandidates(workspaceFolderPath: string, rootPluginName: string | null, projectFileDirectory: string | null = null): string[] {
     if (path.basename(workspaceFolderPath) === CONTENT_FOLDER) {
         return [""];
     }
 
     const candidates = [CONTENT_FOLDER];
     if (rootPluginName && /^[^\\/:*?"<>|]+$/.test(rootPluginName) && rootPluginName !== "." && rootPluginName !== "..") {
+        if (projectFileDirectory) {
+            const composed = path
+                .relative(workspaceFolderPath, path.join(projectFileDirectory, PLUGINS_FOLDER, rootPluginName, CONTENT_FOLDER))
+                .split(path.sep)
+                .join("/");
+            if (composed !== "" && composed.split("/")[0] !== ".." && !path.isAbsolute(composed)) {
+                candidates.push(composed);
+            }
+        }
         candidates.push(`${PLUGINS_FOLDER}/${rootPluginName}/${CONTENT_FOLDER}`);
     }
 
-    return candidates;
+    // Shallowest first is the depth rule; the project-file composition can
+    // land at any depth, including on top of a fixed candidate.
+    return [...new Set(candidates)].sort((a, b) => a.split("/").length - b.split("/").length);
 }
 
 /**
@@ -56,8 +72,8 @@ export function contentRootCandidates(workspaceFolderPath: string, rootPluginNam
  * as far as the platform does, which on Windows - where UEFN runs - is as far
  * as the stat that found the root did.
  */
-export async function findContentRoot(workspaceFolder: { uri: vscode.Uri }, rootPluginName: string | null): Promise<vscode.Uri | null> {
-    for (const candidate of contentRootCandidates(workspaceFolder.uri.fsPath, rootPluginName)) {
+export async function findContentRoot(workspaceFolder: { uri: vscode.Uri }, rootPluginName: string | null, projectFileDirectory: string | null = null): Promise<vscode.Uri | null> {
+    for (const candidate of contentRootCandidates(workspaceFolder.uri.fsPath, rootPluginName, projectFileDirectory)) {
         // The workspace folder is the Content folder itself, which is what it
         // is named rather than what is under it - nothing to stat.
         if (candidate === "") {

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -348,7 +348,7 @@ export class ModuleVisibilityWriter {
             return null;
         }
 
-        const contentRoot = await findContentRoot(folder, await this.projectPathHandler.getRootPluginName(folder.uri));
+        const contentRoot = await findContentRoot(folder, await this.projectPathHandler.getRootPluginName(folder.uri), await this.projectPathHandler.getProjectFileDirectory(folder.uri));
         return contentRoot ? { workspaceFolder: folder, contentRoot } : null;
     }
 

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -129,6 +129,7 @@ const writer = (rootPluginName: string | null = null): ModuleVisibilityWriter =>
     const handler = {
         getProjectVersePath: jest.fn().mockResolvedValue(PROJECT),
         getRootPluginName: jest.fn().mockResolvedValue(rootPluginName),
+        getProjectFileDirectory: jest.fn().mockResolvedValue(null),
     } as unknown as ProjectPathHandler;
     return new ModuleVisibilityWriter({} as vscode.OutputChannel, handler);
 };
@@ -411,6 +412,7 @@ describe("ModuleVisibilityWriter", () => {
         const handler = {
             getProjectVersePath: jest.fn().mockResolvedValue(null),
             getRootPluginName: jest.fn().mockResolvedValue(null),
+            getProjectFileDirectory: jest.fn().mockResolvedValue(null),
         } as unknown as ProjectPathHandler;
 
         await new ModuleVisibilityWriter({} as vscode.OutputChannel, handler).makeModulePublic(REQUEST);


### PR DESCRIPTION
Closes #466

## What

`contentRootCandidates` composed the nested Content root only against the workspace folder, so with the workspace opened above the project root — at `Plugins` — `findContentRoot` returned null and the two scan phases and the visibility writer never globbed, while the document-relative placement path accepted the same layout.

`ProjectPathHandler` now retains the directory the `.uefnproject` was read from (cached per scope as `{ file, directory }`) and exposes it as `getProjectFileDirectory(resource?)`. `contentRootCandidates` composes `<projectDir>/Plugins/<root>/Content` as an additional workspace-relative candidate, dropped when it escapes the workspace folder (the parent-walk case, where no glob rooted in the folder would reach it and the visibility writer must not create files), deduplicated and kept shallowest-first. The three `findContentRoot` callers pass the directory through.

Regression tests pin the entry point the issue names — `findContentRoot` from a workspace opened at `Plugins` — plus the candidate composition, the dedup, the escape drop, and the new accessor including the parent-walk case. Both new suites fail against the unfixed code.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.11.3 compile
> tsc -p ./
```

`npm test`:

```
Test Suites: 57 passed, 57 total
Tests:       1647 passed, 1647 total
```

`npm run format:check`:

```
All matched files use Prettier code style!
```
