### PR TITLE
fix(imports): apply one case rule and one folder anchor to path arithmetic

### DIFF
--- a/changelog.d/396.fixed.md
+++ b/changelog.d/396.fixed.md
@@ -1,0 +1,1 @@
+**Path conversion**: conversions now scan the workspace folder that holds your file, match the Content folder and the definitions file by the platform's case rule, and refuse to write a path holding a folder name Verse cannot parse.

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -655,7 +655,7 @@ export class ImportPathConverter {
         // is built by scanning that folder alone (ProjectPathCache.doRebuild)
         // and its answers are anchored there. A document another folder owns
         // skips it and lets the scans below read the right tree.
-        if (locations.length === 0 && this.projectPathCache && scanFolder === workspaceFolders[0]) {
+        if (locations.length === 0 && this.projectPathCache && scanFolder.index === 0) {
             const candidates = await this.projectPathCache.lookupModuleLocations(modulePath);
             for (const candidate of candidates) {
                 if (locations.includes(candidate.location)) {
@@ -1131,14 +1131,21 @@ export class ImportPathConverter {
             }
         }
 
+        // The segment is quoted without naming its origin: it is usually a
+        // disk folder, but the same gate catches a project prefix from the
+        // `.uefnproject` and a reference the user typed, and "rename that
+        // folder" is the wrong remedy for both.
         if (writablePaths.length === 0) {
-            vscode.window.showWarningMessage(
-                `Cannot convert '${moduleName}': its location contains '${unlexableSegment}', which cannot appear in a Verse path. Rename that folder or write the import by hand.`,
-            );
+            vscode.window.showWarningMessage(`Cannot convert '${moduleName}': '${unlexableSegment}' cannot appear in a Verse path. Write the import by hand.`);
             return null;
         }
 
-        if (writablePaths.length === 1) {
+        // Only where the gate dropped nothing: a dropped candidate is
+        // invisible to the user, so the sole survivor of a real ambiguity
+        // stays ambiguous below and the pick doubles as the notice - writing
+        // it unprompted would silently choose between modules the search
+        // could not tell apart.
+        if (writablePaths.length === 1 && unlexableSegment === null) {
             const fullPath = writablePaths[0];
             logger.debug("ImportPathConverter", `Constructed full path: ${fullPath}`);
 

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -4,6 +4,7 @@ import { logger } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { ProjectPathCache } from "../services";
 import { findContentRoot } from "../services/contentRoot";
+import { sameFsSegment } from "../services/pathCasing";
 import { buildProjectIndexes, resolveFolderModuleLocations, resolveModuleLocations, toContentRelativeDir } from "../services/moduleLocationLookup";
 import { ProjectPathNode } from "../types";
 import { findExplicitModuleDeclarations } from "../visibility/moduleDeclarations";
@@ -155,6 +156,45 @@ export class ImportPathConverter {
      */
     static buildFullVersePath(projectVersePath: string, location: string, modulePath: string): string {
         return location === "/" || location === "" ? `${projectVersePath}/${modulePath}` : `${projectVersePath}${location}/${modulePath}`;
+    }
+
+    /**
+     * A path's first segment as the parser lexes it: a Label - alphanumeric
+     * or `_` or `.` or `-`, and it may start with a digit - optionally
+     * carrying `@` and a second Label. Only the first segment admits either;
+     * VerseGrammar.h's Path production.
+     */
+    private static readonly FIRST_SEGMENT_LABEL = /^[A-Za-z0-9_][A-Za-z0-9_.-]*(?:@[A-Za-z0-9_][A-Za-z0-9_.-]*)?$/;
+
+    /**
+     * Every later segment: an Ident - a letter or `_`, then alphanumerics or
+     * `_` - with an optional quoted suffix of printable ASCII minus
+     * `\ { } " '` and the comment digraphs; VerseGrammar.h's Ident production.
+     */
+    private static readonly IDENT_SEGMENT = /^[A-Za-z_][A-Za-z0-9_]*(?:'(?:(?!<#|#>|[\\{}"'])[ -~])*')?$/;
+
+    /**
+     * The first segment of an absolute Verse path the parser cannot lex, or
+     * null when every segment can.
+     *
+     * The location half of a built path is disk directory names, and a
+     * directory's name answers to the filesystem's rules rather than the
+     * language's - `2Player` and `My Mods` are ordinary folders no `using`
+     * can name. This is the gate between the two: a path failing here must
+     * be refused, because writing it replaces a compiling import with a
+     * parse error reported as success.
+     */
+    private static firstUnlexableSegment(fullVersePath: string): string | null {
+        const segments = ImportPathConverter.splitPath(fullVersePath);
+        if (segments.length === 0) return fullVersePath;
+
+        if (!ImportPathConverter.FIRST_SEGMENT_LABEL.test(segments[0])) return segments[0];
+
+        for (const segment of segments.slice(1)) {
+            if (!ImportPathConverter.IDENT_SEGMENT.test(segment)) return segment;
+        }
+
+        return null;
     }
 
     /**
@@ -325,11 +365,17 @@ export class ImportPathConverter {
         const fileDir = path.dirname(relativeFilePath).replace(/\\/g, "/");
         const dirSegments = fileDir === "" || fileDir === "." ? [] : fileDir.split("/");
 
-        if (path.basename(workspaceFolderPath) === CONTENT_FOLDER) {
+        // The Content segment is matched under the platform's case rule,
+        // because findContentRoot admits an on-disk `content` through its
+        // stat: a byte-exact test here would silently place no file in a
+        // project the scan phases and the visibility writer serve. The
+        // segments kept below stay as disk spells them - they become module
+        // names, which the compiler resolves byte-exact.
+        if (sameFsSegment(path.basename(workspaceFolderPath), CONTENT_FOLDER)) {
             return { contentRootRelative: "", fileDirRelative: dirSegments.join("/") };
         }
 
-        const rootIndex = dirSegments.indexOf(CONTENT_FOLDER);
+        const rootIndex = dirSegments.findIndex((segment) => sameFsSegment(segment, CONTENT_FOLDER));
         if (rootIndex < 0) return null;
 
         const contentRootRelative = dirSegments.slice(0, rootIndex + 1).join("/");
@@ -443,14 +489,14 @@ export class ImportPathConverter {
      * `Outer.Inner` names the inner one, and a file's directory alone cannot say
      * which module a declaration is.
      *
+     * @param workspaceFolder the folder whose project is scanned - the one
+     * holding the importing document, so a multi-root workspace answers from
+     * the tree the file sits in
      * @returns whether the project holds more `.verse` files than
      * DECLARATION_SCAN_FILE_LIMIT, leaving the rest of it unread
      */
-    private async searchExplicitModuleDefinitions(modulePath: string, locations: string[]): Promise<boolean> {
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) return false;
-
-        const contentRoot = await this.scanContentRoot(workspaceFolders[0]);
+    private async searchExplicitModuleDefinitions(modulePath: string, locations: string[], workspaceFolder: vscode.WorkspaceFolder): Promise<boolean> {
+        const contentRoot = await this.scanContentRoot(workspaceFolder);
         if (!contentRoot) return false;
 
         // Scope the scan to the project's Content root. The UEFN-generated
@@ -479,7 +525,7 @@ export class ImportPathConverter {
             // two found it. Taking the path against the folder passed below
             // rather than asking which folder the file sits in is what keeps
             // the anchor and the path from being read off different folders.
-            const sourceFile = path.relative(workspaceFolders[0].uri.fsPath, file.fsPath).replace(/\\/g, "/");
+            const sourceFile = path.relative(workspaceFolder.uri.fsPath, file.fsPath).replace(/\\/g, "/");
 
             // Only a live declaration attests to a location; a commented-out one
             // or one quoted in a string names a module that does not exist.
@@ -496,7 +542,7 @@ export class ImportPathConverter {
         }
 
         const { moduleNameIndex } = buildProjectIndexes(nodes);
-        for (const candidate of resolveModuleLocations(modulePath, moduleNameIndex, { workspaceFolderPath: workspaceFolders[0].uri.fsPath, contentRootPath: contentRoot.fsPath })) {
+        for (const candidate of resolveModuleLocations(modulePath, moduleNameIndex, { workspaceFolderPath: workspaceFolder.uri.fsPath, contentRootPath: contentRoot.fsPath })) {
             logger.debug("ImportPathConverter", `Found module definition in: ${candidate.sourceFile}`);
             if (!locations.includes(candidate.location)) locations.push(candidate.location);
         }
@@ -518,14 +564,13 @@ export class ImportPathConverter {
      *
      * Capped at FOLDER_SCAN_FILE_LIMIT files enumerated.
      *
+     * @param workspaceFolder the folder whose project is enumerated, as in
+     * searchExplicitModuleDefinitions
      * @returns whether the project holds more `.verse` files than
      * FOLDER_SCAN_FILE_LIMIT, leaving the rest of it unenumerated
      */
-    private async searchProjectFolderModules(modulePath: string, locations: string[]): Promise<boolean> {
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) return false;
-
-        const contentRoot = await this.scanContentRoot(workspaceFolders[0]);
+    private async searchProjectFolderModules(modulePath: string, locations: string[], workspaceFolder: vscode.WorkspaceFolder): Promise<boolean> {
+        const contentRoot = await this.scanContentRoot(workspaceFolder);
         if (!contentRoot) return false;
 
         // One file past the limit is asked for and never folded in, so that a
@@ -586,6 +631,13 @@ export class ImportPathConverter {
 
         logger.debug("ImportPathConverter", `Searching for module '${modulePath}'`);
 
+        // The folder the project-wide phases scan: the one holding the
+        // document, so a multi-root workspace answers from the tree the
+        // importing file sits in. The first folder stands in only for a
+        // caller with no document, or a document no folder holds - the one
+        // position with no better anchor to offer.
+        const scanFolder = (currentFileUri && vscode.workspace.getWorkspaceFolder(currentFileUri)) || workspaceFolders[0];
+
         if (currentFileUri) {
             try {
                 await this.searchImplicitModules(modulePath, currentFileUri, locations);
@@ -598,7 +650,12 @@ export class ImportPathConverter {
         // candidate is checked against the filesystem before it is trusted, and
         // the full scan below still runs whenever the cache yields nothing
         // valid - empty, stale, or never set.
-        if (locations.length === 0 && this.projectPathCache) {
+        //
+        // Consulted only for the first folder's documents, because the cache
+        // is built by scanning that folder alone (ProjectPathCache.doRebuild)
+        // and its answers are anchored there. A document another folder owns
+        // skips it and lets the scans below read the right tree.
+        if (locations.length === 0 && this.projectPathCache && scanFolder === workspaceFolders[0]) {
             const candidates = await this.projectPathCache.lookupModuleLocations(modulePath);
             for (const candidate of candidates) {
                 if (locations.includes(candidate.location)) {
@@ -620,7 +677,7 @@ export class ImportPathConverter {
         if (locations.length === 0) {
             logger.debug("ImportPathConverter", `Phase 2: Searching explicit module definitions`);
             try {
-                declarationScanReadPart = await this.searchExplicitModuleDefinitions(modulePath, locations);
+                declarationScanReadPart = await this.searchExplicitModuleDefinitions(modulePath, locations, scanFolder);
             } catch (error) {
                 // A phase that threw read an unknown amount of the project,
                 // which is the position stopping at the cap leaves it in.
@@ -637,7 +694,7 @@ export class ImportPathConverter {
         if (locations.length === 0) {
             logger.debug("ImportPathConverter", `Phase 3: Searching folder modules across the project`);
             try {
-                folderScanEnumeratedPart = await this.searchProjectFolderModules(modulePath, locations);
+                folderScanEnumeratedPart = await this.searchProjectFolderModules(modulePath, locations, scanFolder);
             } catch (error) {
                 // A phase that threw enumerated an unknown amount of the
                 // project, which is the position stopping at the cap leaves it
@@ -812,10 +869,7 @@ export class ImportPathConverter {
      * declaration scan runs only when the folder phases found nothing. A folder
      * whose name differs from the reference only in case satisfies the search
      * on a case-insensitive filesystem, so this confirms the casing it asked
-     * about rather than the casing on disk. And the scanning phases read
-     * `workspaceFolders[0]` rather than the folder holding the document, so in
-     * a multi-root workspace they can answer from a tree the importing file is
-     * nowhere in.
+     * about rather than the casing on disk.
      */
     private async referenceResolvesTo(reference: string, fullPath: string, documentUri: vscode.Uri, projectVersePath: string): Promise<boolean> {
         const referenceSegments = reference.split(".");
@@ -1057,11 +1111,35 @@ export class ImportPathConverter {
             logger.debug("ImportPathConverter", `No locations found for ${modulePath}`);
             vscode.window.showErrorMessage(`Could not find module '${moduleName}'. Please verify the module exists and is properly defined.`);
             return null;
-        } else if (possibleLocations.length === 1) {
-            const location = possibleLocations[0];
-            logger.debug("ImportPathConverter", `Single location found: '${location}'`);
+        }
 
-            const fullPath = ImportPathConverter.buildFullVersePath(projectVersePath, location, modulePath);
+        // Locations are read off disk directory names, so a candidate can hold
+        // a segment no `using` can name. Each is gated before it is offered: a
+        // candidate that cannot lex could only ever be written as a parse
+        // error, so dropping it narrows the choice to the paths that compile,
+        // and losing every candidate refuses the conversion outright.
+        const writablePaths: string[] = [];
+        let unlexableSegment: string | null = null;
+        for (const location of possibleLocations) {
+            const candidate = ImportPathConverter.buildFullVersePath(projectVersePath, location, modulePath);
+            const badSegment = ImportPathConverter.firstUnlexableSegment(candidate);
+            if (badSegment === null) {
+                writablePaths.push(candidate);
+            } else {
+                unlexableSegment = unlexableSegment ?? badSegment;
+                logger.debug("ImportPathConverter", `Dropping ${candidate}: '${badSegment}' cannot appear in a Verse path`);
+            }
+        }
+
+        if (writablePaths.length === 0) {
+            vscode.window.showWarningMessage(
+                `Cannot convert '${moduleName}': its location contains '${unlexableSegment}', which cannot appear in a Verse path. Rename that folder or write the import by hand.`,
+            );
+            return null;
+        }
+
+        if (writablePaths.length === 1) {
+            const fullPath = writablePaths[0];
             logger.debug("ImportPathConverter", `Constructed full path: ${fullPath}`);
 
             const convertedImport = usesCurlyBraces ? `using { ${fullPath} }` : `using. ${fullPath}`;
@@ -1073,18 +1151,16 @@ export class ImportPathConverter {
                 isAmbiguous: false,
                 line,
             };
-        } else {
-            const possiblePaths = possibleLocations.map((location) => ImportPathConverter.buildFullVersePath(projectVersePath, location, modulePath));
-
-            return {
-                originalImport: importStatement,
-                convertedImport: "",
-                moduleName,
-                isAmbiguous: true,
-                possiblePaths,
-                line,
-            };
         }
+
+        return {
+            originalImport: importStatement,
+            convertedImport: "",
+            moduleName,
+            isAmbiguous: true,
+            possiblePaths: writablePaths,
+            line,
+        };
     }
 
     /**

--- a/src/imports/ImportPathConverter.ts
+++ b/src/imports/ImportPathConverter.ts
@@ -24,7 +24,12 @@ interface ImportConversionResult {
      */
     convertedImport: string;
     moduleName: string;
-    /** Whether the module resolved to more than one location, listed in `possiblePaths`. */
+    /**
+     * Whether the caller must put a choice to the user, with the candidates
+     * in `possiblePaths`. Usually several locations; a single candidate means
+     * the lexical gate dropped an unwritable namesake, and the pick is what
+     * keeps that drop visible.
+     */
     isAmbiguous: boolean;
     possiblePaths?: string[];
     /**
@@ -1048,7 +1053,8 @@ export class ImportPathConverter {
      *
      * A module resolving to several locations comes back `isAmbiguous`, with
      * the candidates in `possiblePaths` and no statement built yet - the caller
-     * picks, then hands the choice to applyConversion.
+     * picks, then hands the choice to applyConversion. So does one whose
+     * candidate list the lexical gate narrowed, however few survive.
      */
     async convertToFullPath(importStatement: string, documentUri: vscode.Uri, line?: number): Promise<ImportConversionResult | null> {
         return this.resolveToFullPath(importStatement, documentUri, { pending: true }, line);

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -1392,3 +1392,165 @@ describe("ImportPathConverter.convertToFullPath project-wide folder module searc
         expect(await convert("using { Economy.Shop }", "Scripts/Main.verse")).toBeNull();
     });
 });
+
+// Locations are disk directory names, and a directory answers to the
+// filesystem's rules rather than the language's - so a folder the parser
+// cannot lex used to flow straight into a written `using` as a parse error
+// reported as success.
+describe("ImportPathConverter.convertToFullPath lexical gate", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const documentUri = vscode.Uri.file("C:/project/test.verse");
+
+    /** A converter whose module search answers with these fixed locations. */
+    function converterWithLocations(locations: string[]): ImportPathConverter {
+        const converter = converterWithProjectPath(projectVersePath);
+        converter.findModuleLocations = async () => ({ locations, truncated: false });
+        return converter;
+    }
+
+    beforeEach(() => {
+        (vscode.window.showWarningMessage as jest.Mock).mockClear();
+    });
+
+    it("refuses a location holding a segment that cannot lex, and names the segment", async () => {
+        const converter = converterWithLocations(["/My Mods"]);
+
+        expect(await converter.convertToFullPath("using { Shop }", documentUri, 0)).toBeNull();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("'My Mods'"));
+    });
+
+    it("refuses a segment starting with a digit, which only the path's first label may", async () => {
+        const converter = converterWithLocations(["/2Player"]);
+
+        expect(await converter.convertToFullPath("using { Shop }", documentUri, 0)).toBeNull();
+    });
+
+    it("keeps a quoted-suffix segment, which the parser lexes", async () => {
+        const converter = converterWithLocations(["/Zone'2'"]);
+
+        const result = await converter.convertToFullPath("using { Shop }", documentUri, 0);
+
+        expect(result?.convertedImport).toBe("using { /mygame@fortnite.com/mygame/Zone'2'/Shop }");
+    });
+
+    it("narrows an ambiguous answer to the candidates that can be written", async () => {
+        // The dropped candidate could only ever be written as a parse error,
+        // so the one that compiles is not ambiguous with it.
+        const converter = converterWithLocations(["/My Mods", "/Economy"]);
+
+        const result = await converter.convertToFullPath("using { Shop }", documentUri, 0);
+
+        expect(result?.isAmbiguous).toBe(false);
+        expect(result?.convertedImport).toBe("using { /mygame@fortnite.com/mygame/Economy/Shop }");
+    });
+
+    it("keeps a genuinely ambiguous answer ambiguous", async () => {
+        const converter = converterWithLocations(["/Systems", "/Economy"]);
+
+        const result = await converter.convertToFullPath("using { Shop }", documentUri, 0);
+
+        expect(result?.isAmbiguous).toBe(true);
+        expect(result?.possiblePaths).toEqual(["/mygame@fortnite.com/mygame/Systems/Shop", "/mygame@fortnite.com/mygame/Economy/Shop"]);
+    });
+});
+
+// The project-wide phases used to scan workspaceFolders[0] whatever document
+// asked, so in a multi-root workspace - which the UEFN-generated workspace is -
+// they answered from a tree the importing file is nowhere in.
+describe("ImportPathConverter.findModuleLocations in a multi-root workspace", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const digestRoot = "C:/Digests";
+    const projectRoot = "C:/Project";
+    const documentUri = vscode.Uri.file(`${projectRoot}/Content/Scripts/Feature.verse`);
+
+    beforeEach(() => {
+        setWorkspaceFolders([
+            { uri: { fsPath: digestRoot }, name: "Digests", index: 0 },
+            { uri: { fsPath: projectRoot }, name: "Project", index: 1 },
+        ]);
+        // Only the second folder holds a Content root; the first is the kind
+        // of digest sibling the generated workspace opens ahead of it.
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            if (uri.fsPath.replace(/\\/g, "/") === `${projectRoot}/Content`) return { type: vscode.FileType.Directory };
+            throw new Error("ENOENT");
+        });
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([vscode.Uri.file(`${projectRoot}/Content/Systems/Inventory.verse`)]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(Buffer.from("Inventory := module:\n", "utf8"));
+    });
+
+    afterEach(() => {
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("scans the folder holding the document, not the first folder", async () => {
+        const converter = converterWithProjectPath(projectVersePath);
+
+        expect((await converter.findModuleLocations("Inventory", documentUri)).locations).toEqual(["/Systems"]);
+    });
+
+    it("skips the cache for a document another folder owns", async () => {
+        // The cache is built by scanning the first folder alone, so its
+        // answers are anchored there and cannot speak for this document.
+        const cache = { lookupModuleLocations: jest.fn().mockResolvedValue([{ location: "/Wrong", sourceFile: "Content/Wrong/Mod.verse" }]) };
+        const converter = converterWithProjectPath(projectVersePath);
+        converter.setProjectPathCache(cache as never);
+
+        expect((await converter.findModuleLocations("Inventory", documentUri)).locations).toEqual(["/Systems"]);
+        expect(cache.lookupModuleLocations).not.toHaveBeenCalled();
+    });
+});
+
+// findContentRoot admits an on-disk `content` through its case-insensitive
+// stat, so the scan phases and the visibility writer serve such a project -
+// while the document-relative placement compared byte-exact and silently
+// placed no file in it: no scope for the relative conversion, no near-file
+// search, and no message either way.
+describe("ImportPathConverter.convertFromFullPath under an on-disk `content` root", () => {
+    const projectVersePath = "/mygame@fortnite.com/mygame";
+    const workspaceRoot = "C:/Project";
+    const documentUri = vscode.Uri.file(`${workspaceRoot}/content/Systems/Economy/Feature.verse`);
+
+    const realPlatform = process.platform;
+    const setPlatform = (platform: string): void => {
+        Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    };
+
+    /** A case-insensitive disk holding `content/Systems/Economy/Shop`, as Windows serves it. */
+    const stubCaseInsensitiveTree = (): void => {
+        const folders = ["content", "content/Systems", "content/Systems/Economy", "content/Systems/Economy/Shop"].map((folder) => `${workspaceRoot}/${folder}`.toLowerCase());
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            if (!folders.includes(uri.fsPath.replace(/\\/g, "/").toLowerCase())) throw new Error("ENOENT");
+            return { type: vscode.FileType.Directory };
+        });
+    };
+
+    beforeEach(() => {
+        setWorkspaceFolders([{ uri: { fsPath: workspaceRoot }, name: "Project", index: 0 }]);
+        stubCaseInsensitiveTree();
+    });
+
+    afterEach(() => {
+        setPlatform(realPlatform);
+        setWorkspaceFolders(undefined);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("places the file under the root the stat admits, where the filesystem folds case", async () => {
+        setPlatform("win32");
+        const converter = converterWithProjectPath(projectVersePath);
+
+        const result = await converter.convertFromFullPath(`using. ${projectVersePath}/Systems/Economy/Shop`, documentUri, 0);
+
+        expect(result?.convertedImport).toBe("using. Shop");
+    });
+
+    it("keeps refusing where the filesystem is byte-exact", async () => {
+        setPlatform("linux");
+        const converter = converterWithProjectPath(projectVersePath);
+
+        expect(await converter.convertFromFullPath(`using. ${projectVersePath}/Systems/Economy/Shop`, documentUri, 0)).toBeNull();
+    });
+});

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -1503,6 +1503,23 @@ describe("ImportPathConverter.findModuleLocations in a multi-root workspace", ()
         expect((await converter.findModuleLocations("Inventory", documentUri)).locations).toEqual(["/Systems"]);
         expect(cache.lookupModuleLocations).not.toHaveBeenCalled();
     });
+
+    it("still consults the cache for a document the first folder owns", async () => {
+        // The other half of the guard, pinned so a comparison that stopped
+        // matching could not silently cost every workspace the fast path.
+        const cache = { lookupModuleLocations: jest.fn().mockResolvedValue([{ location: "/Cached", sourceFile: "Content/Cached/Mod.verse" }]) };
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (uri: { fsPath: string }) => {
+            if (uri.fsPath.replace(/\\/g, "/") === `${digestRoot}/Content/Cached/Mod.verse`) return { type: vscode.FileType.File };
+            throw new Error("ENOENT");
+        });
+        const converter = converterWithProjectPath(projectVersePath);
+        converter.setProjectPathCache(cache as never);
+
+        const firstFolderDocument = vscode.Uri.file(`${digestRoot}/Scripts/Feature.verse`);
+
+        expect((await converter.findModuleLocations("Inventory", firstFolderDocument)).locations).toEqual(["/Cached"]);
+        expect(cache.lookupModuleLocations).toHaveBeenCalledWith("Inventory");
+    });
 });
 
 // findContentRoot admits an on-disk `content` through its case-insensitive

--- a/src/imports/__tests__/ImportPathConverter.test.ts
+++ b/src/imports/__tests__/ImportPathConverter.test.ts
@@ -1433,15 +1433,17 @@ describe("ImportPathConverter.convertToFullPath lexical gate", () => {
         expect(result?.convertedImport).toBe("using { /mygame@fortnite.com/mygame/Zone'2'/Shop }");
     });
 
-    it("narrows an ambiguous answer to the candidates that can be written", async () => {
+    it("keeps a narrowed answer ambiguous, so the dropped candidate stays visible", async () => {
         // The dropped candidate could only ever be written as a parse error,
-        // so the one that compiles is not ambiguous with it.
+        // so it is not offered - but writing the survivor unprompted would
+        // silently choose between modules the search could not tell apart.
+        // The single-entry pick is the notice.
         const converter = converterWithLocations(["/My Mods", "/Economy"]);
 
         const result = await converter.convertToFullPath("using { Shop }", documentUri, 0);
 
-        expect(result?.isAmbiguous).toBe(false);
-        expect(result?.convertedImport).toBe("using { /mygame@fortnite.com/mygame/Economy/Shop }");
+        expect(result?.isAmbiguous).toBe(true);
+        expect(result?.possiblePaths).toEqual(["/mygame@fortnite.com/mygame/Economy/Shop"]);
     });
 
     it("keeps a genuinely ambiguous answer ambiguous", async () => {

--- a/src/services/__tests__/contentRoot.test.ts
+++ b/src/services/__tests__/contentRoot.test.ts
@@ -83,3 +83,28 @@ describe("findContentRoot", () => {
         expect(root).toBeNull();
     });
 });
+
+// The stat behind every other candidate is case-insensitive on Windows, so
+// this test used to be the one byte-exact comparison in the resolver: a
+// workspace opened at an on-disk `content` got the "Content" candidate,
+// statted `content/Content`, and found nothing.
+describe("contentRootCandidates under the platform's case rule", () => {
+    const realPlatform = process.platform;
+    const setPlatform = (platform: string): void => {
+        Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    };
+
+    afterEach(() => setPlatform(realPlatform));
+
+    it("offers the folder itself for an on-disk `content`, where the filesystem folds case", () => {
+        setPlatform("win32");
+
+        expect(contentRootCandidates("C:/Project/content", null)).toEqual([""]);
+    });
+
+    it("keeps the spellings apart where the filesystem is byte-exact", () => {
+        setPlatform("linux");
+
+        expect(contentRootCandidates("/repo/content", null)).toEqual(["Content"]);
+    });
+});

--- a/src/services/__tests__/pathCasing.test.ts
+++ b/src/services/__tests__/pathCasing.test.ts
@@ -1,0 +1,47 @@
+import { fileSystemFoldsCase, sameFsPath, sameFsSegment } from "../pathCasing";
+
+const realPlatform = process.platform;
+
+/** `process.platform` is read-only in the typings; redefining it is the seam the helper leaves for tests. */
+const setPlatform = (platform: string): void => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+};
+
+afterEach(() => setPlatform(realPlatform));
+
+describe("pathCasing where the filesystem folds case", () => {
+    beforeEach(() => setPlatform("win32"));
+
+    it("reports the fold", () => {
+        expect(fileSystemFoldsCase()).toBe(true);
+    });
+
+    it("treats two spellings of one segment as the same entry", () => {
+        expect(sameFsSegment("Content", "content")).toBe(true);
+    });
+
+    it("treats two spellings of one path as the same file, whichever separators they carry", () => {
+        expect(sameFsPath("C:\\Project\\Content\\_Definitions.verse", "C:/project/content/_definitions.verse")).toBe(true);
+    });
+
+    it("still tells two different names apart", () => {
+        expect(sameFsSegment("Content", "Contents")).toBe(false);
+    });
+});
+
+describe("pathCasing where the filesystem is byte-exact", () => {
+    beforeEach(() => setPlatform("linux"));
+
+    it("reports no fold", () => {
+        expect(fileSystemFoldsCase()).toBe(false);
+    });
+
+    it("keeps two spellings of one name apart", () => {
+        expect(sameFsSegment("Content", "content")).toBe(false);
+        expect(sameFsPath("/repo/Content/_Definitions.verse", "/repo/Content/_definitions.verse")).toBe(false);
+    });
+
+    it("still matches an identical path across separators", () => {
+        expect(sameFsPath("/repo\\Content/file.verse", "/repo/Content/file.verse")).toBe(true);
+    });
+});

--- a/src/services/contentRoot.ts
+++ b/src/services/contentRoot.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { logger } from "../utils";
+import { sameFsSegment } from "./pathCasing";
 
 /** The Content folder that anchors every importable module location. */
 const CONTENT_FOLDER = "Content";
@@ -37,7 +38,11 @@ const PLUGINS_FOLDER = "Plugins";
  * and the visibility writer must not create files outside the workspace.
  */
 export function contentRootCandidates(workspaceFolderPath: string, rootPluginName: string | null, projectFileDirectory: string | null = null): string[] {
-    if (path.basename(workspaceFolderPath) === CONTENT_FOLDER) {
+    // Under the platform's case rule, because the stat that accepts every
+    // other candidate is case-insensitive on Windows: a byte-exact test here
+    // would refuse a workspace opened at an on-disk `content` while the same
+    // folder passes everywhere else.
+    if (sameFsSegment(path.basename(workspaceFolderPath), CONTENT_FOLDER)) {
         return [""];
     }
 

--- a/src/services/pathCasing.ts
+++ b/src/services/pathCasing.ts
@@ -28,7 +28,13 @@ export function sameFsSegment(a: string, b: string): boolean {
     return fileSystemFoldsCase() ? a.toLowerCase() === b.toLowerCase() : a === b;
 }
 
-/** Whether two paths address the same file under the platform's case rule, whichever separators they carry. */
+/**
+ * Whether two paths address the same file under the platform's case rule,
+ * whichever separators they carry. The comparison is textual after separator
+ * normalization - `.` and `..` are not resolved - which serves callers
+ * passing `Uri.fsPath` values, where neither occurs.
+ */
 export function sameFsPath(a: string, b: string): boolean {
-    return sameFsSegment(a.replace(/\\/g, "/"), b.replace(/\\/g, "/"));
+    const normalize = (candidate: string): string => candidate.replace(/\\/g, "/");
+    return fileSystemFoldsCase() ? normalize(a).toLowerCase() === normalize(b).toLowerCase() : normalize(a) === normalize(b);
 }

--- a/src/services/pathCasing.ts
+++ b/src/services/pathCasing.ts
@@ -1,0 +1,34 @@
+/**
+ * The one case rule for comparing filesystem names, shared so no two
+ * components can disagree about whether two spellings are one path.
+ *
+ * These comparisons are for names the filesystem resolves - the Content
+ * folder, a configured file name matched against a directory listing. Names
+ * the Verse compiler resolves are module names, compared byte-exact
+ * everywhere; folding one of those would name the wrong module.
+ */
+
+/**
+ * Whether this platform's filesystem treats two spellings of one name as the
+ * same entry. Read at call time rather than bound at load, so a test can pin
+ * the platform it exercises.
+ */
+export function fileSystemFoldsCase(): boolean {
+    return process.platform === "win32";
+}
+
+/**
+ * Whether two path segments name the same directory entry under the
+ * platform's case rule: folded where the filesystem folds, byte-exact where
+ * it does not. The fold is the one `path.win32.relative` applies, so a
+ * comparison made here cannot disagree with a placement made through
+ * `path.relative`.
+ */
+export function sameFsSegment(a: string, b: string): boolean {
+    return fileSystemFoldsCase() ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+/** Whether two paths address the same file under the platform's case rule, whichever separators they carry. */
+export function sameFsPath(a: string, b: string): boolean {
+    return sameFsSegment(a.replace(/\\/g, "/"), b.replace(/\\/g, "/"));
+}

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -3,6 +3,7 @@ import { logger, settingsFor } from "../utils";
 import { ProjectPathHandler } from "../project";
 import { findContentRoot } from "../services/contentRoot";
 import { toContentRelativeDir } from "../services/moduleLocationLookup";
+import { sameFsPath } from "../services/pathCasing";
 import { appendDeclarationBlock, buildDeclarationBlock, nestDeclarationEdit } from "./definitionsContent";
 import { findExplicitModuleDeclarations } from "./moduleDeclarations";
 import { ModuleVisibilityRequest } from "./ModuleVisibilityMessage";
@@ -178,19 +179,26 @@ export class ModuleVisibilityWriter {
             return { reason: `'${request.moduleName}' is already reachable from the importing module.` };
         }
 
-        const definitionsUri = this.definitionsUri(contentRoot);
-        if (!definitionsUri) {
+        const configuredDefinitionsUri = this.definitionsUri(contentRoot);
+        if (!configuredDefinitionsUri) {
             return { reason: "verseAutoImports.moduleVisibility.definitionsFileName must be a plain file name ending in .verse." };
         }
-        const definitionsKey = definitionsUri.toString();
 
         // Every module on the path is looked up, the reachable prefix included:
         // the chain written into the definitions file has to nest through them,
         // and a part it writes must repeat whatever they already declare.
-        const scan = await this.findDeclarations(contentRoot, [...prefix, ...segments.map((segment) => segment.name)], definitionsKey);
+        const scan = await this.findDeclarations(contentRoot, [...prefix, ...segments.map((segment) => segment.name)], configuredDefinitionsUri);
         if ("unreadable" in scan) {
             return { reason: `'${vscode.workspace.asRelativePath(scan.unreadable, false)}' could not be read, so whether it declares part of '${request.moduleName}' is unknown.` };
         }
+
+        // The on-disk spelling wins over the configured one wherever the scan
+        // listed the file: VS Code keeps two URI spellings of one Windows file
+        // as two documents, so keying the whole-file replace by the configured
+        // spelling while the scan keys its edits by disk writes the same file
+        // twice in one applyEdit, and whichever document saves last wins.
+        const definitionsUri = scan.definitionsOnDisk ?? configuredDefinitionsUri;
+        const definitionsKey = definitionsUri.toString();
 
         const { declarations, scanned } = scan;
         const resolved = resolveVisibility(prefix, segments, declarations, definitionsKey);
@@ -426,20 +434,24 @@ export class ModuleVisibilityWriter {
      * @param contentRoot the root the scan sweeps and every path is taken
      * against, resolved once by the caller: deriving it a second time here
      * would let the folder written to and the folder read from disagree.
-     * @param definitionsKey the definitions file, whose text is kept even when
-     * it declares none of these modules, because the caller appends to it. A
-     * file holding no module declaration at all is skipped before that, and
-     * reaches the caller through readDefinitions instead.
+     * @param definitionsUri the configured definitions file, matched against
+     * the scan under the platform's case rule so a user-created spelling that
+     * differs only in case is adopted (as `definitionsOnDisk`) rather than
+     * doubled. Its text is kept even when it declares none of these modules,
+     * because the caller appends to it. A file holding no module declaration
+     * at all is skipped before that, and reaches the caller through
+     * readDefinitions instead.
      */
     private async findDeclarations(
         contentRoot: vscode.Uri,
         names: readonly string[],
-        definitionsKey: string,
-    ): Promise<{ declarations: FoundDeclaration[]; scanned: Map<string, ScannedFile> } | UnreadableFile> {
+        definitionsUri: vscode.Uri,
+    ): Promise<{ declarations: FoundDeclaration[]; scanned: Map<string, ScannedFile>; definitionsOnDisk: vscode.Uri | null } | UnreadableFile> {
         const verseFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(contentRoot, "**/*.verse"), "**/*.digest.verse");
         const wanted = new Set(names);
         const declarations: FoundDeclaration[] = [];
         const scanned = new Map<string, ScannedFile>();
+        let definitionsOnDisk: vscode.Uri | null = null;
 
         for (let i = 0; i < verseFiles.length; i += SCAN_CONCURRENCY) {
             const batch = await Promise.all(verseFiles.slice(i, i + SCAN_CONCURRENCY).map((file) => this.readDeclarations(file, contentRoot, wanted)));
@@ -453,16 +465,19 @@ export class ModuleVisibilityWriter {
                     logger.debug("ModuleVisibilityWriter", `Stopped the scan at unreadable file ${result.unreadable.toString()}`);
                     return result;
                 }
-                const key = result.file.uri.toString();
-                if (result.declarations.length > 0 || key === definitionsKey) {
-                    scanned.set(key, result.file);
+                const isDefinitionsFile = sameFsPath(result.file.uri.fsPath, definitionsUri.fsPath);
+                if (isDefinitionsFile && !definitionsOnDisk) {
+                    definitionsOnDisk = result.file.uri;
+                }
+                if (result.declarations.length > 0 || isDefinitionsFile) {
+                    scanned.set(result.file.uri.toString(), result.file);
                     declarations.push(...result.declarations);
                 }
             }
         }
 
         logger.debug("ModuleVisibilityWriter", `Scanned ${verseFiles.length} file(s), found ${declarations.length} matching declaration(s)`);
-        return { declarations, scanned };
+        return { declarations, scanned, definitionsOnDisk };
     }
 
     /**

--- a/src/visibility/ModuleVisibilityWriter.ts
+++ b/src/visibility/ModuleVisibilityWriter.ts
@@ -451,7 +451,17 @@ export class ModuleVisibilityWriter {
         const wanted = new Set(names);
         const declarations: FoundDeclaration[] = [];
         const scanned = new Map<string, ScannedFile>();
+
+        // Adopted from the listing rather than from the read results, so a
+        // definitions file the declaration reader skips - empty, or holding
+        // no `module` at all - still resolves to its on-disk spelling.
         let definitionsOnDisk: vscode.Uri | null = null;
+        for (const file of verseFiles) {
+            if (sameFsPath(file.fsPath, definitionsUri.fsPath)) {
+                definitionsOnDisk = file;
+                break;
+            }
+        }
 
         for (let i = 0; i < verseFiles.length; i += SCAN_CONCURRENCY) {
             const batch = await Promise.all(verseFiles.slice(i, i + SCAN_CONCURRENCY).map((file) => this.readDeclarations(file, contentRoot, wanted)));
@@ -465,11 +475,7 @@ export class ModuleVisibilityWriter {
                     logger.debug("ModuleVisibilityWriter", `Stopped the scan at unreadable file ${result.unreadable.toString()}`);
                     return result;
                 }
-                const isDefinitionsFile = sameFsPath(result.file.uri.fsPath, definitionsUri.fsPath);
-                if (isDefinitionsFile && !definitionsOnDisk) {
-                    definitionsOnDisk = result.file.uri;
-                }
-                if (result.declarations.length > 0 || isDefinitionsFile) {
+                if (result.declarations.length > 0 || sameFsPath(result.file.uri.fsPath, definitionsUri.fsPath)) {
                     scanned.set(result.file.uri.toString(), result.file);
                     declarations.push(...result.declarations);
                 }

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -753,3 +753,67 @@ describe("ModuleVisibilityWriter under a nested plugin Content root", () => {
         expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("no 'Content' folder"));
     });
 });
+
+// A Windows user creates the definitions file by hand as `_Definitions.verse`.
+// The filesystem treats that and the configured `_definitions.verse` as one
+// file; the writer keyed them as two, so the scan's declarations were read as
+// a user file's - conflicting with the very block they belong to - and a
+// whole-file replace could target one spelling while in-place edits targeted
+// the other, both written in one applyEdit.
+describe("ModuleVisibilityWriter under a case-drifted definitions file name", () => {
+    const realPlatform = process.platform;
+    const setPlatform = (platform: string): void => {
+        Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    };
+
+    const publicizeDeepTools = () =>
+        writer().makeModulePublic({
+            targetPath: `${PROJECT}/Gadgets/Deep/Tools`,
+            importerPath: `${PROJECT}/Scripts`,
+            moduleName: "Tools",
+        });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        afterScan.clear();
+        (vscode.workspace.applyEdit as jest.Mock).mockResolvedValue(true);
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn().mockImplementation((_key: string, fallback?: unknown) => fallback),
+            update: jest.fn(),
+        });
+    });
+
+    afterEach(() => {
+        setPlatform(realPlatform);
+        (vscode.workspace as any).workspaceFolders = undefined;
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+    });
+
+    it("adopts the on-disk spelling as its one write target, where the filesystem folds case", async () => {
+        setPlatform("win32");
+        givenProject({ "Content/_Definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
+
+        await publicizeDeepTools();
+
+        const operations = appliedOperations();
+        expect(operations).toHaveLength(1);
+        expect(operations[0].kind).toBe("replace");
+        expect(forwardSlashed(operations[0].uri)).toBe(`${ROOT}/Content/_Definitions.verse`);
+        expect(operations[0].text).toBe("Gadgets := module:\n    Deep<public> := module:\n        Tools<public> := module {}\n");
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it("keeps the two spellings apart where the filesystem does", async () => {
+        // On a byte-exact filesystem the on-disk file really is a different
+        // file, so its declarations are a user file's and restating them is
+        // the conflict the writer refuses.
+        setPlatform("linux");
+        givenProject({ "Content/_Definitions.verse": "Gadgets := module:\n    Deep := module {}\n" });
+
+        await publicizeDeepTools();
+
+        expect(vscode.workspace.applyEdit).not.toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(expect.stringContaining("re-declaring"));
+    });
+});

--- a/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
+++ b/src/visibility/__tests__/ModuleVisibilityWriter.test.ts
@@ -804,6 +804,21 @@ describe("ModuleVisibilityWriter under a case-drifted definitions file name", ()
         expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
     });
 
+    it("adopts the on-disk spelling even when the drifted file is empty", async () => {
+        // An empty file holds no declaration for the reader to report, so the
+        // adoption must come from the scan's listing rather than from what
+        // was read - otherwise the block lands under the configured spelling
+        // while the empty file sits beside it.
+        setPlatform("win32");
+        givenProject({ "Content/_Definitions.verse": "" });
+
+        await publicizeDeepTools();
+
+        const operations = appliedOperations();
+        expect(operations.map((operation: { uri: vscode.Uri }) => forwardSlashed(operation.uri))).toEqual([`${ROOT}/Content/_Definitions.verse`, `${ROOT}/Content/_Definitions.verse`]);
+        expect(operations[1].text).toBe("Gadgets := module:\n    Deep<public> := module:\n        Tools<public> := module {}\n");
+    });
+
     it("keeps the two spellings apart where the filesystem does", async () => {
         // On a byte-exact filesystem the on-disk file really is a different
         // file, so its declarations are a user file's and restating them is


### PR DESCRIPTION
Closes #396

## What

Applies one case rule and one folder anchor to the path arithmetic, fixing the four findings of #396 that survived #427/#447/#465/#468/#470 (H-10 was already fixed; H-09 was settled as documented fail-closed; the writer halves of H-08/H-14 landed with #465/#436):

- **H-08 (converter half)** — the `Content` boundary is now compared under the platform's case rule through a new shared helper (`src/services/pathCasing.ts`): `placeUnderContentRoot`'s basename and segment checks and `contentRootCandidates`' basename check fold on win32, matching the case-insensitive stat that `findContentRoot` already runs. Segments kept below the root stay as disk spells them — module names remain byte-exact, and the `foldAscii` boundary (project prefix, plugin dir) is untouched.
- **H-11 / ABS-3** — emitted absolute paths are gated against the Verse path grammar (`VerseGrammar.h:1952-2011`): first segment per the Label rule (digit-start legal, optional `@`-Label), later segments per the Ident rule with the quoted-suffix alphabet. An unwritable candidate is dropped with the offending segment named; a conversion whose candidate list was narrowed stays ambiguous so the drop is visible; losing every candidate refuses outright.
- **H-12** — the visibility writer adopts the on-disk spelling of the definitions file from the scan's listing (matched by `sameFsPath`), so a user-created `_Definitions.verse` beside a configured `_definitions.verse` resolves to one write target instead of two VS Code documents of one disk file — including when the drifted file is empty.
- **H-14 (converter half)** — `findModuleLocations` derives the owning folder from the document once and threads it through phases 2/3 and their anchors; the folder-0-built `ProjectPathCache` is bypassed (not reinterpreted) for documents other folders own, and consulted as before for first-folder documents. No-document callers keep the old first-folder behaviour.

## Verification

`npm run compile` — clean (tsc, no output).

`npm test`:

```
Test Suites: 64 passed, 64 total
Tests:       1734 passed, 1734 total
Snapshots:   0 total
```

`npm run format:check` — "All matched files use Prettier code style!"

Each of the eight regression scenarios was proven against the unfixed code (fix stashed): exactly those eight failed, every unchanged-behaviour guard passed.

## Review

Two rounds at opus, both `PASS_WITH_SUGGESTIONS`, zero Critical.

- Round 1: one Important — the lexical gate silently wrote the sole survivor of a narrowed ambiguity. Fixed: a narrowed answer stays ambiguous and the single-entry pick doubles as the notice. Three of five Suggestions applied (refusal message no longer prescribes a folder rename, definitions adoption hoisted ahead of the `module`-substring filter, cache guard reads `WorkspaceFolder.index` instead of object identity).
- Round 2: re-probed all four fixes (including full suite under a forced-linux platform and with `path.posix` bindings — CI runs both OSes); two Suggestions, both applied (contract docs for the narrowed-ambiguity case, a test pinning the cache guard's positive branch).
- Left as-is with rationale: the per-file `setPlatform` test helper (repo convention is per-file local builders) and the CommandsHandler quick-pick title.
