### PR TITLE
fix(visibility): nest into the definitions-file block instead of appending a second one

### DIFF
--- a/changelog.d/464.fixed.md
+++ b/changelog.d/464.fixed.md
@@ -1,0 +1,1 @@
+**Module visibility**: the make-module-public quick fix now nests a new declaration inside the block the definitions file already carries, instead of refusing where its own earlier run declared an ancestor there.

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -3,7 +3,7 @@ import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { findContentRoot } from "../services/contentRoot";
 import { toContentRelativeDir } from "../services/moduleLocationLookup";
-import { appendDeclarationBlock, buildDeclarationBlock } from "./definitionsContent";
+import { appendDeclarationBlock, buildDeclarationBlock, nestDeclarationEdit } from "./definitionsContent";
 import { findExplicitModuleDeclarations } from "./moduleDeclarations";
 import { ModuleVisibilityRequest } from "./ModuleVisibilityMessage";
 import { planVisibility, toContentSegments } from "./ModuleVisibilityPlanner";
@@ -72,8 +72,9 @@ export class ModuleVisibilityWriter {
      * would have changed goes with it. A module declared anything but
      * `<public>` or `<internal>` is left alone, whether it is the one to
      * publicize or one a new declaration would sit inside; so is one the chain
-     * would have to declare a second time, since the block is appended whole
-     * and cannot join a declaration the project already carries. That governs
+     * would have to declare a second time in a user file. A declaration the
+     * definitions file itself carries is extended instead of restated: the new
+     * declarations nest inside its existing block. That governs
      * what is offered, not what lands - the preview lets the user apply a
      * subset, so what is reported afterwards is intent rather than outcome.
      *
@@ -192,7 +193,7 @@ export class ModuleVisibilityWriter {
         }
 
         const { declarations, scanned } = scan;
-        const resolved = resolveVisibility(prefix, segments, declarations);
+        const resolved = resolveVisibility(prefix, segments, declarations, definitionsKey);
 
         if (resolved.conflicts.length > 0) {
             return { reason: refusalForConflicts(request.moduleName, resolved.conflicts) };
@@ -239,13 +240,24 @@ export class ModuleVisibilityWriter {
             }
 
             const existing = definitions.text;
-            const withEdits = applySpecifierEdits(existing, inDefinitions);
-            const content = appendDeclarationBlock(withEdits, buildDeclarationBlock(resolved.chain));
+            let content: string;
+            if (resolved.anchor) {
+                const nested = nestDeclarationEdit(existing, resolved.anchor.declaration, resolved.chain);
+                if (!nested) {
+                    return { reason: `the definitions file declares '${resolved.anchor.path}' in a form the extension cannot extend. Declare '${request.moduleName}' inside it by hand.` };
+                }
+                // One pass together with the specifier rewrites: every span
+                // addresses the text as scanned, so applying either half first
+                // would shift the other's offsets.
+                content = applySpecifierEdits(existing, [...inDefinitions, { file: definitionsKey, path: resolved.anchor.path, span: nested.span, text: nested.text }]);
+            } else {
+                content = appendDeclarationBlock(applySpecifierEdits(existing, inDefinitions), buildDeclarationBlock(resolved.chain));
+            }
 
             // The module path, as the specifier entries carry, rather than the
             // file name: the preview groups by file by default, so the name is
             // already on the node above and the description would say nothing.
-            const metadata = confirm(resolved.chain.map((segment) => segment.name).join("/"));
+            const metadata = confirm([...(resolved.anchor ? [resolved.anchor.path] : []), ...resolved.chain.map((segment) => segment.name)].join("/"));
             if (existing.length === 0 && !scannedDefinitions) {
                 edit.createFile(definitionsUri, { ignoreIfExists: true }, metadata);
                 edit.insert(definitionsUri, new vscode.Position(0, 0), content, metadata);

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -207,10 +207,10 @@ describe("ModuleVisibilityWriter", () => {
         expect(replace.text).toBe("Other<public> := module {}\n\nGadgets := module:\n    Tools<public> := module {}\n");
     });
 
-    it("refuses to append a second definition of a module the definitions file already declares", async () => {
+    it("nests into the block the definitions file already carries, instead of appending a second one", async () => {
         // The file the fix wrote on an earlier run. Appending a block through
         // Gadgets and Deep would leave that one file defining each of them
-        // twice, which the second run has no way to make compile.
+        // twice, so the new declaration joins the existing block instead.
         givenProject({ "Content/_definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
 
         await writer().makeModulePublic({
@@ -219,15 +219,51 @@ describe("ModuleVisibilityWriter", () => {
             moduleName: "Tools",
         });
 
+        const replace = appliedOperations().find((operation) => operation.kind === "replace");
+        expect(replace.text).toBe("Gadgets := module:\n    Deep<public> := module:\n        Tools<public> := module {}\n");
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it("publicizes a second module by extending the block the first run wrote", async () => {
+        givenProject({ "Content/Scripts/main.verse": "using { Gadgets.Tools }\n" });
+        await writer().makeModulePublic(REQUEST);
+        const firstRun = appliedOperations()[1].text;
+        expect(firstRun).toBe("Gadgets := module:\n    Tools<public> := module {}\n");
+
+        givenProject({
+            "Content/_definitions.verse": firstRun,
+            "Content/Scripts/main.verse": "using { Gadgets.Other }\n",
+        });
+        await writer().makeModulePublic({
+            targetPath: `${PROJECT}/Gadgets/Other`,
+            importerPath: `${PROJECT}/Scripts`,
+            moduleName: "Other",
+        });
+
+        const replace = appliedOperations().find((operation) => operation.kind === "replace");
+        expect(replace.text).toBe("Gadgets := module:\n    Other<public> := module {}\n    Tools<public> := module {}\n");
+        // The whole point of the merge: each module declared exactly once.
+        expect(replace.text.match(/Gadgets/g)).toHaveLength(1);
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it("refuses a definitions-file block written in a form it cannot extend", async () => {
+        // A hand-edited layout: the dotted body has no line of its own to
+        // insert into, so extending it risks rewriting what its author meant.
+        givenProject({ "Content/_definitions.verse": "Gadgets := module. X:int = 1\n" });
+
+        await writer().makeModulePublic(REQUEST);
+
         expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("re-declaring Gadgets and Gadgets/Deep"));
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("declares 'Gadgets' in a form the extension cannot extend"));
     });
 
     it("punctuates a list of repeats so a path carrying a keyword cannot be read as two", async () => {
         // One conflict per declared ancestor, so three is ordinary rather than
         // exotic. Joined with bare "and" throughout, the keyword clause fuses
-        // with the path after it and the reader cannot tell them apart.
-        givenProject({ "Content/_definitions.verse": "Gadgets := module:\n    Deep := module:\n        Tools<internal> := module {}\n" });
+        // with the path after it and the reader cannot tell them apart. The
+        // chain lives in a user file, which nesting cannot resolve.
+        givenProject({ "Content/nested.verse": "Gadgets := module:\n    Deep := module:\n        Tools<internal> := module {}\n" });
 
         await writer().makeModulePublic({
             targetPath: `${PROJECT}/Gadgets/Deep/Tools/More`,

--- a/src/visibility/__tests__/definitionsContent.test.ts
+++ b/src/visibility/__tests__/definitionsContent.test.ts
@@ -1,4 +1,5 @@
-import { appendDeclarationBlock, buildDeclarationBlock } from "../definitionsContent";
+import { appendDeclarationBlock, buildDeclarationBlock, nestDeclarationEdit } from "../definitionsContent";
+import { findExplicitModuleDeclarations, ModuleDeclaration } from "../moduleDeclarations";
 
 describe("buildDeclarationBlock", () => {
     it("writes a single module in the brace style, which needs no body", () => {
@@ -40,5 +41,78 @@ describe("appendDeclarationBlock", () => {
 
     it("keeps the file's CRLF line endings", () => {
         expect(appendDeclarationBlock("A := module {}\r\n", "B := module:\n    C<public> := module {}")).toBe("A := module {}\r\n\r\nB := module:\r\n    C<public> := module {}\r\n");
+    });
+});
+
+describe("nestDeclarationEdit", () => {
+    /** The declaration of that name in the content, read exactly as the scan reads it. */
+    const anchorNamed = (content: string, name: string): ModuleDeclaration => {
+        const declaration = findExplicitModuleDeclarations(content).find((candidate) => candidate.name === name);
+        if (!declaration) {
+            throw new Error(`no declaration of '${name}' in the fixture`);
+        }
+        return declaration;
+    };
+
+    /** The content with the edit applied, which is what the writer folds into its replace. */
+    const applied = (content: string, name: string, segments: Parameters<typeof nestDeclarationEdit>[2]): string | null => {
+        const edit = nestDeclarationEdit(content, anchorNamed(content, name), segments);
+        return edit === null ? null : content.slice(0, edit.span.start) + edit.text + content.slice(edit.span.end);
+    };
+
+    it("inserts the chain as a colon body's new first child", () => {
+        expect(applied("Gadgets := module:\n    Deep := module {}\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBe(
+            "Gadgets := module:\n    Tools<public> := module {}\n    Deep := module {}\n",
+        );
+    });
+
+    it("copies the body's own indentation byte for byte, stepping deeper from there", () => {
+        // The compiler compares block indentation as a byte-wise prefix, so a
+        // computed width would break a file indented differently than ours.
+        expect(applied("Gadgets := module:\n  Deep := module {}\n", "Gadgets", [{ name: "Sub" }, { name: "Tools", specifier: "public" }])).toBe(
+            "Gadgets := module:\n  Sub := module:\n      Tools<public> := module {}\n  Deep := module {}\n",
+        );
+    });
+
+    it("reads the body indent past blank lines, which stay inside the block", () => {
+        expect(applied("Gadgets := module:\n\n    Deep := module {}\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBe(
+            "Gadgets := module:\n    Tools<public> := module {}\n\n    Deep := module {}\n",
+        );
+    });
+
+    it("converts an empty-brace leaf to a colon body, keeping its specifier", () => {
+        expect(applied("Gadgets := module:\n    Tools<public> := module {}\n", "Tools", [{ name: "More", specifier: "public" }])).toBe(
+            "Gadgets := module:\n    Tools<public> := module:\n        More<public> := module {}\n",
+        );
+    });
+
+    it("keeps the file's CRLF line endings", () => {
+        expect(applied("Gadgets := module:\r\n    Deep := module {}\r\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBe(
+            "Gadgets := module:\r\n    Tools<public> := module {}\r\n    Deep := module {}\r\n",
+        );
+    });
+
+    it("appends a body to a colon head the file ends on without a newline", () => {
+        expect(applied("Gadgets := module:", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBe("Gadgets := module:\n    Tools<public> := module {}\n");
+    });
+
+    it("declines the dotted form, whose body it cannot place", () => {
+        expect(applied("Gadgets := module. X:int = 1\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBeNull();
+    });
+
+    it("declines a brace body holding content", () => {
+        expect(applied("Gadgets := module { X:int = 1 }\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBeNull();
+    });
+
+    it("declines trailing text after the empty braces", () => {
+        expect(applied("Gadgets := module {} # note\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBeNull();
+    });
+
+    it("declines trailing text after the colon", () => {
+        expect(applied("Gadgets := module: # note\n    Deep := module {}\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBeNull();
+    });
+
+    it("declines a brace opening on its own line, which leaves no head for the colon", () => {
+        expect(applied("Gadgets := module\n{\n}\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBeNull();
     });
 });

--- a/src/visibility/__tests__/definitionsContent.test.ts
+++ b/src/visibility/__tests__/definitionsContent.test.ts
@@ -74,6 +74,14 @@ describe("nestDeclarationEdit", () => {
         );
     });
 
+    it("reads the body indent past a comment line, which may sit at any indent", () => {
+        // Copying the comment's 8 spaces would leave the block's first code
+        // line deeper than Deep, which the compiler rejects as inconsistent.
+        expect(applied("Gadgets := module:\n        # note\n    Deep := module {}\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBe(
+            "Gadgets := module:\n    Tools<public> := module {}\n        # note\n    Deep := module {}\n",
+        );
+    });
+
     it("reads the body indent past blank lines, which stay inside the block", () => {
         expect(applied("Gadgets := module:\n\n    Deep := module {}\n", "Gadgets", [{ name: "Tools", specifier: "public" }])).toBe(
             "Gadgets := module:\n    Tools<public> := module {}\n\n    Deep := module {}\n",

--- a/src/visibility/__tests__/visibilityResolution.test.ts
+++ b/src/visibility/__tests__/visibilityResolution.test.ts
@@ -254,3 +254,80 @@ describe("resolveVisibility", () => {
         expect(resolved.edits.map((edit) => edit.text)).toEqual(["<public>"]);
     });
 });
+
+describe("resolveVisibility with a definitions file", () => {
+    const DEFINITIONS = "file://definitions";
+
+    it("anchors the chain on a declaration the definitions file carries, instead of repeating it", () => {
+        const found = declarationsIn(DEFINITIONS, "", "Gadgets := module:\n    Deep := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found, DEFINITIONS);
+
+        expect(resolved.conflicts).toEqual([]);
+        expect(resolved.anchor?.path).toBe("Gadgets");
+        // Only what the file does not already declare is left to write.
+        expect(resolved.chain).toEqual([{ name: "Tools", specifier: "public" }]);
+    });
+
+    it("anchors at the deepest declaration on the path, editing its specifier in place where needed", () => {
+        const found = declarationsIn(DEFINITIONS, "", "Gadgets := module:\n    Deep := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Deep", true], ["Tools", true]), found, DEFINITIONS);
+
+        expect(resolved.conflicts).toEqual([]);
+        expect(resolved.anchor?.path).toBe("Gadgets/Deep");
+        expect(resolved.chain).toEqual([{ name: "Tools", specifier: "public" }]);
+        // Deep still becomes public, by rewriting the declaration that exists.
+        expect(resolved.edits).toEqual([{ file: DEFINITIONS, path: "Gadgets/Deep", span: { start: 27, end: 27 }, text: "<public>" }]);
+    });
+
+    it("still repeats a user-file declaration the written chain restates below the anchor", () => {
+        const found = [...declarationsIn(DEFINITIONS, "", "Gadgets := module:\n    X := module {}\n"), ...declarationsIn("file://user", "Gadgets", "Deep := module:\n    Y:int = 1\n")];
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Deep", true], ["Tools", true]), found, DEFINITIONS);
+
+        // Deep's declaration lives in a file the chain cannot join, and Tools
+        // has to be written under it, so the restatement stands.
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets/Deep", keyword: undefined, reason: "repeat" }]);
+    });
+
+    it("does not anchor on a narrowed declaration, even in the definitions file", () => {
+        const found = declarationsIn(DEFINITIONS, "", "Gadgets<scoped{Scripts}> := module:\n    X:int = 1\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found, DEFINITIONS);
+
+        // The narrowing is deliberate wherever it is written; extending the
+        // block would declare a new module inside a boundary somebody drew.
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets", keyword: "scoped", reason: "nest" }]);
+        expect(resolved.anchor).toBeUndefined();
+    });
+
+    it("reports the repeat exactly as before when no definitions file is named", () => {
+        const found = declarationsIn(DEFINITIONS, "", "Gadgets := module:\n    Deep := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found);
+
+        expect(resolved.conflicts).toEqual([{ path: "Gadgets", keyword: undefined, reason: "repeat" }]);
+        expect(resolved.anchor).toBeUndefined();
+    });
+
+    it("extends the last block where the file declares the same module twice", () => {
+        // Two explicit parts in one file do not compile, so this only fixes
+        // which block a broken file grows: the one appended most recently.
+        const found = declarationsIn(DEFINITIONS, "", "Gadgets := module:\n    X:int = 1\nGadgets := module:\n    Y:int = 1\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found, DEFINITIONS);
+
+        expect(resolved.anchor?.declaration.line).toBe(3);
+    });
+
+    it("carries no anchor when nothing is left to write", () => {
+        const found = declarationsIn(DEFINITIONS, "", "Gadgets := module:\n    Tools := module {}\n");
+
+        const resolved = resolveVisibility([], segments(["Gadgets", false], ["Tools", true]), found, DEFINITIONS);
+
+        expect(resolved.chain).toEqual([]);
+        expect(resolved.anchor).toBeUndefined();
+        expect(resolved.edits.map((edit) => edit.path)).toEqual(["Gadgets/Tools"]);
+    });
+});

--- a/src/visibility/definitionsContent.ts
+++ b/src/visibility/definitionsContent.ts
@@ -3,6 +3,8 @@
  * in, string out - no VS Code dependencies.
  */
 
+import { ModuleDeclaration, SourceSpan } from "./moduleDeclarations";
+
 /** One module in a chain about to be written, and the specifier it carries. */
 export interface DeclarationSpec {
     name: string;
@@ -24,13 +26,16 @@ const INDENT = "    ";
  * Every module but the last opens a colon body holding the next one. The last
  * has no body to hold, so it is written in the brace style: `module:` with
  * nothing indented under it does not parse.
+ *
+ * @param basePrefix prepended to every line, so the chain can be rendered
+ * inside an existing body; the top level passes none.
  */
-export function buildDeclarationBlock(segments: readonly DeclarationSpec[]): string {
+export function buildDeclarationBlock(segments: readonly DeclarationSpec[], basePrefix = ""): string {
     return segments
         .map((segment, depth) => {
             const specifier = segment.specifier ? `<${segment.specifier}>` : "";
             const body = depth === segments.length - 1 ? "module {}" : "module:";
-            return `${INDENT.repeat(depth)}${segment.name}${specifier} := ${body}`;
+            return `${basePrefix}${INDENT.repeat(depth)}${segment.name}${specifier} := ${body}`;
         })
         .join("\n");
 }
@@ -51,4 +56,103 @@ export function appendDeclarationBlock(existingContent: string, block: string): 
     }
 
     return `${existing}${eol}${eol}${normalized}${eol}`;
+}
+
+/**
+ * The single text edit that nests a declaration chain inside a declaration the
+ * file already carries, or null when that declaration's body is not written in
+ * a shape this can extend.
+ *
+ * Only the two shapes the writer itself emits are extended. A colon body gains
+ * the chain as its new first child, indented with the existing body's own
+ * prefix - the compiler compares block indentation as a byte-wise prefix, so a
+ * copied prefix is the only safe one. An empty-brace body becomes a colon body
+ * holding the chain, the conversion writing a child under a leaf always needs.
+ * Anything else - the dotted form, a brace body with content, trailing text or
+ * a comment on the head line - is somebody's hand-written layout, and editing
+ * around it risks rewriting what they meant, so the caller refuses instead.
+ *
+ * @param anchor must have been read from exactly this content, since its
+ * offsets address it.
+ */
+export function nestDeclarationEdit(existingContent: string, anchor: ModuleDeclaration, segments: readonly DeclarationSpec[]): { span: SourceSpan; text: string } | null {
+    const eol = existingContent.includes("\r\n") ? "\r\n" : "\n";
+
+    if (anchor.bodyStyle === ":") {
+        return nestIntoColonBody(existingContent, anchor, segments, eol);
+    }
+    if (anchor.bodyStyle === "{") {
+        return convertEmptyBraceBody(existingContent, anchor, segments, eol);
+    }
+    return null;
+}
+
+/** Inserts the chain as the colon body's new first child, before whatever it holds. */
+function nestIntoColonBody(content: string, anchor: ModuleDeclaration, segments: readonly DeclarationSpec[], eol: string): { span: SourceSpan; text: string } | null {
+    const headLineEnd = content.indexOf("\n", anchor.bodyStart);
+    const headTail = content.slice(anchor.bodyStart, headLineEnd === -1 ? content.length : headLineEnd);
+    if (!/^[ \t\r]*$/.test(headTail)) {
+        return null;
+    }
+
+    const anchorPrefix = linePrefix(content, anchor.insertionPoint - anchor.name.length);
+    const insertAt = headLineEnd === -1 ? content.length : headLineEnd + 1;
+    const childPrefix = bodyPrefix(content, insertAt, anchorPrefix) ?? anchorPrefix + INDENT;
+
+    const block = buildDeclarationBlock(segments, childPrefix).split("\n").join(eol);
+    return { span: { start: insertAt, end: insertAt }, text: headLineEnd === -1 ? `${eol}${block}${eol}` : `${block}${eol}` };
+}
+
+/**
+ * Replaces an empty `{}` body with a colon body holding the chain, colon
+ * directly on the keyword as the writer spells it.
+ */
+function convertEmptyBraceBody(content: string, anchor: ModuleDeclaration, segments: readonly DeclarationSpec[], eol: string): { span: SourceSpan; text: string } | null {
+    const body = content.slice(anchor.bodyStart).match(/^[ \t\r\n]*\}/);
+    if (!body) {
+        return null;
+    }
+    const braceEnd = anchor.bodyStart + body[0].length;
+    const braceLineEnd = content.indexOf("\n", braceEnd);
+    const tail = content.slice(braceEnd, braceLineEnd === -1 ? content.length : braceLineEnd);
+    if (!/^[ \t\r]*$/.test(tail)) {
+        return null;
+    }
+
+    let start = anchor.bodyStart - 1;
+    while (start > 0 && (content[start - 1] === " " || content[start - 1] === "\t")) {
+        start--;
+    }
+    if (start > 0 && (content[start - 1] === "\n" || content[start - 1] === "\r")) {
+        // A brace opening on its own line leaves no head to hang the colon on.
+        return null;
+    }
+
+    const anchorPrefix = linePrefix(content, anchor.insertionPoint - anchor.name.length);
+    const block = buildDeclarationBlock(segments, anchorPrefix + INDENT)
+        .split("\n")
+        .join(eol);
+    return { span: { start, end: braceEnd }, text: `:${eol}${block}` };
+}
+
+/** Leading whitespace of the line the offset falls on. */
+function linePrefix(content: string, offset: number): string {
+    const lineStart = content.lastIndexOf("\n", offset - 1) + 1;
+    return content.slice(lineStart).match(/^[ \t]*/)![0];
+}
+
+/**
+ * The literal indentation of the first non-blank line at or after `from`, or
+ * null when there is none or it does not byte-extend the anchor's own prefix -
+ * an empty or inconsistently indented body, which no copied prefix can serve.
+ */
+function bodyPrefix(content: string, from: number, anchorPrefix: string): string | null {
+    for (const line of content.slice(from).split("\n")) {
+        if (/^[ \t\r]*$/.test(line)) {
+            continue;
+        }
+        const prefix = line.match(/^[ \t]*/)![0];
+        return prefix.length > anchorPrefix.length && prefix.startsWith(anchorPrefix) ? prefix : null;
+    }
+    return null;
 }

--- a/src/visibility/definitionsContent.ts
+++ b/src/visibility/definitionsContent.ts
@@ -3,6 +3,7 @@
  * in, string out - no VS Code dependencies.
  */
 
+import { maskCommentsAndStrings } from "../utils/verseText";
 import { ModuleDeclaration, SourceSpan } from "./moduleDeclarations";
 
 /** One module in a chain about to be written, and the specifier it carries. */
@@ -97,7 +98,9 @@ function nestIntoColonBody(content: string, anchor: ModuleDeclaration, segments:
 
     const anchorPrefix = linePrefix(content, anchor.insertionPoint - anchor.name.length);
     const insertAt = headLineEnd === -1 ? content.length : headLineEnd + 1;
-    const childPrefix = bodyPrefix(content, insertAt, anchorPrefix) ?? anchorPrefix + INDENT;
+    // Masked, so a comment-only line - which may sit at any indent - reads as
+    // blank rather than supplying the prefix the block's code lines must match.
+    const childPrefix = bodyPrefix(maskCommentsAndStrings(content), insertAt, anchorPrefix) ?? anchorPrefix + INDENT;
 
     const block = buildDeclarationBlock(segments, childPrefix).split("\n").join(eol);
     return { span: { start: insertAt, end: insertAt }, text: headLineEnd === -1 ? `${eol}${block}${eol}` : `${block}${eol}` };

--- a/src/visibility/moduleDeclarations.ts
+++ b/src/visibility/moduleDeclarations.ts
@@ -78,6 +78,12 @@ export interface ModuleDeclaration {
     /** Where a specifier is inserted when the declaration carries none. */
     insertionPoint: number;
 
+    /** The character the declaration head ends at, naming its body style. */
+    bodyStyle: ":" | "{" | "." | ">";
+
+    /** Offset just past that character, where the body's own text begins. */
+    bodyStart: number;
+
     /**
      * The access specifier's span, and its keyword as written, absent when the
      * declaration carries none. A named access level puts a user-chosen
@@ -173,6 +179,8 @@ export function findExplicitModuleDeclarations(content: string): ModuleDeclarati
             chain,
             line,
             insertionPoint: nameEnd,
+            bodyStyle: match[0][match[0].length - 1] as ModuleDeclaration["bodyStyle"],
+            bodyStart: nameStart + match[0].length,
         };
 
         // The specifier block starts exactly at the name's end, so an offset

--- a/src/visibility/visibilityResolution.ts
+++ b/src/visibility/visibilityResolution.ts
@@ -49,9 +49,10 @@ export interface VisibilityConflict {
     /**
      * `widen` where the module itself has to become public, `nest` where a new
      * part would be written inside it, `repeat` where the chain would restate a
-     * declaration the project already carries. The remedies differ: the first
-     * is a change to this module's specifier, the other two a declaration the
-     * user must make by hand where the existing one lives.
+     * declaration the project carries somewhere the caller cannot extend. The
+     * remedies differ: the first is a change to this module's specifier, the
+     * other two a declaration the user must make by hand where the existing
+     * one lives.
      */
     reason: "widen" | "nest" | "repeat";
 }
@@ -63,9 +64,18 @@ export interface ResolvedVisibility {
 
     /**
      * The chain to write into the definitions file, outermost first, or empty
-     * when every module that needed publicizing was already declared.
+     * when every module that needed publicizing was already declared. With an
+     * `anchor` it nests inside that declaration's body; without one it stands
+     * alone at the Content root.
      */
     chain: DeclarationSpec[];
+
+    /**
+     * The definitions-file declaration the chain extends: the deepest module
+     * on the target's path that file already declares. Absent when the chain
+     * stands alone or there is nothing left to write.
+     */
+    anchor?: FoundDeclaration;
 
     /** Modules that could not be made public, with what blocks each. */
     conflicts: VisibilityConflict[];
@@ -87,26 +97,35 @@ const PUBLIC_SPECIFIER = "<public>";
  * would nest a new part inside (`nest`); the second is mechanical as well,
  * since `scoped`'s module list resolves against the scope that declared it and
  * cannot be copied into a file at the Content root at all. One that already
- * carries an explicit declaration anywhere in the project is a `repeat`: the
- * chain restates it, and a restatement is a second explicit definition, which
- * is `ErrSemantic_AmbiguousDefinition` in a user package unless that package
- * sets `treatModulesAsImplicit`. The specifier is not what makes it one - a
- * bare part counts the same - so every declared module the retained chain
- * carries is reported, and only a module with no declaration at all is safe to
- * write.
+ * carries an explicit declaration is a `repeat`: the chain restates it, and a
+ * restatement is a second explicit definition, which is
+ * `ErrSemantic_AmbiguousDefinition` in a user package unless that package sets
+ * `treatModulesAsImplicit`. The specifier is not what makes it one - a bare
+ * part counts the same - so a declared module is safe only where nothing is
+ * written for it.
+ *
+ * The definitions file is that exception. A declaration there is a block the
+ * caller owns and can extend, so the deepest run of them from the root becomes
+ * the `anchor`: nothing at or above it is restated, and the chain that remains
+ * nests inside it. A declared module BELOW the anchor still repeats - its
+ * declaration lives in a user file the chain cannot join.
  *
  * Refusing is the caller's job, and a conflict leaves the chain as it is rather
  * than emptying it. Nothing reads the chain on that path today, so the fact
  * worth knowing before editing either half is the invariant rather than the
- * consumer: the trim and the `repeat` test are the same predicate, so a chain
- * entry whose specifier was copied off an existing declaration always coincides
- * with a conflict, and that specifier never reaches a file.
+ * consumer: the trim and the `repeat` test cover the same range, so a chain
+ * entry whose specifier was copied off an existing declaration either falls to
+ * the anchor's slice or coincides with a conflict, and that specifier never
+ * reaches a file.
  *
  * @param prefix Content-relative segments above the planned ones. They are
  * already reachable, but the chain is written at the Content root, so it has to
  * carry them or the declaration it nests would name a different module.
+ * @param definitionsFile opaque identifier of the definitions file the caller
+ * owns, as `FoundDeclaration.file` spells it. Declarations there anchor the
+ * chain instead of conflicting with it.
  */
-export function resolveVisibility(prefix: readonly string[], segments: readonly VisibilitySegment[], found: readonly FoundDeclaration[]): ResolvedVisibility {
+export function resolveVisibility(prefix: readonly string[], segments: readonly VisibilitySegment[], found: readonly FoundDeclaration[], definitionsFile?: string): ResolvedVisibility {
     const byPath = new Map<string, FoundDeclaration[]>();
     for (const entry of found) {
         const existing = byPath.get(entry.path);
@@ -131,6 +150,11 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     // the trim below.
     const declared: { chainIndex: number; path: string; keyword?: string }[] = [];
 
+    // The definitions-file declaration at each walk index, null where the
+    // module is undeclared there, narrowed, or declared only elsewhere. The
+    // anchor search below walks this.
+    const definitionsDeclarations: (FoundDeclaration | null)[] = [];
+
     // The prefix modules are reachable already, so they are walked purely as
     // the nesting the chain needs - never marked, but still matched against
     // what the project declares so a written part cannot disagree with one.
@@ -143,6 +167,7 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
         const declarations = byPath.get(modulePath) ?? [];
 
         if (declarations.length === 0) {
+            definitionsDeclarations.push(null);
             chain.push({ name: segment.name, specifier: segment.needsPublic ? "public" : undefined });
             written.push(segment.needsPublic);
             continue;
@@ -151,6 +176,9 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
         const blocking = declarations.find((entry) => entry.declaration.visibility && entry.declaration.visibility.keyword !== "public" && entry.declaration.visibility.keyword !== "internal");
 
         if (blocking) {
+            // Null even when the narrowed declaration sits in the definitions
+            // file: the narrowing is deliberate, so its block is not extended.
+            definitionsDeclarations.push(null);
             blocked.push({ chainIndex: chain.length, path: modulePath, keyword: blocking.declaration.visibility!.keyword, needsPublic: segment.needsPublic });
             // Bare so the chain still nests, and never carrying the blocking
             // keyword: `<scoped>` without its module list does not compile.
@@ -158,6 +186,12 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
             written.push(false);
             continue;
         }
+
+        // The last part in scan order, because a file declaring one module
+        // twice does not compile and the writer's own appends come last: the
+        // most recent block is the least surprising one to extend.
+        const inDefinitions = declarations.filter((entry) => entry.file === definitionsFile);
+        definitionsDeclarations.push(inDefinitions.length > 0 ? inDefinitions[inDefinitions.length - 1] : null);
 
         if (segment.needsPublic) {
             for (const entry of declarations) {
@@ -194,6 +228,16 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     // none to carry, the nesting above them is noise.
     const deepestWritten = written.lastIndexOf(true);
 
+    // The deepest module, contiguously from the root, whose declaration the
+    // definitions file already carries. Contiguity is what makes the nest
+    // sound: everything above the anchor is the existing block's own nesting,
+    // so the chain can start directly inside it. It costs nothing real,
+    // because a nested declaration's ancestors are declared in the same file.
+    let anchorIndex = -1;
+    while (anchorIndex + 1 < definitionsDeclarations.length && definitionsDeclarations[anchorIndex + 1] !== null) {
+        anchorIndex++;
+    }
+
     // A narrowed module blocks when it is the one to publicize, and equally
     // when the retained chain nests through it. Anything trimmed away is never
     // written, so a narrowing there is nobody's business.
@@ -204,16 +248,20 @@ export function resolveVisibility(prefix: readonly string[], segments: readonly 
     // Same trim, for the same reason: a declaration is only restated where the
     // retained chain reaches it. A module publicized in place sits below the
     // deepest written part whenever nothing new goes under it, and is edited
-    // rather than restated.
+    // rather than restated. At or above the anchor nothing is written either -
+    // the existing block already carries those declarations.
     for (const entry of declared) {
-        if (entry.chainIndex <= deepestWritten) {
+        if (entry.chainIndex > anchorIndex && entry.chainIndex <= deepestWritten) {
             conflicts.push({ path: entry.path, keyword: entry.keyword, reason: "repeat" });
         }
     }
 
+    const anchor = anchorIndex >= 0 && deepestWritten > anchorIndex ? definitionsDeclarations[anchorIndex]! : undefined;
+
     return {
         edits,
-        chain: deepestWritten === -1 ? [] : chain.slice(0, deepestWritten + 1),
+        chain: deepestWritten === -1 ? [] : chain.slice(anchorIndex + 1, deepestWritten + 1),
+        ...(anchor ? { anchor } : {}),
         conflicts,
     };
 }


### PR DESCRIPTION
Closes #464

## What

Where the declaration chain runs through a module the definitions file already declares, the writer now nests the new declarations inside that existing block instead of refusing. Ancestors declared in user files keep the #449 refusal, and so does a definitions-file block hand-edited into a shape the writer cannot extend (dotted body, braces with content, trailing text on the head line), with a message naming the declaration.

## How

- `resolveVisibility` takes the definitions file's key and anchors the chain on the deepest contiguous-from-root declaration that file carries; only what lies below the anchor is written, and `repeat` conflicts fire only for declarations the written portion still restates. A narrowed declaration never anchors, so `widen`/`nest` refusals are untouched.
- `nestDeclarationEdit` (new, pure) renders the nested insertion as a `{span, text}` edit against the original definitions text: a colon body gains the chain as its new first child at the body's own byte-copied indent; an empty-brace leaf converts to a colon body. The edit is folded into the existing `applySpecifierEdits` pass, so specifier rewrites in the same file cannot shift its offsets.
- `findExplicitModuleDeclarations` records `bodyStyle` and `bodyStart` per declaration (additive; the other consumer reads only existing fields).

## Review

Fresh reviewer at opus, round 1: PASS_WITH_SUGGESTIONS (0 Critical, 1 Important, 4 Suggestions), with 24 behavioral probes across both writer-emitted shapes, CRLF, tabs, multi-segment chains, folded specifier edits, user-file refusals, and the boundary shapes. The Important finding (a comment-only body line could supply the copied indent) is fixed in 50410b2: the indent scan runs on masked text, pinned by a test. The Suggestions (naming the span+text pair, one per-segment record array in `resolveVisibility`, extracting the definitions-file composition from `buildEdit`, a ragged doc-comment line) are left as reported.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.11.3 compile
> tsc -p ./
```

`npm test`:

```
Test Suites: 57 passed, 57 total
Tests:       1661 passed, 1661 total
Snapshots:   0 total
Time:        10.047 s
```

`npm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```

The three new writer-level tests were run against the unfixed sources and fail there, so they detect the defect they pin. The regression test drives `makeModulePublic` twice against the same fake project, feeding the first run's output back as the second run's definitions file.
