### PR TITLE
fix(imports): take the pair override only from evidence inside its span

### DIFF
--- a/changelog.d/472.fixed.md
+++ b/changelog.d/472.fixed.md
@@ -1,0 +1,1 @@
+**Imports**: A diagnostic about a statement written beside a pinned `X := 1; using:` pair no longer places the new import above the provider the pair's dotted path may need.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -473,12 +473,20 @@ export class ImportDocumentEditor {
      * the line, outside a clause written after a `;`, which refuses the
      * override - the same safe direction.
      *
-     * Without `columns` the whole span still counts. That keeps a statement
+     * A multi-line pair carries `spanColumns` instead, and the evidence must
+     * start at or after its opener: from there to the end of the path on the
+     * last line, everything is the clause, and a diagnostic before the opener
+     * is about the statement written beside it - the same shared-line shape
+     * one line taller. Lines strictly inside the span count whole; the pair
+     * tolerates a blank or comment line there, and such a line holds no other
+     * statement for the evidence to be about.
+     *
+     * Without either field the whole span still counts. That keeps a statement
      * owning its span exactly as sharp as before, and leaves one shape loose:
-     * a pinned multi-line span - `X := 1; using:` over its indented path -
-     * still takes the override from a diagnostic about the statement beside
-     * its opener. A standing gap rather than one this predicate closes;
-     * narrowing it needs a span the scanner does not measure.
+     * a pinned multi-line braced clause still takes the override from a
+     * diagnostic about a statement beside its opener. Its paths can be split
+     * across lines, so it has no one line to measure an endpoint on, and the
+     * span goes unrecorded.
      *
      * Still kept to a pinned dotted consumer and a new import that can supply a
      * first segment for it, because the override is only worth the risk that
@@ -495,10 +503,20 @@ export class ImportDocumentEditor {
             return false;
         }
         const columns = imp.columns;
-        if (!columns) {
-            return diagnosticPositions.some((position) => position.line >= imp.startLine && position.line <= imp.endLine);
+        if (columns) {
+            return diagnosticPositions.some((position) => position.line === imp.startLine && position.character >= columns.start && position.character < columns.end);
         }
-        return diagnosticPositions.some((position) => position.line === imp.startLine && position.character >= columns.start && position.character < columns.end);
+        const spanColumns = imp.spanColumns;
+        if (spanColumns) {
+            return diagnosticPositions.some((position) =>
+                position.line === imp.startLine
+                    ? position.character >= spanColumns.start
+                    : position.line === imp.endLine
+                      ? position.character < spanColumns.end
+                      : position.line > imp.startLine && position.line < imp.endLine,
+            );
+        }
+        return diagnosticPositions.some((position) => position.line >= imp.startLine && position.line <= imp.endLine);
     }
 
     /**

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -474,19 +474,25 @@ export class ImportDocumentEditor {
      * override - the same safe direction.
      *
      * A multi-line pair carries `spanColumns` instead, and the evidence must
-     * start at or after its opener: from there to the end of the path on the
-     * last line, everything is the clause, and a diagnostic before the opener
-     * is about the statement written beside it - the same shared-line shape
-     * one line taller. Lines strictly inside the span count whole; the pair
-     * tolerates a blank or comment line there, and such a line holds no other
-     * statement for the evidence to be about.
+     * start at or after its opener: from there to the end of the recorded
+     * path on the last line, everything is read as the pair's own text, and a
+     * diagnostic before the opener is about the statement written beside it -
+     * the same shared-line shape one line taller. Lines strictly inside the
+     * span count whole; the pair tolerates a blank or comment line there, and
+     * such a line holds no other statement for the evidence to be about. The
+     * reach is exactly the recorded path's: where the scan deliberately
+     * over-records one (pairPathBelow's classifyContent), `end` reaches past
+     * the clause with it, which only ever widens toward the fallback this
+     * narrows.
      *
      * Without either field the whole span still counts. That keeps a statement
      * owning its span exactly as sharp as before, and leaves one shape loose:
-     * a pinned multi-line braced clause still takes the override from a
-     * diagnostic about a statement beside its opener. Its paths can be split
-     * across lines, so it has no one line to measure an endpoint on, and the
-     * span goes unrecorded.
+     * a pinned multi-line braced clause whose closing line carries a statement
+     * after the `}` - `}; X := 1` - still takes the override from a diagnostic
+     * inside that statement. Its span goes unmeasured today. A statement
+     * beside the opener is not the loose case: the scan records no braced
+     * span for a line the clause does not head, so nothing there carries the
+     * override at all.
      *
      * Still kept to a pinned dotted consumer and a new import that can supply a
      * first segment for it, because the override is only worth the risk that

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -84,13 +84,14 @@ export interface ScannedImport {
     columns?: ColumnSpan;
     /**
      * The endpoints of an indented pair's span: where its `using` opener
-     * starts on `startLine`, and where its path text ends on `endLine`.
-     * Everything between the two positions is the clause, so evidence there
-     * is about the pair, where evidence before the opener is about a
-     * statement written beside it (ImportDocumentEditor.couldResolveAgainst).
-     * Present only with `startLine !== endLine`, and only for the pair shape -
-     * a multi-line braced clause records nothing, its paths having no one
-     * line to measure an endpoint on.
+     * starts on `startLine`, and where its recorded path ends on `endLine`.
+     * Evidence between the two positions is read as being about the pair,
+     * where evidence before the opener is about a statement written beside
+     * it (ImportDocumentEditor.couldResolveAgainst). The reach is the
+     * recorded path's, no narrower: a branch that deliberately over-records
+     * the path (pairPathBelow's classifyContent) carries that reach into
+     * `end`. Present only with `startLine !== endLine`, and only for the
+     * pair shape - a multi-line braced clause records nothing.
      *
      * Absent means no column knowledge, exactly as for `columns`: a span the
      * masked lines cannot corroborate leaves it unset, and evidence anywhere

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -73,14 +73,30 @@ export interface ScannedImport {
      * cannot decide, since a diagnostic on the line may be about the code
      * beside the statement rather than the statement itself
      * (ImportDocumentEditor.couldResolveAgainst). Present only with
-     * `startLine === endLine`.
+     * `startLine === endLine`; a multi-line pair carries `spanColumns`
+     * instead.
      *
      * Absent means no column knowledge, not that none is needed: a statement
-     * owning its whole span, a multi-line span, and a line whose comment
-     * structure defeats the column measurement all leave it unset, and evidence
-     * anywhere on the span then counts.
+     * owning its whole span and a line whose comment structure defeats the
+     * column measurement both leave it unset, and evidence anywhere on the
+     * span then counts.
      */
     columns?: ColumnSpan;
+    /**
+     * The endpoints of an indented pair's span: where its `using` opener
+     * starts on `startLine`, and where its path text ends on `endLine`.
+     * Everything between the two positions is the clause, so evidence there
+     * is about the pair, where evidence before the opener is about a
+     * statement written beside it (ImportDocumentEditor.couldResolveAgainst).
+     * Present only with `startLine !== endLine`, and only for the pair shape -
+     * a multi-line braced clause records nothing, its paths having no one
+     * line to measure an endpoint on.
+     *
+     * Absent means no column knowledge, exactly as for `columns`: a span the
+     * masked lines cannot corroborate leaves it unset, and evidence anywhere
+     * on the span then counts.
+     */
+    spanColumns?: SpanColumns;
 }
 
 /**
@@ -89,6 +105,18 @@ export interface ScannedImport {
  * the raw line - the space vscode.Position.character measures in.
  */
 export interface ColumnSpan {
+    start: number;
+    end: number;
+}
+
+/**
+ * Raw column endpoints of a multi-line span, one per end: `start` is the first
+ * character of the span's opener on its first line, `end` the offset just past
+ * its content on its last, both UTF-16 offsets into their raw lines - the
+ * space vscode.Position.character measures in. Not a ColumnSpan: the two
+ * offsets index different lines.
+ */
+export interface SpanColumns {
     start: number;
     end: number;
 }
@@ -639,6 +667,29 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         return path ? { path, pathLine } : null;
     };
 
+    // The span endpoints of the pair `opener` opens, or undefined where the
+    // masked lines cannot corroborate them. Both ends are measured on `masked`
+    // - the one string whose offsets are raw columns - and each is reconciled
+    // against the code-derived reading that admitted the pair: the opener must
+    // show the same trailing `using:` the branch gated on, and the path line's
+    // masked content must be exactly the path the raw line yielded. A comment
+    // splicing or gluing a token breaks one of the two and leaves the span
+    // unmeasured, which only ever falls back to the whole-span test - the same
+    // one-sided degradation columnsForLinePaths documents.
+    const pairSpanColumns = (opener: number, pair: { path: string; pathLine: number }): SpanColumns | undefined => {
+        const openerMatch = /\busing\s*:\s*$/.exec(classifications[opener].masked);
+        if (!openerMatch) {
+            return undefined;
+        }
+        const pathMasked = classifications[pair.pathLine].masked;
+        const start = pathMasked.length - pathMasked.trimStart().length;
+        const end = pathMasked.trimEnd().length;
+        if (pathMasked.slice(start, end) !== pair.path) {
+            return undefined;
+        }
+        return { start: openerMatch.index, end };
+    };
+
     let i = 0;
     while (i < lines.length) {
         const line = lines[i];
@@ -729,6 +780,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     anchorsCommentBelow: anchorsCommentBelow(i, pair.pathLine),
                     rebuildLosesText: true,
                     trailingComment: ImportFormatter.extractTrailingComment(lines[pair.pathLine]),
+                    spanColumns: pairSpanColumns(i, pair),
                 });
                 i = pair.pathLine + 1;
                 continue;
@@ -801,6 +853,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                     anchorsCommentBelow: anchorsCommentBelow(i, pair.pathLine),
                     rebuildLosesText: false,
                     trailingComment: ImportFormatter.extractTrailingComment(lines[pair.pathLine]),
+                    spanColumns: pairSpanColumns(i, pair),
                 });
                 i = pair.pathLine + 1;
                 continue;
@@ -892,6 +945,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 anchorsCommentBelow: anchorsCommentBelow(i, pair.pathLine),
                 rebuildLosesText: true,
                 trailingComment: ImportFormatter.extractTrailingComment(lines[pair.pathLine]),
+                spanColumns: pairSpanColumns(i, pair),
             });
             i = pair.pathLine + 1;
             continue;

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -651,6 +651,26 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             );
         });
 
+        // The path ends at column 16 and the span is half-open, so evidence
+        // starting exactly there is past the pair, not inside it.
+        it("takes no override from a diagnostic starting exactly at the end of a pair's path", () => {
+            const input = ["X := 1; using:", "    Economy.Shop", "code()"].join("\n");
+
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 1, character: 16 }]]]))).toBe(
+                ["X := 1; using:", "    Economy.Shop", "using { Features }", "code()"].join("\n"),
+            );
+        });
+
+        // A comment line inside the pair counts whole: it belongs to the
+        // clause and holds no other statement for the evidence to be about.
+        it("still writes the provider above a pair the diagnostic reports on a comment line inside it", () => {
+            const input = ["X := 1; using:", "    # note", "    Economy.Shop", "code()"].join("\n");
+
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 1, character: 4 }]]]))).toBe(
+                ["using { Features }", "", "X := 1; using:", "    # note", "    Economy.Shop", "code()"].join("\n"),
+            );
+        });
+
         // Only the paths the pinned import could provide are held back. An
         // absolute path needs nothing in scope, so the file is still organized
         // around what stays.

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -628,6 +628,29 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
             );
         });
 
+        // The diagnostic is on the pinned pair's opener line but at column 0,
+        // inside `X := 1` - the compiler reporting on the definition, not on
+        // the pair whose `using:` starts at column 8. Read span-wide, that
+        // evidence hoisted the provider above the import that may bring its
+        // first segment into scope, and a compiling file stopped compiling.
+        it("leaves an added bare consumer below a pinned pair when the diagnostic is about the statement beside its opener", () => {
+            const input = ["X := 1; using:", "    Economy.Shop", "code()"].join("\n");
+
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 0, character: 0 }]]]))).toBe(
+                ["X := 1; using:", "    Economy.Shop", "using { Features }", "code()"].join("\n"),
+            );
+        });
+
+        // The same file with the diagnostic inside the `using:` opener itself -
+        // the narrowing must not cost the override its reach on a pair.
+        it("still writes the provider above a pinned pair the diagnostic reports on its opener", () => {
+            const input = ["X := 1; using:", "    Economy.Shop", "code()"].join("\n");
+
+            expect(editor.buildOrganizedContent(input, ["Features"], curlySorted, new Map([["Features", [{ line: 0, character: 8 }]]]))).toBe(
+                ["using { Features }", "", "X := 1; using:", "    Economy.Shop", "code()"].join("\n"),
+            );
+        });
+
         // Only the paths the pinned import could provide are held back. An
         // absolute path needs nothing in scope, so the file is still organized
         // around what stays.
@@ -2405,6 +2428,80 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(insert).toBeDefined();
             expect(insert!.position!.line).toBe(0);
             expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // Regression for the diagnostic landing on the opener line of a pinned
+        // pair but inside the definition beside the clause. The `using:` starts
+        // at column 8, and column 0 is `X := 1` - the compiler reporting on the
+        // definition, not on the pair. Read span-wide, that evidence took the
+        // override and the provider was written above the import that may
+        // bring its first segment into scope, and a compiling file stopped
+        // compiling.
+        it("leaves a new import below a pinned pair when the diagnostic is about the statement beside its opener", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["X := 1; using:", "    Economy.Shop", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 0));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(2);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+        });
+
+        // The same file with the diagnostic inside the `using:` opener itself -
+        // column 8 is its `u`. The narrowing must not cost the override its
+        // reach on the opener line.
+        it("still writes the provider above a pinned pair the diagnostic reports on its opener", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["X := 1; using:", "    Economy.Shop", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 8));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "replace")).toBe(false);
+
+            const insert = operations.find((op) => op.kind === "insert");
+            expect(insert).toBeDefined();
+            expect(insert!.position!.line).toBe(0);
+            expect(insert!.text).toBe("using { Features }\n\n");
+        });
+
+        // The path text ends at column 16 and column 17 is inside the trailing
+        // comment - evidence about nothing the pair imports. Refusing it is the
+        // safe direction the whole predicate leans: a wrong override breaks a
+        // compiling file.
+        it("takes no override from a diagnostic past the path of a pinned pair", async () => {
+            mockConfig({
+                "behavior.preserveImportLocations": true,
+                "behavior.importGrouping": "none",
+                "behavior.sortImportsAlphabetically": true,
+            });
+            const input = ["X := 1; using:", "    Economy.Shop # note", "using { /Verse.org/Simulation }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 1, 17));
+
+            expect(success).toBe(true);
+            const operations = appliedOperations(0);
+            expect(operations.some((op) => op.kind === "insert")).toBe(false);
+
+            const replace = operations.find((op) => op.kind === "replace");
+            expect(replace).toBeDefined();
+            expect(replace!.range!.start.line).toBe(2);
+            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
         });
 
         // The floor reaches past the pinned statement, because the `using:` at

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -423,7 +423,7 @@ describe("scanModuleImports", () => {
 
     it("consumes the indented using: pair as one two-line entry", () => {
         expect(scanModuleImports(["using:", "    /Verse.org/Simulation", "code()"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "", spanColumns: { start: 0, end: 25 } },
         ]);
     });
 
@@ -435,7 +435,7 @@ describe("scanModuleImports", () => {
     it("consumes a using: pair opened after a semicolon, pinning both paths", () => {
         expect(scanModuleImports(["using { /X }; using:", "    Economy.Shop", "", "code()"])).toEqual([
             { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
-            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 14, end: 16 } },
         ]);
     });
 
@@ -446,7 +446,7 @@ describe("scanModuleImports", () => {
     it("consumes a using: pair opened after a bare dotted import, pinning both paths", () => {
         expect(scanModuleImports(["using. Features; using:", "    Economy.Shop", "", "code()"])).toEqual([
             { path: "Features", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 15 } },
-            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 17, end: 16 } },
         ]);
     });
 
@@ -461,7 +461,7 @@ describe("scanModuleImports", () => {
     // its own line is one entry spanning both lines, and still rewritable.
     it("leaves the plain indented pair rewritable", () => {
         expect(rewritableImports(scanModuleImports(["using:", "    Economy.Shop", "code()"]))).toEqual([
-            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "", spanColumns: { start: 0, end: 16 } },
         ]);
     });
 
@@ -474,13 +474,13 @@ describe("scanModuleImports", () => {
     // path alone, so rewriting this one would delete the lines between.
     it("consumes a pair holding a blank line, pinned", () => {
         expect(scanModuleImports(["using:", "", "    /Verse.org/Random", "code()"])).toEqual([
-            { path: "/Verse.org/Random", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/Verse.org/Random", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 0, end: 21 } },
         ]);
     });
 
     it("consumes a pair holding a comment indented into it, pinned", () => {
         expect(scanModuleImports(["using:", "    # the path below", "    /Verse.org/Simulation", "code()"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 0, end: 25 } },
         ]);
     });
 
@@ -488,7 +488,7 @@ describe("scanModuleImports", () => {
     // indented one does, so the pair reaches past it.
     it("consumes a pair holding a comment written at column 0, pinned", () => {
         expect(scanModuleImports(["using:", "# a note of its own", "    /A", "code()"])).toEqual([
-            { path: "/A", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/A", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 0, end: 6 } },
         ]);
     });
 
@@ -503,7 +503,7 @@ describe("scanModuleImports", () => {
     it("consumes a pair opened after a semicolon when a comment trails the opener", () => {
         expect(scanModuleImports(["using { /X }; using: # note", "    Economy.Shop", "code()"])).toEqual([
             { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "# note", columns: { start: 0, end: 12 } },
-            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 14, end: 16 } },
         ]);
     });
 
@@ -557,7 +557,7 @@ describe("scanModuleImports", () => {
     it("keeps a content-declined path a pair opened after a using provides", () => {
         expect(scanModuleImports(["using { /A }; using:", "    Foo'Loc'", "code()"])).toEqual([
             { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
-            { path: "Foo'Loc'", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Foo'Loc'", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 14, end: 12 } },
         ]);
         expect(scanModuleImports(["using:", "    Foo'Loc'", "code()"])).toEqual([]);
         expect(scanModuleImports(["X := 1; using:", "    Foo'Loc'", "code()"])).toEqual([]);
@@ -572,7 +572,7 @@ describe("scanModuleImports", () => {
         expect(scanModuleImports(["using { /X }; using { /Y }; using:", "    Economy.Shop", "", "code()"])).toEqual([
             { path: "/X", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
             { path: "/Y", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 14, end: 26 } },
-            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 28, end: 16 } },
         ]);
     });
 
@@ -584,6 +584,17 @@ describe("scanModuleImports", () => {
     // line itself was never at risk.
     it("records the path below a using: opened after a definition, pinned", () => {
         expect(scanModuleImports(["X := 1; using:", "    Economy.Shop", "code()"])).toEqual([
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 8, end: 16 } },
+        ]);
+    });
+
+    // The code reading glued `us` to `ing:` across the removed comment, so the
+    // branch admits the pair, but the masked line shows no trailing `using:`
+    // where the code saw one. The span endpoints go unmeasured rather than
+    // measured against text the author never wrote, and evidence anywhere on
+    // the span then counts - the same one-sided fallback columns takes.
+    it("leaves the pair span unmeasured when a comment glues its opener together", () => {
+        expect(scanModuleImports(["X := 1; us<#c#>ing:", "    Economy.Shop", "code()"])).toEqual([
             { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
         ]);
     });
@@ -597,7 +608,7 @@ describe("scanModuleImports", () => {
     it("records every statement written before a pair opened after a definition", () => {
         expect(scanModuleImports(["X := 1; using { /A }; using:", "    Economy.Shop", "code()"])).toEqual([
             { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 8, end: 20 } },
-            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 22, end: 16 } },
         ]);
     });
 
@@ -606,7 +617,7 @@ describe("scanModuleImports", () => {
     // line, and the path line keeps its own comment for a writer to put back.
     it("records a pair opened after a definition when a comment trails the opener", () => {
         expect(scanModuleImports(["X := 1; using: # note", "    Economy.Shop # why", "code()"])).toEqual([
-            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "# why" },
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "# why", spanColumns: { start: 8, end: 16 } },
         ]);
     });
 
@@ -651,7 +662,7 @@ describe("scanModuleImports", () => {
     // cannot put back.
     it("records the path below a plain pair whose opener carries a line comment", () => {
         expect(scanModuleImports(["using: # note", "    /Verse.org/Random", "code()"])).toEqual([
-            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 0, end: 21 } },
         ]);
     });
 
@@ -661,7 +672,7 @@ describe("scanModuleImports", () => {
     // and drop this one.
     it("records the path below a pair whose opener closes the comment it opens", () => {
         expect(scanModuleImports(["using: <# note #>", "    /Verse.org/Random", "code()"])).toEqual([
-            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 0, end: 21 } },
         ]);
     });
 
@@ -670,7 +681,7 @@ describe("scanModuleImports", () => {
     // either way; what this pins is that the flag is read rather than assumed.
     it("flags a pair after a definition whose path line opens a comment", () => {
         expect(scanModuleImports(["X := 1; using:", "    /Verse.org/Random <#>", "        body", "code()"])).toEqual([
-            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<#>" },
+            { path: "/Verse.org/Random", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: true, trailingComment: "<#>", spanColumns: { start: 8, end: 21 } },
         ]);
     });
 
@@ -936,7 +947,7 @@ describe("scanModuleImports", () => {
             { path: "/Verse.org/Simulation", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# keep me" },
         ]);
         expect(scanModuleImports(["using:", "    /Verse.org/Simulation # keep me", "code()"])).toEqual([
-            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# keep me" },
+            { path: "/Verse.org/Simulation", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "# keep me", spanColumns: { start: 0, end: 25 } },
         ]);
     });
 
@@ -1040,7 +1051,7 @@ describe("scanModuleImports", () => {
         // be read at endLine rather than startLine.
         const lines = ["using:", "    /A <# disabled below", "using { /Old/Path }", "#>", "using { /B }"];
         expect(scanModuleImports(lines)).toEqual([
-            { path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<# disabled below" },
+            { path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<# disabled below", spanColumns: { start: 0, end: 6 } },
             { path: "/B", startLine: 4, endLine: 4, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });
@@ -1073,7 +1084,9 @@ describe("scanModuleImports", () => {
 
     it("flags an indented pair whose path line carries an indented comment marker", () => {
         const lines = ["using:", "    /A <#> why", "        the body of the marker's comment", "code()"];
-        expect(scanModuleImports(lines)).toEqual([{ path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<#> why" }]);
+        expect(scanModuleImports(lines)).toEqual([
+            { path: "/A", startLine: 0, endLine: 1, anchorsCommentBelow: true, rebuildLosesText: false, trailingComment: "<#> why", spanColumns: { start: 0, end: 6 } },
+        ]);
     });
 
     it("flags a marker with no body below it, unlike an unclosed block opener", () => {
@@ -1130,7 +1143,7 @@ describe("scanModuleImports", () => {
         const lines = ["using { /A }", "using:", "    /B", "using. /C"];
         expect(scanModuleImports(lines)).toEqual([
             { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
-            { path: "/B", startLine: 1, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
+            { path: "/B", startLine: 1, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "", spanColumns: { start: 0, end: 6 } },
             { path: "/C", startLine: 3, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: false, trailingComment: "" },
         ]);
     });

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -599,6 +599,25 @@ describe("scanModuleImports", () => {
         ]);
     });
 
+    // The path read from the raw line stops at the mid-line comment, so the
+    // masked slice and the recorded path disagree, and measuring anyway would
+    // hand the span an end inside text the path does not cover.
+    it("leaves the pair span unmeasured when a comment splices its path line", () => {
+        expect(scanModuleImports(["using { /A }; using:", "    Eco.nomy<#c#>Shop", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
+            { path: "Eco.nomy", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "<#c#>Shop" },
+        ]);
+    });
+
+    // Raw UTF-16 columns, not display width: the tab is one character, so the
+    // path ends at 13. Measured in display columns this passes every other
+    // test here and misplaces only tab-indented files.
+    it("measures a tab-indented path line in raw columns", () => {
+        expect(scanModuleImports(["X := 1; using:", "\tEconomy.Shop", "code()"])).toEqual([
+            { path: "Economy.Shop", startLine: 0, endLine: 1, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", spanColumns: { start: 8, end: 13 } },
+        ]);
+    });
+
     // Two lines the scanner cannot reproduce from one path, so the acceptance
     // criterion is that both stay exactly as written.
     it("offers no rewritable import for a pair opened after a definition", () => {


### PR DESCRIPTION
Closes #472

## What

`couldResolveAgainst` read a pinned multi-line pair's evidence line-wide, so a diagnostic about the statement beside the opener — `X := 1` on `X := 1; using:` — took the consumer override and the new import was written above a provider the pair's dotted path may genuinely need: a compiling file stopped compiling, the #412 failure one shape further along.

The scanner now records the span endpoints the predicate needs (`ScannedImport.spanColumns`: the `using` opener's column on `startLine`, the offset just past the path on `endLine`), measured on the length-preserving `masked` strings and reconciled against the code-derived reading that admitted the pair — either side disagreeing leaves the field unset and the predicate on today's whole-span test, the same one-sided degradation `columns` takes. `couldResolveAgainst` requires opener-line evidence to start at or after the opener and endLine evidence to start before the path's end; lines strictly inside the span count whole, since the pair tolerates a blank or comment line there and such a line holds no other statement for the evidence to be about.

The multi-line braced clause keeps line-granular evidence — its paths can split across lines, so it has no one line to measure an endpoint on. Named at the predicate as the remaining loose shape.

## Domain rules relied on

- A missing-`using` diagnostic anchors to the identifier's own VstNode, so its start position lands inside the statement it is about (`CreateGlitchForMissingUsing` call sites, SemanticAnalyzer.cpp:12544, :12864).
- The indented clause's body is the first line of code below the opener; neither a blank line nor a comment ends it, and the clause holds exactly one expression (`AnalyzeMacroCall_Using`, SemanticAnalyzer.cpp:6378-6381; the `Line` production's unconditional `Gen.BlankLine`, VerseGrammar.h:1683).
- `X := 1; using:` over an indented path is legal Verse — `;` separates definitions as a newline does (maintainer live-compiler check, 2026-08-10).

## Verification

`npm run compile` — exit 0.

`npm test`:

```
Test Suites: 58 passed, 58 total
Tests:       1696 passed, 1696 total
```

`npm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```

Written red-first: with the predicate and scanner unfixed, the three defect-direction tests fail (override still taken from evidence beside the opener at both entry points, and from evidence past the path) and the override-retained tests pass.
