### PR TITLE
fix(project): share one in-flight run across each loader's overlapping calls

### DIFF
--- a/changelog.d/377.fixed.md
+++ b/changelog.d/377.fixed.md
@@ -1,0 +1,1 @@
+**Project cache**: Overlapping loads of the project cache, the bundled API digests, the assets digest, and the project file now share one run, and a superseded rebuild can no longer overwrite a newer one's result and persist it.

--- a/src/project/ProjectPathHandler.ts
+++ b/src/project/ProjectPathHandler.ts
@@ -69,6 +69,13 @@ export class ProjectPathHandler {
      */
     private readonly projectFilesByScope = new Map<string, LocatedProjectFile>();
 
+    /**
+     * The running search per scope key, shared with every caller that overlaps
+     * it. Keyed like {@link projectFilesByScope}: only a search for the same
+     * scope repeats the same folder scan, so only that one is worth joining.
+     */
+    private readonly searchesInFlight = new Map<string, Promise<LocatedProjectFile | null>>();
+
     constructor(private outputChannel: vscode.OutputChannel) {}
 
     /**
@@ -76,7 +83,8 @@ export class ProjectPathHandler {
      * workspace when nothing names a folder.
      *
      * Only a success is cached, so in a workspace with no `.uefnproject` every
-     * call redoes the folder scan and the parent walk from scratch.
+     * call redoes the folder scan and the parent walk from scratch; calls that
+     * overlap one running search share its result instead of each searching.
      *
      * @param resource a file in the project being asked about. A resource
      * outside every workspace folder falls back to the whole-workspace search
@@ -109,12 +117,29 @@ export class ProjectPathHandler {
             return cached;
         }
 
-        const projectFile = await this.searchForProjectFile(scope);
-        if (projectFile) {
-            this.projectFilesByScope.set(key, projectFile);
+        const running = this.searchesInFlight.get(key);
+        if (running) {
+            return running;
         }
 
-        return projectFile;
+        const flight: Promise<LocatedProjectFile | null> = this.searchForProjectFile(scope)
+            .then((projectFile) => {
+                // The cache was cleared while searching - a .uefnproject
+                // change dropped this flight - so the parse predates the file
+                // on disk and must not be cached over the fresh search's.
+                if (projectFile && this.searchesInFlight.get(key) === flight) {
+                    this.projectFilesByScope.set(key, projectFile);
+                }
+                return projectFile;
+            })
+            .finally(() => {
+                if (this.searchesInFlight.get(key) === flight) {
+                    this.searchesInFlight.delete(key);
+                }
+            });
+        this.searchesInFlight.set(key, flight);
+
+        return flight;
     }
 
     /**
@@ -303,6 +328,10 @@ export class ProjectPathHandler {
      */
     clearCache(): void {
         this.projectFilesByScope.clear();
+        // Dropping the in-flight searches is what abandons their commits: a
+        // search still running parsed the file from before this clear, and its
+        // result must not be cached over the next, fresher search's.
+        this.searchesInFlight.clear();
         logger.debug("ProjectPathHandler", "Cleared project path cache");
     }
 

--- a/src/project/__tests__/ProjectPathHandler.singleFlight.test.ts
+++ b/src/project/__tests__/ProjectPathHandler.singleFlight.test.ts
@@ -1,0 +1,81 @@
+import * as fs from "fs";
+import * as vscode from "vscode";
+import { ProjectPathHandler } from "../ProjectPathHandler";
+
+/**
+ * Regression tests for issue #377: findAndParseProjectFile cached only a
+ * finished success, so overlapping calls for the same scope each redid the
+ * folder scan and the parent walk, and a search running across a `.uefnproject`
+ * change could cache the pre-change parse over the fresh one.
+ */
+describe("ProjectPathHandler.findAndParseProjectFile under concurrent invocation", () => {
+    const ROOT = "/workspace/game";
+    const PROJECT_PATH = `${ROOT}/Project.uefnproject`;
+
+    const PROJECT = {
+        title: "MyGame",
+        bindings: { projectVersePath: "/mygame@fortnite.com/mygame" },
+    };
+
+    /** Project files read, in order, so a cache hit can be told from a miss. */
+    let reads: string[];
+    let handler: ProjectPathHandler;
+
+    const forwardSlashed = (fsPath: string) => fsPath.replace(/\\/g, "/").replace(/\/+$/, "");
+
+    beforeEach(() => {
+        reads = [];
+
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = [{ uri: vscode.Uri.file(ROOT), name: "game", index: 0 }];
+
+        (vscode.workspace.findFiles as jest.Mock).mockImplementation(async (pattern: { base: { uri?: { fsPath: string }; fsPath?: string } }) => {
+            const base = pattern.base.uri ?? (pattern.base as { fsPath: string });
+            return forwardSlashed(base.fsPath) === ROOT ? [vscode.Uri.file(PROJECT_PATH)] : [];
+        });
+
+        jest.spyOn(fs, "readFileSync").mockImplementation(((target: string): string => {
+            reads.push(forwardSlashed(String(target)));
+            return JSON.stringify(PROJECT);
+        }) as unknown as typeof fs.readFileSync);
+
+        handler = new ProjectPathHandler(vscode.window.createOutputChannel("test"));
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        (vscode.workspace.findFiles as jest.Mock).mockReset().mockResolvedValue([]);
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = undefined;
+    });
+
+    it("shares one search among overlapping calls for the same scope", async () => {
+        const [first, second] = await Promise.all([handler.findAndParseProjectFile(), handler.findAndParseProjectFile()]);
+
+        expect(first?.title).toBe("MyGame");
+        expect(second?.title).toBe("MyGame");
+        expect(reads).toHaveLength(1);
+    });
+
+    it("does not cache a search that a clearCache overtook", async () => {
+        // Park the search on its folder listing while the cache is cleared
+        // underneath it - what the .uefnproject watcher does on a change.
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        (vscode.workspace.findFiles as jest.Mock).mockImplementationOnce(async () => {
+            await gate;
+            return [vscode.Uri.file(PROJECT_PATH)];
+        });
+
+        const pending = handler.findAndParseProjectFile();
+        handler.clearCache();
+        release();
+        await pending;
+
+        // The overtaken search's parse predates the change, so the next call
+        // must search again rather than answer from it.
+        reads = [];
+        await handler.findAndParseProjectFile();
+        expect(reads).toHaveLength(1);
+    });
+});

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -115,6 +115,13 @@ export class AssetsDigestParser {
      * arrives while a parse is in flight passes it and would re-read the file.
      */
     private readonly parseOnce = singleFlight(() => this.doParse());
+    /**
+     * Bumped by {@link clearCache} and captured at each parse's start, and
+     * re-checked before the parse commits, so a parse that a clear overtook -
+     * the digest watcher refreshing while one is in flight - abandons its
+     * pre-change names instead of committing them and stamping the TTL.
+     */
+    private parseGeneration: number = 0;
 
     /**
      * Refreshes the cached names, doing nothing if they were parsed within
@@ -134,6 +141,7 @@ export class AssetsDigestParser {
 
     private async doParse(): Promise<void> {
         const now = Date.now();
+        const generation = this.parseGeneration;
         const digestPath = await this.getAssetsDigestPath();
         if (!digestPath) {
             return;
@@ -142,6 +150,14 @@ export class AssetsDigestParser {
         try {
             logger.debug("AssetsDigestParser", `Parsing Assets.digest.verse: ${digestPath}`);
             const content = fs.readFileSync(digestPath, "utf8");
+
+            // The cache was cleared while locating the file; these names were
+            // resolved against the pre-clear project, and committing them
+            // would also stamp the TTL over the refresh that cleared it.
+            if (generation !== this.parseGeneration) {
+                logger.debug("AssetsDigestParser", "Cache cleared during parse, discarding the parsed names");
+                return;
+            }
 
             this.classNames.clear();
             for (const name of AssetsDigestParser.parseDigestContent(content)) {
@@ -247,6 +263,12 @@ export class AssetsDigestParser {
         this.classNames.clear();
         this.lastParsed = 0;
         this.cachedDigestPath = null;
+        // Invalidate any parse still in flight - its names predate this clear
+        // - and drop its memo so the next parse runs fresh instead of joining
+        // the overtaken one. refreshCache depends on this: it clears and then
+        // parses immediately, expecting a post-change read.
+        this.parseGeneration++;
+        this.parseOnce.reset();
         logger.debug("AssetsDigestParser", "Cache cleared");
     }
 

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { logger } from "../utils";
+import { singleFlight } from "../utils/singleFlight";
 import { DeclarationHead, matchDeclarationHead } from "../utils/verseDeclarationHead";
 import { lineIndentWidth, popClosedBlocks } from "../utils/verseText";
 import { ProjectPathHandler } from "../project";
@@ -109,9 +110,17 @@ export class AssetsDigestParser {
     }
 
     /**
+     * Overlapping refresh calls must share one run: the TTL check reads state
+     * from before {@link getAssetsDigestPath}'s awaits, so every call that
+     * arrives while a parse is in flight passes it and would re-read the file.
+     */
+    private readonly parseOnce = singleFlight(() => this.doParse());
+
+    /**
      * Refreshes the cached names, doing nothing if they were parsed within
      * CACHE_DURATION or if the digest cannot be located. A file that cannot be
-     * read leaves the previously cached names in place.
+     * read leaves the previously cached names in place. A call that overlaps a
+     * running refresh joins it rather than parsing again.
      */
     async parseAssetsDigest(): Promise<void> {
         const now = Date.now();
@@ -120,6 +129,11 @@ export class AssetsDigestParser {
             return;
         }
 
+        return this.parseOnce();
+    }
+
+    private async doParse(): Promise<void> {
+        const now = Date.now();
         const digestPath = await this.getAssetsDigestPath();
         if (!digestPath) {
             return;

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -147,17 +147,19 @@ export class AssetsDigestParser {
             return;
         }
 
+        // The cache was cleared while locating the file; the path was
+        // resolved against the pre-clear project, so committing its names
+        // would stamp the TTL over the refresh that cleared it, and the path
+        // itself was just memoized over the one the clear dropped.
+        if (generation !== this.parseGeneration) {
+            this.cachedDigestPath = null;
+            logger.debug("AssetsDigestParser", "Cache cleared during parse, discarding the parsed names");
+            return;
+        }
+
         try {
             logger.debug("AssetsDigestParser", `Parsing Assets.digest.verse: ${digestPath}`);
             const content = fs.readFileSync(digestPath, "utf8");
-
-            // The cache was cleared while locating the file; these names were
-            // resolved against the pre-clear project, and committing them
-            // would also stamp the TTL over the refresh that cleared it.
-            if (generation !== this.parseGeneration) {
-                logger.debug("AssetsDigestParser", "Cache cleared during parse, discarding the parsed names");
-                return;
-            }
 
             this.classNames.clear();
             for (const name of AssetsDigestParser.parseDigestContent(content)) {

--- a/src/services/AssetsDigestParser.ts
+++ b/src/services/AssetsDigestParser.ts
@@ -74,8 +74,13 @@ export class AssetsDigestParser {
      * `{LOCALAPPDATA}\UnrealEditorFortnite\Saved\VerseProject\{ProjectName}\`,
      * in a `{ProjectName}-Assets` subfolder on current UEFN and directly in the
      * project folder on older versions.
+     *
+     * The memo this writes is resolved against a project name read after an
+     * await, so it can belong to a project a clearCache has since dropped. A
+     * caller must revalidate with its own generation check and undo the memo
+     * on discard, as {@link doParse} does - which is why this stays private.
      */
-    async getAssetsDigestPath(): Promise<string | null> {
+    private async getAssetsDigestPath(): Promise<string | null> {
         if (this.cachedDigestPath && fs.existsSync(this.cachedDigestPath)) {
             return this.cachedDigestPath;
         }

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -59,7 +59,8 @@ export class PrecompiledDigestLoader {
      * {@link isLoaded} true may still be holding a partial index. Only a total
      * failure leaves it false. Calling again after success is a no-op, and a
      * call that overlaps a running load joins it; only a settled failure runs
-     * the load again.
+     * the load again. A load that {@link clear} overtakes resolves without
+     * loading: resolution alone is not success - {@link isLoaded} is.
      */
     async loadPrecompiledDigests(): Promise<void> {
         if (this.loaded) {

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -41,6 +41,13 @@ export class PrecompiledDigestLoader {
      * concurrent run would append every declaration twice.
      */
     private readonly loadOnce = singleFlight(() => this.doLoad());
+    /**
+     * Bumped by {@link clear} and captured at each load's start, and re-checked
+     * before the load latches, so a load that a clear overtook cannot set
+     * `loaded` over the emptied index - which would make every later call
+     * return early onto nothing.
+     */
+    private loadGeneration: number = 0;
 
     constructor(private extensionContext: vscode.ExtensionContext) {}
 
@@ -64,6 +71,7 @@ export class PrecompiledDigestLoader {
 
     private async doLoad(): Promise<void> {
         const startTime = Date.now();
+        const generation = this.loadGeneration;
         logger.debug("PrecompiledDigestLoader", "Loading pre-compiled digest files...");
 
         try {
@@ -78,6 +86,14 @@ export class PrecompiledDigestLoader {
             }
 
             const successCount = await this.loadFromDirectory(dataDir);
+
+            // The index was cleared while loading; what this run merged is
+            // gone, so latching `loaded` here would leave it true over an
+            // empty cache.
+            if (generation !== this.loadGeneration) {
+                logger.debug("PrecompiledDigestLoader", "Cache cleared during load, leaving it unloaded");
+                return;
+            }
 
             if (successCount > 0) {
                 this.loaded = true;
@@ -188,6 +204,11 @@ export class PrecompiledDigestLoader {
         this.moduleIndex.clear();
         this.loaded = false;
         this.loadError = null;
+        // Invalidate any load still in flight - what it merged was just
+        // emptied - and drop its memo so the next call starts a fresh load
+        // instead of joining the overtaken one.
+        this.loadGeneration++;
+        this.loadOnce.reset();
         logger.debug("PrecompiledDigestLoader", "Cache cleared");
     }
 }

--- a/src/services/PrecompiledDigestLoader.ts
+++ b/src/services/PrecompiledDigestLoader.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import { logger } from "../utils";
+import { singleFlight } from "../utils/singleFlight";
 import { DigestEntry } from "./DigestParser";
 import { appendDeclaration } from "./digestParsing";
 import { BUNDLED_DIGEST_NAMES, digestDataFile } from "./digestManifest";
@@ -34,6 +35,12 @@ export class PrecompiledDigestLoader {
     private moduleIndex: Map<string, string[]> = new Map();
     private loaded: boolean = false;
     private loadError: Error | null = null;
+    /**
+     * Overlapping load calls must share one run: each run merges into
+     * digestCache, and `loaded` only latches after the merge, so a second
+     * concurrent run would append every declaration twice.
+     */
+    private readonly loadOnce = singleFlight(() => this.doLoad());
 
     constructor(private extensionContext: vscode.ExtensionContext) {}
 
@@ -43,13 +50,19 @@ export class PrecompiledDigestLoader {
      *
      * One file is enough to count as loaded, so a caller that sees
      * {@link isLoaded} true may still be holding a partial index. Only a total
-     * failure leaves it false. Calling again after success is a no-op.
+     * failure leaves it false. Calling again after success is a no-op, and a
+     * call that overlaps a running load joins it; only a settled failure runs
+     * the load again.
      */
     async loadPrecompiledDigests(): Promise<void> {
         if (this.loaded) {
             return;
         }
 
+        return this.loadOnce();
+    }
+
+    private async doLoad(): Promise<void> {
         const startTime = Date.now();
         logger.debug("PrecompiledDigestLoader", "Loading pre-compiled digest files...");
 

--- a/src/services/ProjectPathCache.ts
+++ b/src/services/ProjectPathCache.ts
@@ -18,6 +18,15 @@ export class ProjectPathCache {
     private pendingUpdates: Set<string> = new Set();
     private updateDebounceTimer: NodeJS.Timeout | null = null;
     private initialized: boolean = false;
+    /** The running rebuild, shared with every caller that overlaps it. */
+    private rebuildInFlight: Promise<void> | null = null;
+    /**
+     * Bumped by {@link clear} and at each scan's start, and re-checked before a
+     * scan commits, so a scan that was superseded while awaiting - the
+     * .uefnproject watcher clears and rebuilds mid-flight - abandons its result
+     * instead of reverting the cache to it and persisting the regression.
+     */
+    private generation: number = 0;
 
     private static readonly CACHE_KEY = "projectPathTree";
     /** Storage key of the pre-2 metadata payload; cleared on save. */
@@ -143,9 +152,30 @@ export class ProjectPathCache {
      *
      * A scan that finds no project leaves the existing cache untouched rather
      * than emptying it, so a rebuild can never be worse than not rebuilding.
+     *
+     * A call that overlaps a running rebuild joins it rather than starting a
+     * second scan of the same project.
      */
     async rebuildCache(): Promise<void> {
+        if (this.rebuildInFlight) {
+            return this.rebuildInFlight;
+        }
+
+        const flight = this.doRebuild().finally(() => {
+            // Identity-checked so a clear() that nulled the field mid-flight,
+            // and any newer rebuild memoized since, are not clobbered.
+            if (this.rebuildInFlight === flight) {
+                this.rebuildInFlight = null;
+            }
+        });
+        this.rebuildInFlight = flight;
+
+        return flight;
+    }
+
+    private async doRebuild(): Promise<void> {
         const startTime = Date.now();
+        const generation = ++this.generation;
         logger.info("ProjectPathCache", "Rebuilding project path cache...");
 
         try {
@@ -159,6 +189,14 @@ export class ProjectPathCache {
             const data = await scanner.scanProject(workspaceFolders[0]);
 
             if (data) {
+                // The cache was cleared while scanning; this scan's snapshot
+                // predates whatever the clear made way for, so committing it
+                // would revert the cache and persist the reversion.
+                if (generation !== this.generation) {
+                    logger.debug("ProjectPathCache", "Cache changed during rebuild, discarding the scanned result");
+                    return;
+                }
+
                 this.data = data;
                 this.initialized = true;
                 this.rebuildIndexes();
@@ -313,6 +351,11 @@ export class ProjectPathCache {
         // Keeps `initialized` meaning "the cache holds data", so a later
         // initialize() rebuilds instead of returning early onto nothing.
         this.initialized = false;
+        // Invalidate any scan still in flight - its result predates this clear
+        // - and drop its memo so the next rebuildCache() starts a fresh scan
+        // instead of joining the superseded one.
+        this.generation++;
+        this.rebuildInFlight = null;
         this.indexes = buildProjectIndexes([]);
         this.pendingUpdates.clear();
 

--- a/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
+++ b/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
@@ -127,6 +127,42 @@ describe("AssetsDigestParser.parseAssetsDigest under concurrent invocation", () 
         expect(parser.getAssetClassNames().has("OldAsset")).toBe(false);
     });
 
+    it("recovers the current project's path after a settled refresh is overwritten by an overtaken parse", async () => {
+        // The stricter interleaving: the fresh parse settles and memoizes the
+        // current path BEFORE the overtaken run resumes and the discard
+        // branch drops the memo. The cost must be one extra search, never a
+        // wrong answer.
+        const OLD_DIGEST_PATH = path.join(LOCAL_APP_DATA, "UnrealEditorFortnite", "Saved", "VerseProject", "OldGame", "OldGame-Assets", "Assets.digest.verse");
+        jest.spyOn(fs, "existsSync").mockImplementation((target) => String(target) === DIGEST_PATH || String(target) === OLD_DIGEST_PATH);
+        readFileSync.mockImplementation(((target: fs.PathOrFileDescriptor) =>
+            String(target) === OLD_DIGEST_PATH ? "OldAsset<scoped {/mygame@fortnite.com/oldgame}> := class(mesh_component):\n" : DIGEST_SOURCE) as unknown as typeof fs.readFileSync);
+
+        let nowValue = 1_000_000;
+        jest.spyOn(Date, "now").mockImplementation(() => nowValue);
+
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        gateNextLookup = async () => {
+            await gate;
+            return "OldGame";
+        };
+
+        const overtaken = parser.parseAssetsDigest();
+        parser.clearCache();
+        await parser.parseAssetsDigest();
+        release();
+        await overtaken;
+
+        nowValue += 6 * 60 * 1000;
+        readFileSync.mockClear();
+        await parser.parseAssetsDigest();
+        expect(readFileSync).toHaveBeenCalledTimes(1);
+        expect(readFileSync).toHaveBeenCalledWith(DIGEST_PATH, "utf8");
+        expect(parser.getAssetClassNames().has("OldAsset")).toBe(false);
+    });
+
     it("still serves the TTL cache once a parse has settled", async () => {
         await parser.parseAssetsDigest();
         readFileSync.mockClear();

--- a/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
+++ b/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
@@ -18,16 +18,24 @@ describe("AssetsDigestParser.parseAssetsDigest under concurrent invocation", () 
     let parser: AssetsDigestParser;
     let readFileSync: jest.SpyInstance;
     let savedLocalAppData: string | undefined;
+    /** When set, answers the next project-name lookup instead of "MyGame". */
+    let gateNextLookup: (() => Promise<string | null>) | null;
 
     beforeEach(() => {
         savedLocalAppData = process.env.LOCALAPPDATA;
         process.env.LOCALAPPDATA = LOCAL_APP_DATA;
+        gateNextLookup = null;
 
         jest.spyOn(fs, "existsSync").mockImplementation((target) => String(target) === DIGEST_PATH);
         readFileSync = jest.spyOn(fs, "readFileSync").mockReturnValue(DIGEST_SOURCE);
 
         const handler = {
             async getProjectName(): Promise<string | null> {
+                const gated = gateNextLookup;
+                if (gated) {
+                    gateNextLookup = null;
+                    return gated();
+                }
                 return "MyGame";
             },
         } as unknown as ProjectPathHandler;
@@ -46,6 +54,38 @@ describe("AssetsDigestParser.parseAssetsDigest under concurrent invocation", () 
         await expect(first).resolves.toBeUndefined();
         await expect(second).resolves.toBeUndefined();
 
+        expect(readFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("discards an in-flight parse's names when clearCache overtakes it", async () => {
+        // Park the parse inside getProjectName - where getAssetsDigestPath
+        // awaits - while the digest watcher's refresh clears the cache.
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        gateNextLookup = async () => {
+            await gate;
+            return "MyGame";
+        };
+
+        const overtaken = parser.parseAssetsDigest();
+        parser.clearCache();
+
+        // What refreshCache does after its clear: parse immediately. It must
+        // run its own read rather than join the overtaken parse.
+        const refreshed = parser.parseAssetsDigest();
+        release();
+        await Promise.all([overtaken, refreshed]);
+
+        expect(readFileSync).toHaveBeenCalledTimes(2);
+        expect(parser.getAssetClassNames().has("TestSphere")).toBe(true);
+
+        // The overtaken parse must not have stamped the TTL over the clear:
+        // after another clear, a parse still re-reads instead of no-opping.
+        parser.clearCache();
+        readFileSync.mockClear();
+        await parser.parseAssetsDigest();
         expect(readFileSync).toHaveBeenCalledTimes(1);
     });
 

--- a/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
+++ b/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
@@ -78,7 +78,9 @@ describe("AssetsDigestParser.parseAssetsDigest under concurrent invocation", () 
         release();
         await Promise.all([overtaken, refreshed]);
 
-        expect(readFileSync).toHaveBeenCalledTimes(2);
+        // One read: the refresh's own. The overtaken parse discards before
+        // it reads, and the refresh must not have joined it.
+        expect(readFileSync).toHaveBeenCalledTimes(1);
         expect(parser.getAssetClassNames().has("TestSphere")).toBe(true);
 
         // The overtaken parse must not have stamped the TTL over the clear:
@@ -87,6 +89,42 @@ describe("AssetsDigestParser.parseAssetsDigest under concurrent invocation", () 
         readFileSync.mockClear();
         await parser.parseAssetsDigest();
         expect(readFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops the digest path an overtaken parse memoized for the pre-clear project", async () => {
+        // A project rename: the overtaken parse resolves the old name and, on
+        // resume, re-memoizes the old project's digest path over the one the
+        // clear dropped. Both digest files still exist on disk.
+        const OLD_DIGEST_PATH = path.join(LOCAL_APP_DATA, "UnrealEditorFortnite", "Saved", "VerseProject", "OldGame", "OldGame-Assets", "Assets.digest.verse");
+        jest.spyOn(fs, "existsSync").mockImplementation((target) => String(target) === DIGEST_PATH || String(target) === OLD_DIGEST_PATH);
+        readFileSync.mockImplementation(((target: fs.PathOrFileDescriptor) =>
+            String(target) === OLD_DIGEST_PATH ? "OldAsset<scoped {/mygame@fortnite.com/oldgame}> := class(mesh_component):\n" : DIGEST_SOURCE) as unknown as typeof fs.readFileSync);
+
+        let nowValue = 1_000_000;
+        jest.spyOn(Date, "now").mockImplementation(() => nowValue);
+
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        gateNextLookup = async () => {
+            await gate;
+            return "OldGame";
+        };
+
+        const overtaken = parser.parseAssetsDigest();
+        parser.clearCache();
+        const refreshed = parser.parseAssetsDigest();
+        release();
+        await Promise.all([overtaken, refreshed]);
+        expect(parser.getAssetClassNames().has("TestSphere")).toBe(true);
+
+        // Past the TTL, the next parse must locate the current project's
+        // digest rather than reuse the renamed-away project's memoized path.
+        nowValue += 6 * 60 * 1000;
+        await parser.parseAssetsDigest();
+        expect(parser.getAssetClassNames().has("TestSphere")).toBe(true);
+        expect(parser.getAssetClassNames().has("OldAsset")).toBe(false);
     });
 
     it("still serves the TTL cache once a parse has settled", async () => {

--- a/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
+++ b/src/services/__tests__/AssetsDigestParser.singleFlight.test.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { AssetsDigestParser } from "../AssetsDigestParser";
+import { ProjectPathHandler } from "../../project";
+
+/**
+ * Regression tests for issue #377: parseAssetsDigest read its TTL before the
+ * first await, so every call that arrived while a parse was in flight passed
+ * the check and re-read the digest file.
+ */
+describe("AssetsDigestParser.parseAssetsDigest under concurrent invocation", () => {
+    const LOCAL_APP_DATA = path.join("C:", "Users", "tester", "AppData", "Local");
+    const DIGEST_PATH = path.join(LOCAL_APP_DATA, "UnrealEditorFortnite", "Saved", "VerseProject", "MyGame", "MyGame-Assets", "Assets.digest.verse");
+
+    const DIGEST_SOURCE = "TestSphere<scoped {/mygame@fortnite.com/mygame}> := class(mesh_component):\n";
+
+    let parser: AssetsDigestParser;
+    let readFileSync: jest.SpyInstance;
+    let savedLocalAppData: string | undefined;
+
+    beforeEach(() => {
+        savedLocalAppData = process.env.LOCALAPPDATA;
+        process.env.LOCALAPPDATA = LOCAL_APP_DATA;
+
+        jest.spyOn(fs, "existsSync").mockImplementation((target) => String(target) === DIGEST_PATH);
+        readFileSync = jest.spyOn(fs, "readFileSync").mockReturnValue(DIGEST_SOURCE);
+
+        const handler = {
+            async getProjectName(): Promise<string | null> {
+                return "MyGame";
+            },
+        } as unknown as ProjectPathHandler;
+        parser = new AssetsDigestParser(vscode.window.createOutputChannel("test"), handler);
+    });
+
+    afterEach(() => {
+        process.env.LOCALAPPDATA = savedLocalAppData;
+        jest.restoreAllMocks();
+    });
+
+    it("reads the digest once for overlapping refresh calls", async () => {
+        const first = parser.parseAssetsDigest();
+        const second = parser.parseAssetsDigest();
+
+        await expect(first).resolves.toBeUndefined();
+        await expect(second).resolves.toBeUndefined();
+
+        expect(readFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("still serves the TTL cache once a parse has settled", async () => {
+        await parser.parseAssetsDigest();
+        readFileSync.mockClear();
+
+        await parser.parseAssetsDigest();
+
+        expect(readFileSync).not.toHaveBeenCalled();
+    });
+});

--- a/src/services/__tests__/PrecompiledDigestLoader.singleFlight.test.ts
+++ b/src/services/__tests__/PrecompiledDigestLoader.singleFlight.test.ts
@@ -52,6 +52,21 @@ describe("PrecompiledDigestLoader under concurrent invocation", () => {
         expect(loader.isLoaded()).toBe(true);
     });
 
+    it("does not latch `loaded` for a load that clear() overtook", async () => {
+        // The one await in a load sits between the merge and the latch, so
+        // start a load, clear while it is suspended there, and let it finish.
+        const overtaken = loader.loadPrecompiledDigests();
+        loader.clear();
+        await overtaken;
+
+        // Latching over the emptied index would make every later call return
+        // early onto nothing; instead the loader stays unloaded and reloads.
+        expect(loader.isLoaded()).toBe(false);
+        await loader.loadPrecompiledDigests();
+        expect(loader.isLoaded()).toBe(true);
+        expect(loader.getEntry("device")).toHaveLength(1);
+    });
+
     it("still short-circuits a call after the load has settled", async () => {
         await loader.loadPrecompiledDigests();
         readFileSync.mockClear();

--- a/src/services/__tests__/PrecompiledDigestLoader.singleFlight.test.ts
+++ b/src/services/__tests__/PrecompiledDigestLoader.singleFlight.test.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { PrecompiledDigestLoader } from "../PrecompiledDigestLoader";
+import { BUNDLED_DIGEST_NAMES, digestDataFile } from "../digestManifest";
+
+/**
+ * Regression tests for issue #377: loadPrecompiledDigests latched `loaded`
+ * only after the merge, so overlapping calls each read and merged every digest
+ * file into the shared cache.
+ */
+describe("PrecompiledDigestLoader under concurrent invocation", () => {
+    const EXTENSION_PATH = path.join("C:", "extensions", "vukefn.verse-auto-imports");
+    const DATA_DIR = path.join(EXTENSION_PATH, "src", "data");
+
+    const payload = JSON.stringify({
+        version: "2",
+        generatedAt: "2026-01-01",
+        sourceFile: "test",
+        sourceBuild: "test",
+        entries: {
+            device: [{ identifier: "device", modulePath: "/Fortnite.com/Devices", type: "class", isPublic: true }],
+        },
+        moduleIndex: { "/Fortnite.com/Devices": ["device"] },
+    });
+
+    let loader: PrecompiledDigestLoader;
+    let readFileSync: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.spyOn(fs, "existsSync").mockImplementation((target) => {
+            const asString = String(target);
+            return asString === DATA_DIR || BUNDLED_DIGEST_NAMES.some((name) => asString === path.join(DATA_DIR, digestDataFile(name)));
+        });
+        readFileSync = jest.spyOn(fs, "readFileSync").mockReturnValue(payload);
+
+        loader = new PrecompiledDigestLoader({ extensionPath: EXTENSION_PATH } as unknown as vscode.ExtensionContext);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("reads each digest file once for overlapping load calls", async () => {
+        const first = loader.loadPrecompiledDigests();
+        const second = loader.loadPrecompiledDigests();
+
+        await expect(first).resolves.toBeUndefined();
+        await expect(second).resolves.toBeUndefined();
+
+        expect(readFileSync).toHaveBeenCalledTimes(BUNDLED_DIGEST_NAMES.length);
+        expect(loader.isLoaded()).toBe(true);
+    });
+
+    it("still short-circuits a call after the load has settled", async () => {
+        await loader.loadPrecompiledDigests();
+        readFileSync.mockClear();
+
+        await loader.loadPrecompiledDigests();
+
+        expect(readFileSync).not.toHaveBeenCalled();
+    });
+});

--- a/src/services/__tests__/ProjectPathCache.singleFlight.test.ts
+++ b/src/services/__tests__/ProjectPathCache.singleFlight.test.ts
@@ -1,0 +1,138 @@
+import * as vscode from "vscode";
+import { ProjectPathCache } from "../ProjectPathCache";
+
+/**
+ * Regression tests for issue #377: rebuildCache had no in-flight guard and
+ * committed in completion order.
+ *
+ * Two overlapping rebuild requests each ran a full scan, and a rebuild that
+ * resolved after a newer one - a slow initial scan racing the user's rebuild
+ * command, or the .uefnproject watcher's clear-and-rebuild - overwrote the
+ * newer result in memory and persisted the regression to workspace storage,
+ * where the next session restored it.
+ */
+describe("ProjectPathCache.rebuildCache under concurrent invocation", () => {
+    const openTextDocument = vscode.workspace.openTextDocument as unknown as jest.Mock;
+    const findFiles = vscode.workspace.findFiles as unknown as jest.Mock;
+
+    /** A module declaration, so a scanned file yields a node to commit. */
+    const VERSE_SOURCE = "device_module := module:\n";
+
+    /** Minimal in-memory stand-in for vscode.Memento (workspaceState). */
+    class FakeMemento {
+        private readonly store: Map<string, unknown> = new Map();
+
+        get<T>(key: string): T | undefined {
+            return this.store.get(key) as T | undefined;
+        }
+
+        async update(key: string, value: unknown): Promise<void> {
+            if (value === undefined) {
+                this.store.delete(key);
+            } else {
+                this.store.set(key, value);
+            }
+        }
+    }
+
+    /**
+     * Stands in for ProjectPathHandler, with a gate the next scan parks on:
+     * scanProject awaits getProjectVersePath first, so arming the gate holds
+     * that scan mid-flight while the test acts on the cache.
+     */
+    class GateableProjectPathHandler {
+        private gate: Promise<void> | null = null;
+        private release: () => void = () => {};
+
+        armGate(): () => void {
+            this.gate = new Promise<void>((resolve) => {
+                this.release = resolve;
+            });
+            return () => this.release();
+        }
+
+        async getProjectVersePath(): Promise<string | null> {
+            const gate = this.gate;
+            if (gate) {
+                this.gate = null;
+                await gate;
+            }
+            return "/mygame@fortnite.com/mygame";
+        }
+
+        async getProjectName(): Promise<string | null> {
+            return "MyGame";
+        }
+    }
+
+    type CacheParams = ConstructorParameters<typeof ProjectPathCache>;
+
+    /** ProjectPathCache's own storage key; kept in sync with its private static. */
+    const CACHE_KEY = "projectPathTree";
+
+    let cache: ProjectPathCache;
+    let storage: FakeMemento;
+    let handler: GateableProjectPathHandler;
+
+    /** The node count in the payload workspace storage currently holds. */
+    const persistedNodeCount = (): number => storage.get<{ nodes: unknown[] }>(CACHE_KEY)?.nodes.length ?? -1;
+
+    /** Drains the microtask queue so an in-flight scan reaches its await. */
+    const flushAsync = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+    /** workspaceFolders is readonly in the real typings; the mock is writable. */
+    const setWorkspaceFolders = (folders: unknown): void => {
+        (vscode.workspace as unknown as { workspaceFolders: unknown }).workspaceFolders = folders;
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        findFiles.mockResolvedValue([]);
+        openTextDocument.mockResolvedValue({ getText: () => VERSE_SOURCE });
+
+        setWorkspaceFolders([{ uri: { fsPath: "C:\\Project\\Content" }, name: "Content", index: 0 }]);
+
+        storage = new FakeMemento();
+        handler = new GateableProjectPathHandler();
+        cache = new ProjectPathCache({ workspaceState: storage } as unknown as CacheParams[0], { appendLine: jest.fn() } as unknown as CacheParams[1], handler as unknown as CacheParams[2]);
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        findFiles.mockResolvedValue([]);
+        openTextDocument.mockResolvedValue({ getText: () => "" });
+    });
+
+    it("runs one scan for overlapping rebuild calls", async () => {
+        const first = cache.rebuildCache();
+        const second = cache.rebuildCache();
+
+        await expect(first).resolves.toBeUndefined();
+        await expect(second).resolves.toBeUndefined();
+
+        expect(findFiles).toHaveBeenCalledTimes(1);
+        expect(cache.getStats().loaded).toBe(true);
+    });
+
+    it("keeps the newer rebuild's result when a superseded scan resolves after it", async () => {
+        // Rebuild A parks on the gate before it lists any files.
+        const release = handler.armGate();
+        const slowRebuild = cache.rebuildCache();
+        await flushAsync();
+
+        // What the .uefnproject watcher does: clear, then rebuild. B's scan
+        // finds one file; A's, once released, will find none.
+        findFiles.mockResolvedValueOnce([{ fsPath: "C:\\Project\\Content\\Scripts\\device.verse" }]);
+        cache.clear();
+        await cache.rebuildCache();
+        expect(cache.getStats().files).toBe(1);
+
+        release();
+        await expect(slowRebuild).resolves.toBeUndefined();
+
+        // A resolved last but committed nothing: memory and workspace storage
+        // both keep B's file set.
+        expect(cache.getStats().files).toBe(1);
+        expect(persistedNodeCount()).toBe(1);
+    });
+});

--- a/src/utils/__tests__/singleFlight.test.ts
+++ b/src/utils/__tests__/singleFlight.test.ts
@@ -1,0 +1,48 @@
+import { singleFlight } from "../singleFlight";
+
+describe("singleFlight", () => {
+    it("shares one run among overlapping calls", async () => {
+        let runs = 0;
+        let release: (value: string) => void = () => {};
+        const wrapped = singleFlight(() => {
+            runs++;
+            return new Promise<string>((resolve) => {
+                release = resolve;
+            });
+        });
+
+        const first = wrapped();
+        const second = wrapped();
+        release("done");
+
+        expect(await first).toBe("done");
+        expect(await second).toBe("done");
+        expect(runs).toBe(1);
+    });
+
+    it("starts a fresh run after the shared one settles", async () => {
+        let runs = 0;
+        const wrapped = singleFlight(async () => ++runs);
+
+        expect(await wrapped()).toBe(1);
+        expect(await wrapped()).toBe(2);
+    });
+
+    it("propagates rejection to every sharer and stays retryable", async () => {
+        let attempts = 0;
+        const wrapped = singleFlight(async () => {
+            attempts++;
+            if (attempts === 1) {
+                throw new Error("first run fails");
+            }
+            return attempts;
+        });
+
+        const first = wrapped();
+        const second = wrapped();
+
+        await expect(first).rejects.toThrow("first run fails");
+        await expect(second).rejects.toThrow("first run fails");
+        expect(await wrapped()).toBe(2);
+    });
+});

--- a/src/utils/__tests__/singleFlight.test.ts
+++ b/src/utils/__tests__/singleFlight.test.ts
@@ -28,6 +28,32 @@ describe("singleFlight", () => {
         expect(await wrapped()).toBe(2);
     });
 
+    it("starts a fresh run after a reset instead of joining the dropped one", async () => {
+        let runs = 0;
+        const releases: Array<() => void> = [];
+        const wrapped = singleFlight(() => {
+            const run = ++runs;
+            return new Promise<number>((resolve) => {
+                releases.push(() => resolve(run));
+            });
+        });
+
+        const dropped = wrapped();
+        wrapped.reset();
+        const fresh = wrapped();
+        expect(wrapped()).toBe(fresh);
+
+        // The dropped run settles first; that must not clear the fresh
+        // run's memo.
+        releases[0]();
+        expect(await dropped).toBe(1);
+        expect(wrapped()).toBe(fresh);
+
+        releases[1]();
+        expect(await fresh).toBe(2);
+        expect(runs).toBe(2);
+    });
+
     it("propagates rejection to every sharer and stays retryable", async () => {
         let attempts = 0;
         const wrapped = singleFlight(async () => {

--- a/src/utils/singleFlight.ts
+++ b/src/utils/singleFlight.ts
@@ -1,3 +1,14 @@
+/** A single-flight wrapper: call it to run or join, reset it to invalidate. */
+export interface SingleFlight<T> {
+    (): Promise<T>;
+    /**
+     * Drops the memo, so the next call starts a fresh run instead of joining
+     * one already in flight. The dropped run keeps running for the callers
+     * that hold it; whether its result may still commit is the owner's check.
+     */
+    reset(): void;
+}
+
 /**
  * Wraps an async operation so overlapping calls share one run.
  *
@@ -6,10 +17,10 @@
  * cleared, so the next call starts a fresh run - which is what keeps a failed
  * run retryable.
  */
-export function singleFlight<T>(run: () => Promise<T>): () => Promise<T> {
+export function singleFlight<T>(run: () => Promise<T>): SingleFlight<T> {
     let inFlight: Promise<T> | null = null;
 
-    return () => {
+    const wrapped = (): Promise<T> => {
         if (!inFlight) {
             const flight = run().finally(() => {
                 // Identity-checked so a wrapper reset while this run was
@@ -23,4 +34,10 @@ export function singleFlight<T>(run: () => Promise<T>): () => Promise<T> {
 
         return inFlight;
     };
+
+    wrapped.reset = (): void => {
+        inFlight = null;
+    };
+
+    return wrapped;
 }

--- a/src/utils/singleFlight.ts
+++ b/src/utils/singleFlight.ts
@@ -1,0 +1,26 @@
+/**
+ * Wraps an async operation so overlapping calls share one run.
+ *
+ * The first call starts `run()`; every call that arrives while it is pending
+ * gets the same promise, rejection included. Once the run settles, the memo is
+ * cleared, so the next call starts a fresh run - which is what keeps a failed
+ * run retryable.
+ */
+export function singleFlight<T>(run: () => Promise<T>): () => Promise<T> {
+    let inFlight: Promise<T> | null = null;
+
+    return () => {
+        if (!inFlight) {
+            const flight = run().finally(() => {
+                // Identity-checked so a wrapper reset while this run was
+                // pending does not clobber the run that replaced it.
+                if (inFlight === flight) {
+                    inFlight = null;
+                }
+            });
+            inFlight = flight;
+        }
+
+        return inFlight;
+    };
+}


### PR DESCRIPTION
Closes #377

## What

All four loaders in the project-detection/digest layer were double-runnable, and `rebuildCache` committed in completion order, so a slow scan could revert a newer rebuild in memory and persist the regression to workspace storage.

- New `src/utils/singleFlight.ts`: a memoized in-flight promise wrapper with a `reset()` that lets an invalidator drop the memo.
- `ProjectPathCache.rebuildCache`: overlapping calls join one scan; a generation counter, bumped by `clear()` and at each scan's start, abandons a superseded scan's commit — mirroring `invalidateFiles`' snapshot guard.
- `PrecompiledDigestLoader.loadPrecompiledDigests`: overlapping loads share one run (no more double-merge); `clear()` invalidates an in-flight load so it cannot latch `loaded` over the emptied index.
- `AssetsDigestParser.parseAssetsDigest`: overlapping refreshes share one parse; `clearCache()` invalidates an in-flight parse so it cannot commit pre-change names, stamp the TTL, or re-memoize the pre-clear project's digest path.
- `ProjectPathHandler.findAndParseProjectFile`: overlapping same-scope searches share one run; `clearCache()` abandons an overtaken search's commit.

Regression tests pin every guard at the entry points the issue names; each was proven to fail against the unguarded code.

## Verification

`npm run compile`:

```
> verse-auto-imports@0.11.3 compile
> tsc -p ./
```

`npm test`:

```
Test Suites: 63 passed, 63 total
Tests:       1702 passed, 1702 total
```

`npm run format:check`:

```
All matched files use Prettier code style!
```

## Review

Three rounds at opus, each a fresh reviewer probing the interleavings: PASS_WITH_SUGGESTIONS each round, zero Critical. Round-1 and round-2 Important findings (clear-time invalidation gaps in the two digest loaders, and the overtaken parse re-memoizing the pre-clear digest path) are fixed and regression-tested; round-3 confirmed no post-await write remains that an overtaken run can land after a clear, and its two suggestions are applied.

One reviewer observation left open by design: an explicit user-triggered rebuild that overlaps a running scan joins it rather than forcing a fresh scan, so its result can predate files added just before the command. That is the coalescing the ticket asked for; forcing freshness for the command path would be a follow-up decision, not part of this fix.
