### PR TITLE
fix(imports): report the folder scan's own cap as a truncated search

### DIFF
--- a/changelog.d/444.fixed.md
+++ b/changelog.d/444.fixed.md
@@ -1,0 +1,1 @@
+**Import path conversion**: A project holding more than 5000 .verse files no longer gets a folder-module location resolved from a partial file listing and written as certain; the conversion is refused, as it already is for the declaration scan.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -37,7 +37,7 @@ interface ImportConversionResult {
 /**
  * Where a module could be, and whether the search that answered was complete.
  *
- * `truncated` says the declaration scan stopped at its file cap, so `locations`
+ * `truncated` says a project-wide scan stopped at its file cap, so `locations`
  * holds whatever a sample of the project attested to. A location absent from it
  * may still exist, and a single entry is no evidence that the name is
  * unambiguous, so nothing may be written from a truncated answer.
@@ -517,18 +517,25 @@ export class ImportPathConverter {
      * no members to import, so nothing would name it.
      *
      * Capped at FOLDER_SCAN_FILE_LIMIT files enumerated.
+     *
+     * @returns whether the project holds more `.verse` files than
+     * FOLDER_SCAN_FILE_LIMIT, leaving the rest of it unenumerated
      */
-    private async searchProjectFolderModules(modulePath: string, locations: string[]): Promise<void> {
+    private async searchProjectFolderModules(modulePath: string, locations: string[]): Promise<boolean> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) return;
+        if (!workspaceFolders || workspaceFolders.length === 0) return false;
 
         const contentRoot = await this.scanContentRoot(workspaceFolders[0]);
-        if (!contentRoot) return;
+        if (!contentRoot) return false;
 
-        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(contentRoot, "**/*.verse"), "**/*.digest.verse", FOLDER_SCAN_FILE_LIMIT);
+        // One file past the limit is asked for and never folded in, so that a
+        // project holding exactly the limit is told apart from one holding
+        // more - the same boundary the declaration scan draws above.
+        const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(contentRoot, "**/*.verse"), "**/*.digest.verse", FOLDER_SCAN_FILE_LIMIT + 1);
+        const enumeratedPartOnly = verseFiles.length > FOLDER_SCAN_FILE_LIMIT;
 
         const contentRelativeDirs = new Set<string>();
-        for (const file of verseFiles) {
+        for (const file of verseFiles.slice(0, FOLDER_SCAN_FILE_LIMIT)) {
             const directory = toContentRelativeDir(file.fsPath, contentRoot.fsPath);
 
             // null is a file outside Content, which contributes no importable
@@ -539,6 +546,8 @@ export class ImportPathConverter {
         for (const location of resolveFolderModuleLocations(modulePath, contentRelativeDirs)) {
             if (!locations.includes(location)) locations.push(location);
         }
+
+        return enumeratedPartOnly;
     }
 
     /**
@@ -566,8 +575,9 @@ export class ImportPathConverter {
      * answer here is a result and not a fault.
      *
      * `truncated` covers the declaration scan's own answer and an empty result,
-     * not an answer the folder search gave. The reasoning for that boundary,
-     * and what it knowingly leaves exposed, is at the assignment itself.
+     * not an answer a complete folder search gave. A folder search that hit
+     * its own cap clouds the result too, whatever it ends in. The reasoning
+     * for that boundary is at the assignment itself.
      */
     async findModuleLocations(modulePath: string, currentFileUri?: vscode.Uri): Promise<ModuleLocationSearch> {
         const locations: string[] = [];
@@ -623,28 +633,44 @@ export class ImportPathConverter {
             }
         }
 
+        let folderScanEnumeratedPart = false;
         if (locations.length === 0) {
             logger.debug("ImportPathConverter", `Phase 3: Searching folder modules across the project`);
             try {
-                await this.searchProjectFolderModules(modulePath, locations);
+                folderScanEnumeratedPart = await this.searchProjectFolderModules(modulePath, locations);
             } catch (error) {
+                // A phase that threw enumerated an unknown amount of the
+                // project, which is the position stopping at the cap leaves it
+                // in.
+                folderScanEnumeratedPart = true;
                 logger.debug("ImportPathConverter", `Error in Phase 3 (project folder modules): ${error}`);
+            }
+            if (folderScanEnumeratedPart) {
+                logger.debug("ImportPathConverter", `Phase 3 enumerated part of the project, so its answer is a sample`);
             }
         }
 
         // A partial declaration scan clouds its own answer, and clouds an empty
         // result, where the module may be declared in the part left unread.
         //
-        // It is deliberately not extended to the folder search's answer, and
-        // that is a trade rather than a proof. A declaration outranks a distant
-        // folder, so a declaration in the unread remainder would have answered
-        // instead of the folder chain, and trusting the folder chain can still
-        // put out the wrong location silently. Distrusting it costs more: a
-        // folder module has no declaration anywhere for this phase or the cache
-        // to hold, so the veto would refuse every folder module in a project
-        // past the cap - the commonest thing that reaches this search at all.
-        // Raising the cap is what shrinks the exposure; the rule cannot.
-        const truncated = declarationScanReadPart && (answeredByDeclarationScan || locations.length === 0);
+        // It is deliberately not extended to a complete folder search's answer,
+        // and that is a trade rather than a proof. A declaration outranks a
+        // distant folder, so a declaration in the unread remainder would have
+        // answered instead of the folder chain, and trusting the folder chain
+        // can still put out the wrong location silently. Distrusting it costs
+        // more: a folder module has no declaration anywhere for this phase or
+        // the cache to hold, so the veto would refuse every folder module in a
+        // project past the declaration cap - the commonest thing that reaches
+        // this search at all. Raising the cap is what shrinks the exposure; the
+        // rule cannot.
+        //
+        // That trade leans on the folder search reading the project's
+        // directories for itself, which stops being true past its own cap - so
+        // a partial folder enumeration clouds whatever the search ends in. The
+        // phase only runs while nothing is found, so either its answer is a
+        // sample's or the empty result may miss a folder in the unenumerated
+        // remainder.
+        const truncated = (declarationScanReadPart && (answeredByDeclarationScan || locations.length === 0)) || folderScanEnumeratedPart;
 
         logger.debug("ImportPathConverter", `Module search complete for '${modulePath}'`);
         logger.debug("ImportPathConverter", `Found ${locations.length} possible locations:`);
@@ -802,10 +828,7 @@ export class ImportPathConverter {
 
         const { locations, truncated } = await this.findModuleLocations(firstSegment, documentUri);
         if (truncated) {
-            logger.debug(
-                "ImportPathConverter",
-                `Refusing '${reference}' for ${fullPath}: the declaration scan stopped at ${DECLARATION_SCAN_FILE_LIMIT} files, so '${firstSegment}' was resolved against part of the project`,
-            );
+            logger.debug("ImportPathConverter", `Refusing '${reference}' for ${fullPath}: a project-wide scan stopped at its file cap, so '${firstSegment}' was resolved against part of the project`);
             return false;
         }
         if (locations.length !== 1) {
@@ -1018,11 +1041,11 @@ export class ImportPathConverter {
         // count decides: a location it did not reach is missing from the list,
         // and a namesake it did not reach is missing from the ambiguity.
         if (truncated) {
-            logger.debug("ImportPathConverter", `Refusing ${modulePath}: the declaration scan read part of the project`);
+            logger.debug("ImportPathConverter", `Refusing ${modulePath}: a project-wide scan read part of the project`);
             if (notice.pending) {
                 notice.pending = false;
                 vscode.window.showWarningMessage(
-                    `This project holds more than ${DECLARATION_SCAN_FILE_LIMIT} .verse files, which is as many as the search for a declared module reads. Imports that need one are left alone rather than pointed at a module found in part of the project; write those absolute paths by hand.`,
+                    `This project holds more .verse files than the project-wide module search reads through. Imports that need that search are left alone rather than pointed at a module found in part of the project; write those absolute paths by hand.`,
                 );
             }
             return null;

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -1181,6 +1181,131 @@ describe("ImportPathConverter declaration scan file cap", () => {
     });
 });
 
+describe("ImportPathConverter folder scan file cap", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    /**
+     * A project of `fileCount` `.verse` files, each under Content/Target and
+     * none declaring a module, so only the folder search can place `Target`.
+     * The glob honours its maxResults in production, so the mock caps its own
+     * answer the same way rather than handing back more than was asked for.
+     */
+    const folderProjectOf = (fileCount: number): void => {
+        const files = Array.from({ length: fileCount }, (_, index) => `Content/Target/File${index}.verse`).map((file) => vscode.Uri.file(`${workspaceRoot}/${file}`));
+        (vscode.workspace.findFiles as jest.Mock).mockImplementation(async (_pattern: unknown, _exclude: unknown, maxResults?: number) =>
+            maxResults === undefined ? files : files.slice(0, maxResults),
+        );
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Helper := class:\n", "utf8"));
+    };
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubTreeUnder(`${workspaceRoot}/Content`, []);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.findFiles as jest.Mock).mockReset();
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    const convert = (statement: string) => converterWithProjectPath(projectVersePath).convertToFullPath(statement, vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`), 0);
+
+    it("reports a folder search that enumerated only part of the project, so a caller can tell it from a complete one", async () => {
+        folderProjectOf(5001);
+
+        expect((await converterWithProjectPath(projectVersePath).findModuleLocations("Target")).truncated).toBe(true);
+    });
+
+    // The boundary is the whole point of the signal: a project of exactly the
+    // limit is enumerated end to end, and calling that truncated is the same
+    // conflation of complete and partial that the signal exists to end.
+    it("reports a project of exactly the limit as enumerated in full", async () => {
+        folderProjectOf(5000);
+
+        const search = await converterWithProjectPath(projectVersePath).findModuleLocations("Target");
+
+        expect(search.truncated).toBe(false);
+        expect(search.locations).toHaveLength(1);
+    });
+
+    // The one location a partial enumeration returns is a sample's answer: a
+    // namesake chain in the part it never listed would have made the
+    // conversion ambiguous, so writing this path unambiguously is the silent
+    // wrong module the cap hides.
+    it("refuses the conversion rather than writing a sample's answer", async () => {
+        folderProjectOf(5001);
+
+        expect(await convert("using { Target }")).toBeNull();
+    });
+
+    // The file past the limit is asked for to be counted, never to be folded
+    // in. Folding it in would make the enumeration's reach one more than the
+    // limit says.
+    it("never derives a directory from the file it asks for past the limit", async () => {
+        const filler = Array.from({ length: 5000 }, (_, index) => `Content/Filler/File${index}.verse`);
+        (vscode.workspace.findFiles as jest.Mock).mockImplementation(async (_pattern: unknown, _exclude: unknown, maxResults?: number) => {
+            const uris = filler.concat("Content/Target/Thing.verse").map((file) => vscode.Uri.file(`${workspaceRoot}/${file}`));
+            return maxResults === undefined ? uris : uris.slice(0, maxResults);
+        });
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Helper := class:\n", "utf8"));
+
+        const search = await converterWithProjectPath(projectVersePath).findModuleLocations("Target");
+
+        expect(search.locations).toEqual([]);
+        expect(search.truncated).toBe(true);
+    });
+
+    // The cap belongs to the project-wide phases, which run only when the
+    // phases before them found nothing. An answer from proximity is not a
+    // sample's, however many files the project holds.
+    it("leaves an answer found near the file untouched by the cap", async () => {
+        folderProjectOf(5001);
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            if (uri.fsPath.replace(/\\/g, "/") === `${workspaceRoot}/Content/Scripts/Target`) return { type: vscode.FileType.Directory };
+            throw new Error("ENOENT");
+        });
+
+        const search = await converterWithProjectPath(projectVersePath).findModuleLocations("Target", vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`));
+
+        expect(search).toEqual({ locations: ["/Scripts"], truncated: false });
+    });
+
+    // The condition belongs to the project, not to any one import, so a
+    // document-wide run states it once instead of once per line.
+    it("reports the cap once for a whole document", async () => {
+        folderProjectOf(5001);
+        const document = fakeDocument(["using { Target }", "using { Economy }", "using { Weapons }", "", "code()"]);
+        const warn = vscode.window.showWarningMessage as jest.Mock;
+        warn.mockClear();
+
+        const results = await converterWithProjectPath(projectVersePath).convertAllImportsToFullPath(document);
+
+        expect(results).toEqual([]);
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    // A phase that threw enumerated an unknown amount of the project, which
+    // leaves the caller where stopping at the cap leaves it. The declaration
+    // scan completes here, so only the folder search's own failure can cloud
+    // the answer.
+    it("treats a folder search that threw as a partial enumeration", async () => {
+        const files = Array.from({ length: 50 }, (_, index) => vscode.Uri.file(`${workspaceRoot}/Content/Target/File${index}.verse`));
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValueOnce(files).mockRejectedValueOnce(new Error("scan failed"));
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Helper := class:\n", "utf8"));
+
+        expect((await converterWithProjectPath(projectVersePath).findModuleLocations("Target")).truncated).toBe(true);
+    });
+});
+
 describe("ImportPathConverter.convertToFullPath project-wide folder module search", () => {
     const projectVersePath = "/mygame@fortnite.com/mygame";
     const workspaceRoot = "C:/Project";

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -1269,14 +1269,19 @@ describe("ImportPathConverter folder scan file cap", () => {
     // sample's, however many files the project holds.
     it("leaves an answer found near the file untouched by the cap", async () => {
         folderProjectOf(5001);
+        // The Content root stays stubbed so the project-wide phases are
+        // reachable; the glob staying uncalled is then proximity outranking
+        // them, not a scan that could not start.
         (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
-            if (uri.fsPath.replace(/\\/g, "/") === `${workspaceRoot}/Content/Scripts/Target`) return { type: vscode.FileType.Directory };
+            const relative = uri.fsPath.replace(/\\/g, "/");
+            if ([`${workspaceRoot}/Content`, `${workspaceRoot}/Content/Scripts/Target`].includes(relative)) return { type: vscode.FileType.Directory };
             throw new Error("ENOENT");
         });
 
         const search = await converterWithProjectPath(projectVersePath).findModuleLocations("Target", vscode.Uri.file(`${workspaceRoot}/Content/Scripts/Main.verse`));
 
         expect(search).toEqual({ locations: ["/Scripts"], truncated: false });
+        expect(vscode.workspace.findFiles as jest.Mock).not.toHaveBeenCalled();
     });
 
     // The condition belongs to the project, not to any one import, so a
@@ -1291,6 +1296,9 @@ describe("ImportPathConverter folder scan file cap", () => {
 
         expect(results).toEqual([]);
         expect(warn).toHaveBeenCalledTimes(1);
+        // The wording must stay true for whichever cap fired, so it names the
+        // project-wide search rather than a phase or a number.
+        expect(warn.mock.calls[0][0]).toMatch(/more \.verse files than the project-wide module search/);
     });
 
     // A phase that threw enumerated an unknown amount of the project, which


### PR DESCRIPTION
Closes #444

## What

`searchProjectFolderModules` — phase 3 of `findModuleLocations` — now mirrors the phase-2 cap pattern: it asks `findFiles` for `FOLDER_SCAN_FILE_LIMIT + 1`, derives directories from only the first `FOLDER_SCAN_FILE_LIMIT`, and reports `length > limit` as a partial enumeration. `findModuleLocations` folds that signal (and a phase-3 throw, mirroring the phase-2 catch) into `ModuleLocationSearch.truncated`, so a project past 5000 `.verse` files gets its folder-module answer refused as partial instead of written as certain.

The comment at the `truncated` assignment is updated: the deliberate trust in a complete folder search's answer after a partial phase-2 scan stands, and now states that it leans on the folder search reading the directories for itself — which the new signal keeps true. Two debug messages that named the declaration scan specifically are generalized, since `truncated` can now come from either scan.

## Regression tests

New `describe("ImportPathConverter folder scan file cap")` with seven tests pinned at `findModuleLocations` and the `convertToFullPath` entry point: partial enumeration reported, exact-limit boundary read as complete, conversion refused on a sample's answer, the past-limit file counted but never folded in, a proximity answer untouched by the cap (with the glob proven uncalled), one notice per document with the cap-agnostic wording pinned, and a phase-3 throw treated as partial. The three defect-detecting tests were verified to fail against the unfixed code (`git stash` round trip).

The user-facing truncation warning is reworded cap-agnostically — it could previously only fire from the declaration cap and named that cap's number, which would have been a false diagnosis when the folder cap fires.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.11.3 compile
> tsc -p ./
```

(clean, no output)

`npm test`:

```
Test Suites: 57 passed, 57 total
Tests:       1647 passed, 1647 total
```

`npm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```
