### PR TITLE
fix(imports): take the consumer override only from a diagnostic inside the using clause

### DIFF
--- a/changelog.d/412.fixed.md
+++ b/changelog.d/412.fixed.md
@@ -1,0 +1,1 @@
+**Import placement**: a new import is no longer forced above a `using` sharing its line with another statement when the compiler's error was about that other statement, which could stop the file compiling.

--- a/src/commands/CommandsHandler.ts
+++ b/src/commands/CommandsHandler.ts
@@ -4,6 +4,7 @@ import { ImportHandler, ImportPathConverter, ImportCodeLensProvider } from "../i
 import { StatusBarHandler } from "../ui";
 import { ProjectPathCache } from "../services";
 import { ModuleVisibilityRequest, ModuleVisibilityWriter } from "../visibility";
+import { DiagnosticPosition } from "../types";
 
 /** The collaborators the commands act on, wired once during activation. */
 export interface CommandsDependencies {
@@ -114,17 +115,21 @@ export class CommandsHandler {
     /**
      * Adds one import statement to a document.
      *
-     * @param diagnosticLine The 0-based line the diagnostic behind this import
-     *   was reported on, which decides whether a pinned import may be read as
-     *   the one that needs it. Optional because a caller that cannot name a
+     * @param diagnosticPosition The start position of the diagnostic behind
+     *   this import, which decides whether a pinned import may be read as the
+     *   one that needs it. Optional because a caller that cannot name a
      *   diagnostic must not imply it knows of one - placement then follows the
      *   written order alone.
      */
-    async addSingleImport(document: vscode.TextDocument, importStatement: string, diagnosticLine?: number): Promise<void> {
+    async addSingleImport(document: vscode.TextDocument, importStatement: string, diagnosticPosition?: DiagnosticPosition): Promise<void> {
         // A false here means applyEdit was rejected - a stale document version
         // or a read-only file - and the document is unchanged. Reporting the
         // import as added would leave the only trace in the output channel.
-        const applied = await this.deps.importHandler.addImportsToDocument(document, [importStatement], diagnosticLine === undefined ? undefined : new Map([[importStatement, [diagnosticLine]]]));
+        const applied = await this.deps.importHandler.addImportsToDocument(
+            document,
+            [importStatement],
+            diagnosticPosition === undefined ? undefined : new Map([[importStatement, [diagnosticPosition]]]),
+        );
 
         if (!applied) {
             logger.warn("CommandsHandler", `Failed to add import: ${importStatement}`);
@@ -193,7 +198,7 @@ export class CommandsHandler {
             // Read straight from the current diagnostics rather than waiting on
             // the auto-import debounce, so the command does not race it.
             const diagnostics = vscode.languages.getDiagnostics(document.uri);
-            const { paths, diagnosticLinesByPath } = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
+            const { paths, diagnosticPositionsByPath } = this.deps.importHandler.extractImportsFromDiagnostics(diagnostics);
             logger.debug("CommandsHandler", `Found ${paths.length} missing import(s) in current diagnostics`);
 
             // The missing paths are handed to the organizer rather than added
@@ -202,7 +207,7 @@ export class CommandsHandler {
             // with them, or the organizer cannot tell a pinned import the
             // compiler is reporting on from one that already resolves, and
             // writes the fix below the statement that needed it.
-            const applied = await this.deps.importHandler.organizeImports(document, paths, diagnosticLinesByPath);
+            const applied = await this.deps.importHandler.organizeImports(document, paths, diagnosticPositionsByPath);
 
             if (!applied) {
                 logger.warn("CommandsHandler", "Import organization was not applied to the document");

--- a/src/commands/__tests__/CommandsHandler.test.ts
+++ b/src/commands/__tests__/CommandsHandler.test.ts
@@ -30,7 +30,7 @@ function makeHandler(importHandlerOverrides: Partial<ImportHandler>): CommandsHa
     const importHandler = {
         addImportsToDocument: jest.fn().mockResolvedValue(true),
         organizeImports: jest.fn().mockResolvedValue(true),
-        extractImportsFromDiagnostics: jest.fn().mockReturnValue({ paths: [], diagnosticLinesByPath: new Map() }),
+        extractImportsFromDiagnostics: jest.fn().mockReturnValue({ paths: [], diagnosticPositionsByPath: new Map() }),
         ...importHandlerOverrides,
     } as unknown as ImportHandler;
 
@@ -159,28 +159,28 @@ describe("CommandsHandler.optimizeImports", () => {
     });
 
     // Regression for #385: the command adds what the compiler currently reports
-    // as missing, so the lines it reported on are evidence the organizer needs
-    // to tell a pinned import that failed to resolve from one that already
-    // resolves. Dropped here, the command writes the fix below the statement
-    // that needed it and still reports success.
+    // as missing, so the positions it reported them at are evidence the
+    // organizer needs to tell a pinned import that failed to resolve from one
+    // that already resolves. Dropped here, the command writes the fix below the
+    // statement that needed it and still reports success.
     //
     // Asserted through the delegating entry point as well as at
     // organizeImportsInDocument, since it is the delegation that carries the
     // evidence to the source action too.
-    it("hands the organizer the lines the diagnostics were reported on", async () => {
+    it("hands the organizer the positions the diagnostics were reported at", async () => {
         activateVerseDocument();
-        const diagnosticLinesByPath = new Map([["Features", [4]]]);
+        const diagnosticPositionsByPath = new Map([["Features", [{ line: 4, character: 2 }]]]);
         const organizeImports = jest.fn().mockResolvedValue(true);
         const handler = makeHandler({
             organizeImports,
-            extractImportsFromDiagnostics: jest.fn().mockReturnValue({ paths: ["Features"], diagnosticLinesByPath }),
+            extractImportsFromDiagnostics: jest.fn().mockReturnValue({ paths: ["Features"], diagnosticPositionsByPath }),
         });
 
         await handler.optimizeImports();
 
         expect(organizeImports).toHaveBeenCalledTimes(1);
         expect(organizeImports.mock.calls[0][1]).toEqual(["Features"]);
-        expect(organizeImports.mock.calls[0][2]).toBe(diagnosticLinesByPath);
+        expect(organizeImports.mock.calls[0][2]).toBe(diagnosticPositionsByPath);
     });
 });
 
@@ -192,16 +192,16 @@ describe("CommandsHandler.organizeImportsInDocument", () => {
     it("organizes the document it is given, with the paths the diagnostics report missing", async () => {
         const document = makeDocument();
         const organizeImports = jest.fn().mockResolvedValue(true);
-        const diagnosticLinesByPath = new Map([["/Fortnite.com/Devices", [3]]]);
+        const diagnosticPositionsByPath = new Map([["/Fortnite.com/Devices", [{ line: 3, character: 0 }]]]);
         const handler = makeHandler({
             organizeImports,
-            extractImportsFromDiagnostics: jest.fn().mockReturnValue({ paths: ["/Fortnite.com/Devices"], diagnosticLinesByPath }),
+            extractImportsFromDiagnostics: jest.fn().mockReturnValue({ paths: ["/Fortnite.com/Devices"], diagnosticPositionsByPath }),
         });
 
         const applied = await handler.organizeImportsInDocument(document);
 
         expect(applied).toBe(true);
-        expect(organizeImports).toHaveBeenCalledWith(document, ["/Fortnite.com/Devices"], diagnosticLinesByPath);
+        expect(organizeImports).toHaveBeenCalledWith(document, ["/Fortnite.com/Devices"], diagnosticPositionsByPath);
     });
 
     it("does not save, and does not fall back to the active editor", async () => {

--- a/src/diagnostics/DiagnosticsHandler.ts
+++ b/src/diagnostics/DiagnosticsHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { logger, settingsFor } from "../utils";
-import { ImportSuggestion } from "../types";
+import { DiagnosticPosition, ImportSuggestion } from "../types";
 import { ImportHandler } from "../imports";
 
 /**
@@ -157,7 +157,7 @@ export class DiagnosticsHandler {
                 const multiOptionStrategy = config.get<string>("behavior.multiOptionStrategy", "quickfix");
 
                 const autoImportSuggestions = new Set<string>();
-                // The line a diagnostic was reported on, kept beside the
+                // The position a diagnostic was reported at, kept beside the
                 // statement it asked for. Placement needs it to tell a pinned
                 // import that failed to resolve from one that merely looks as
                 // though it could (ImportDocumentEditor.couldResolveAgainst),
@@ -165,12 +165,14 @@ export class DiagnosticsHandler {
                 //
                 // Both go through one function so the set and the map cannot
                 // disagree about which statements were added: a statement in
-                // the set with no line placed as though no diagnostic asked for
-                // it, which is the reading this signal exists to correct.
-                const diagnosticLinesByStatement = new Map<string, number[]>();
+                // the set with no position is placed as though no diagnostic
+                // asked for it, which is the reading this signal exists to
+                // correct.
+                const diagnosticPositionsByStatement = new Map<string, DiagnosticPosition[]>();
                 const recordSuggestion = (statement: string, diagnostic: vscode.Diagnostic): void => {
                     autoImportSuggestions.add(statement);
-                    diagnosticLinesByStatement.set(statement, [...(diagnosticLinesByStatement.get(statement) ?? []), diagnostic.range.start.line]);
+                    const start = { line: diagnostic.range.start.line, character: diagnostic.range.start.character };
+                    diagnosticPositionsByStatement.set(statement, [...(diagnosticPositionsByStatement.get(statement) ?? []), start]);
                 };
                 let hasMultiOptionSuggestions = false;
 
@@ -224,7 +226,7 @@ export class DiagnosticsHandler {
                     // The edit is rejected when the document moved on between
                     // the read and the write, or when the file is read-only.
                     // Reporting the imports as applied hides that entirely.
-                    const applied = await this.importHandler.addImportsToDocument(document, Array.from(autoImportSuggestions), diagnosticLinesByStatement);
+                    const applied = await this.importHandler.addImportsToDocument(document, Array.from(autoImportSuggestions), diagnosticPositionsByStatement);
 
                     if (applied) {
                         vscode.window.setStatusBarMessage(`Auto-imported ${autoImportSuggestions.size} statements to ${displayName}`, 3000);

--- a/src/imports/ImportCodeActionProvider.ts
+++ b/src/imports/ImportCodeActionProvider.ts
@@ -104,13 +104,15 @@ export class ImportCodeActionProvider implements vscode.CodeActionProvider {
         action.kind = vscode.CodeActionKind.QuickFix.append("verse.import");
         action.diagnostics = [diagnostic];
 
-        // The diagnostic's line travels with the statement: placement reads it
-        // to tell a pinned import that failed to resolve, and so needs this
-        // import above it, from one that merely has the form of a consumer.
+        // The diagnostic's start position travels with the statement: placement
+        // reads it to tell a pinned import that failed to resolve, and so needs
+        // this import above it, from one that merely has the form of a
+        // consumer. A plain object rather than the vscode.Position, so nothing
+        // downstream depends on a vscode class crossing the command boundary.
         action.command = {
             title: "Add Import",
             command: "verseAutoImports.addSingleImport",
-            arguments: [document, suggestion.importStatement, diagnostic.range.start.line],
+            arguments: [document, suggestion.importStatement, { line: diagnostic.range.start.line, character: diagnostic.range.start.character }],
         };
 
         return action;

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { logger, settingsFor } from "../utils";
-import { DiagnosticLinesByPath, DiagnosticLinesByStatement } from "../types";
+import { DiagnosticPosition, DiagnosticPositionsByPath, DiagnosticPositionsByStatement } from "../types";
 import { ImportFormatter } from "./ImportFormatter";
 import { QueuedEdit, verifyImportEdits, verifyOrganizedRewrite } from "./ImportRewriteGuard";
 import {
@@ -265,7 +265,7 @@ interface PinnedBounds {
  * For a caller that cannot name the diagnostic behind a path. It raises no
  * ceiling, which is the ordering every other rule here keeps.
  */
-const NO_DIAGNOSTIC_LINES: DiagnosticLinesByPath = new Map();
+const NO_DIAGNOSTIC_POSITIONS: DiagnosticPositionsByPath = new Map();
 
 /**
  * Managing a document's import block: adding the imports a diagnostic asked
@@ -453,17 +453,28 @@ export class ImportDocumentEditor {
      *
      * This is the one place a newly added import is read as the provider rather
      * than the consumer, and it overrides the written order every other rule
-     * here keeps. `diagnosticLines` is what licenses that override: a diagnostic
-     * reported on this import's own line is the compiler saying something there
-     * failed to resolve, so whatever is being added for it has to precede it.
-     * Form alone cannot say that. A pinned dotted import that already resolves
-     * is far commoner - the file compiled before the edit - and against one of
-     * those the new import is the consumer, which the written order keeps below
-     * it.
+     * here keeps. `diagnosticPositions` is what licenses that override: a
+     * diagnostic reported inside this import's own text is the compiler saying
+     * it failed to resolve, so whatever is being added for it has to precede
+     * it. Form alone cannot say that. A pinned dotted import that already
+     * resolves is far commoner - the file compiled before the edit - and
+     * against one of those the new import is the consumer, which the written
+     * order keeps below it.
      *
-     * A line, not a range, so an import pinned by a statement sharing its line
-     * still takes the override from a diagnostic about that other statement.
-     * Narrowing it needs a column, which ScannedImport does not carry.
+     * Where the import carries `columns`, the evidence must start inside them:
+     * a statement sharing its line with other code would otherwise take the
+     * override from a diagnostic about that other statement, and the override's
+     * failure direction is a file that stops compiling, which outranks a fixed
+     * diagnostic (see hoistFloor on the same asymmetry). The compiler anchors
+     * an unresolved-identifier diagnostic to the identifier's own token, so a
+     * start position is enough to tell the two statements apart.
+     *
+     * Without `columns` the whole span still counts. That keeps a statement
+     * owning its span exactly as sharp as before, and leaves one shape loose:
+     * a pinned multi-line span - `X := 1; using:` over its indented path -
+     * still takes the override from a diagnostic about the statement beside
+     * its opener. A standing gap rather than one this predicate closes;
+     * narrowing it needs a span the scanner does not measure.
      *
      * Still kept to a pinned dotted consumer and a new import that can supply a
      * first segment for it, because the override is only worth the risk that
@@ -471,15 +482,19 @@ export class ImportDocumentEditor {
      * and writing a standalone line, so widening it fragments a file into
      * import regions to satisfy nothing.
      *
-     * @param diagnosticLines 0-based lines of the diagnostics that asked for the
-     *   new import. Empty where the caller knows of none, and empty raises no
-     *   ceiling.
+     * @param diagnosticPositions Start positions of the diagnostics that asked
+     *   for the new import. Empty where the caller knows of none, and empty
+     *   raises no ceiling.
      */
-    private couldResolveAgainst(imp: ScannedImport, rank: number, diagnosticLines: readonly number[]): boolean {
+    private couldResolveAgainst(imp: ScannedImport, rank: number, diagnosticPositions: readonly DiagnosticPosition[]): boolean {
         if (this.formatter.importRank(imp.path) !== 2 || rank >= 2) {
             return false;
         }
-        return diagnosticLines.some((line) => line >= imp.startLine && line <= imp.endLine);
+        const columns = imp.columns;
+        if (!columns) {
+            return diagnosticPositions.some((position) => position.line >= imp.startLine && position.line <= imp.endLine);
+        }
+        return diagnosticPositions.some((position) => position.line === imp.startLine && position.character >= columns.start && position.character < columns.end);
     }
 
     /**
@@ -533,12 +548,12 @@ export class ImportDocumentEditor {
      *
      * Exempts the path from itself for the reason crossesPinnedProvider does.
      */
-    private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string, diagnosticLines: DiagnosticLinesByPath): number {
+    private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string, diagnosticPositions: DiagnosticPositionsByPath): number {
         return this.pinnedBounds(
             pinned.filter((imp) => imp.path !== path),
             classifications,
             path,
-            diagnosticLines,
+            diagnosticPositions,
         ).floor;
     }
 
@@ -546,10 +561,10 @@ export class ImportDocumentEditor {
      * Where the imports pinned to their line allow a new `path` to be written.
      * See PinnedBounds.
      */
-    private pinnedBounds(pinned: ScannedImport[], classifications: LineClassification[], path: string, diagnosticLines: DiagnosticLinesByPath): PinnedBounds {
+    private pinnedBounds(pinned: ScannedImport[], classifications: LineClassification[], path: string, diagnosticPositions: DiagnosticPositionsByPath): PinnedBounds {
         const rank = this.formatter.importRank(path);
         const needsScopeAbove = this.formatter.resolvesAgainstScopeAbove(path);
-        const linesForPath = diagnosticLines.get(path) ?? [];
+        const positionsForPath = diagnosticPositions.get(path) ?? [];
 
         let floor = -1;
         let ceiling = -1;
@@ -559,7 +574,7 @@ export class ImportDocumentEditor {
             // below the ceiling it raised, and blockIsWithin would then refuse
             // every block - including one lying entirely above the ceiling,
             // which satisfies the ceiling and the written order both.
-            if (this.couldResolveAgainst(imp, rank, linesForPath)) {
+            if (this.couldResolveAgainst(imp, rank, positionsForPath)) {
                 ceiling = ceiling === -1 ? imp.startLine : Math.min(ceiling, imp.startLine);
                 continue;
             }
@@ -694,10 +709,16 @@ export class ImportDocumentEditor {
      * starting from the line the site would have used had no import been
      * pinned. Paths wanting the same line are written together.
      */
-    private groupByPlacementLine(paths: string[], desired: number, pinned: ScannedImport[], classifications: LineClassification[], diagnosticLines: DiagnosticLinesByPath): Map<number, string[]> {
+    private groupByPlacementLine(
+        paths: string[],
+        desired: number,
+        pinned: ScannedImport[],
+        classifications: LineClassification[],
+        diagnosticPositions: DiagnosticPositionsByPath,
+    ): Map<number, string[]> {
         const byLine = new Map<number, string[]>();
         for (const path of paths) {
-            const line = this.placementLine(desired, this.pinnedBounds(pinned, classifications, path, diagnosticLines));
+            const line = this.placementLine(desired, this.pinnedBounds(pinned, classifications, path, diagnosticPositions));
             byLine.set(line, [...(byLine.get(line) ?? []), path]);
         }
         return new Map([...byLine].sort(([a], [b]) => a - b));
@@ -757,18 +778,18 @@ export class ImportDocumentEditor {
      * the imports it must sit relative to; with it off, the movable imports are
      * consolidated at the top, bar any a pinned line holds where it is.
      *
-     * @param diagnosticLinesByStatement The 0-based lines of the diagnostics
+     * @param diagnosticPositionsByStatement The start positions of the diagnostics
      *   that asked for each statement, keyed on the statement as it appears in
      *   `importStatements`. A statement with no entry is placed by the written
      *   order alone; only couldResolveAgainst reads these, to tell a pinned
      *   import that failed to resolve from one that merely looks like it could.
      */
-    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: DiagnosticLinesByStatement): Promise<boolean> {
-        return this.serialize(document, () => this.applyImports(document, importStatements, diagnosticLinesByStatement));
+    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticPositionsByStatement?: DiagnosticPositionsByStatement): Promise<boolean> {
+        return this.serialize(document, () => this.applyImports(document, importStatements, diagnosticPositionsByStatement));
     }
 
     /** addImportsToDocument, without the wait for the writes ahead of it. */
-    private async applyImports(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: DiagnosticLinesByStatement): Promise<boolean> {
+    private async applyImports(document: vscode.TextDocument, importStatements: string[], diagnosticPositionsByStatement?: DiagnosticPositionsByStatement): Promise<boolean> {
         logger.info("ImportDocumentEditor", `Adding ${importStatements.length} import statements to document`);
 
         const config = settingsFor(document.uri);
@@ -831,16 +852,16 @@ export class ImportDocumentEditor {
         // placement rule below works in, and concatenated where two statements
         // share a path: a second diagnostic asking for the same import is
         // further evidence, not a replacement for the first.
-        const diagnosticLinesByPath = new Map<string, number[]>();
+        const diagnosticPositionsByPath = new Map<string, DiagnosticPosition[]>();
         importStatements.forEach((imp) => {
             const path = this.formatter.extractPathFromImport(imp);
             if (path && !existingPaths.has(path)) {
                 logger.debug("ImportDocumentEditor", `New import needed: ${path}`);
                 newImportPaths.add(path);
 
-                const diagnosticLines = diagnosticLinesByStatement?.get(imp);
-                if (diagnosticLines?.length) {
-                    diagnosticLinesByPath.set(path, [...(diagnosticLinesByPath.get(path) ?? []), ...diagnosticLines]);
+                const diagnosticPositions = diagnosticPositionsByStatement?.get(imp);
+                if (diagnosticPositions?.length) {
+                    diagnosticPositionsByPath.set(path, [...(diagnosticPositionsByPath.get(path) ?? []), ...diagnosticPositions]);
                 }
             }
         });
@@ -927,7 +948,7 @@ export class ImportDocumentEditor {
                     for (const path of paths) {
                         const canTake =
                             blockIndex >= 0 &&
-                            this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path, diagnosticLinesByPath)) &&
+                            this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath)) &&
                             this.blockKeepsRelativeOrder(importBlocks, blockIndex, path);
                         (canTake ? taken : unhandled).push(path);
                     }
@@ -963,7 +984,7 @@ export class ImportDocumentEditor {
 
                 if (unhandledPaths.length > 0) {
                     const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
-                    for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, pinned, classifications, diagnosticLinesByPath)) {
+                    for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, pinned, classifications, diagnosticPositionsByPath)) {
                         this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, importBlocks.length === 0);
                     }
                 }
@@ -979,7 +1000,7 @@ export class ImportDocumentEditor {
                     // already inside the block being rebuilt in place.
                     const displacedPaths =
                         importBlocks.length > 0
-                            ? Array.from(newImportPaths).filter((path) => !this.blockIsWithin(importBlocks[0], this.pinnedBounds(pinned, classifications, path, diagnosticLinesByPath)))
+                            ? Array.from(newImportPaths).filter((path) => !this.blockIsWithin(importBlocks[0], this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath)))
                             : [];
                     const displaced = new Set(displacedPaths);
 
@@ -1003,7 +1024,7 @@ export class ImportDocumentEditor {
                             edit.delete(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)));
                         }
 
-                        for (const [line, paths] of this.groupByPlacementLine(displacedPaths, firstBlock.end + 1, pinned, classifications, diagnosticLinesByPath)) {
+                        for (const [line, paths] of this.groupByPlacementLine(displacedPaths, firstBlock.end + 1, pinned, classifications, diagnosticPositionsByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, false);
                         }
                     } else {
@@ -1020,7 +1041,7 @@ export class ImportDocumentEditor {
                         // rewritable import opens or extends a block, so no
                         // block means none of them, which is also why the
                         // trailing comments here are always empty.
-                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, headerEnd, pinned, classifications, diagnosticLinesByPath)) {
+                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, headerEnd, pinned, classifications, diagnosticPositionsByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, true);
                         }
                     }
@@ -1050,7 +1071,7 @@ export class ImportDocumentEditor {
                         const pathsByBlock = new Map<number, string[]>();
                         const unblockedPaths: string[] = [];
                         for (const path of newImportPathsArray) {
-                            const bounds = this.pinnedBounds(pinned, classifications, path, diagnosticLinesByPath);
+                            const bounds = this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath);
                             const eligible = importBlocks.map((block, index) => ({ block, index })).filter(({ block }) => this.blockIsWithin(block, bounds));
 
                             if (eligible.length === 0) {
@@ -1103,7 +1124,7 @@ export class ImportDocumentEditor {
                         // path with unconstrained bounds finds every block
                         // eligible, so an unblocked one always has a floor or a
                         // ceiling, and both sit at or below the header's end.
-                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, headerEnd, pinned, classifications, diagnosticLinesByPath)) {
+                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, headerEnd, pinned, classifications, diagnosticPositionsByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), eol, true);
                         }
                     } else {
@@ -1130,7 +1151,7 @@ export class ImportDocumentEditor {
                         const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
                         const blankLineAfter = importBlocks.length === 0;
 
-                        for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, pinned, classifications, diagnosticLinesByPath)) {
+                        for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, pinned, classifications, diagnosticPositionsByPath)) {
                             this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, blankLineAfter);
                         }
                     }
@@ -1149,7 +1170,7 @@ export class ImportDocumentEditor {
             const blockPaths = new Set<string>(Array.from(relocatablePaths).filter((path) => !grounded.has(path)));
             const newPathsByLine = new Map<number, string[]>();
             for (const path of newImportPaths) {
-                const floor = this.hoistFloor(pinned, classifications, path, diagnosticLinesByPath);
+                const floor = this.hoistFloor(pinned, classifications, path, diagnosticPositionsByPath);
                 if (floor === -1) {
                     blockPaths.add(path);
                     continue;
@@ -1248,7 +1269,7 @@ export class ImportDocumentEditor {
             /** Line ending to use when the text has no line break to detect one from. */
             fallbackEol?: LineEnding;
         },
-        diagnosticLinesByPath: DiagnosticLinesByPath = NO_DIAGNOSTIC_LINES,
+        diagnosticPositionsByPath: DiagnosticPositionsByPath = NO_DIAGNOSTIC_POSITIONS,
     ): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
         const lines = text.split(LINE_SPLIT);
@@ -1348,7 +1369,7 @@ export class ImportDocumentEditor {
             // raises a ceiling rather than a floor, and the block above every
             // pinned line satisfies it. Only the floor is read, for the reason
             // hoistFloor gives.
-            const floor = this.hoistFloor(pinned, classifications, path, diagnosticLinesByPath);
+            const floor = this.hoistFloor(pinned, classifications, path, diagnosticPositionsByPath);
             if (floor === -1) {
                 topExtraPaths.push(path);
                 continue;
@@ -1446,12 +1467,12 @@ export class ImportDocumentEditor {
      * and written in the preferred syntax at the top of the file. Unlike
      * addImportsToDocument this reorganizes even when nothing new is added.
      */
-    async organizeImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath = NO_DIAGNOSTIC_LINES): Promise<boolean> {
-        return this.serialize(document, () => this.applyOrganizedImports(document, additionalPaths, diagnosticLinesByPath));
+    async organizeImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticPositionsByPath: DiagnosticPositionsByPath = NO_DIAGNOSTIC_POSITIONS): Promise<boolean> {
+        return this.serialize(document, () => this.applyOrganizedImports(document, additionalPaths, diagnosticPositionsByPath));
     }
 
     /** organizeImports, without the wait for the writes ahead of it. */
-    private async applyOrganizedImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath: DiagnosticLinesByPath): Promise<boolean> {
+    private async applyOrganizedImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticPositionsByPath: DiagnosticPositionsByPath): Promise<boolean> {
         const config = settingsFor(document.uri);
         const preferDotSyntax = config.get<string>("behavior.importSyntax", "curly") === "dot";
         const sortAlphabetically = config.get<boolean>("behavior.sortImportsAlphabetically", true);
@@ -1467,7 +1488,7 @@ export class ImportDocumentEditor {
                 importGrouping,
                 fallbackEol: documentEol(document),
             },
-            diagnosticLinesByPath,
+            diagnosticPositionsByPath,
         );
 
         if (organized === null || organized === text) {

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -466,8 +466,12 @@ export class ImportDocumentEditor {
      * override from a diagnostic about that other statement, and the override's
      * failure direction is a file that stops compiling, which outranks a fixed
      * diagnostic (see hoistFloor on the same asymmetry). The compiler anchors
-     * an unresolved-identifier diagnostic to the identifier's own token, so a
-     * start position is enough to tell the two statements apart.
+     * an unresolved-identifier diagnostic to the identifier's own node
+     * (CreateGlitchForMissingUsing's call sites, SemanticAnalyzer.cpp:12544,
+     * :12864), so a start position is enough to tell the two statements apart.
+     * A compiler reporting a whole-line range instead starts it at the head of
+     * the line, outside a clause written after a `;`, which refuses the
+     * override - the same safe direction.
      *
      * Without `columns` the whole span still counts. That keeps a statement
      * owning its span exactly as sharp as before, and leaves one shape loose:

--- a/src/imports/ImportFormatter.ts
+++ b/src/imports/ImportFormatter.ts
@@ -279,6 +279,20 @@ export class ImportFormatter {
     }
 
     /**
+     * The `using` statement starting at offset `at` of `text`: its path, and
+     * the offset just past the statement in `text` itself.
+     *
+     * @param at Must index the statement's own `using`. matchImport trims its
+     *   input, so a slice beginning anywhere before the keyword would shift
+     *   every offset it reports; starting on the keyword makes the trim a
+     *   no-op and `at + end` an offset into `text`.
+     */
+    matchImportAt(text: string, at: number): { path: string; end: number } | null {
+        const match = ImportFormatter.matchImport(text.slice(at));
+        return match ? { path: match.path, end: at + match.end } : null;
+    }
+
+    /**
      * Whether an import comes from a digest source, which the
      * `behavior.digestImportPrefixes` setting defines and defaults to
      * Verse.org, Fortnite.com and UnrealEngine.com.

--- a/src/imports/ImportHandler.ts
+++ b/src/imports/ImportHandler.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { DiagnosticLinesByPath, DiagnosticLinesByStatement, ImportSuggestion, MissingImports } from "../types";
+import { DiagnosticPositionsByPath, DiagnosticPositionsByStatement, ImportSuggestion, MissingImports } from "../types";
 import { AssetsDigestParser } from "../services";
 import { ImportFormatter } from "./ImportFormatter";
 import { ImportSuggestionExtractor } from "./ImportSuggestionExtractor";
@@ -38,8 +38,8 @@ export class ImportHandler {
         return this.suggestionExtractor.extractImportSuggestions(errorMessage, resource);
     }
 
-    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticLinesByStatement?: DiagnosticLinesByStatement): Promise<boolean> {
-        return this.documentEditor.addImportsToDocument(document, importStatements, diagnosticLinesByStatement);
+    async addImportsToDocument(document: vscode.TextDocument, importStatements: string[], diagnosticPositionsByStatement?: DiagnosticPositionsByStatement): Promise<boolean> {
+        return this.documentEditor.addImportsToDocument(document, importStatements, diagnosticPositionsByStatement);
     }
 
     /**
@@ -47,14 +47,14 @@ export class ImportHandler {
      * imports plus the given additional paths, deduplicated, grouped,
      * sorted, and formatted per settings.
      *
-     * @param diagnosticLinesByPath Pass whatever produced `additionalPaths`
+     * @param diagnosticPositionsByPath Pass whatever produced `additionalPaths`
      *   reported, where it came from diagnostics. Without it a pinned import
      *   the compiler is reporting on cannot be told from one that already
      *   resolves, and an added path can land below the statement it was added
      *   for.
      */
-    async organizeImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticLinesByPath?: DiagnosticLinesByPath): Promise<boolean> {
-        return this.documentEditor.organizeImports(document, additionalPaths, diagnosticLinesByPath);
+    async organizeImports(document: vscode.TextDocument, additionalPaths: string[], diagnosticPositionsByPath?: DiagnosticPositionsByPath): Promise<boolean> {
+        return this.documentEditor.organizeImports(document, additionalPaths, diagnosticPositionsByPath);
     }
 
     extractImportsFromDiagnostics(diagnostics: vscode.Diagnostic[]): MissingImports {

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -68,11 +68,11 @@ export interface ScannedImport {
      */
     trailingComment: string;
     /**
-     * The raw column span `[start, end)` of the statement's own text, recorded
-     * where the statement shares a single line with code it did not write - the
-     * one shape a line-granular test cannot decide, since a diagnostic on the
-     * line may be about the code beside the statement rather than the statement
-     * itself (ImportDocumentEditor.couldResolveAgainst). Present only with
+     * The statement's own text on its line, recorded where it shares a single
+     * line with code it did not write - the one shape a line-granular test
+     * cannot decide, since a diagnostic on the line may be about the code
+     * beside the statement rather than the statement itself
+     * (ImportDocumentEditor.couldResolveAgainst). Present only with
      * `startLine === endLine`.
      *
      * Absent means no column knowledge, not that none is needed: a statement
@@ -80,7 +80,17 @@ export interface ScannedImport {
      * structure defeats the column measurement all leave it unset, and evidence
      * anywhere on the span then counts.
      */
-    columns?: { start: number; end: number };
+    columns?: ColumnSpan;
+}
+
+/**
+ * A half-open raw column span on one line: `start` is the first character of
+ * the spanned text, `end` the offset just past it, both UTF-16 offsets into
+ * the raw line - the space vscode.Position.character measures in.
+ */
+export interface ColumnSpan {
+    start: number;
+    end: number;
 }
 
 /**
@@ -683,7 +693,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     anchorsCommentBelow: anchorsCommentBelow(i, i),
                     rebuildLosesText: true,
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
-                    ...(headlessColumns[statementIndex] ? { columns: headlessColumns[statementIndex] } : {}),
+                    columns: headlessColumns[statementIndex],
                 });
             });
 
@@ -852,7 +862,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     // Nothing re-emits a pinned entry, and the code has its
                     // comments already removed so it could only answer "none".
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
-                    ...(precedingColumns[statementIndex] ? { columns: precedingColumns[statementIndex] } : {}),
+                    columns: precedingColumns[statementIndex],
                 });
             });
 
@@ -916,7 +926,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     // The same comment for each entry, since they share a line.
                     // Nothing re-emits it - that is what being pinned means.
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
-                    ...(sharedColumns[statementIndex] ? { columns: sharedColumns[statementIndex] } : {}),
+                    columns: sharedColumns[statementIndex],
                 });
             });
             i += 1;
@@ -952,7 +962,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 anchorsCommentBelow: anchorsCommentBelow(i, i),
                 rebuildLosesText: losesText,
                 trailingComment: ImportFormatter.extractTrailingComment(trimmed),
-                ...(headColumns ? { columns: headColumns } : {}),
+                columns: headColumns,
             });
         }
         i += 1;
@@ -997,11 +1007,10 @@ export function pinnedImports(scannedImports: ScannedImport[]): ScannedImport[] 
  * The path of every `using` written anywhere in a line of live code, in written
  * order, or [] when it writes none.
  *
- * extractPathFromImport reads a statement from the head of what it is given, so
- * a statement that does not open the line is handed its own head rather than
- * the line. That keeps one copy of the two statement patterns instead of a
- * looser second copy that searches, which is what reads a comment as the line's
- * statement.
+ * matchImportAt reads a statement from the offset it is given, so a statement
+ * that does not open the line is read from its own head rather than the line's.
+ * That keeps one copy of the two statement patterns instead of a looser second
+ * copy that searches, which is what reads a comment as the line's statement.
  *
  * Every `using` is collected rather than the first, because `;` separates
  * definitions in a scope exactly as a newline does. Stopping at the first hides
@@ -1018,60 +1027,47 @@ export function pinnedImports(scannedImports: ScannedImport[]): ScannedImport[] 
  * between them, `X := 1<# note #>using { /A }`, which this does not report.
  */
 function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
-    const paths: string[] = [];
-    for (let at = code.indexOf("using"); at !== -1; at = code.indexOf("using", at + 1)) {
-        if (at > 0 && /[A-Za-z0-9_]/.test(code[at - 1])) {
-            continue;
-        }
-        const path = formatter.extractPathFromImport(code.slice(at));
-        if (path) {
-            paths.push(path);
-        }
-    }
-    return paths;
+    return usingStatementsOnLine(formatter, code).map((statement) => statement.path);
 }
 
 /**
- * Every `using` statement on a masked line, with the raw column span each
- * occupies: usingPathsOnLine's loop run over `masked` instead of the line's
- * code, so the offsets address the original text (LineClassification.masked).
- *
- * Not a replacement for that function, and never the count of record: masking
- * blanks a comment in place where the code strings remove it, so the two can
- * disagree wherever a comment splices or glues a token - `us<##>ing` writes a
- * statement only the rejoined code sees, `X<##>using` one only the masked text
- * sees. columnsForLinePaths reconciles the two answers and stands down when
- * they differ.
+ * Every `using` statement written anywhere in `text`, each with the offsets
+ * it occupies there. The one walk under both usingPathsOnLine and
+ * columnsForLinePaths: reader and measurer share it, so they cannot drift
+ * into the looser second copy usingPathsOnLine's doc warns against. Offsets
+ * mean what `text` means - raw columns only when `text` is the masked line.
  */
-function usingSpansOnMaskedLine(formatter: ImportFormatter, masked: string): { path: string; start: number; end: number }[] {
-    const spans: { path: string; start: number; end: number }[] = [];
-    for (let at = masked.indexOf("using"); at !== -1; at = masked.indexOf("using", at + 1)) {
-        if (at > 0 && /[A-Za-z0-9_]/.test(masked[at - 1])) {
+function usingStatementsOnLine(formatter: ImportFormatter, text: string): { path: string; start: number; end: number }[] {
+    const statements: { path: string; start: number; end: number }[] = [];
+    for (let at = text.indexOf("using"); at !== -1; at = text.indexOf("using", at + 1)) {
+        if (at > 0 && /[A-Za-z0-9_]/.test(text[at - 1])) {
             continue;
         }
-        const match = formatter.matchImportAt(masked, at);
+        const match = formatter.matchImportAt(text, at);
         if (match) {
-            spans.push({ path: match.path, start: at, end: match.end });
+            statements.push({ path: match.path, start: at, end: match.end });
         }
     }
-    return spans;
+    return statements;
 }
 
 /**
  * The column span for each of a line's recorded paths, or undefined for all of
  * them where the columns cannot be trusted.
  *
- * `paths` is what usingPathsOnLine read from the line's code and is the count
- * of record; the masked run only supplies positions. The two are matched by
- * path sequence: masking preserves every raw position and blanks only trivia,
- * so when the sequences agree the k-th masked span is the k-th recorded
- * statement. They disagree only where a comment spliced or glued a token, or
- * split a path - and then no index can be trusted, so no entry gets columns
- * and the diagnostic span test falls back to whole lines rather than measuring
- * against the wrong statement.
+ * `paths` is what usingPathsOnLine read from the line's code and stays the
+ * count of record; the walk over `masked` only supplies positions, and never
+ * adds an entry of its own. The two are matched by path sequence, which is
+ * evidence rather than proof: one comment splicing or gluing a token changes
+ * the count or a path and is caught here, but a splice and a glue cancelling
+ * in count with equal paths passes and hands an entry its neighbour's span.
+ * What bounds that: a span is always a subset of its line, so a wrong one
+ * grants nothing the whole-line fallback would not have granted - it can only
+ * refuse an override, the direction placement already prefers
+ * (ImportDocumentEditor.couldResolveAgainst).
  */
-function columnsForLinePaths(formatter: ImportFormatter, paths: string[], masked: string): ({ start: number; end: number } | undefined)[] {
-    const spans = usingSpansOnMaskedLine(formatter, masked);
+function columnsForLinePaths(formatter: ImportFormatter, paths: string[], masked: string): (ColumnSpan | undefined)[] {
+    const spans = usingStatementsOnLine(formatter, masked);
     if (spans.length !== paths.length || spans.some((span, index) => span.path !== paths[index])) {
         return paths.map(() => undefined);
     }

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -67,6 +67,20 @@ export interface ScannedImport {
      * otherwise discard it, deleting text the author wrote.
      */
     trailingComment: string;
+    /**
+     * The raw column span `[start, end)` of the statement's own text, recorded
+     * where the statement shares a single line with code it did not write - the
+     * one shape a line-granular test cannot decide, since a diagnostic on the
+     * line may be about the code beside the statement rather than the statement
+     * itself (ImportDocumentEditor.couldResolveAgainst). Present only with
+     * `startLine === endLine`.
+     *
+     * Absent means no column knowledge, not that none is needed: a statement
+     * owning its whole span, a multi-line span, and a line whose comment
+     * structure defeats the column measurement all leave it unset, and evidence
+     * anywhere on the span then counts.
+     */
+    columns?: { start: number; end: number };
 }
 
 /**
@@ -133,6 +147,14 @@ export interface LineClassification {
      * as imported; see LexedLine.codeOutsideLiterals.
      */
     codeOutsideLiterals: string;
+    /**
+     * The whole line with comments and literal contents replaced by spaces,
+     * length-preserving, so an offset into it is a raw column. The only string
+     * here that can answer where on its line a statement sits; both code
+     * strings drop comments without replacement and so disagree with the raw
+     * line about every offset past one. See LexedLine.masked.
+     */
+    masked: string;
 }
 
 /**
@@ -177,6 +199,7 @@ export function classifyLines(lines: string[]): LineClassification[] {
             continuesCommentAbove: insideBlockComment || scan.insideIndentedComment,
             codeWithoutComments: scan.codeWithoutComments,
             codeOutsideLiterals: scan.codeOutsideLiterals,
+            masked: scan.masked,
         };
 
         state.depth = scan.depth;
@@ -650,7 +673,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // than widened to admit them. Everything below it may then keep
             // testing the raw line, as the `using:` branch does - see the note
             // there on why the two inputs have to agree.
-            for (const linePath of usingPathsOnLine(formatter, statements)) {
+            const headlessPaths = usingPathsOnLine(formatter, statements);
+            const headlessColumns = columnsForLinePaths(formatter, headlessPaths, classifications[i].masked);
+            headlessPaths.forEach((linePath, statementIndex) => {
                 imports.push({
                     path: linePath,
                     startLine: i,
@@ -658,8 +683,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     anchorsCommentBelow: anchorsCommentBelow(i, i),
                     rebuildLosesText: true,
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                    ...(headlessColumns[statementIndex] ? { columns: headlessColumns[statementIndex] } : {}),
                 });
-            }
+            });
 
             // The pair such a line opens, `X := 1; using:` over an indented
             // path. The loop above records nothing for it - a `using:` writes
@@ -812,7 +838,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // Counted with usingPathsOnLine because this branch holds first
             // refusal over the one below, so a line ending in `using:` is
             // counted here or nowhere.
-            for (const precedingPath of usingPathsOnLine(formatter, statements)) {
+            const precedingPaths = usingPathsOnLine(formatter, statements);
+            const precedingColumns = columnsForLinePaths(formatter, precedingPaths, classifications[i].masked);
+            precedingPaths.forEach((precedingPath, statementIndex) => {
                 imports.push({
                     path: precedingPath,
                     startLine: i,
@@ -824,8 +852,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     // Nothing re-emits a pinned entry, and the code has its
                     // comments already removed so it could only answer "none".
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                    ...(precedingColumns[statementIndex] ? { columns: precedingColumns[statementIndex] } : {}),
                 });
-            }
+            });
 
             // A complete `using` at the head of the line is what carries it
             // past the gate above, so the trivia that gate refuses a
@@ -876,7 +905,8 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // needs the count exact in both directions.
         const pathsOnLine = usingPathsOnLine(formatter, statements);
         if (pathsOnLine.length > 1) {
-            for (const linePath of pathsOnLine) {
+            const sharedColumns = columnsForLinePaths(formatter, pathsOnLine, classifications[i].masked);
+            pathsOnLine.forEach((linePath, statementIndex) => {
                 imports.push({
                     path: linePath,
                     startLine: i,
@@ -886,8 +916,9 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     // The same comment for each entry, since they share a line.
                     // Nothing re-emits it - that is what being pinned means.
                     trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                    ...(sharedColumns[statementIndex] ? { columns: sharedColumns[statementIndex] } : {}),
                 });
-            }
+            });
             i += 1;
             continue;
         }
@@ -907,13 +938,21 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         // means being right about which ones mean nothing.
         const path = formatter.extractPathFromImport(trimmed);
         if (path) {
+            // Columns only where the leftover text makes the line shared:
+            // a statement owning its line needs no narrower span, and leaving
+            // the field absent there keeps "present" meaning "shared". The
+            // masked run must agree it is the line's one statement, through
+            // the same reconciliation every shared site uses.
+            const losesText = formatter.textAfterImport(codeWithoutComments) !== "";
+            const headColumns = losesText ? columnsForLinePaths(formatter, [path], classifications[i].masked)[0] : undefined;
             imports.push({
                 path,
                 startLine: i,
                 endLine: i,
                 anchorsCommentBelow: anchorsCommentBelow(i, i),
-                rebuildLosesText: formatter.textAfterImport(codeWithoutComments) !== "",
+                rebuildLosesText: losesText,
                 trailingComment: ImportFormatter.extractTrailingComment(trimmed),
+                ...(headColumns ? { columns: headColumns } : {}),
             });
         }
         i += 1;
@@ -990,6 +1029,53 @@ function usingPathsOnLine(formatter: ImportFormatter, code: string): string[] {
         }
     }
     return paths;
+}
+
+/**
+ * Every `using` statement on a masked line, with the raw column span each
+ * occupies: usingPathsOnLine's loop run over `masked` instead of the line's
+ * code, so the offsets address the original text (LineClassification.masked).
+ *
+ * Not a replacement for that function, and never the count of record: masking
+ * blanks a comment in place where the code strings remove it, so the two can
+ * disagree wherever a comment splices or glues a token - `us<##>ing` writes a
+ * statement only the rejoined code sees, `X<##>using` one only the masked text
+ * sees. columnsForLinePaths reconciles the two answers and stands down when
+ * they differ.
+ */
+function usingSpansOnMaskedLine(formatter: ImportFormatter, masked: string): { path: string; start: number; end: number }[] {
+    const spans: { path: string; start: number; end: number }[] = [];
+    for (let at = masked.indexOf("using"); at !== -1; at = masked.indexOf("using", at + 1)) {
+        if (at > 0 && /[A-Za-z0-9_]/.test(masked[at - 1])) {
+            continue;
+        }
+        const match = formatter.matchImportAt(masked, at);
+        if (match) {
+            spans.push({ path: match.path, start: at, end: match.end });
+        }
+    }
+    return spans;
+}
+
+/**
+ * The column span for each of a line's recorded paths, or undefined for all of
+ * them where the columns cannot be trusted.
+ *
+ * `paths` is what usingPathsOnLine read from the line's code and is the count
+ * of record; the masked run only supplies positions. The two are matched by
+ * path sequence: masking preserves every raw position and blanks only trivia,
+ * so when the sequences agree the k-th masked span is the k-th recorded
+ * statement. They disagree only where a comment spliced or glued a token, or
+ * split a path - and then no index can be trusted, so no entry gets columns
+ * and the diagnostic span test falls back to whole lines rather than measuring
+ * against the wrong statement.
+ */
+function columnsForLinePaths(formatter: ImportFormatter, paths: string[], masked: string): ({ start: number; end: number } | undefined)[] {
+    const spans = usingSpansOnMaskedLine(formatter, masked);
+    if (spans.length !== paths.length || spans.some((span, index) => span.path !== paths[index])) {
+        return paths.map(() => undefined);
+    }
+    return spans.map((span) => ({ start: span.start, end: span.end }));
 }
 
 /**

--- a/src/imports/ImportSuggestionExtractor.ts
+++ b/src/imports/ImportSuggestionExtractor.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { logger, settingsFor } from "../utils";
-import { ImportSuggestion, ImportSuggestionSource, ImportConfidence, MissingImports } from "../types";
+import { DiagnosticPosition, ImportSuggestion, ImportSuggestionSource, ImportConfidence, MissingImports } from "../types";
 import { DigestParser, AssetsDigestParser } from "../services";
 import { ImportFormatter } from "./ImportFormatter";
 
@@ -489,13 +489,14 @@ export class ImportSuggestionExtractor {
 
         // One collection, so the paths and their evidence cannot disagree about
         // which diagnostic named which path: the keys are the deduplicated
-        // paths, in the order the diagnostics named them. Lines are concatenated
-        // where two diagnostics name one path, because a second diagnostic
-        // asking for the same import is further evidence, not a replacement for
-        // the first.
-        const diagnosticLinesByPath = new Map<string, number[]>();
+        // paths, in the order the diagnostics named them. Positions are
+        // concatenated where two diagnostics name one path, because a second
+        // diagnostic asking for the same import is further evidence, not a
+        // replacement for the first.
+        const diagnosticPositionsByPath = new Map<string, DiagnosticPosition[]>();
         const record = (path: string, diagnostic: vscode.Diagnostic): void => {
-            diagnosticLinesByPath.set(path, [...(diagnosticLinesByPath.get(path) ?? []), diagnostic.range.start.line]);
+            const start = { line: diagnostic.range.start.line, character: diagnostic.range.start.character };
+            diagnosticPositionsByPath.set(path, [...(diagnosticPositionsByPath.get(path) ?? []), start]);
         };
 
         for (const diagnostic of diagnostics) {
@@ -530,8 +531,8 @@ export class ImportSuggestionExtractor {
             }
         }
 
-        const paths = Array.from(diagnosticLinesByPath.keys());
+        const paths = Array.from(diagnosticPositionsByPath.keys());
         logger.debug("ImportSuggestionExtractor", `Extracted ${paths.length} unique import paths from diagnostics`);
-        return { paths, diagnosticLinesByPath };
+        return { paths, diagnosticPositionsByPath };
     }
 }

--- a/src/imports/__tests__/ImportCodeActionProvider.test.ts
+++ b/src/imports/__tests__/ImportCodeActionProvider.test.ts
@@ -77,7 +77,7 @@ describe("ImportCodeActionProvider quick fix titles", () => {
                 { uri: { toString: () => `${folder}device.verse` } } as unknown as vscode.TextDocument,
                 {} as unknown as vscode.Range,
                 {
-                    diagnostics: [{ message: "Unknown identifier `player`. Did you forget to specify using { /Verse.org/Simulation }", range: { start: { line: 7 } } }],
+                    diagnostics: [{ message: "Unknown identifier `player`. Did you forget to specify using { /Verse.org/Simulation }", range: { start: { line: 7, character: 3 } } }],
                 } as unknown as vscode.CodeActionContext,
                 {} as unknown as vscode.CancellationToken,
             );
@@ -87,6 +87,10 @@ describe("ImportCodeActionProvider quick fix titles", () => {
             // addSingleImport is what gets written, so the title describes the
             // insertion only while these two agree.
             expect((actions ?? []).map((action) => action.command?.arguments?.[1])).toEqual(["using. /Verse.org/Simulation"]);
+            // The diagnostic's start position rides along as the placement
+            // evidence, so dropping either half silently loosens the span
+            // test back to whole lines.
+            expect((actions ?? []).map((action) => action.command?.arguments?.[2])).toEqual([{ line: 7, character: 3 }]);
         } finally {
             getConfiguration.mockReset();
             if (original) {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -588,7 +588,7 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         it("writes an added bare provider above a pinned dotted import the diagnostic reports on", () => {
             const input = ["using { Economy.Shop } <#> note", "    body", "code()"].join("\n");
 
-            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [0]]]))).toBe(
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 0, character: 0 }]]]))).toBe(
                 ["using { Features }", "", "using { Economy.Shop } <#> note", "    body", "code()"].join("\n"),
             );
         });
@@ -600,8 +600,31 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         it("leaves an added bare consumer below a pinned dotted import when the diagnostic points elsewhere", () => {
             const input = ["using { Economy.Shop } <#> note", "    body", "code()"].join("\n");
 
-            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [2]]]))).toBe(
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 2, character: 0 }]]]))).toBe(
                 ["using { Economy.Shop } <#> note", "    body", "using { Features }", "code()"].join("\n"),
+            );
+        });
+
+        // The diagnostic is on the pinned line but at column 24, inside
+        // `MyVal := 5` - the compiler reporting on the definition sharing the
+        // line, not on the clause. Read line-wide, that evidence hoisted the
+        // provider above the import that may bring its first segment into
+        // scope, and a compiling file stopped compiling.
+        it("leaves an added bare consumer below a pinned import when the diagnostic is about the statement beside it", () => {
+            const input = ["using { Economy.Shop }; MyVal := 5", "code()"].join("\n");
+
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 0, character: 24 }]]]))).toBe(
+                ["using { Economy.Shop }; MyVal := 5", "using { Features }", "code()"].join("\n"),
+            );
+        });
+
+        // The same line with the diagnostic inside the clause itself - the
+        // narrowing must not cost the override its reach on a shared line.
+        it("still writes the provider above a shared-line consumer the diagnostic reports inside", () => {
+            const input = ["using { Economy.Shop }; MyVal := 5", "code()"].join("\n");
+
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 0, character: 8 }]]]))).toBe(
+                ["using { Features }", "", "using { Economy.Shop }; MyVal := 5", "code()"].join("\n"),
             );
         });
 
@@ -1008,14 +1031,17 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
     const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
 
     /**
-     * The diagnostic-line argument addImportsToDocument takes, for one statement
-     * the compiler reported on one line.
+     * The diagnostic-position argument addImportsToDocument takes, for one
+     * statement the compiler reported at one position.
      *
      * A pinned import is read as the consumer of a new import only where a
      * diagnostic lands inside its own statement, so a call that omits this is
      * exercising the no-evidence path and expects the written order to hold.
+     *
+     * Character 0 is the head of the line: inside a clause that heads its
+     * line, outside one written after a `;`.
      */
-    const reportedOn = (statement: string, line: number): ReadonlyMap<string, readonly number[]> => new Map([[statement, [line]]]);
+    const reportedOn = (statement: string, line: number, character = 0): ReadonlyMap<string, readonly { line: number; character: number }[]> => new Map([[statement, [{ line, character }]]]);
 
     beforeEach(() => {
         const outputChannel = vscode.window.createOutputChannel("test");
@@ -2265,6 +2291,101 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
         });
 
+        // Regression for the diagnostic landing on the pinned line but inside
+        // the statement beside the clause. The pinned import's own text ends at
+        // column 22, and column 24 is `MyVal := 5` - the compiler reporting on
+        // the definition, not on the import. Read line-wide, that evidence took
+        // the override and the provider was written above the import that may
+        // bring its first segment into scope, and a compiling file stopped
+        // compiling.
+        it("leaves a new import below a pinned consumer when the diagnostic is about the statement beside it", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Economy.Shop }; MyVal := 5", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 24));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(1);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+        });
+
+        // The same line, the diagnostic now inside the clause itself - column 8
+        // is the `E` of Economy. The narrowing must not cost the override its
+        // reach: a shared line whose own clause failed to resolve still forces
+        // the provider above it.
+        it("still writes the provider above a shared-line consumer the diagnostic reports inside", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["using { Economy.Shop }; MyVal := 5", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 8));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // A clause written after a definition starts at column 8, so the head
+        // of its line is outside it. Both directions on one fixture: evidence
+        // inside the clause takes the override, evidence on the definition at
+        // the head of the line does not.
+        it("reads the columns of a clause written after a definition", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["X := 1; using { Economy.Shop }", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 16));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        it("takes no override from a diagnostic on the definition preceding a clause", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["X := 1; using { Economy.Shop }", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 0));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(1);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+        });
+
         // The span is two lines and the compiler reports an unresolved path on
         // the path line, so the bound is the pinned import's end and not its
         // start. Narrowed to the start, this file takes no ceiling and the
@@ -2709,7 +2830,7 @@ describe("ImportDocumentEditor.organizeImports carries the diagnostic evidence",
     it("writes the provider above the pinned consumer the diagnostic reports on", async () => {
         const input = ["using { Economy.Shop } <#> note", "    body", "code()"].join("\n");
 
-        const success = await editor.organizeImports(fakeDocument(input), ["Features"], new Map([["Features", [0]]]));
+        const success = await editor.organizeImports(fakeDocument(input), ["Features"], new Map([["Features", [{ line: 0, character: 0 }]]]));
 
         expect(success).toBe(true);
         expect(appliedOperations(0)[0].text).toBe(["using { Features }", "", "using { Economy.Shop } <#> note", "    body", "code()"].join("\n"));
@@ -2718,7 +2839,7 @@ describe("ImportDocumentEditor.organizeImports carries the diagnostic evidence",
     it("leaves the written order alone when the evidence names a line elsewhere", async () => {
         const input = ["using { Economy.Shop } <#> note", "    body", "code()"].join("\n");
 
-        const success = await editor.organizeImports(fakeDocument(input), ["Features"], new Map([["Features", [2]]]));
+        const success = await editor.organizeImports(fakeDocument(input), ["Features"], new Map([["Features", [{ line: 2, character: 0 }]]]));
 
         expect(success).toBe(true);
         expect(appliedOperations(0)[0].text).toBe(["using { Economy.Shop } <#> note", "    body", "using { Features }", "code()"].join("\n"));

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -376,7 +376,7 @@ describe("scanModuleImports", () => {
     it("records an import written after the closing brace of a braced span", () => {
         expect(scanModuleImports(["using{", "    /A", "}; using { /B }", "code()"])).toEqual([
             { path: "/A", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
-            { path: "/B", startLine: 2, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/B", startLine: 2, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 3, end: 15 } },
         ]);
     });
 
@@ -417,7 +417,7 @@ describe("scanModuleImports", () => {
     // making that import.
     it("records a bare dotted import that shares its line with a definition, pinned", () => {
         expect(scanModuleImports(["using. Features; MyVal := 5", "", "code()"])).toEqual([
-            { path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 15 } },
         ]);
     });
 
@@ -434,7 +434,7 @@ describe("scanModuleImports", () => {
     // Economy.Shop stranded in the body as a bare indented expression.
     it("consumes a using: pair opened after a semicolon, pinning both paths", () => {
         expect(scanModuleImports(["using { /X }; using:", "    Economy.Shop", "", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
     });
@@ -445,7 +445,7 @@ describe("scanModuleImports", () => {
     // bare expression, imported by nothing.
     it("consumes a using: pair opened after a bare dotted import, pinning both paths", () => {
         expect(scanModuleImports(["using. Features; using:", "    Economy.Shop", "", "code()"])).toEqual([
-            { path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 15 } },
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
     });
@@ -502,7 +502,7 @@ describe("scanModuleImports", () => {
     // path before the `;`.
     it("consumes a pair opened after a semicolon when a comment trails the opener", () => {
         expect(scanModuleImports(["using { /X }; using: # note", "    Economy.Shop", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "# note" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "# note", columns: { start: 0, end: 12 } },
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
     });
@@ -521,9 +521,11 @@ describe("scanModuleImports", () => {
     // single-statement branch - which would rebuild it and delete the
     // `; using:`.
     it("pins a pair opened after a semicolon whose using: opens no indented path", () => {
-        expect(scanModuleImports(["using { /X }; using:", "code()"])).toEqual([{ path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" }]);
+        expect(scanModuleImports(["using { /X }; using:", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
+        ]);
         expect(scanModuleImports(["using { /X }; using:", "    # just a note", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
         ]);
     });
 
@@ -538,10 +540,10 @@ describe("scanModuleImports", () => {
     // gate and into this branch instead.
     it("does not count a path the pair opener comments out", () => {
         expect(scanModuleImports(["using { /A }; using: <#>", "    /Verse.org/Random", "code()"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<#>" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<#>", columns: { start: 0, end: 12 } },
         ]);
         expect(scanModuleImports(["using { /A }; using: <# note", "    /Verse.org/Random", "code()"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<# note" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<# note", columns: { start: 0, end: 12 } },
         ]);
     });
 
@@ -554,7 +556,7 @@ describe("scanModuleImports", () => {
     // other two strand nothing by declining, and do.
     it("keeps a content-declined path a pair opened after a using provides", () => {
         expect(scanModuleImports(["using { /A }; using:", "    Foo'Loc'", "code()"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
             { path: "Foo'Loc'", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
         expect(scanModuleImports(["using:", "    Foo'Loc'", "code()"])).toEqual([]);
@@ -568,8 +570,8 @@ describe("scanModuleImports", () => {
     // path the file already imports.
     it("records every statement written before the pair a line opens", () => {
         expect(scanModuleImports(["using { /X }; using { /Y }; using:", "    Economy.Shop", "", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
-            { path: "/Y", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
+            { path: "/Y", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 14, end: 26 } },
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
     });
@@ -594,7 +596,7 @@ describe("scanModuleImports", () => {
 
     it("records every statement written before a pair opened after a definition", () => {
         expect(scanModuleImports(["X := 1; using { /A }; using:", "    Economy.Shop", "code()"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 8, end: 20 } },
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
     });
@@ -679,20 +681,20 @@ describe("scanModuleImports", () => {
     // affected.
     it("records a using written after a definition on its line, pinned", () => {
         expect(scanModuleImports(["X := 1; using { /Verse.org/Random }", "code()"])).toEqual([
-            { path: "/Verse.org/Random", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/Verse.org/Random", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 8, end: 35 } },
         ]);
     });
 
     it("records a dotted using written after a definition on its line", () => {
         expect(scanModuleImports(["X := 1; using. /Verse.org/Random", "code()"])).toEqual([
-            { path: "/Verse.org/Random", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/Verse.org/Random", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 8, end: 32 } },
         ]);
     });
 
     it("records every using written after a definition, in written order", () => {
         expect(scanModuleImports(["X := 1; using { /X }; using { Economy.Shop }", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
-            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 8, end: 20 } },
+            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 22, end: 44 } },
         ]);
     });
 
@@ -729,8 +731,38 @@ describe("scanModuleImports", () => {
     // the literal beside it does not.
     it("records only the statement a line writes beside a literal naming a path", () => {
         expect(scanModuleImports(['using { /A }; Hint := "using { /B }"', "code()"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
         ]);
+    });
+
+    // Columns are measured on the masked line, where a comment is blanked in
+    // place, so the second statement's span starts where the raw text writes
+    // it - an offset into the comment-stripped code would land 7 short here
+    // and hand the diagnostic span test the wrong statement.
+    it("measures columns on the raw line where a comment sits between two statements", () => {
+        expect(scanModuleImports(["using { /X }<# n #>; using { Economy.Shop }", "", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "<# n #>; using { Economy.Shop }", columns: { start: 0, end: 12 } },
+            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "<# n #>; using { Economy.Shop }", columns: { start: 21, end: 43 } },
+        ]);
+    });
+
+    // A comment splicing the keyword apart writes a statement only the
+    // rejoined code sees; the masked line has no `using` token there, so the
+    // two runs disagree and no column can be trusted. The path is still
+    // recorded - dropping it is the error the rejoin exists to prevent - and
+    // the entry falls back to line-granular evidence.
+    it("records a comment-spliced using without columns", () => {
+        expect(scanModuleImports(["us<##>ing { /A }; X := 1", "", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "<##>ing { /A }; X := 1" },
+        ]);
+    });
+
+    // The mirror disagreement: removing the comment glues the keyword to the
+    // identifier before it, so only the masked line sees a `using` token. The
+    // masked run supplies positions for the recorded paths and never adds a
+    // statement of its own.
+    it("does not let the masked run add a using the code does not write", () => {
+        expect(scanModuleImports(["X<##>using { /A }", "", "code()"])).toEqual([]);
     });
 
     // The masking must not reach a `'`. The lexer opens a char literal on one,
@@ -757,8 +789,8 @@ describe("scanModuleImports", () => {
     // one path fewer than the file had, with nothing left behind to say so.
     it("records both statements a line carrying two writes, pinning both", () => {
         expect(scanModuleImports(["using { /X }; using { Economy.Shop }", "", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
-            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
+            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 14, end: 36 } },
         ]);
     });
 
@@ -800,8 +832,8 @@ describe("scanModuleImports", () => {
     // imported and a writer was free to add a second copy of it.
     it("pins a line whose dotted statement precedes another, under both real paths", () => {
         expect(scanModuleImports(["using. /X; using { Economy.Shop }", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
-            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 9 } },
+            { path: "Economy.Shop", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 11, end: 33 } },
         ]);
     });
 
@@ -811,7 +843,9 @@ describe("scanModuleImports", () => {
     // rebuilt the line from that path into `using { /X; MyVal := 5 }` - the
     // definition folded inside the braces, and the file no longer compiled.
     it("pins a line that writes a definition after its dotted import", () => {
-        expect(scanModuleImports(["using. /X; MyVal := 5", "", "code()"])).toEqual([{ path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" }]);
+        expect(scanModuleImports(["using. /X; MyVal := 5", "", "code()"])).toEqual([
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 9 } },
+        ]);
     });
 
     it("offers no rewritable import for a line that writes a definition after its dotted import", () => {
@@ -856,7 +890,7 @@ describe("scanModuleImports", () => {
     // was gone, under an import block well-formed enough to say nothing.
     it("pins a line that writes a definition after its import", () => {
         expect(scanModuleImports(["using { /X }; MyVal := 5", "", "code()"])).toEqual([
-            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
         ]);
     });
 

--- a/src/imports/__tests__/ImportSuggestionExtractor.test.ts
+++ b/src/imports/__tests__/ImportSuggestionExtractor.test.ts
@@ -9,10 +9,11 @@ describe("ImportSuggestionExtractor", () => {
 
     /**
      * A diagnostic carries a range in the real API, and extraction reads its
-     * start line, so a fixture without one exercises nothing the extension ever
-     * sees.
+     * start position, so a fixture without one exercises nothing the extension
+     * ever sees.
      */
-    const diag = (message: string, line = 0): vscode.Diagnostic => ({ message, range: new vscode.Range(new vscode.Position(line, 0), new vscode.Position(line, 1)) }) as vscode.Diagnostic;
+    const diag = (message: string, line = 0, character = 0): vscode.Diagnostic =>
+        ({ message, range: new vscode.Range(new vscode.Position(line, character), new vscode.Position(line, character + 1)) }) as vscode.Diagnostic;
 
     beforeEach(() => {
         outputChannel = vscode.window.createOutputChannel("test");
@@ -357,24 +358,27 @@ describe("ImportSuggestionExtractor", () => {
 
         // Placement reads these to tell a pinned import the compiler is
         // reporting on from one that already resolves, so a path that arrives
-        // without its line is placed by the written order alone.
-        it("reports the line of every diagnostic that asked for a path", () => {
-            const { diagnosticLinesByPath } = extractor.extractImportsFromDiagnostics([
-                diag("Unknown identifier `button_device`. Did you forget to specify using { /Fortnite.com/Devices }", 12),
+        // without its position is placed by the written order alone.
+        it("reports the start position of every diagnostic that asked for a path", () => {
+            const { diagnosticPositionsByPath } = extractor.extractImportsFromDiagnostics([
+                diag("Unknown identifier `button_device`. Did you forget to specify using { /Fortnite.com/Devices }", 12, 5),
                 diag("Unknown identifier `creative_device`. Did you forget to specify using { /Fortnite.com/Devices }", 30),
-                diag("Unknown identifier `player`. Did you forget to specify using { /Verse.org/Simulation }", 7),
+                diag("Unknown identifier `player`. Did you forget to specify using { /Verse.org/Simulation }", 7, 21),
             ]);
 
-            expect(diagnosticLinesByPath.get("/Fortnite.com/Devices")).toEqual([12, 30]);
-            expect(diagnosticLinesByPath.get("/Verse.org/Simulation")).toEqual([7]);
+            expect(diagnosticPositionsByPath.get("/Fortnite.com/Devices")).toEqual([
+                { line: 12, character: 5 },
+                { line: 30, character: 0 },
+            ]);
+            expect(diagnosticPositionsByPath.get("/Verse.org/Simulation")).toEqual([{ line: 7, character: 21 }]);
         });
 
-        it("records no line for a message it declines to import from", () => {
-            const { diagnosticLinesByPath } = extractor.extractImportsFromDiagnostics([
+        it("records no position for a message it declines to import from", () => {
+            const { diagnosticPositionsByPath } = extractor.extractImportsFromDiagnostics([
                 diag("Unknown identifier `thing`. Did you forget to specify one of:\nusing { /GameA/Combat }\nusing { /GameB/Combat }", 4),
             ]);
 
-            expect(diagnosticLinesByPath.size).toBe(0);
+            expect(diagnosticPositionsByPath.size).toBe(0);
         });
     });
 });

--- a/src/types/moduleInfo.ts
+++ b/src/types/moduleInfo.ts
@@ -22,30 +22,40 @@ export interface ImportSuggestion {
 }
 
 /**
- * The 0-based lines of the diagnostics that asked for each import, keyed on the
- * import's trimmed path. A path with no entry is placed by the written order
- * alone, so a key carrying surrounding whitespace silently supplies no
+ * Where a diagnostic was reported: its range's 0-based start line and start
+ * character. Structurally a vscode.Position, kept as a bare shape so the pure
+ * placement logic stays free of the vscode runtime.
+ */
+export interface DiagnosticPosition {
+    readonly line: number;
+    readonly character: number;
+}
+
+/**
+ * The start positions of the diagnostics that asked for each import, keyed on
+ * the import's trimmed path. A path with no entry is placed by the written
+ * order alone, so a key carrying surrounding whitespace silently supplies no
  * evidence rather than failing.
  *
  * Placement reads these to tell a pinned import that failed to resolve from one
  * that merely looks as though it could
- * (ImportDocumentEditor.couldResolveAgainst). The line is a diagnostic's start
- * line, so every producer must record that same one or the span test compares
- * unlike things.
+ * (ImportDocumentEditor.couldResolveAgainst). The position is a diagnostic's
+ * range *start* - line and character both - so every producer must record that
+ * same one or the span test compares unlike things.
  */
-export type DiagnosticLinesByPath = ReadonlyMap<string, readonly number[]>;
+export type DiagnosticPositionsByPath = ReadonlyMap<string, readonly DiagnosticPosition[]>;
 
 /**
- * The same lines keyed on the whole import statement rather than on the path,
- * for a caller holding statements. Distinct from DiagnosticLinesByPath only in
- * its key, which the structural type cannot express: passing one where the
- * other belongs silently supplies no evidence at all.
+ * The same positions keyed on the whole import statement rather than on the
+ * path, for a caller holding statements. Distinct from DiagnosticPositionsByPath
+ * only in its key, which the structural type cannot express: passing one where
+ * the other belongs silently supplies no evidence at all.
  */
-export type DiagnosticLinesByStatement = ReadonlyMap<string, readonly number[]>;
+export type DiagnosticPositionsByStatement = ReadonlyMap<string, readonly DiagnosticPosition[]>;
 
 /** What a set of compiler diagnostics asks to be imported, and where each was reported. */
 export interface MissingImports {
     /** Deduplicated, in the order the diagnostics named them. */
     paths: string[];
-    diagnosticLinesByPath: DiagnosticLinesByPath;
+    diagnosticPositionsByPath: DiagnosticPositionsByPath;
 }


### PR DESCRIPTION
Closes #412

## What

`couldResolveAgainst` read its evidence by line, so a diagnostic about a statement sharing a `;`-joined line with a pinned `using` licensed the consumer override, and the new import was written above a provider the pinned import may genuinely need — a compiling file stopped compiling.

The scanner now records the raw column span of a statement that shares its single line with other code (`ScannedImport.columns`), measured on the length-preserving `masked` string and reconciled against the code-derived path sequence — any disagreement leaves the span absent, falling back to today's line test rather than measuring against the wrong statement. Diagnostic evidence carries the range's start position instead of the line alone (`DiagnosticPositionsByPath` / `DiagnosticPositionsByStatement`), recorded by all three producers. `couldResolveAgainst` requires the position to start inside the clause where a span is recorded.

Multi-line pinned spans (a trailing `using:` pair over its indented path) keep line-granular evidence — the same class of gap one shape along, documented at the predicate and left for a follow-up rather than half-closed here.

## Domain rules relied on

- `using { X }; Y := 1` on one line is legal Verse; `;` separates definitions as a newline does (maintainer live-compiler check, 2026-08-10).
- The missing-`using` / unknown-identifier glitch anchors to the identifier's own VstNode (`SemanticAnalyzer.cpp:12544`, `:12864`), so a diagnostic's start character lands inside the text it is about.
- Degradation is one-sided: a whole-line-range diagnostic reproduces today's behavior or refuses the override, and a refused override leaves a diagnostic unfixed where a wrong override breaks a compiling file — the asymmetry `hoistFloor` already encodes.

## Verification

`npm run compile` — exit 0.

`npm test`:

```
Test Suites: 57 passed, 57 total
Tests:       1649 passed, 1649 total
```

`npm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```

Regression tests are pinned at both entry points (`addImportsToDocument` and `organizeImports`/`buildOrganizedContent`); with the predicate reverted to the line test, the three defect-direction tests fail and the override-retained tests pass.
