### PR TITLE
fix(imports): scan a braced clause opened after a statement on its line

### DIFF
--- a/changelog.d/476.fixed.md
+++ b/changelog.d/476.fixed.md
@@ -1,0 +1,1 @@
+**Import scanning**: a braced `using` clause opened after a statement on its line now counts as present, so a diagnostic no longer writes a second copy of an import the file already makes.

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -408,7 +408,11 @@ export function indentedBodyLine(classifications: LineClassification[], opener: 
  * span here; the statements before the clause are the caller's to record.
  *
  * Read from the classifications rather than the raw text, so a brace written in
- * a comment or inside a string literal closes nothing.
+ * a comment or inside a string literal closes nothing. One caveat rides along
+ * from the lexer: on a line the tracked lex leaves inside an open literal,
+ * classification falls back to reading the text as code, so an unterminated
+ * string spelling `; using {` can open a phantom span here. That input does
+ * not compile, and the exposure predates this reader.
  *
  * Indentation is the caller's question, not this one's: scanModuleImports asks
  * only about column 0, allUsingPaths about every line.
@@ -421,6 +425,12 @@ export function indentedBodyLine(classifications: LineClassification[], opener: 
  *   one path where the file does not compile: a `using` clause takes a single
  *   path, and a buffer being edited need not compile yet.
  */
+// What may precede a braced clause's `{` or end a line whose brace sits below:
+// a statement-head `using`, alone on the line or after a `;`. One rule, tested
+// against the code before the brace in one form and the whole line in the
+// other, so the two spellings cannot drift apart.
+const USING_CLAUSE_HEAD = /(?:^|;)\s*using\s*$/;
+
 function bracedUsingSpan(classifications: LineClassification[], opener: number): { paths: string[]; endLine: number } | null {
     const openerCode = classifications[opener].codeOutsideLiterals;
 
@@ -453,12 +463,12 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     let braceLine: number;
     let braceCol: number;
     if (lineDepth > 0) {
-        if (!/(?:^|;)\s*using\s*$/.test(openerCode.slice(0, openAt))) {
+        if (!USING_CLAUSE_HEAD.test(openerCode.slice(0, openAt))) {
             return null;
         }
         braceLine = opener;
         braceCol = openAt;
-    } else if (/(?:^|;)\s*using\s*$/.test(openerCode)) {
+    } else if (USING_CLAUSE_HEAD.test(openerCode)) {
         const below = firstCodeLineBelow(classifications, opener);
         if (below === -1 || !classifications[below].codeOutsideLiterals.trim().startsWith("{")) {
             return null;
@@ -473,9 +483,10 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     // column it sits at, so the content is cut at that brace rather than at the
     // last one on its line.
     //
-    // Counted by scanBraces, the one brace primitive, rather than by a loop of
-    // its own: a second counter is a second opinion about which `{` delimits a
-    // body.
+    // Counted by scanBraces, the one brace primitive. The walk above is not a
+    // second opinion about this question: it decides where the clause opens,
+    // clamping at zero because a closing brace pairs upward; from the `{` it
+    // named, pairing is scanBraces's alone.
     let depth = 0;
     let endLine = -1;
     let closeAt = -1;
@@ -494,7 +505,7 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     // lines carry removes a comment written on the line; it knows nothing of an
     // indented comment opened above it, which is what can leave the whole
     // closing line inert while still spelling a brace.
-    if (endLine === -1 || endLine === opener || classifications[endLine].kind !== "code") {
+    if (endLine === -1 || classifications[endLine].kind !== "code") {
         return null;
     }
 

--- a/src/imports/ImportScanner.ts
+++ b/src/imports/ImportScanner.ts
@@ -403,6 +403,10 @@ export function indentedBodyLine(classifications: LineClassification[], opener: 
  * closes on one line, which is why every caller that has to see a span asks
  * this instead of asking them.
  *
+ * The clause need not head its line. `;` separates statements exactly as a
+ * newline does, so `X := 1; using {` and `using { /A }; using {` each open a
+ * span here; the statements before the clause are the caller's to record.
+ *
  * Read from the classifications rather than the raw text, so a brace written in
  * a comment or inside a string literal closes nothing.
  *
@@ -418,21 +422,49 @@ export function indentedBodyLine(classifications: LineClassification[], opener: 
  *   path, and a buffer being edited need not compile yet.
  */
 function bracedUsingSpan(classifications: LineClassification[], opener: number): { paths: string[]; endLine: number } | null {
-    const openerCode = classifications[opener].codeOutsideLiterals.trim();
+    const openerCode = classifications[opener].codeOutsideLiterals;
 
-    // Where the braces begin. On the opener's own line for `using {`, and on
-    // the first line of code below it for a `using` whose brace is written
-    // there - a line break before the `{` is whitespace to the parser, so both
-    // spell the same clause.
+    // The `{` of the clause the line leaves open at its end: the last brace
+    // that took the depth up from the line's own base level without coming
+    // back. Depth is clamped at zero on the way there, because a `}` closing a
+    // construct opened on an earlier line pairs upward, never with a `{`
+    // written after it - `}; using {` opens a clause exactly as a fresh line
+    // would.
+    let lineDepth = 0;
+    let openAt = -1;
+    for (let pos = 0; pos < openerCode.length; pos++) {
+        const character = openerCode[pos];
+        if (character === "{") {
+            if (lineDepth === 0) {
+                openAt = pos;
+            }
+            lineDepth += 1;
+        } else if (character === "}") {
+            lineDepth = Math.max(0, lineDepth - 1);
+        }
+    }
+
+    // Where the braces begin. On the opener's own line for a clause whose `{`
+    // the line leaves open, and on the first line of code below it for a
+    // `using` the line ends on - a line break before the `{` is whitespace to
+    // the parser, so both spell the same clause. Neither spelling need head
+    // the line: `;` separates statements exactly as a newline does, so what
+    // must end in `using` is the code before the brace, not the line.
     let braceLine: number;
-    if (/^using\s*\{/.test(openerCode)) {
+    let braceCol: number;
+    if (lineDepth > 0) {
+        if (!/(?:^|;)\s*using\s*$/.test(openerCode.slice(0, openAt))) {
+            return null;
+        }
         braceLine = opener;
-    } else if (/^using$/.test(openerCode)) {
+        braceCol = openAt;
+    } else if (/(?:^|;)\s*using\s*$/.test(openerCode)) {
         const below = firstCodeLineBelow(classifications, opener);
         if (below === -1 || !classifications[below].codeOutsideLiterals.trim().startsWith("{")) {
             return null;
         }
         braceLine = below;
+        braceCol = classifications[below].codeOutsideLiterals.indexOf("{");
     } else {
         return null;
     }
@@ -449,7 +481,7 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     let closeAt = -1;
     for (let line = braceLine; line < classifications.length && endLine === -1; line++) {
         const code = classifications[line].codeOutsideLiterals;
-        const scan = scanBraces(code, 0, code.length, depth);
+        const scan = scanBraces(code, line === braceLine ? braceCol : 0, code.length, depth);
         if (scan.closedAt !== -1) {
             endLine = line;
             closeAt = scan.closedAt;
@@ -469,9 +501,9 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
     const braceCode = classifications[braceLine].codeOutsideLiterals;
     const between: string[] = [];
     if (braceLine === endLine) {
-        between.push(braceCode.slice(braceCode.indexOf("{") + 1, closeAt));
+        between.push(braceCode.slice(braceCol + 1, closeAt));
     } else {
-        between.push(braceCode.slice(braceCode.indexOf("{") + 1));
+        between.push(braceCode.slice(braceCol + 1));
         for (let line = braceLine + 1; line < endLine; line++) {
             // Only code, because a `<#>` written on the opener makes the lines
             // indented past it comment text, and the masking these lines carry
@@ -541,7 +573,10 @@ function bracedUsingSpan(classifications: LineClassification[], opener: number):
  *   before the brace is whitespace to the parser. Without this the span is
  *   invisible whole: the opener fails a classification that needs the closing
  *   brace on one line, and the path between the braces is indented, which the
- *   rule above skips. See bracedUsingSpan.
+ *   rule above skips. A clause opened after a statement on its line - a
+ *   definition or a complete `using` alike - is read the same way, with the
+ *   statements before it recorded against the opener line, pinned.
+ *   See bracedUsingSpan.
  * - Content classification (module import vs local-scope using) is delegated
  *   to ImportFormatter.isModuleImport, passing `{ atFileScope: true }` since
  *   every candidate here already sits at column 0. So a bare identifier at
@@ -691,6 +726,46 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
         return { start: openerMatch.index, end };
     };
 
+    // Every complete `using` statement `line` writes, each recorded against
+    // the line alone and pinned: a line recorded this way also carries text no
+    // rebuild from one path reproduces, so no writer may rebuild it.
+    const pushPinnedLineStatements = (line: number): void => {
+        const statements = classifications[line].codeOutsideLiterals.trim();
+        const linePaths = usingPathsOnLine(formatter, statements);
+        const lineColumns = columnsForLinePaths(formatter, linePaths, classifications[line].masked);
+        linePaths.forEach((linePath, statementIndex) => {
+            imports.push({
+                path: linePath,
+                startLine: line,
+                endLine: line,
+                anchorsCommentBelow: anchorsCommentBelow(line, line),
+                rebuildLosesText: true,
+                trailingComment: ImportFormatter.extractTrailingComment(lines[line].trim()),
+                columns: lineColumns[statementIndex],
+            });
+        });
+    };
+
+    // Every path of the braced span `opener` opens, pinned: the span holds
+    // lines no rebuild from one path reproduces - the braces may sit around a
+    // comment or a blank line the author wrote, and collapsing the span onto a
+    // single line is a rewrite nothing asked for.
+    const pushBracedSpan = (opener: number, braced: { paths: string[]; endLine: number }): void => {
+        for (const bracedPath of braced.paths) {
+            imports.push({
+                path: bracedPath,
+                startLine: opener,
+                endLine: braced.endLine,
+                anchorsCommentBelow: anchorsCommentBelow(opener, braced.endLine),
+                rebuildLosesText: true,
+                // The opener's own comment. Nothing re-emits a pinned entry,
+                // and the path sits on a line inside the braces rather than
+                // after the statement.
+                trailingComment: ImportFormatter.extractTrailingComment(lines[opener].trim()),
+            });
+        }
+    };
+
     let i = 0;
     while (i < lines.length) {
         const line = lines[i];
@@ -735,19 +810,7 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // than widened to admit them. Everything below it may then keep
             // testing the raw line, as the `using:` branch does - see the note
             // there on why the two inputs have to agree.
-            const headlessPaths = usingPathsOnLine(formatter, statements);
-            const headlessColumns = columnsForLinePaths(formatter, headlessPaths, classifications[i].masked);
-            headlessPaths.forEach((linePath, statementIndex) => {
-                imports.push({
-                    path: linePath,
-                    startLine: i,
-                    endLine: i,
-                    anchorsCommentBelow: anchorsCommentBelow(i, i),
-                    rebuildLosesText: true,
-                    trailingComment: ImportFormatter.extractTrailingComment(trimmed),
-                    columns: headlessColumns[statementIndex],
-                });
-            });
+            pushPinnedLineStatements(i);
 
             // The pair such a line opens, `X := 1; using:` over an indented
             // path. The loop above records nothing for it - a `using:` writes
@@ -794,26 +857,11 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
             // that too. The whole span goes uncounted, and a writer then adds a
             // second copy of a path the file already imports.
             //
-            // Pinned, like everything else this branch records. The span holds
-            // lines no rebuild from one path reproduces: the braces may sit
-            // around a comment or a blank line the author wrote, and collapsing
-            // the span onto a single line is a rewrite nothing asked for.
-            // Counting the path is what the duplicate needed.
+            // Pinned, like everything else this branch records. Counting the
+            // path is what the duplicate needed.
             const braced = bracedUsingSpan(classifications, i);
             if (braced) {
-                for (const bracedPath of braced.paths) {
-                    imports.push({
-                        path: bracedPath,
-                        startLine: i,
-                        endLine: braced.endLine,
-                        anchorsCommentBelow: anchorsCommentBelow(i, braced.endLine),
-                        rebuildLosesText: true,
-                        // The opener's own comment. Nothing re-emits a pinned
-                        // entry, and the path sits on a line inside the braces
-                        // rather than after the statement.
-                        trailingComment: ImportFormatter.extractTrailingComment(trimmed),
-                    });
-                }
+                pushBracedSpan(i, braced);
                 // Resumed *on* the closing line, not past it. A `;` separates
                 // statements exactly as a newline does, so `}; using { /B }`
                 // writes an import after the clause closes, and stepping over
@@ -949,6 +997,28 @@ export function scanModuleImports(lines: string[]): ScannedImport[] {
                 spanColumns: pairSpanColumns(i, pair),
             });
             i = pair.pathLine + 1;
+            continue;
+        }
+
+        // The braced clause the line's last statement leaves open,
+        // `using { /A }; using {` over an indented path over its own `}`. The
+        // complete statement at the head is what carries the line past the
+        // gate above - the classification reads the line from its head and
+        // says nothing about the remainder - and every branch below reads
+        // complete statements only, so without this the trailing clause's
+        // whole span goes uncounted and a writer adds a second copy of a path
+        // the file already imports. The reject branch closes the same gap for
+        // a line a definition heads; this is its mirror for a line a complete
+        // `using` does.
+        //
+        // Everything recorded is pinned: the line and the span alike hold
+        // text no rebuild from one path reproduces. Resumed *on* the closing
+        // line, not past it, for the reason the reject branch gives.
+        const bracedTail = bracedUsingSpan(classifications, i);
+        if (bracedTail) {
+            pushPinnedLineStatements(i);
+            pushBracedSpan(i, bracedTail);
+            i = bracedTail.endLine;
             continue;
         }
 

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -33,6 +33,17 @@ describe("allUsingPaths", () => {
         expect(allUsingPaths(["using{", "    /A", "}; using { /B }", "code()"])).toEqual(["/A", "/B"]);
     });
 
+    // The clause need not head its line: `;` separates statements exactly as a
+    // newline does, so a definition can precede the opener. A path this reader
+    // drops is what the caller reads as permission to remove an import.
+    it("collects the path of a braced clause opened after a definition", () => {
+        expect(allUsingPaths(["X := 1; using {", "    Economy.Shop", "}", "code()"])).toEqual(["Economy.Shop"]);
+    });
+
+    it("collects the path of a braced clause opened after a complete using", () => {
+        expect(allUsingPaths(["using { /A }; using {", "    /B", "}", "code()"])).toEqual(["/A", "/B"]);
+    });
+
     it("collects a multi-line braced path indented inside a module body, which scanModuleImports skips", () => {
         const lines = ["using { /A }", "MyModule := module:", "    using{", "        Economy.Shop", "    }", "code()"];
         expect(allUsingPaths(lines)).toEqual(["/A", "Economy.Shop"]);
@@ -378,6 +389,54 @@ describe("scanModuleImports", () => {
             { path: "/A", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
             { path: "/B", startLine: 2, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 3, end: 15 } },
         ]);
+    });
+
+    // A `using` may follow a non-using definition after `;` on one line, and a
+    // braced clause opens across line breaks, so the span is real code. With no
+    // entry recorded, the path did not count as present and a diagnostic asking
+    // for it wrote a second copy above lines already making the import.
+    it("records the span of a braced clause opened after a definition, pinned", () => {
+        expect(scanModuleImports(["X := 1; using {", "    Economy.Shop", "}", "code()"])).toEqual([
+            { path: "Economy.Shop", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The complete statement at the head is what carries the line past the
+    // module-import classification, so this shape strands its trailing clause
+    // on the headed side of the scan rather than the reject branch - both are
+    // read now, and both entries are pinned.
+    it("records a complete using and the braced clause it leaves open, both pinned", () => {
+        expect(scanModuleImports(["using { /A }; using {", "    /B", "}", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
+            { path: "/B", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The same clause with its brace on the line below: a line break before
+    // the `{` is whitespace to the parser, so both spell one clause.
+    it("records a braced clause whose bare using ends a definition-headed line", () => {
+        expect(scanModuleImports(["X := 1; using", "{", "    /A", "}", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The closing line of one span can open the next: a `}` closing a clause
+    // opened above pairs upward, never with a `{` written after it.
+    it("records a braced clause opened on the closing line of another", () => {
+        expect(scanModuleImports(["using{", "    /A", "}; using {", "    /B", "}", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 2, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+            { path: "/B", startLine: 2, endLine: 4, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // An unclosed brace that is not a `using` clause opens a body, not an
+    // import - the code before the brace decides.
+    it("records nothing for a class body opened at the end of its line", () => {
+        expect(scanModuleImports(["Foo := class {", "    using { /A }", "}", "code()"])).toEqual([]);
+    });
+
+    it("records nothing for a definition-headed braced using the file never closes", () => {
+        expect(scanModuleImports(["X := 1; using {", "    /A", "code()"])).toEqual([]);
     });
 
     // The `<#>` makes every line indented past it comment text, so the path

--- a/src/imports/__tests__/ImportScanner.test.ts
+++ b/src/imports/__tests__/ImportScanner.test.ts
@@ -420,6 +420,21 @@ describe("scanModuleImports", () => {
         ]);
     });
 
+    it("records a braced clause whose bare using ends a complete-using line", () => {
+        expect(scanModuleImports(["using { /A }; using", "{", "    /B", "}", "code()"])).toEqual([
+            { path: "/A", startLine: 0, endLine: 0, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "", columns: { start: 0, end: 12 } },
+            { path: "/B", startLine: 0, endLine: 3, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
+    // The line closing a class body is a closing line like any other: its `}`
+    // pairs upward, and the clause opened after it is a file-level import.
+    it("records a braced clause opened on the line closing a class body", () => {
+        expect(scanModuleImports(["Foo := class {", "    X := 1", "}; using {", "    /A", "}", "code()"])).toEqual([
+            { path: "/A", startLine: 2, endLine: 4, anchorsCommentBelow: false, rebuildLosesText: true, trailingComment: "" },
+        ]);
+    });
+
     // The closing line of one span can open the next: a `}` closing a clause
     // opened above pairs upward, never with a `{` written after it.
     it("records a braced clause opened on the closing line of another", () => {


### PR DESCRIPTION
Closes #476

## What

A braced `using` clause opened after a statement on its line — `X := 1; using {` over its indented path over `}` — was never scanned, so the path did not count as present and a diagnostic asking for it wrote a second copy of an import the file already makes. The neighbour shape `using { /A }; using {` stranded its trailing clause the same way.

## How

Two entry gaps, one per side of the module-import classification:

- `bracedUsingSpan` now finds the clause the line leaves open at its end: the code before the unclosed `{` must end in a statement-head `using` (`USING_CLAUSE_HEAD`), with the depth walk clamped at zero so a `}` pairing upward cannot cancel a clause opened after it. The bare-`using` spelling with the brace on the line below is widened the same way. Both callers (`scanModuleImports`'s reject branch and `allUsingPaths`) inherit this.
- `using { /A }; using {` passes `isModuleImport` at its head and never reached the reject branch's `bracedUsingSpan` call, so `scanModuleImports` gains the mirror branch on the headed side, recording the line's complete statements and the span through two closures both sides now share.

All new entries are pinned (`rebuildLosesText: true`): the spans hold text no rebuild from one path reproduces.

Domain rules relied on, cited in the code review: a `using` may follow a non-using definition after `;` (live-compiler verified 2026-08-10); a macro's braced clause opens on the same line or after a newline (`VerseGrammar.h`, settled for #274); `;` separates definitions exactly as a newline does (`Tests/SemicolonsVsCommas.versetest`).

## Verification

`npm run compile` — clean (tsc, no output).

`npm test`:

```
Test Suites: 63 passed, 63 total
Tests:       1722 passed, 1722 total
```

`npm run format:check` — "All matched files use Prettier code style!"

Eight regression tests pin the new shapes at `scanModuleImports` and `allUsingPaths`; the six behaviour tests fail against the unfixed scanner (verified by stashing the fix).

## Review

One round, opus, verdict PASS_WITH_SUGGESTIONS: 0 Critical, 0 Important, 6 Suggestions, 30+ behaviour probes including comment/string interference, tabs, CRLF, nesting, and the resume-on-closing-line shape. Five suggestions applied in the follow-up commit (named clause-head rule, dead guard dropped, stale comment corrected, open-literal caveat documented, two probed shapes pinned as tests). The sixth — `allUsingPaths` returning a nested clause's path twice — predates this change and its sole caller folds duplicates.
