### PR TITLE
refactor(imports): route both entry points through a single rebuilder

### DIFF
--- a/changelog.d/384.fixed.md
+++ b/changelog.d/384.fixed.md
@@ -1,0 +1,1 @@
+**Import placement**: auto-import and Optimize Imports now decide placement by one shared rule, so a missing import lands on the same line whichever command adds it, and an import's own comment moves with it when consolidating.

--- a/changelog.d/384.fixed.md
+++ b/changelog.d/384.fixed.md
@@ -1,1 +1,1 @@
-**Import placement**: auto-import and Optimize Imports now decide placement by one shared rule, so a missing import lands on the same line whichever command adds it, and an import's own comment moves with it when consolidating.
+**Import placement**: auto-import and Optimize Imports now decide placement by one shared rule and rewrite only the import region, so a missing import lands on the same line whichever command adds it, and an import's comment moves with it when consolidating.

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -65,6 +65,89 @@ function resolveEol(document: vscode.TextDocument, text: string): LineEnding {
     return detectEol(text) ?? documentEol(document);
 }
 
+/** A rewrite of lines [start, endExclusive) as `newLines`. Equal bounds insert above `start`. */
+export interface LineSplice {
+    start: number;
+    endExclusive: number;
+    newLines: string[];
+}
+
+/**
+ * `lines` with every splice applied, or null where two overlap or one reaches
+ * outside the array. No placement branch emits either shape, so a null is a
+ * composition bug - and it has to be answered here rather than by the rewrite
+ * guard, which compares paths as a set and so cannot see an import written
+ * twice by overlapping splices.
+ *
+ * Insertions at one line keep their given order, and an insertion at the start
+ * of a replaced range goes first, as VS Code applies a WorkspaceEdit's.
+ */
+export function applyLineSplices(lines: string[], splices: LineSplice[]): string[] | null {
+    const ordered = [...splices].sort((a, b) => a.start - b.start || a.endExclusive - b.endExclusive);
+
+    const result: string[] = [];
+    let cursor = 0;
+    for (const splice of ordered) {
+        if (splice.start < cursor || splice.endExclusive < splice.start || splice.endExclusive > lines.length) {
+            return null;
+        }
+        result.push(...lines.slice(cursor, splice.start), ...splice.newLines);
+        cursor = splice.endExclusive;
+    }
+    result.push(...lines.slice(cursor));
+    return result;
+}
+
+/**
+ * A replacement of characters [start, end) with `newText`. Offsets are UTF-16
+ * units into the text the splice was computed from, which is how VS Code
+ * positions count as well.
+ */
+export interface TextSplice {
+    start: number;
+    end: number;
+    newText: string;
+}
+
+/**
+ * The one line-aligned edit that turns `before` into `after`, or null when the
+ * two already match.
+ *
+ * Character-offset arithmetic rather than a line diff, for two shapes a line
+ * diff gets wrong: a hunk reaching the end of a document with no trailing
+ * newline, where rejoining lines invents one; and a rebuild that only
+ * normalizes line endings, whose lines all compare equal while the text does
+ * not. Both bounds sit on a line start or the text's own end, so the range
+ * never splits a CRLF pair.
+ */
+export function minimalSplice(before: string, after: string): TextSplice | null {
+    if (before === after) {
+        return null;
+    }
+
+    const sharedMax = Math.min(before.length, after.length);
+    let shared = 0;
+    while (shared < sharedMax && before[shared] === after[shared]) {
+        shared++;
+    }
+    const start = shared === 0 ? 0 : before.lastIndexOf("\n", shared - 1) + 1;
+
+    // Bounded away from the snapped prefix in both texts, so the two never
+    // claim one character twice.
+    const suffixMax = sharedMax - start;
+    let suffix = 0;
+    while (suffix < suffixMax && before[before.length - 1 - suffix] === after[after.length - 1 - suffix]) {
+        suffix++;
+    }
+    let end = before.length - suffix;
+    if (end > start && end < before.length && before[end - 1] !== "\n") {
+        const lineBreak = before.indexOf("\n", end);
+        end = lineBreak === -1 ? before.length : lineBreak + 1;
+    }
+
+    return { start, end, newText: after.slice(start, after.length - (before.length - end)) };
+}
+
 /**
  * The edits queued for one document, in the shape ImportRewriteGuard reads.
  *

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { logger, settingsFor } from "../utils";
 import { DiagnosticPosition, DiagnosticPositionsByPath, DiagnosticPositionsByStatement } from "../types";
 import { ImportFormatter } from "./ImportFormatter";
-import { QueuedEdit, verifyImportEdits, verifyOrganizedRewrite } from "./ImportRewriteGuard";
+import { verifyOrganizedRewrite } from "./ImportRewriteGuard";
 import {
     allUsingPaths,
     classifyLines,
@@ -149,24 +149,20 @@ export function minimalSplice(before: string, after: string): TextSplice | null 
 }
 
 /**
- * The edits queued for one document, in the shape ImportRewriteGuard reads.
- *
- * Taken from the WorkspaceEdit rather than recorded as the writers build it, so
- * the guard answers for what is about to be applied rather than for what some
- * parallel bookkeeping says was meant.
+ * The position of `offset` in `text`, counting lines by "\n". Computed from
+ * the text a splice was measured against, never from the document, which may
+ * disagree with it by the time the edit is built.
  */
-function queuedEditsFor(edit: vscode.WorkspaceEdit, uri: vscode.Uri): QueuedEdit[] {
-    return edit
-        .entries()
-        .filter(([entryUri]) => entryUri.toString() === uri.toString())
-        .flatMap(([, edits]) => edits)
-        .map((textEdit) => ({
-            startLine: textEdit.range.start.line,
-            startCharacter: textEdit.range.start.character,
-            endLine: textEdit.range.end.line,
-            endCharacter: textEdit.range.end.character,
-            newText: textEdit.newText,
-        }));
+function positionAt(text: string, offset: number): vscode.Position {
+    let line = 0;
+    let lineStart = 0;
+    for (let i = 0; i < offset; i++) {
+        if (text[i] === "\n") {
+            line++;
+            lineStart = i + 1;
+        }
+    }
+    return new vscode.Position(line, offset - lineStart);
 }
 
 /**
@@ -486,31 +482,7 @@ export class ImportDocumentEditor {
         return statements.map((statement) => this.withTrailingComment(statement, trailingByStatement));
     }
 
-    private createBlockReplacementEdit(
-        edit: vscode.WorkspaceEdit,
-        document: vscode.TextDocument,
-        block: ImportBlock,
-        newPaths: string[],
-        preferDotSyntax: boolean,
-        sortAlphabetically: boolean,
-        eol: LineEnding,
-    ): void {
-        const existingBlockPaths = block.imports.map((imp) => imp.path);
-
-        let combinedPaths = [...existingBlockPaths, ...newPaths];
-        if (sortAlphabetically) {
-            combinedPaths = this.formatter.sortImportsByRank(combinedPaths);
-        }
-
-        const formattedImports = this.withTrailingComments(
-            combinedPaths.map((path) => this.formatter.formatImportStatement(path, preferDotSyntax)),
-            this.trailingCommentsByStatement(block.imports, preferDotSyntax),
-        );
-
-        edit.replace(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)), formattedImports.join(eol) + eol);
-    }
-
-    /** The lines a block rebuilds to once `newPaths` join it: createBlockReplacementEdit's content, without the edit. */
+    /** The lines a block rebuilds to once `newPaths` join it, sorted as one where the sort is on. */
     private blockReplacementLines(block: ImportBlock, newPaths: string[], preferDotSyntax: boolean, sortAlphabetically: boolean): string[] {
         const existingBlockPaths = block.imports.map((imp) => imp.path);
 
@@ -529,7 +501,7 @@ export class ImportDocumentEditor {
      * Chooses which existing import block a new path must be merged into so the
      * ordering holds across the whole file rather than only inside one block.
      *
-     * createBlockReplacementEdit sorts the block it rewrites, so it keeps a new
+     * blockReplacementLines sorts the block it rebuilds, so it keeps a new
      * import below a provider only while both sit in that same block. Any blank
      * line between imports starts a second block, so always merging into
      * `importBlocks[0]` could place a new `using { Economy.Shop }` above the
@@ -570,9 +542,9 @@ export class ImportDocumentEditor {
      *
      * Where the import carries `columns`, the evidence must start inside them:
      * a statement sharing its line with other code would otherwise take the
-     * override from a diagnostic about that other statement, and the override's
-     * failure direction is a file that stops compiling, which outranks a fixed
-     * diagnostic (see hoistFloor on the same asymmetry). The compiler anchors
+     * override from a diagnostic about that other statement, and a false
+     * override's failure direction is a file that stops compiling for a
+     * diagnostic that was never about this import. The compiler anchors
      * an unresolved-identifier diagnostic to the identifier's own node
      * (CreateGlitchForMissingUsing's call sites, SemanticAnalyzer.cpp:12544,
      * :12864), so a start position is enough to tell the two statements apart.
@@ -657,39 +629,6 @@ export class ImportDocumentEditor {
             return false;
         }
         return pinned.some((other) => other.path !== imp.path && other.startLine < imp.startLine);
-    }
-
-    /**
-     * The last line a pinned import forbids `path` from being hoisted above, or
-     * -1 where none does. `path` has no line of its own to keep, so a pinned
-     * import that must precede it both rules the block out and names the line
-     * the path is written below instead.
-     *
-     * The floor is pinnedBounds', so a rebuilt block and a singly added import
-     * read one rule rather than two. Only the floor: the ceiling pinnedBounds
-     * returns with it answers a question this caller has already answered,
-     * since a block above every pinned line, and a path written directly below
-     * this floor, both precede every pinned import further down.
-     *
-     * The diagnostic evidence still has to reach it, because a pinned import
-     * that evidence shows is the consumer raises no floor either - carrying the
-     * new import past that one is the fix the diagnostic asked for.
-     *
-     * A ceiling raised *above* the floor is the one it genuinely drops: the
-     * path lands below a pinned import that could have been the consumer it was
-     * added for, leaving that diagnostic unfixed. Deliberate - the alternative
-     * carries it above the pinned import bringing its own first segment into
-     * scope, and a compiling file outranks a fixed diagnostic.
-     *
-     * Exempts the path from itself for the reason crossesPinnedProvider does.
-     */
-    private hoistFloor(pinned: ScannedImport[], classifications: LineClassification[], path: string, diagnosticPositions: DiagnosticPositionsByPath): number {
-        return this.pinnedBounds(
-            pinned.filter((imp) => imp.path !== path),
-            classifications,
-            path,
-            diagnosticPositions,
-        ).floor;
     }
 
     /**
@@ -820,31 +759,10 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * Writes a run of import statements on their own lines at `line`.
-     *
-     * One home for the end-of-document case, which every caller has to handle
-     * the same way: the line after the last one does not exist in a document
-     * with no trailing newline, and VS Code clamps a position past the end onto
-     * the end of the last line - splicing the first statement onto whatever is
-     * already there and leaving one unreadable line where two belong.
-     */
-    private insertImportLines(edit: vscode.WorkspaceEdit, document: vscode.TextDocument, line: number, statements: string[], eol: LineEnding, blankLineAfter: boolean): void {
-        const text = statements.join(eol);
-
-        if (line < document.lineCount) {
-            edit.insert(document.uri, new vscode.Position(line, 0), text + eol + (blankLineAfter ? eol : ""));
-            return;
-        }
-
-        edit.insert(document.uri, document.lineAt(document.lineCount - 1).range.end, eol + text);
-    }
-
-    /**
-     * A splice writing a run of import statements on their own lines at `line`.
-     * insertImportLines' shape in text space, where past-the-end needs no
-     * clamping - but the blank line is still dropped there, as the append
-     * branch of that writer drops it: nothing follows the run, so the blank
-     * would only add a trailing empty line the old writer never wrote.
+     * A splice writing a run of import statements on their own lines at
+     * `line`. Past the end of the document the statements append with no
+     * blank line after them: nothing follows the run, so the blank would only
+     * add a trailing empty line.
      */
     private insertSplice(line: number, lineCount: number, statements: string[], blankLineAfter: boolean): LineSplice {
         const start = Math.min(line, lineCount);
@@ -853,11 +771,10 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * A splice rebuilding a block's line range as `newLines`.
-     * createBlockReplacementEdit's shape in text space: that writer replaced
-     * [start, end + 1) with every statement followed by the line ending, so a
-     * block ending the document gains a trailing break. The join only writes
-     * endings between lines, so here that break is an explicit empty line.
+     * A splice rebuilding a block's line range as `newLines`, each written
+     * with a line ending after it - so a block ending the document gains a
+     * trailing break. The join only writes endings between lines, which makes
+     * that break an explicit empty line here.
      */
     private blockSplice(block: ImportBlock, newLines: string[], lineCount: number): LineSplice {
         const endExclusive = block.end + 1;
@@ -903,32 +820,6 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * The line ranges of a block that consolidating at the top may delete: the
-     * runs of imports it hoists, with the grounded ones left out.
-     *
-     * Deleting the block whole would take a grounded import's line with it while
-     * its path is deliberately not re-emitted at the top, losing the import
-     * rather than moving it. A block's imports are adjacent by construction, so
-     * a block with nothing grounded yields one run covering exactly the block.
-     */
-    private hoistedRuns(block: ImportBlock, grounded: Set<string>): Array<{ start: number; end: number }> {
-        const runs: Array<{ start: number; end: number }> = [];
-        for (const imp of block.imports) {
-            if (grounded.has(imp.path)) {
-                continue;
-            }
-
-            const last = runs[runs.length - 1];
-            if (last && imp.startLine === last.end + 1) {
-                last.end = imp.endLine;
-            } else {
-                runs.push({ start: imp.startLine, end: imp.endLine });
-            }
-        }
-        return runs;
-    }
-
-    /**
      * Writes the statements whose paths the document does not already import,
      * then normalizes the blank lines after the block. True when nothing needed
      * adding, as well as when the edit succeeded.
@@ -964,52 +855,14 @@ export class ImportDocumentEditor {
         });
 
         const text = document.getText();
-        const eol = resolveEol(document, text);
-        const lines = text.split(LINE_SPLIT);
-        const scannedImports = scanModuleImports(lines);
-
-        // Blocks are built from the movable imports below, so a pinned one is
-        // in none of them and no placement decision can see it. Kept here, with
-        // the comment structure a placement needs to read its span, so every
-        // site can bound itself against them. See PinnedBounds.
-        //
-        // Both pin reasons, because the two are indistinguishable to placement:
-        // either way the line stays where it was written, and a new import may
-        // not cross it.
-        const classifications = classifyLines(lines);
-        const pinned = pinnedImports(scannedImports);
-
-        // The top of the file for everything written below, in place of line 0.
-        // See headerLineCount. Every line it covers is comment or blank, so
-        // starting here crosses no `using` and changes no resolution order.
-        const headerEnd = headerLineCount(classifications);
-
-        const importBlocks: ImportBlock[] = [];
-        for (const imp of rewritableImports(scannedImports)) {
-            logger.debug("ImportDocumentEditor", `Found existing import at line ${imp.startLine}: ${imp.path}`);
-
-            const lastBlock = importBlocks[importBlocks.length - 1];
-            if (lastBlock && imp.startLine === lastBlock.end + 1) {
-                lastBlock.end = imp.endLine;
-                lastBlock.imports.push(imp);
-            } else {
-                importBlocks.push({ start: imp.startLine, end: imp.endLine, imports: [imp] });
-            }
-        }
-
-        logger.debug("ImportDocumentEditor", `Found ${scannedImports.length} existing imports in ${importBlocks.length} blocks`);
 
         // Existence is judged from every import, a pinned one included: it is
         // imported, so nothing needs adding for it.
-        const existingPaths = new Set<string>(scannedImports.map((imp) => imp.path));
-        // Relocation is judged only from the movable ones. Re-emitting a
-        // pinned path at the top while its own line necessarily stays put
-        // would duplicate the import rather than move it.
-        const relocatablePaths = new Set<string>(rewritableImports(scannedImports).map((imp) => imp.path));
+        const existingPaths = new Set<string>(scanModuleImports(text.split(LINE_SPLIT)).map((imp) => imp.path));
 
         const newImportPaths = new Set<string>();
         // Re-keyed from the statement the caller holds to the path every
-        // placement rule below works in, and concatenated where two statements
+        // placement rule works in, and concatenated where two statements
         // share a path: a second diagnostic asking for the same import is
         // further evidence, not a replacement for the first.
         const diagnosticPositionsByPath = new Map<string, DiagnosticPosition[]>();
@@ -1031,347 +884,64 @@ export class ImportDocumentEditor {
             return true;
         }
 
-        const edit = new vscode.WorkspaceEdit();
+        const options: RebuildOptions = { preferDotSyntax, sortAlphabetically, importGrouping, fallbackEol: documentEol(document) };
+        const requestedPaths = Array.from(newImportPaths);
+        const target = preserveImportLocations
+            ? this.buildPreservedContent(text, requestedPaths, options, diagnosticPositionsByPath)
+            : this.buildOrganizedContent(text, requestedPaths, options, diagnosticPositionsByPath);
 
-        if (preserveImportLocations) {
-            // A gap between two blocks is the author's own grouping, so the
-            // configured strategy is applied by adding to whichever group each
-            // new path belongs in rather than by regrouping the file.
-            const hasGrouping =
-                importGrouping !== "none" &&
-                importBlocks.length >= 2 &&
-                importBlocks.some((block, i) => {
-                    if (i === 0) return false;
-                    return block.start > importBlocks[i - 1].end + 1;
-                });
-
-            if (hasGrouping && importBlocks.length >= 2) {
-                let digestBlockIndex = -1;
-                let firstLocalBlockIndex = -1;
-                let lastLocalBlockIndex = -1;
-
-                importBlocks.forEach((block, index) => {
-                    const blockPaths = block.imports.map((imp) => imp.path);
-                    const hasDigest = blockPaths.some((path) => this.formatter.isDigestImport(path));
-                    const hasLocal = blockPaths.some((path) => !this.formatter.isDigestImport(path));
-
-                    // A block counts as a group only if it is pure. A mixed one
-                    // is evidence of nothing, so it is left as neither and
-                    // takes no new import.
-                    if (hasDigest && !hasLocal) {
-                        digestBlockIndex = index;
-                    } else if (hasLocal && !hasDigest) {
-                        firstLocalBlockIndex = firstLocalBlockIndex === -1 ? index : firstLocalBlockIndex;
-                        lastLocalBlockIndex = index;
-                    }
-                });
-
-                // localFirst writes the local imports as two groups either side
-                // of the digest one (ImportFormatter.groupAndFormatImports), so
-                // a file it organized offers two local blocks rather than one.
-                // Which of them a new local path belongs in is the question
-                // selectTargetBlockIndex already answers: an absolute path
-                // needs nothing in scope and goes in the first, a relative one
-                // may resolve through anything above it and goes in the last.
-                // The two indices coincide under every other strategy, which
-                // leaves one local block and the same answer either way.
-                const newDigestPaths: string[] = [];
-                const newLocalAbsolutePaths: string[] = [];
-                const newLocalRelativePaths: string[] = [];
-
-                for (const path of newImportPaths) {
-                    if (this.formatter.isDigestImport(path)) {
-                        newDigestPaths.push(path);
-                    } else if (this.formatter.resolvesAgainstScopeAbove(path)) {
-                        newLocalRelativePaths.push(path);
-                    } else {
-                        newLocalAbsolutePaths.push(path);
-                    }
-                }
-
-                // A block can only take a new import where both the pinned
-                // imports and the movable ones below it leave room for it.
-                // Rebuilding a block writes the new statement at that block's
-                // lines, so which block absorbs a path is a placement decision
-                // like any other, and a block sitting above a provider cannot
-                // make one. The two bounds count different imports, though:
-                // see blockKeepsRelativeOrder for why an absolute import in a
-                // later block is let through where a pinned one is not.
-                //
-                // Partitioned in one pass rather than filtered twice, so taken
-                // and unhandled are complements by construction: two filters
-                // that have to stay each other's negation write a path into
-                // both lists, or into neither, as soon as one is edited alone.
-                const splitForBlock = (blockIndex: number, paths: string[]): { taken: string[]; unhandled: string[] } => {
-                    const taken: string[] = [];
-                    const unhandled: string[] = [];
-                    for (const path of paths) {
-                        const canTake =
-                            blockIndex >= 0 &&
-                            this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath)) &&
-                            this.blockKeepsRelativeOrder(importBlocks, blockIndex, path);
-                        (canTake ? taken : unhandled).push(path);
-                    }
-                    return { taken, unhandled };
-                };
-
-                // Collected per block before any edit is made, because the two
-                // local routes reach the same block under every strategy but
-                // localFirst. Rewriting that block once per route would leave
-                // two replacements over the same lines, and the second would
-                // drop what the first added.
-                const takenByBlock = new Map<number, string[]>();
-                const unhandledPaths: string[] = [];
-
-                for (const [blockIndex, paths] of [
-                    [digestBlockIndex, newDigestPaths],
-                    [firstLocalBlockIndex, newLocalAbsolutePaths],
-                    [lastLocalBlockIndex, newLocalRelativePaths],
-                ] as Array<[number, string[]]>) {
-                    const { taken, unhandled } = splitForBlock(blockIndex, paths);
-                    if (taken.length > 0) {
-                        takenByBlock.set(blockIndex, [...(takenByBlock.get(blockIndex) ?? []), ...taken]);
-                    }
-                    // Imports no block took: one with no matching block, and
-                    // one its matching block cannot hold - because a pinned
-                    // import keeps it out, or a relative import below it does.
-                    unhandledPaths.push(...unhandled);
-                }
-
-                for (const blockIndex of [...takenByBlock.keys()].sort((a, b) => a - b)) {
-                    this.createBlockReplacementEdit(edit, document, importBlocks[blockIndex], takenByBlock.get(blockIndex)!, preferDotSyntax, sortAlphabetically, eol);
-                }
-
-                if (unhandledPaths.length > 0) {
-                    const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
-                    for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, pinned, classifications, diagnosticPositionsByPath)) {
-                        this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, importBlocks.length === 0);
-                    }
-                }
-            } else {
-                if (importGrouping !== "none" && existingPaths.size > 0) {
-                    // Grouping is wanted and the file has none, so the imports
-                    // are regrouped in place. A new path a pinned import
-                    // keeps out of the rebuilt block is written on its own line
-                    // below that import instead, rather than into a group that
-                    // sits above it. Only the new paths are asked: this branch
-                    // sees at most one block (2+ gapped blocks reach the
-                    // hasGrouping branch above), so every relocated path is
-                    // already inside the block being rebuilt in place.
-                    const displacedPaths =
-                        importBlocks.length > 0
-                            ? Array.from(newImportPaths).filter((path) => !this.blockIsWithin(importBlocks[0], this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath)))
-                            : [];
-                    const displaced = new Set(displacedPaths);
-
-                    const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths].filter((path) => !displaced.has(path)));
-                    const allImportsArray = Array.from(allPaths);
-                    const groupedImports = this.withTrailingComments(
-                        this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping),
-                        this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
-                    );
-
-                    if (importBlocks.length > 0) {
-                        // In place, so the block stays where the author put it
-                        // rather than moving to the top of the file. The loop
-                        // over any further block is defensive: this branch sees
-                        // only one, as above.
-                        const firstBlock = importBlocks[0];
-                        edit.replace(document.uri, new vscode.Range(new vscode.Position(firstBlock.start, 0), new vscode.Position(firstBlock.end + 1, 0)), groupedImports.join(eol) + eol);
-
-                        for (let i = importBlocks.length - 1; i >= 1; i--) {
-                            const block = importBlocks[i];
-                            edit.delete(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)));
-                        }
-
-                        for (const [line, paths] of this.groupByPlacementLine(displacedPaths, firstBlock.end + 1, pinned, classifications, diagnosticPositionsByPath)) {
-                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, false);
-                        }
-                    } else {
-                        // No existing block - write the imports at the top, or
-                        // below a pinned import that has to precede one of
-                        // them. Split by line like every other site rather than
-                        // written as one run under a merged bound: paths of
-                        // different ranks take their bounds from different
-                        // pinned imports, and one path's floor can sit below
-                        // another's ceiling, leaving the group no line it can
-                        // legally occupy at all.
-                        //
-                        // A relocated path is never among these. Every
-                        // rewritable import opens or extends a block, so no
-                        // block means none of them, which is also why the
-                        // trailing comments here are always empty.
-                        for (const [line, paths] of this.groupByPlacementLine(allImportsArray, headerEnd, pinned, classifications, diagnosticPositionsByPath)) {
-                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, true);
-                        }
-                    }
-                } else {
-                    const newImportPathsArray = Array.from(newImportPaths);
-
-                    if (sortAlphabetically && importBlocks.length > 0) {
-                        // Merge each new import into an existing block in place
-                        // so the combined block is sorted as one, with the
-                        // absolute paths at the top and every relative import
-                        // in its written order. Appending the new imports after
-                        // the block instead would leave them below imports the
-                        // sort had already placed, in a second region the sort
-                        // never sees together.
-                        //
-                        // Which block each import joins is a whole-file
-                        // decision, not always the first one: sorting one block
-                        // orders the new import against that block alone, which
-                        // leaves it free to sit above a provider in another
-                        // block (see selectTargetBlockIndex).
-                        //
-                        // Only a block inside the space the pinned imports
-                        // leave is eligible, and the selector chooses among
-                        // those. A pinned import is in no block, so offering
-                        // the selector every block lets it merge an import into
-                        // one above the pinned provider that import needs.
-                        const pathsByBlock = new Map<number, string[]>();
-                        const unblockedPaths: string[] = [];
-                        for (const path of newImportPathsArray) {
-                            const bounds = this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath);
-                            const eligible = importBlocks.map((block, index) => ({ block, index })).filter(({ block }) => this.blockIsWithin(block, bounds));
-
-                            if (eligible.length === 0) {
-                                // No block sits where this import may go, so it
-                                // is written on its own line there instead.
-                                unblockedPaths.push(path);
-                                continue;
-                            }
-
-                            // The selector reports a position in the list it was
-                            // given, so its answer is read back through that
-                            // list to reach the real block.
-                            const chosen = this.selectTargetBlockIndex(
-                                eligible.map(({ block }) => block),
-                                path,
-                            );
-                            const index = eligible[chosen].index;
-                            const targetPaths = pathsByBlock.get(index);
-                            if (targetPaths) {
-                                targetPaths.push(path);
-                            } else {
-                                pathsByBlock.set(index, [path]);
-                            }
-                        }
-
-                        // Blocks are disjoint, so the replacements never overlap.
-                        // Neither can a standalone line below collide with one.
-                        // placementLine returns one of two things, and a pinned
-                        // import's span holds no block line either way: its own
-                        // line breaks the contiguity a block is built from, and
-                        // past that line the span is comment body or the lines
-                        // indented under it, neither of which holds a column-0
-                        // import the scanner would collect - an indented body
-                        // ends at the first column-0 line of code, which is the
-                        // earliest a block could start.
-                        //
-                        // - A ceiling, which is a pinned import's own line.
-                        // - floor + 1, reached only when every block was
-                        //   refused, which for a path with no ceiling means
-                        //   every block starts at or below the floor. The floor
-                        //   is the end of a pinned span, so a block starting
-                        //   at or below it ends before that span begins, and
-                        //   floor + 1 is past the end of the block.
-                        for (const index of [...pathsByBlock.keys()].sort((a, b) => a - b)) {
-                            this.createBlockReplacementEdit(edit, document, importBlocks[index], pathsByBlock.get(index)!, preferDotSyntax, true, eol);
-                        }
-
-                        // headerEnd never decides anything here, and is passed
-                        // so that no site holds a different top of the file: a
-                        // path with unconstrained bounds finds every block
-                        // eligible, so an unblocked one always has a floor or a
-                        // ceiling, and both sit at or below the header's end.
-                        for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, headerEnd, pinned, classifications, diagnosticPositionsByPath)) {
-                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), eol, true);
-                        }
-                    } else {
-                        // Sorting off, or no block to merge into: the new
-                        // imports are appended and no existing line is touched.
-                        //
-                        // After the last import block, not the first: with
-                        // sorting off nothing reorders a block afterwards, so
-                        // any earlier position could leave a new import above
-                        // one that has to stay above it.
-                        //
-                        // Wherever that block sits, not only when it starts at
-                        // line 0. A file whose imports open below a licence
-                        // header has its first block at a later line, so
-                        // inserting at line 0 there writes the new import above
-                        // the header and leaves two disconnected import regions
-                        // behind.
-                        //
-                        // With no block at all the top of the file is where a
-                        // new import goes - unless a pinned import that has to
-                        // precede it sits there, which is the one case a file
-                        // whose only import is pinned always reaches. That is
-                        // what groupByPlacementLine answers, from either start.
-                        const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
-                        const blankLineAfter = importBlocks.length === 0;
-
-                        for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, pinned, classifications, diagnosticPositionsByPath)) {
-                            this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, blankLineAfter);
-                        }
-                    }
-                }
-            }
-        } else {
-            // The block is written above every pinned line, so hoisting an
-            // import from below one carries it across. See groundedPaths.
-            const grounded = this.groundedPaths(pinned, rewritableImports(scannedImports));
-
-            // A new path has no line of its own to keep, so a pinned import
-            // that has to precede it names the line it is written below
-            // instead. The floor alone, as buildOrganizedContent asks of a path
-            // it adds and for its reason: this block goes above every pinned
-            // line, so a ceiling is already satisfied by it. See hoistFloor.
-            const blockPaths = new Set<string>(Array.from(relocatablePaths).filter((path) => !grounded.has(path)));
-            const newPathsByLine = new Map<number, string[]>();
-            for (const path of newImportPaths) {
-                const floor = this.hoistFloor(pinned, classifications, path, diagnosticPositionsByPath);
-                if (floor === -1) {
-                    blockPaths.add(path);
-                    continue;
-                }
-                newPathsByLine.set(floor + 1, [...(newPathsByLine.get(floor + 1) ?? []), path]);
-            }
-
-            // Grounding can leave the block with nothing to write, and an empty
-            // block is a stray line ending at the top of the file.
-            if (blockPaths.size > 0) {
-                const formattedImports = this.withTrailingComments(
-                    this.formatter.groupAndFormatImports(Array.from(blockPaths), preferDotSyntax, sortAlphabetically, importGrouping),
-                    this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
-                );
-
-                // No blank line after the block: ensureEmptyLinesAfterImports
-                // runs once the edit has been applied and puts the configured
-                // number there.
-                this.insertImportLines(edit, document, headerEnd, formattedImports, eol, false);
-            }
-
-            for (const [line, paths] of [...newPathsByLine].sort(([a], [b]) => a - b)) {
-                this.insertImportLines(edit, document, line, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), eol, false);
-            }
-
-            for (let i = importBlocks.length - 1; i >= 0; i--) {
-                for (const run of this.hoistedRuns(importBlocks[i], grounded).reverse()) {
-                    edit.delete(document.uri, new vscode.Range(new vscode.Position(run.start, 0), new vscode.Position(run.end + 1, 0)));
-                }
-            }
-        }
-
-        const refusal = verifyImportEdits(lines, queuedEditsFor(edit, document.uri), newImportPaths);
-        if (refusal) {
-            logger.error("ImportDocumentEditor", `Refusing to update imports: ${refusal}`);
+        // Neither builder may answer null here: the paths are non-empty and
+        // none is imported yet, so a null is buildPreservedContent refusing
+        // colliding splices rather than "nothing to do".
+        if (target === null) {
+            logger.error("ImportDocumentEditor", "Refusing to update imports: the rebuilt text could not be composed");
             return false;
         }
 
+        return this.applyRebuiltText(document, text, target, requestedPaths, {
+            unchanged: "No import changes needed, skipping update",
+            refuse: "Refusing to update imports",
+            applied: "Successfully updated imports in document",
+            failed: "Failed to update imports in document",
+            errored: "Error updating imports",
+        });
+    }
+
+    /**
+     * Applies a rebuilt document text as one minimal, line-aligned edit, after
+     * the rewrite guard has read the whole text back. True when the target
+     * already matches the document.
+     *
+     * `text` must be the exact string the rebuild read: the splice's offsets
+     * are coordinates in it, and reading the document again here would hand
+     * them to a buffer an edit may have moved under us.
+     */
+    private async applyRebuiltText(
+        document: vscode.TextDocument,
+        text: string,
+        target: string,
+        requestedPaths: readonly string[],
+        messages: { unchanged: string; refuse: string; applied: string; failed: string; errored: string },
+    ): Promise<boolean> {
+        if (target === text) {
+            logger.debug("ImportDocumentEditor", messages.unchanged);
+            return true;
+        }
+
+        const refusal = verifyOrganizedRewrite(text, target, requestedPaths);
+        if (refusal) {
+            logger.error("ImportDocumentEditor", `${messages.refuse}: ${refusal}`);
+            return false;
+        }
+
+        // Null only for equal texts, which the skip above already answered.
+        const splice = minimalSplice(text, target)!;
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(document.uri, new vscode.Range(positionAt(text, splice.start), positionAt(text, splice.end)), splice.newText);
+
         try {
             const success = await vscode.workspace.applyEdit(edit);
-            logger.info("ImportDocumentEditor", success ? "Successfully updated imports in document" : "Failed to update imports in document");
+            logger.info("ImportDocumentEditor", success ? messages.applied : messages.failed);
 
             if (success) {
                 await this.applyEmptyLinesAfterImports(document);
@@ -1379,7 +949,7 @@ export class ImportDocumentEditor {
 
             return success;
         } catch (error) {
-            logger.error("ImportDocumentEditor", `Error updating imports: ${error}`, error);
+            logger.error("ImportDocumentEditor", `${messages.errored}: ${error}`, error);
             return false;
         }
     }
@@ -1767,7 +1337,7 @@ export class ImportDocumentEditor {
      * above that line as well; one written below it keeps its line, untidy but
      * compiling. An additional path has no line to keep, so it is written
      * directly below the pinned statement that constrains it. See
-     * crossesPinnedProvider and hoistFloor.
+     * crossesPinnedProvider, pinnedBounds and placementLine.
      *
      * The result keeps the text's own line ending, so rebuilding an already
      * organized document reproduces it byte for byte and organizeImports can
@@ -1855,29 +1425,37 @@ export class ImportDocumentEditor {
         }
 
         // An additional path the block cannot take is written on its own line
-        // directly below the pinned statement that constrains it, since it has
-        // no line of its own to keep. Declining to write it at all would make
-        // organizing a file with such an import silently add nothing.
+        // in the space its bounds leave, since it has no line of its own to
+        // keep. Declining to write it at all would make organizing a file with
+        // such an import silently add nothing.
         //
-        // Grouped by line as groupByPlacementLine groups the add path's, and
-        // deliberately not through it: that one places a run against a document
-        // being edited, honouring a ceiling as well, while these are spliced
-        // into text being rebuilt and hoistFloor says why no ceiling binds.
+        // The bounds are pinnedBounds', with the path exempted from itself for
+        // the reason crossesPinnedProvider gives, so a rebuilt block and a
+        // singly placed path read one rule rather than two. No floor means the
+        // block takes it: the block sits above every pinned line, so a ceiling
+        // alone is already satisfied there. A floored path goes through
+        // placementLine, whose ceiling-over-floor precedence is the one
+        // conflict rule both entry points share - a diagnostic reaches here
+        // whenever the caller has one, and the pinned consumer it names must
+        // end up below the path added to resolve it.
+        //
+        // Keys name the line the run is written above, clamped to the header's
+        // end so no bound can carry an import into the header.
         const topExtraPaths: string[] = [];
         const groundedExtrasByLine = new Map<number, string[]>();
         for (const path of extraPaths) {
-            // A diagnostic reaches here whenever the caller has one: Optimize
-            // Imports adds what the compiler currently reports as missing. A
-            // pinned import the evidence shows to be the consumer therefore
-            // raises a ceiling rather than a floor, and the block above every
-            // pinned line satisfies it. Only the floor is read, for the reason
-            // hoistFloor gives.
-            const floor = this.hoistFloor(pinned, classifications, path, diagnosticPositionsByPath);
-            if (floor === -1) {
+            const bounds = this.pinnedBounds(
+                pinned.filter((imp) => imp.path !== path),
+                classifications,
+                path,
+                diagnosticPositionsByPath,
+            );
+            if (bounds.floor === -1) {
                 topExtraPaths.push(path);
                 continue;
             }
-            groundedExtrasByLine.set(floor, [...(groundedExtrasByLine.get(floor) ?? []), path]);
+            const line = Math.max(this.placementLine(bounds.floor + 1, bounds), headerEnd);
+            groundedExtrasByLine.set(line, [...(groundedExtrasByLine.get(line) ?? []), path]);
         }
 
         // Every line the rebuilt block accounts for: the import statements
@@ -1909,17 +1487,28 @@ export class ImportDocumentEditor {
         const header = lines.slice(0, headerEnd);
         const body: string[] = [];
         for (let index = headerEnd; index < lines.length; index++) {
-            if (!hoistedLines.has(index)) {
-                body.push(lines[index]);
-            }
             const groundedExtras = groundedExtrasByLine.get(index);
             if (groundedExtras) {
                 // Grouping is a property of the block at the top, so a run
                 // written between two body lines is emitted ungrouped: the
                 // separator a strategy puts between its two groups would read
                 // as a gap in the code around it.
+                //
+                // Emitted above the keyed line whether or not that line itself
+                // survives the hoist: a floor's own line is pinned and always
+                // survives, but a placement one past a hoisted import must not
+                // vanish with it.
                 body.push(...this.formatter.groupAndFormatImports(groundedExtras, options.preferDotSyntax, options.sortAlphabetically, "none"));
             }
+            if (!hoistedLines.has(index)) {
+                body.push(lines[index]);
+            }
+        }
+        // A path floored by a span ending the file is keyed one past the last
+        // line, which the loop never reaches.
+        const trailingExtras = groundedExtrasByLine.get(lines.length);
+        if (trailingExtras) {
+            body.push(...this.formatter.groupAndFormatImports(trailingExtras, options.preferDotSyntax, options.sortAlphabetically, "none"));
         }
 
         const uniquePaths = Array.from(new Set([...paths, ...topExtraPaths]));
@@ -1994,34 +1583,18 @@ export class ImportDocumentEditor {
             diagnosticPositionsByPath,
         );
 
-        if (organized === null || organized === text) {
+        if (organized === null) {
             logger.debug("ImportDocumentEditor", "No import changes needed by organize");
             return true;
         }
 
-        const refusal = verifyOrganizedRewrite(text, organized, additionalPaths);
-        if (refusal) {
-            logger.error("ImportDocumentEditor", `Refusing to organize imports: ${refusal}`);
-            return false;
-        }
-
-        const edit = new vscode.WorkspaceEdit();
-        const fullRange = new vscode.Range(new vscode.Position(0, 0), document.lineAt(document.lineCount - 1).range.end);
-        edit.replace(document.uri, fullRange, organized);
-
-        try {
-            const success = await vscode.workspace.applyEdit(edit);
-            logger.info("ImportDocumentEditor", success ? "Organized imports in document" : "Failed to organize imports");
-
-            if (success) {
-                await this.applyEmptyLinesAfterImports(document);
-            }
-
-            return success;
-        } catch (error) {
-            logger.error("ImportDocumentEditor", `Error organizing imports: ${error}`, error);
-            return false;
-        }
+        return this.applyRebuiltText(document, text, organized, additionalPaths, {
+            unchanged: "No import changes needed by organize",
+            refuse: "Refusing to organize imports",
+            applied: "Organized imports in document",
+            failed: "Failed to organize imports",
+            errored: "Error organizing imports",
+        });
     }
 
     /**

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -120,7 +120,10 @@ export function spliceLines(text: string, splices: LineSplice[], eol: LineEnding
             continue;
         }
         if (splice.start >= lineCount) {
-            out += eol + splice.newLines.join(eol);
+            // A file that ended in a line break still does after the append;
+            // one that did not stays that way, with the run's opening break
+            // the one separator the append adds.
+            out += eol + splice.newLines.join(eol) + (text.endsWith("\n") ? eol : "");
         } else {
             for (const line of splice.newLines) {
                 out += line + eol;
@@ -1372,9 +1375,11 @@ export class ImportDocumentEditor {
      * A line the rebuild does not touch comes back byte for byte, its own
      * line ending included; the rebuilt block takes the text's dominant
      * ending. Rebuilding an already organized document therefore reproduces
-     * it exactly and organizeImports can skip the edit, with one convergence:
-     * the first rebuild of a mixed-ending block normalizes that block, and
-     * only it.
+     * it exactly and organizeImports can skip the edit, with two
+     * convergences that settle after one further pass: the first rebuild of
+     * a mixed-ending block normalizes that block, and a block appended to a
+     * comment-only file with no final break gains one on the next rebuild,
+     * once the appended import gives the file a code line to insert above.
      */
     buildOrganizedContent(text: string, additionalPaths: string[], options: RebuildOptions, diagnosticPositionsByPath: DiagnosticPositionsByPath = NO_DIAGNOSTIC_POSITIONS): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -113,6 +113,12 @@ export function spliceLines(text: string, splices: LineSplice[], eol: LineEnding
             return null;
         }
         out += raw(cursor, splice.start);
+        if (splice.newLines.length === 0) {
+            // Nothing to write; falling through would open a past-the-end run
+            // with a break it never closes.
+            cursor = splice.endExclusive;
+            continue;
+        }
         if (splice.start >= lineCount) {
             out += eol + splice.newLines.join(eol);
         } else {
@@ -985,8 +991,7 @@ export class ImportDocumentEditor {
      * preserve-locations policy puts them: merged into an existing block,
      * added to the author's own grouping, or written on their own line beside
      * the imports each must sit relative to. Every line the policy does not
-     * rewrite comes back byte for byte, modulo the one line ending the result
-     * is joined with.
+     * rewrite comes back byte for byte, its own line ending included.
      *
      * Returns null when nothing is left to add - every path blank or already
      * imported - and null when the computed splices collide, which is a
@@ -1364,9 +1369,12 @@ export class ImportDocumentEditor {
      * directly below the pinned statement that constrains it. See
      * crossesPinnedProvider, pinnedBounds and placementLine.
      *
-     * The result keeps the text's own line ending, so rebuilding an already
-     * organized document reproduces it byte for byte and organizeImports can
-     * skip the edit.
+     * A line the rebuild does not touch comes back byte for byte, its own
+     * line ending included; the rebuilt block takes the text's dominant
+     * ending. Rebuilding an already organized document therefore reproduces
+     * it exactly and organizeImports can skip the edit, with one convergence:
+     * the first rebuild of a mixed-ending block normalizes that block, and
+     * only it.
      */
     buildOrganizedContent(text: string, additionalPaths: string[], options: RebuildOptions, diagnosticPositionsByPath: DiagnosticPositionsByPath = NO_DIAGNOSTIC_POSITIONS): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
@@ -1512,33 +1520,6 @@ export class ImportDocumentEditor {
             commentsByPath.set(imp.path, [...(commentsByPath.get(imp.path) ?? []), ...lines.slice(commentStart, imp.startLine)]);
         }
 
-        const header = lines.slice(0, headerEnd);
-        const body: string[] = [];
-        for (let index = headerEnd; index < lines.length; index++) {
-            const groundedExtras = groundedExtrasByLine.get(index);
-            if (groundedExtras) {
-                // Grouping is a property of the block at the top, so a run
-                // written between two body lines is emitted ungrouped: the
-                // separator a strategy puts between its two groups would read
-                // as a gap in the code around it.
-                //
-                // Emitted above the keyed line whether or not that line itself
-                // survives the hoist: a floor's own line is pinned and always
-                // survives, but a placement one past a hoisted import must not
-                // vanish with it.
-                body.push(...this.formatter.groupAndFormatImports(groundedExtras, options.preferDotSyntax, options.sortAlphabetically, "none"));
-            }
-            if (!hoistedLines.has(index)) {
-                body.push(lines[index]);
-            }
-        }
-        // A path floored by a span ending the file is keyed one past the last
-        // line, which the loop never reaches.
-        const trailingExtras = groundedExtrasByLine.get(lines.length);
-        if (trailingExtras) {
-            body.push(...this.formatter.groupAndFormatImports(trailingExtras, options.preferDotSyntax, options.sortAlphabetically, "none"));
-        }
-
         const uniquePaths = Array.from(new Set([...paths, ...topExtraPaths]));
         const formatted = this.formatter.groupAndFormatImports(uniquePaths, options.preferDotSyntax, options.sortAlphabetically, options.importGrouping);
 
@@ -1559,26 +1540,60 @@ export class ImportDocumentEditor {
             return comments ? [...comments, line] : [line];
         });
 
-        // Drop blank lines the removed imports left at the top; the gap after
-        // the block is normalized by ensureEmptyLinesAfterImports afterwards.
-        let firstContent = 0;
-        while (firstContent < body.length && body[firstContent].trim() === "") {
-            firstContent++;
-        }
-        const remainingBody = body.slice(firstContent);
+        // The rest is composed as splices over the original text, so a line
+        // the rebuild does not touch comes back byte for byte - the contract
+        // buildPreservedContent keeps, stated once in spliceLines.
+        const splices: LineSplice[] = [];
 
-        if (remainingBody.length === 0) {
-            return [...header, ...block].join(eol) + eol;
+        // Blank lines the removed imports would leave at the head of the body
+        // are dropped; the gap after the block is normalized by
+        // ensureEmptyLinesAfterImports afterwards. The walk stops where the
+        // body's first content will sit: a grounded run, or the first
+        // surviving non-blank line.
+        const trimmedBlanks = new Set<number>();
+        let firstBodyLine = -1;
+        for (let index = headerEnd; index < lines.length; index++) {
+            if (groundedExtrasByLine.has(index)) {
+                firstBodyLine = index;
+                break;
+            }
+            if (hoistedLines.has(index)) {
+                continue;
+            }
+            if (lines[index].trim() === "") {
+                trimmedBlanks.add(index);
+                continue;
+            }
+            firstBodyLine = index;
+            break;
+        }
+        const bodyRemains = firstBodyLine !== -1 || groundedExtrasByLine.size > 0;
+
+        if (block.length > 0) {
+            // The separator stands between the block and a body that follows;
+            // with nothing below, the block just ends the file. No block, no
+            // separator either - a blank line would stand where the block
+            // would have been.
+            splices.push({ start: headerEnd, endExclusive: headerEnd, newLines: bodyRemains ? [...block, ""] : block });
         }
 
-        // Every path was withheld, so there is no block to separate from the
-        // body. Writing the separator anyway would put a blank line where the
-        // block would have been.
-        if (block.length === 0) {
-            return [...header, ...remainingBody].join(eol);
+        for (const line of [...hoistedLines, ...trimmedBlanks]) {
+            splices.push({ start: line, endExclusive: line + 1, newLines: [] });
         }
 
-        return [...header, ...block, "", ...remainingBody].join(eol);
+        for (const [line, extraPathsAtLine] of groundedExtrasByLine) {
+            // Grouping is a property of the block at the top, so a run written
+            // between two body lines is emitted ungrouped: the separator a
+            // strategy puts between its two groups would read as a gap in the
+            // code around it.
+            //
+            // Written above the keyed line whether or not that line itself
+            // survives the hoist: an insertion at the start of a removed range
+            // lands before the removal.
+            splices.push({ start: line, endExclusive: line, newLines: this.formatter.groupAndFormatImports(extraPathsAtLine, options.preferDotSyntax, options.sortAlphabetically, "none") });
+        }
+
+        return spliceLines(text, splices, eol);
     }
 
     /**

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -73,29 +73,57 @@ export interface LineSplice {
 }
 
 /**
- * `lines` with every splice applied, or null where two overlap or one reaches
- * outside the array. No placement branch emits either shape, so a null is a
+ * `text` with every splice applied, or null where two overlap or one reaches
+ * outside its lines. No placement branch emits either shape, so a null is a
  * composition bug - and it has to be answered here rather than by the rewrite
  * guard, which compares paths as a set and so cannot see an import written
  * twice by overlapping splices.
  *
+ * A line no splice touches comes back byte for byte, its own line ending
+ * included - rejoining the whole document with one ending would rewrite lines
+ * the caller never asked about, in a file whose endings are mixed. Only the
+ * spliced-in lines take `eol`, each written with an ending after it; a run
+ * appended past the last line instead opens with one and closes without, the
+ * one way to extend a document that does not end in a line break.
+ *
  * Insertions at one line keep their given order, and an insertion at the start
  * of a replaced range goes first, as VS Code applies a WorkspaceEdit's.
  */
-export function applyLineSplices(lines: string[], splices: LineSplice[]): string[] | null {
+export function spliceLines(text: string, splices: LineSplice[], eol: LineEnding): string | null {
+    const lineStarts = [0];
+    for (let i = 0; i < text.length; i++) {
+        if (text[i] === "\n") {
+            lineStarts.push(i + 1);
+        }
+    }
+    const lineCount = lineStarts.length;
+    const raw = (fromLine: number, toLineExclusive: number): string => {
+        if (fromLine >= lineCount) {
+            return "";
+        }
+        return text.slice(lineStarts[fromLine], toLineExclusive < lineCount ? lineStarts[toLineExclusive] : text.length);
+    };
+
     const ordered = [...splices].sort((a, b) => a.start - b.start || a.endExclusive - b.endExclusive);
 
-    const result: string[] = [];
+    let out = "";
     let cursor = 0;
     for (const splice of ordered) {
-        if (splice.start < cursor || splice.endExclusive < splice.start || splice.endExclusive > lines.length) {
+        if (splice.start < cursor || splice.endExclusive < splice.start || splice.endExclusive > lineCount) {
             return null;
         }
-        result.push(...lines.slice(cursor, splice.start), ...splice.newLines);
+        out += raw(cursor, splice.start);
+        if (splice.start >= lineCount) {
+            out += eol + splice.newLines.join(eol);
+        } else {
+            for (const line of splice.newLines) {
+                out += line + eol;
+            }
+        }
         cursor = splice.endExclusive;
     }
-    result.push(...lines.slice(cursor));
-    return result;
+    out += raw(cursor, lineCount);
+    return out;
 }
 
 /**
@@ -771,14 +799,12 @@ export class ImportDocumentEditor {
     }
 
     /**
-     * A splice rebuilding a block's line range as `newLines`, each written
-     * with a line ending after it - so a block ending the document gains a
-     * trailing break. The join only writes endings between lines, which makes
-     * that break an explicit empty line here.
+     * A splice rebuilding a block's line range as `newLines`. Each spliced
+     * line is written with an ending after it, so a block ending the document
+     * gains a trailing break.
      */
-    private blockSplice(block: ImportBlock, newLines: string[], lineCount: number): LineSplice {
-        const endExclusive = block.end + 1;
-        return { start: block.start, endExclusive, newLines: endExclusive >= lineCount ? [...newLines, ""] : newLines };
+    private blockSplice(block: ImportBlock, newLines: string[]): LineSplice {
+        return { start: block.start, endExclusive: block.end + 1, newLines };
     }
 
     /**
@@ -812,8 +838,8 @@ export class ImportDocumentEditor {
      * declines to re-emit. The cost is declining to hoist a copy written above
      * every pinned import when another copy below one is grounded.
      *
-     * Shared by the two writers that hoist into such a block, which is what
-     * keeps them from holding two rules about what a pinned line stops.
+     * Read by the one rebuild that hoists into such a block, which both entry
+     * points run when consolidating.
      */
     private groundedPaths(pinned: ScannedImport[], movable: ScannedImport[]): Set<string> {
         return new Set(movable.filter((imp) => this.crossesPinnedProvider(pinned, imp)).map((imp) => imp.path));
@@ -1122,7 +1148,7 @@ export class ImportDocumentEditor {
 
             for (const blockIndex of [...takenByBlock.keys()].sort((a, b) => a - b)) {
                 const block = importBlocks[blockIndex];
-                splices.push(this.blockSplice(block, this.blockReplacementLines(block, takenByBlock.get(blockIndex)!, preferDotSyntax, sortAlphabetically), lines.length));
+                splices.push(this.blockSplice(block, this.blockReplacementLines(block, takenByBlock.get(blockIndex)!, preferDotSyntax, sortAlphabetically)));
             }
 
             if (unhandledPaths.length > 0) {
@@ -1159,7 +1185,7 @@ export class ImportDocumentEditor {
                 // over any further block is defensive: this branch sees
                 // only one, as above.
                 const firstBlock = importBlocks[0];
-                splices.push(this.blockSplice(firstBlock, groupedImports, lines.length));
+                splices.push(this.blockSplice(firstBlock, groupedImports));
 
                 for (let i = importBlocks.length - 1; i >= 1; i--) {
                     const block = importBlocks[i];
@@ -1258,12 +1284,12 @@ export class ImportDocumentEditor {
                 //   at or below it ends before that span begins, and
                 //   floor + 1 is past the end of the block.
                 //
-                // applyLineSplices still checks, because this argument
+                // spliceLines still checks, because this argument
                 // holds for these two sites alone and a future site
                 // joins the splice list without re-reading it.
                 for (const index of [...pathsByBlock.keys()].sort((a, b) => a - b)) {
                     const block = importBlocks[index];
-                    splices.push(this.blockSplice(block, this.blockReplacementLines(block, pathsByBlock.get(index)!, preferDotSyntax, true), lines.length));
+                    splices.push(this.blockSplice(block, this.blockReplacementLines(block, pathsByBlock.get(index)!, preferDotSyntax, true)));
                 }
 
                 // headerEnd never decides anything here, and is passed
@@ -1304,8 +1330,7 @@ export class ImportDocumentEditor {
             }
         }
 
-        const spliced = applyLineSplices(lines, splices);
-        return spliced === null ? null : spliced.join(eol);
+        return spliceLines(text, splices, eol);
     }
 
     /**
@@ -1439,8 +1464,11 @@ export class ImportDocumentEditor {
         // whenever the caller has one, and the pinned consumer it names must
         // end up below the path added to resolve it.
         //
-        // Keys name the line the run is written above, clamped to the header's
-        // end so no bound can carry an import into the header.
+        // Keys name the line the run is written above. The header clamp is
+        // unreachable today - every bound derives from a pinned code line, and
+        // the header holds none - and is kept because the failure it insures
+        // against is an extra silently written into the header, which the
+        // guard cannot see.
         const topExtraPaths: string[] = [];
         const groundedExtrasByLine = new Map<number, string[]>();
         for (const path of extraPaths) {

--- a/src/imports/ImportDocumentEditor.ts
+++ b/src/imports/ImportDocumentEditor.ts
@@ -350,6 +350,15 @@ interface PinnedBounds {
  */
 const NO_DIAGNOSTIC_POSITIONS: DiagnosticPositionsByPath = new Map();
 
+/** The options every rebuild takes, whichever placement policy runs it. */
+export interface RebuildOptions {
+    preferDotSyntax: boolean;
+    sortAlphabetically: boolean;
+    importGrouping: string;
+    /** Line ending to use when the text has no line break to detect one from. */
+    fallbackEol?: LineEnding;
+}
+
 /**
  * Managing a document's import block: adding the imports a diagnostic asked
  * for, reorganizing what is there, and the blank lines after it.
@@ -499,6 +508,21 @@ export class ImportDocumentEditor {
         );
 
         edit.replace(document.uri, new vscode.Range(new vscode.Position(block.start, 0), new vscode.Position(block.end + 1, 0)), formattedImports.join(eol) + eol);
+    }
+
+    /** The lines a block rebuilds to once `newPaths` join it: createBlockReplacementEdit's content, without the edit. */
+    private blockReplacementLines(block: ImportBlock, newPaths: string[], preferDotSyntax: boolean, sortAlphabetically: boolean): string[] {
+        const existingBlockPaths = block.imports.map((imp) => imp.path);
+
+        let combinedPaths = [...existingBlockPaths, ...newPaths];
+        if (sortAlphabetically) {
+            combinedPaths = this.formatter.sortImportsByRank(combinedPaths);
+        }
+
+        return this.withTrailingComments(
+            combinedPaths.map((path) => this.formatter.formatImportStatement(path, preferDotSyntax)),
+            this.trailingCommentsByStatement(block.imports, preferDotSyntax),
+        );
     }
 
     /**
@@ -813,6 +837,31 @@ export class ImportDocumentEditor {
         }
 
         edit.insert(document.uri, document.lineAt(document.lineCount - 1).range.end, eol + text);
+    }
+
+    /**
+     * A splice writing a run of import statements on their own lines at `line`.
+     * insertImportLines' shape in text space, where past-the-end needs no
+     * clamping - but the blank line is still dropped there, as the append
+     * branch of that writer drops it: nothing follows the run, so the blank
+     * would only add a trailing empty line the old writer never wrote.
+     */
+    private insertSplice(line: number, lineCount: number, statements: string[], blankLineAfter: boolean): LineSplice {
+        const start = Math.min(line, lineCount);
+        const newLines = blankLineAfter && line < lineCount ? [...statements, ""] : [...statements];
+        return { start, endExclusive: start, newLines };
+    }
+
+    /**
+     * A splice rebuilding a block's line range as `newLines`.
+     * createBlockReplacementEdit's shape in text space: that writer replaced
+     * [start, end + 1) with every statement followed by the line ending, so a
+     * block ending the document gains a trailing break. The join only writes
+     * endings between lines, so here that break is an explicit empty line.
+     */
+    private blockSplice(block: ImportBlock, newLines: string[], lineCount: number): LineSplice {
+        const endExclusive = block.end + 1;
+        return { start: block.start, endExclusive, newLines: endExclusive >= lineCount ? [...newLines, ""] : newLines };
     }
 
     /**
@@ -1336,6 +1385,360 @@ export class ImportDocumentEditor {
     }
 
     /**
+     * The document text with `additionalPaths` written in where the
+     * preserve-locations policy puts them: merged into an existing block,
+     * added to the author's own grouping, or written on their own line beside
+     * the imports each must sit relative to. Every line the policy does not
+     * rewrite comes back byte for byte, modulo the one line ending the result
+     * is joined with.
+     *
+     * Returns null when nothing is left to add - every path blank or already
+     * imported - and null when the computed splices collide, which is a
+     * composition bug the caller must turn into a refused edit rather than
+     * apply: the rewrite guard compares paths as a set, so an import written
+     * twice by colliding splices would pass it.
+     */
+    buildPreservedContent(text: string, additionalPaths: string[], options: RebuildOptions, diagnosticPositionsByPath: DiagnosticPositionsByPath = NO_DIAGNOSTIC_POSITIONS): string | null {
+        const { preferDotSyntax, sortAlphabetically, importGrouping } = options;
+        const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
+        const lines = text.split(LINE_SPLIT);
+        const scannedImports = scanModuleImports(lines);
+
+        // Blocks are built from the movable imports below, so a pinned one is
+        // in none of them and no placement decision can see it. Kept here, with
+        // the comment structure a placement needs to read its span, so every
+        // site can bound itself against them. See PinnedBounds.
+        //
+        // Both pin reasons, because the two are indistinguishable to placement:
+        // either way the line stays where it was written, and a new import may
+        // not cross it.
+        const classifications = classifyLines(lines);
+        const pinned = pinnedImports(scannedImports);
+
+        // The top of the file for everything written below, in place of line 0.
+        // See headerLineCount. Every line it covers is comment or blank, so
+        // starting here crosses no `using` and changes no resolution order.
+        const headerEnd = headerLineCount(classifications);
+
+        const importBlocks: ImportBlock[] = [];
+        for (const imp of rewritableImports(scannedImports)) {
+            const lastBlock = importBlocks[importBlocks.length - 1];
+            if (lastBlock && imp.startLine === lastBlock.end + 1) {
+                lastBlock.end = imp.endLine;
+                lastBlock.imports.push(imp);
+            } else {
+                importBlocks.push({ start: imp.startLine, end: imp.endLine, imports: [imp] });
+            }
+        }
+
+        // Existence is judged from every import, a pinned one included: it is
+        // imported, so nothing needs adding for it.
+        const existingPaths = new Set<string>(scannedImports.map((imp) => imp.path));
+        // Relocation is judged only from the movable ones. Re-emitting a
+        // pinned path while its own line necessarily stays put would duplicate
+        // the import rather than move it.
+        const relocatablePaths = new Set<string>(rewritableImports(scannedImports).map((imp) => imp.path));
+
+        const newImportPaths = new Set<string>(additionalPaths.map((path) => path.trim()).filter((path) => path.length > 0 && !existingPaths.has(path)));
+        if (newImportPaths.size === 0) {
+            return null;
+        }
+
+        const splices: LineSplice[] = [];
+
+        // A gap between two blocks is the author's own grouping, so the
+        // configured strategy is applied by adding to whichever group each
+        // new path belongs in rather than by regrouping the file.
+        const hasGrouping =
+            importGrouping !== "none" &&
+            importBlocks.length >= 2 &&
+            importBlocks.some((block, i) => {
+                if (i === 0) return false;
+                return block.start > importBlocks[i - 1].end + 1;
+            });
+
+        if (hasGrouping && importBlocks.length >= 2) {
+            let digestBlockIndex = -1;
+            let firstLocalBlockIndex = -1;
+            let lastLocalBlockIndex = -1;
+
+            importBlocks.forEach((block, index) => {
+                const blockPaths = block.imports.map((imp) => imp.path);
+                const hasDigest = blockPaths.some((path) => this.formatter.isDigestImport(path));
+                const hasLocal = blockPaths.some((path) => !this.formatter.isDigestImport(path));
+
+                // A block counts as a group only if it is pure. A mixed one
+                // is evidence of nothing, so it is left as neither and
+                // takes no new import.
+                if (hasDigest && !hasLocal) {
+                    digestBlockIndex = index;
+                } else if (hasLocal && !hasDigest) {
+                    firstLocalBlockIndex = firstLocalBlockIndex === -1 ? index : firstLocalBlockIndex;
+                    lastLocalBlockIndex = index;
+                }
+            });
+
+            // localFirst writes the local imports as two groups either side
+            // of the digest one (ImportFormatter.groupAndFormatImports), so
+            // a file it organized offers two local blocks rather than one.
+            // Which of them a new local path belongs in is the question
+            // selectTargetBlockIndex already answers: an absolute path
+            // needs nothing in scope and goes in the first, a relative one
+            // may resolve through anything above it and goes in the last.
+            // The two indices coincide under every other strategy, which
+            // leaves one local block and the same answer either way.
+            const newDigestPaths: string[] = [];
+            const newLocalAbsolutePaths: string[] = [];
+            const newLocalRelativePaths: string[] = [];
+
+            for (const path of newImportPaths) {
+                if (this.formatter.isDigestImport(path)) {
+                    newDigestPaths.push(path);
+                } else if (this.formatter.resolvesAgainstScopeAbove(path)) {
+                    newLocalRelativePaths.push(path);
+                } else {
+                    newLocalAbsolutePaths.push(path);
+                }
+            }
+
+            // A block can only take a new import where both the pinned
+            // imports and the movable ones below it leave room for it.
+            // Rebuilding a block writes the new statement at that block's
+            // lines, so which block absorbs a path is a placement decision
+            // like any other, and a block sitting above a provider cannot
+            // make one. The two bounds count different imports, though:
+            // see blockKeepsRelativeOrder for why an absolute import in a
+            // later block is let through where a pinned one is not.
+            //
+            // Partitioned in one pass rather than filtered twice, so taken
+            // and unhandled are complements by construction: two filters
+            // that have to stay each other's negation write a path into
+            // both lists, or into neither, as soon as one is edited alone.
+            const splitForBlock = (blockIndex: number, paths: string[]): { taken: string[]; unhandled: string[] } => {
+                const taken: string[] = [];
+                const unhandled: string[] = [];
+                for (const path of paths) {
+                    const canTake =
+                        blockIndex >= 0 &&
+                        this.blockIsWithin(importBlocks[blockIndex], this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath)) &&
+                        this.blockKeepsRelativeOrder(importBlocks, blockIndex, path);
+                    (canTake ? taken : unhandled).push(path);
+                }
+                return { taken, unhandled };
+            };
+
+            // Collected per block before any splice is made, because the two
+            // local routes reach the same block under every strategy but
+            // localFirst. Rebuilding that block once per route would leave
+            // two replacements over the same lines, and the second would
+            // drop what the first added.
+            const takenByBlock = new Map<number, string[]>();
+            const unhandledPaths: string[] = [];
+
+            for (const [blockIndex, paths] of [
+                [digestBlockIndex, newDigestPaths],
+                [firstLocalBlockIndex, newLocalAbsolutePaths],
+                [lastLocalBlockIndex, newLocalRelativePaths],
+            ] as Array<[number, string[]]>) {
+                const { taken, unhandled } = splitForBlock(blockIndex, paths);
+                if (taken.length > 0) {
+                    takenByBlock.set(blockIndex, [...(takenByBlock.get(blockIndex) ?? []), ...taken]);
+                }
+                // Imports no block took: one with no matching block, and
+                // one its matching block cannot hold - because a pinned
+                // import keeps it out, or a relative import below it does.
+                unhandledPaths.push(...unhandled);
+            }
+
+            for (const blockIndex of [...takenByBlock.keys()].sort((a, b) => a - b)) {
+                const block = importBlocks[blockIndex];
+                splices.push(this.blockSplice(block, this.blockReplacementLines(block, takenByBlock.get(blockIndex)!, preferDotSyntax, sortAlphabetically), lines.length));
+            }
+
+            if (unhandledPaths.length > 0) {
+                const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
+                for (const [line, paths] of this.groupByPlacementLine(unhandledPaths, desired, pinned, classifications, diagnosticPositionsByPath)) {
+                    splices.push(this.insertSplice(line, lines.length, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), importBlocks.length === 0));
+                }
+            }
+        } else if (importGrouping !== "none" && existingPaths.size > 0) {
+            // Grouping is wanted and the file has none, so the imports
+            // are regrouped in place. A new path a pinned import
+            // keeps out of the rebuilt block is written on its own line
+            // below that import instead, rather than into a group that
+            // sits above it. Only the new paths are asked: this branch
+            // sees at most one block (2+ gapped blocks reach the
+            // hasGrouping branch above), so every relocated path is
+            // already inside the block being rebuilt in place.
+            const displacedPaths =
+                importBlocks.length > 0
+                    ? Array.from(newImportPaths).filter((path) => !this.blockIsWithin(importBlocks[0], this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath)))
+                    : [];
+            const displaced = new Set(displacedPaths);
+
+            const allPaths = new Set<string>([...relocatablePaths, ...newImportPaths].filter((path) => !displaced.has(path)));
+            const allImportsArray = Array.from(allPaths);
+            const groupedImports = this.withTrailingComments(
+                this.formatter.groupAndFormatImports(allImportsArray, preferDotSyntax, sortAlphabetically, importGrouping),
+                this.trailingCommentsByStatement(rewritableImports(scannedImports), preferDotSyntax),
+            );
+
+            if (importBlocks.length > 0) {
+                // In place, so the block stays where the author put it
+                // rather than moving to the top of the file. The loop
+                // over any further block is defensive: this branch sees
+                // only one, as above.
+                const firstBlock = importBlocks[0];
+                splices.push(this.blockSplice(firstBlock, groupedImports, lines.length));
+
+                for (let i = importBlocks.length - 1; i >= 1; i--) {
+                    const block = importBlocks[i];
+                    splices.push({ start: block.start, endExclusive: block.end + 1, newLines: [] });
+                }
+
+                for (const [line, paths] of this.groupByPlacementLine(displacedPaths, firstBlock.end + 1, pinned, classifications, diagnosticPositionsByPath)) {
+                    splices.push(this.insertSplice(line, lines.length, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), false));
+                }
+            } else {
+                // No existing block - write the imports at the top, or
+                // below a pinned import that has to precede one of
+                // them. Split by line like every other site rather than
+                // written as one run under a merged bound: paths of
+                // different ranks take their bounds from different
+                // pinned imports, and one path's floor can sit below
+                // another's ceiling, leaving the group no line it can
+                // legally occupy at all.
+                //
+                // A relocated path is never among these. Every
+                // rewritable import opens or extends a block, so no
+                // block means none of them, which is also why the
+                // trailing comments here are always empty.
+                for (const [line, paths] of this.groupByPlacementLine(allImportsArray, headerEnd, pinned, classifications, diagnosticPositionsByPath)) {
+                    splices.push(this.insertSplice(line, lines.length, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), true));
+                }
+            }
+        } else {
+            const newImportPathsArray = Array.from(newImportPaths);
+
+            if (sortAlphabetically && importBlocks.length > 0) {
+                // Merge each new import into an existing block in place
+                // so the combined block is sorted as one, with the
+                // absolute paths at the top and every relative import
+                // in its written order. Appending the new imports after
+                // the block instead would leave them below imports the
+                // sort had already placed, in a second region the sort
+                // never sees together.
+                //
+                // Which block each import joins is a whole-file
+                // decision, not always the first one: sorting one block
+                // orders the new import against that block alone, which
+                // leaves it free to sit above a provider in another
+                // block (see selectTargetBlockIndex).
+                //
+                // Only a block inside the space the pinned imports
+                // leave is eligible, and the selector chooses among
+                // those. A pinned import is in no block, so offering
+                // the selector every block lets it merge an import into
+                // one above the pinned provider that import needs.
+                const pathsByBlock = new Map<number, string[]>();
+                const unblockedPaths: string[] = [];
+                for (const path of newImportPathsArray) {
+                    const bounds = this.pinnedBounds(pinned, classifications, path, diagnosticPositionsByPath);
+                    const eligible = importBlocks.map((block, index) => ({ block, index })).filter(({ block }) => this.blockIsWithin(block, bounds));
+
+                    if (eligible.length === 0) {
+                        // No block sits where this import may go, so it
+                        // is written on its own line there instead.
+                        unblockedPaths.push(path);
+                        continue;
+                    }
+
+                    // The selector reports a position in the list it was
+                    // given, so its answer is read back through that
+                    // list to reach the real block.
+                    const chosen = this.selectTargetBlockIndex(
+                        eligible.map(({ block }) => block),
+                        path,
+                    );
+                    const index = eligible[chosen].index;
+                    const targetPaths = pathsByBlock.get(index);
+                    if (targetPaths) {
+                        targetPaths.push(path);
+                    } else {
+                        pathsByBlock.set(index, [path]);
+                    }
+                }
+
+                // Blocks are disjoint, so the replacements never overlap.
+                // Neither can a standalone line below collide with one.
+                // placementLine returns one of two things, and a pinned
+                // import's span holds no block line either way: its own
+                // line breaks the contiguity a block is built from, and
+                // past that line the span is comment body or the lines
+                // indented under it, neither of which holds a column-0
+                // import the scanner would collect - an indented body
+                // ends at the first column-0 line of code, which is the
+                // earliest a block could start.
+                //
+                // - A ceiling, which is a pinned import's own line.
+                // - floor + 1, reached only when every block was
+                //   refused, which for a path with no ceiling means
+                //   every block starts at or below the floor. The floor
+                //   is the end of a pinned span, so a block starting
+                //   at or below it ends before that span begins, and
+                //   floor + 1 is past the end of the block.
+                //
+                // applyLineSplices still checks, because this argument
+                // holds for these two sites alone and a future site
+                // joins the splice list without re-reading it.
+                for (const index of [...pathsByBlock.keys()].sort((a, b) => a - b)) {
+                    const block = importBlocks[index];
+                    splices.push(this.blockSplice(block, this.blockReplacementLines(block, pathsByBlock.get(index)!, preferDotSyntax, true), lines.length));
+                }
+
+                // headerEnd never decides anything here, and is passed
+                // so that no site holds a different top of the file: a
+                // path with unconstrained bounds finds every block
+                // eligible, so an unblocked one always has a floor or a
+                // ceiling, and both sit at or below the header's end.
+                for (const [line, paths] of this.groupByPlacementLine(unblockedPaths, headerEnd, pinned, classifications, diagnosticPositionsByPath)) {
+                    splices.push(this.insertSplice(line, lines.length, this.formatter.groupAndFormatImports(paths, preferDotSyntax, true, importGrouping), true));
+                }
+            } else {
+                // Sorting off, or no block to merge into: the new
+                // imports are appended and no existing line is touched.
+                //
+                // After the last import block, not the first: with
+                // sorting off nothing reorders a block afterwards, so
+                // any earlier position could leave a new import above
+                // one that has to stay above it.
+                //
+                // Wherever that block sits, not only when it starts at
+                // line 0. A file whose imports open below a licence
+                // header has its first block at a later line, so
+                // inserting at line 0 there writes the new import above
+                // the header and leaves two disconnected import regions
+                // behind.
+                //
+                // With no block at all the top of the file is where a
+                // new import goes - unless a pinned import that has to
+                // precede it sits there, which is the one case a file
+                // whose only import is pinned always reaches. That is
+                // what groupByPlacementLine answers, from either start.
+                const desired = importBlocks.length > 0 ? importBlocks[importBlocks.length - 1].end + 1 : headerEnd;
+                const blankLineAfter = importBlocks.length === 0;
+
+                for (const [line, paths] of this.groupByPlacementLine(newImportPathsArray, desired, pinned, classifications, diagnosticPositionsByPath)) {
+                    splices.push(this.insertSplice(line, lines.length, this.formatter.groupAndFormatImports(paths, preferDotSyntax, sortAlphabetically, importGrouping), blankLineAfter));
+                }
+            }
+        }
+
+        const spliced = applyLineSplices(lines, splices);
+        return spliced === null ? null : spliced.join(eol);
+    }
+
+    /**
      * Computes the document text with every module import consolidated into
      * one organized block at the top: existing imports plus additional paths,
      * deduplicated, grouped, sorted, and formatted per the given options.
@@ -1370,18 +1773,7 @@ export class ImportDocumentEditor {
      * organized document reproduces it byte for byte and organizeImports can
      * skip the edit.
      */
-    buildOrganizedContent(
-        text: string,
-        additionalPaths: string[],
-        options: {
-            preferDotSyntax: boolean;
-            sortAlphabetically: boolean;
-            importGrouping: string;
-            /** Line ending to use when the text has no line break to detect one from. */
-            fallbackEol?: LineEnding;
-        },
-        diagnosticPositionsByPath: DiagnosticPositionsByPath = NO_DIAGNOSTIC_POSITIONS,
-    ): string | null {
+    buildOrganizedContent(text: string, additionalPaths: string[], options: RebuildOptions, diagnosticPositionsByPath: DiagnosticPositionsByPath = NO_DIAGNOSTIC_POSITIONS): string | null {
         const eol = detectEol(text) ?? options.fallbackEol ?? "\n";
         const lines = text.split(LINE_SPLIT);
         const classifications = classifyLines(lines);

--- a/src/imports/ImportRewriteGuard.ts
+++ b/src/imports/ImportRewriteGuard.ts
@@ -1,20 +1,5 @@
 import { classifyLines, LINE_SPLIT, ScannedImport, scanModuleImports } from "./ImportScanner";
 
-/**
- * A text edit queued for the document, with no dependency on `vscode`.
- *
- * Positions are 0-based and carry the same meaning `vscode.Range` gives them,
- * so a range reaching character 0 of a line stops above that line. An edit
- * whose start and end coincide is an insertion and removes nothing.
- */
-export interface QueuedEdit {
-    startLine: number;
-    startCharacter: number;
-    endLine: number;
-    endCharacter: number;
-    newText: string;
-}
-
 /** Every line index an import statement covers, its own span only. */
 function importSpanLines(imports: readonly ScannedImport[]): Set<number> {
     const covered = new Set<number>();
@@ -86,10 +71,11 @@ function firstBodyDifference(before: BodyLine[], after: BodyLine[]): string | nu
  * The reason a rebuilt document must not be applied over `before`, or null when
  * it is safe to apply.
  *
- * The organize path replaces the whole document, so a composition bug in the
- * rebuild - a body line claimed twice, a hoisted line never re-emitted, an
- * off-by-one in the partition - reaches the file as silent text loss. Reading
- * the rebuilt text back turns that class into a refused edit.
+ * Every writer rebuilds the document as one target text, so a composition bug
+ * in a rebuild - a body line claimed twice, a hoisted line never re-emitted,
+ * an off-by-one in a splice - reaches the file as silent text loss. Reading
+ * the rebuilt text back turns that class into a refused edit, on the add path
+ * and the organize path alike.
  *
  * Both texts are read through the same scanner, so this answers whether the
  * writer and the scanner agree, not whether either is right about Verse: a bug
@@ -120,115 +106,4 @@ export function verifyOrganizedRewrite(before: string, after: string, requestedP
     }
 
     return firstBodyDifference(bodyLines(beforeLines), bodyLines(afterLines));
-}
-
-/** Whether the edit writes text in without taking any away. */
-function isInsertion(edit: QueuedEdit): boolean {
-    return edit.startLine === edit.endLine && edit.startCharacter === edit.endCharacter;
-}
-
-/**
- * Every line index the edits delete or overwrite.
- *
- * A line an edit only partly covers counts as removed: the part it takes is
- * text loss just the same, and no writer here produces such a range, so
- * counting it costs nothing.
- */
-function removedLines(edits: readonly QueuedEdit[]): Set<number> {
-    const removed = new Set<number>();
-    for (const edit of edits) {
-        if (isInsertion(edit)) {
-            continue;
-        }
-
-        for (let line = edit.startLine; line <= edit.endLine; line++) {
-            // The range stops above a line it reaches at character 0.
-            if (line === edit.endLine && edit.endCharacter === 0) {
-                continue;
-            }
-            removed.add(line);
-        }
-    }
-    return removed;
-}
-
-/**
- * The reason a set of queued edits must not be applied to `lines`, or null when
- * they are safe to apply.
- *
- * The add path never builds one output text, so there is nothing to read back:
- * the edits themselves are what gets checked. Everything it removes should be an
- * import statement it writes again somewhere else, which is what the two
- * questions below ask.
- *
- * Read from the edits actually queued rather than from a record kept while
- * building them, so this answers for what will be applied rather than for what
- * was meant. It carries the same limitation as verifyOrganizedRewrite: the
- * scanner decides what counts as an import on both sides.
- *
- * @param intendedPaths The paths the caller decided to add. Only these may be
- *   written in that the document does not already import.
- */
-export function verifyImportEdits(lines: string[], edits: readonly QueuedEdit[], intendedPaths: Iterable<string>): string | null {
-    const classifications = classifyLines(lines);
-    const imports = scanModuleImports(lines);
-    const inImportSpan = importSpanLines(imports);
-    const removed = removedLines(edits);
-
-    // An insertion takes no text away, but one landing in the middle of a line
-    // splices its statement onto whatever is already there and leaves one
-    // unreadable line where two belong. Writing past the last line is the
-    // legitimate reason to start anywhere but column 0, and that text opens
-    // with the line break that keeps the two apart. See insertImportLines.
-    for (const edit of edits) {
-        if (isInsertion(edit) && edit.startCharacter !== 0 && !/^\r?\n/.test(edit.newText)) {
-            return `the queued edits splice ${JSON.stringify(edit.newText)} into the middle of line ${edit.startLine + 1}`;
-        }
-    }
-
-    for (const line of [...removed].sort((a, b) => a - b)) {
-        // A position past the end is one VS Code clamps; no line of the
-        // document is under it.
-        if (line >= lines.length) {
-            continue;
-        }
-
-        if (classifications[line].kind === "code" && !inImportSpan.has(line)) {
-            return `the queued edits remove line ${line + 1}, which is code rather than an import: ${JSON.stringify(lines[line])}`;
-        }
-    }
-
-    const written = new Set<string>();
-    for (const edit of edits) {
-        for (const imp of scanModuleImports(edit.newText.split(LINE_SPLIT))) {
-            written.add(imp.path);
-        }
-    }
-
-    const existingPaths = new Set(imports.map((imp) => imp.path));
-    const allowed = new Set([...existingPaths, ...intendedPaths]);
-    const invented = [...written].filter((path) => !allowed.has(path));
-    if (invented.length > 0) {
-        return `the queued edits import ${invented.join(", ")}, which nothing asked for`;
-    }
-
-    const surviving = new Set(written);
-    // A path written on two lines survives while either is left alone, so the
-    // question is asked per statement rather than per path.
-    for (const imp of imports) {
-        let spanRemoved = true;
-        for (let line = imp.startLine; line <= imp.endLine && spanRemoved; line++) {
-            spanRemoved = removed.has(line);
-        }
-        if (!spanRemoved) {
-            surviving.add(imp.path);
-        }
-    }
-
-    const dropped = [...existingPaths].filter((path) => !surviving.has(path));
-    if (dropped.length > 0) {
-        return `the queued edits remove ${dropped.join(", ")} without writing it back`;
-    }
-
-    return null;
 }

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -192,6 +192,11 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent("foo := 1\nbar := 2", [], curlyNoSort)).toBeNull();
     });
 
+    it("keeps the stray endings of a mixed-ending file outside the rebuilt block", () => {
+        const input = "using { /M }\nusing { /Z }\n\ncode()\r\nmore()\nlast()\n";
+        expect(editor.buildOrganizedContent(input, ["/A"], curlySorted)).toBe("using { /A }\nusing { /M }\nusing { /Z }\n\ncode()\r\nmore()\nlast()\n");
+    });
+
     it("consolidates existing imports at the top with one blank line before code", () => {
         const input = "using { /A }\nusing { /B }\ncode()";
         expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe("using { /A }\nusing { /B }\n\ncode()");
@@ -1037,7 +1042,7 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
     // being open, so neither of these moves.
     it("still writes below a header of entirely closed comment", () => {
         const input = ["<# note #>", "# more"].join("\n");
-        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["<# note #>", "# more", "using { /B }", ""].join("\n"));
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["<# note #>", "# more", "using { /B }"].join("\n"));
     });
 
     // A `<#>` marker raises no block-comment depth, and a column-0 line ends
@@ -1045,7 +1050,7 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
     // code and the import belongs there.
     it("still writes below an indented comment whose body ends the buffer", () => {
         const input = ["<#> note", "    body"].join("\n");
-        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["<#> note", "    body", "using { /B }", ""].join("\n"));
+        expect(editor.buildOrganizedContent(input, ["/B"], curlySorted)).toBe(["<#> note", "    body", "using { /B }"].join("\n"));
     });
 
     it("writes the preferred dot syntax", () => {

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { applyLineSplices, detectEol, ImportDocumentEditor, minimalSplice } from "../ImportDocumentEditor";
+import { detectEol, ImportDocumentEditor, minimalSplice, spliceLines } from "../ImportDocumentEditor";
 import { ImportFormatter } from "../ImportFormatter";
 import * as vscode from "vscode";
 
@@ -27,23 +27,27 @@ describe("detectEol", () => {
     });
 });
 
-describe("applyLineSplices", () => {
-    const lines = ["a", "b", "c", "d"];
+describe("spliceLines", () => {
+    const text = "a\nb\nc\nd";
 
-    it("returns the lines unchanged with no splices", () => {
-        expect(applyLineSplices(lines, [])).toEqual(["a", "b", "c", "d"]);
+    it("returns the text unchanged with no splices", () => {
+        expect(spliceLines(text, [], "\n")).toBe("a\nb\nc\nd");
     });
 
     it("replaces a range", () => {
-        expect(applyLineSplices(lines, [{ start: 1, endExclusive: 3, newLines: ["B"] }])).toEqual(["a", "B", "d"]);
+        expect(spliceLines(text, [{ start: 1, endExclusive: 3, newLines: ["B"] }], "\n")).toBe("a\nB\nd");
     });
 
     it("inserts above the line equal bounds name", () => {
-        expect(applyLineSplices(lines, [{ start: 2, endExclusive: 2, newLines: ["X"] }])).toEqual(["a", "b", "X", "c", "d"]);
+        expect(spliceLines(text, [{ start: 2, endExclusive: 2, newLines: ["X"] }], "\n")).toBe("a\nb\nX\nc\nd");
     });
 
-    it("appends with equal bounds at the array's length", () => {
-        expect(applyLineSplices(lines, [{ start: 4, endExclusive: 4, newLines: ["X"] }])).toEqual(["a", "b", "c", "d", "X"]);
+    it("appends past the last line by opening with a break and closing without one", () => {
+        expect(spliceLines(text, [{ start: 4, endExclusive: 4, newLines: ["X"] }], "\n")).toBe("a\nb\nc\nd\nX");
+    });
+
+    it("replaces a block ending the document with a trailing break after it", () => {
+        expect(spliceLines(text, [{ start: 2, endExclusive: 4, newLines: ["C"] }], "\n")).toBe("a\nb\nC\n");
     });
 
     it("applies splices by position whatever order they arrive in", () => {
@@ -51,7 +55,7 @@ describe("applyLineSplices", () => {
             { start: 3, endExclusive: 4, newLines: ["D"] },
             { start: 0, endExclusive: 1, newLines: ["A"] },
         ];
-        expect(applyLineSplices(lines, splices)).toEqual(["A", "b", "c", "D"]);
+        expect(spliceLines(text, splices, "\n")).toBe("A\nb\nc\nD\n");
     });
 
     it("puts an insertion at the start of a replaced range first", () => {
@@ -59,7 +63,7 @@ describe("applyLineSplices", () => {
             { start: 1, endExclusive: 3, newLines: ["B"] },
             { start: 1, endExclusive: 1, newLines: ["X"] },
         ];
-        expect(applyLineSplices(lines, splices)).toEqual(["a", "X", "B", "d"]);
+        expect(spliceLines(text, splices, "\n")).toBe("a\nX\nB\nd");
     });
 
     it("keeps two insertions at one line in their given order", () => {
@@ -67,7 +71,17 @@ describe("applyLineSplices", () => {
             { start: 2, endExclusive: 2, newLines: ["X"] },
             { start: 2, endExclusive: 2, newLines: ["Y"] },
         ];
-        expect(applyLineSplices(lines, splices)).toEqual(["a", "b", "X", "Y", "c", "d"]);
+        expect(spliceLines(text, splices, "\n")).toBe("a\nb\nX\nY\nc\nd");
+    });
+
+    it("keeps the exact ending of every line it does not touch", () => {
+        const mixed = "a\r\nb\nc\r\nd\n";
+        expect(spliceLines(mixed, [{ start: 1, endExclusive: 2, newLines: ["B"] }], "\n")).toBe("a\r\nB\nc\r\nd\n");
+    });
+
+    it("writes only the spliced-in lines with the given ending", () => {
+        const crlf = "a\r\nb\r\n";
+        expect(spliceLines(crlf, [{ start: 1, endExclusive: 1, newLines: ["X"] }], "\r\n")).toBe("a\r\nX\r\nb\r\n");
     });
 
     it("refuses overlapping splices", () => {
@@ -75,15 +89,15 @@ describe("applyLineSplices", () => {
             { start: 0, endExclusive: 2, newLines: ["A"] },
             { start: 1, endExclusive: 3, newLines: ["B"] },
         ];
-        expect(applyLineSplices(lines, splices)).toBeNull();
+        expect(spliceLines(text, splices, "\n")).toBeNull();
     });
 
-    it("refuses a splice reaching past the array", () => {
-        expect(applyLineSplices(lines, [{ start: 3, endExclusive: 5, newLines: [] }])).toBeNull();
+    it("refuses a splice reaching past the lines", () => {
+        expect(spliceLines(text, [{ start: 3, endExclusive: 5, newLines: [] }], "\n")).toBeNull();
     });
 
     it("refuses inverted bounds", () => {
-        expect(applyLineSplices(lines, [{ start: 2, endExclusive: 1, newLines: [] }])).toBeNull();
+        expect(spliceLines(text, [{ start: 2, endExclusive: 1, newLines: [] }], "\n")).toBeNull();
     });
 });
 
@@ -1417,8 +1431,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
     });
 
     // The auto-import path, which users reach without invoking a command. It
-    // rebuilds a block through createBlockReplacementEdit rather than through
-    // buildOrganizedContent, and reads trailing comments off that block alone.
+    // rebuilds a block in place through blockReplacementLines rather than
+    // through buildOrganizedContent, and reads trailing comments off that
+    // block alone.
     it("keeps the comment trailing an existing import when a new one joins its block", async () => {
         const input = ["using { /Zebra } # network only", "", "hello := 1"].join("\n");
 
@@ -1774,6 +1789,18 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\r\nusing { /Verse.org/Simulation }\r\n\r\nhello := 1\r\n");
     });
 
+    // Auto-import fires on every compile diagnostic, so a line it was never
+    // asked about must come back byte for byte - a mixed-ending file included,
+    // where rejoining with one dominant ending would rewrite it.
+    it("leaves the stray endings of a mixed-ending document alone", async () => {
+        const input = "using { /M }\nusing { /Z }\n\ncode()\r\nmore()\nlast()\n";
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /A }"]);
+
+        expect(success).toBe(true);
+        expect(appliedText(input)).toBe("using { /A }\nusing { /M }\nusing { /Z }\n\ncode()\r\nmore()\nlast()\n");
+    });
+
     it("preserve + digestFirst: inserts at the top when the file has no existing imports", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,
@@ -1835,8 +1862,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
 
         // Every case above has code below the header. Where the header is an
         // opener that never closes it runs to the last line instead, and the
-        // insert took insertImportLines' end-of-document branch - appending the
-        // import after that line, inside the comment.
+        // import was appended past that line - inside the comment.
         it("writes above an opener that never closes, not past the last line", async () => {
             mockConfig({ "behavior.preserveImportLocations": true });
             const input = ["<# note", "still note"].join("\n");
@@ -2744,7 +2770,8 @@ describe("ImportDocumentEditor rewrite verification", () => {
             ["an annotated import", "# why /A is here\nusing { /A }\n\ncode()"],
             ["an import pinned by a second statement", "X := 1; using { /A }\ncode()"],
             ["a commented-out import", "<#\nusing { /Old }\n#>\nusing { /A }\n\ncode()"],
-            ["an indented using pair", "using{\n    /A\n}\ncode()"],
+            ["a multi-line braced clause", "using{\n    /A\n}\ncode()"],
+            ["an indented using pair", "using:\n    /A\ncode()"],
             ["a using inside a module body", "using { /A }\n\nM := module:\n    using { /B }\n    F():void = {}"],
             ["two gapped blocks", "using { /A }\n\nusing { Local.One }\n\ncode()"],
             ["a relative import under an absolute one", "using { /A }\nusing { Local.One }\n\ncode()"],
@@ -2809,6 +2836,11 @@ describe("ImportDocumentEditor.buildPreservedContent", () => {
     it("leaves every line it does not rewrite untouched", () => {
         const input = "# note\nusing { /A }\n\ncode()\nmore()";
         expect(editor.buildPreservedContent(input, ["/B"], defaults)).toBe("# note\nusing { /A }\nusing { /B }\n\ncode()\nmore()");
+    });
+
+    it("keeps the stray endings of a mixed-ending file outside the rewrite", () => {
+        const input = "using { /M }\nusing { /Z }\n\ncode()\r\nmore()\nlast()\n";
+        expect(editor.buildPreservedContent(input, ["/A"], defaults)).toBe("using { /A }\nusing { /M }\nusing { /Z }\n\ncode()\r\nmore()\nlast()\n");
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -2436,6 +2436,8 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
     // import across the pinned one that may bring its first segment into scope -
     // the hoist buildOrganizedContent already refuses. Verse resolves `using`
     // top-down, so the file stopped compiling.
+    // Consolidating runs the same rebuilder as Optimize Imports, so the block
+    // it writes carries that rebuild's blank separator before the body.
     describe("consolidating past an import pinned to its line", () => {
         const consolidating = {
             "behavior.preserveImportLocations": false,
@@ -2450,7 +2452,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Features }; X := 1\nusing { Economy.Shop }\ncode()");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\n\nusing { Features }; X := 1\nusing { Economy.Shop }\ncode()");
         });
 
         it("still hoists a consumer written above the pinned line", async () => {
@@ -2462,7 +2464,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(success).toBe(true);
             // Position is the question, not presence: hoisting this one lands
             // it above the pinned line, which is where it already was.
-            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Economy.Shop }\nusing { Features }; MyVal := 5\ncode()");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Economy.Shop }\n\nusing { Features }; MyVal := 5\ncode()");
         });
 
         it("writes a new consumer below the pinned provider instead of into the block", async () => {
@@ -2474,7 +2476,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(success).toBe(true);
             // The hoisted import leaves the line it was written on, or the
             // file imports it twice.
-            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\ncode()");
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\n\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\ncode()");
         });
 
         // The same shape as the test below, with no diagnostic naming the
@@ -2489,7 +2491,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
             expect(success).toBe(true);
-            expect(appliedText(input)).toBe("using { /A }\ncode()\nusing { Economy.Shop }; X := 1\nusing { Features }\nmore()");
+            expect(appliedText(input)).toBe("using { /A }\n\ncode()\nusing { Economy.Shop }; X := 1\nusing { Features }\nmore()");
         });
 
         it("still consolidates a new provider the pinned consumer below it may need", async () => {
@@ -2501,7 +2503,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(success).toBe(true);
             // The block itself sits above the pinned consumer, so nothing is
             // gained by writing the provider on a line of its own further down.
-            expect(appliedText(input)).toBe("using { /A }\nusing { Features }\ncode()\nusing { Economy.Shop }; X := 1");
+            expect(appliedText(input)).toBe("using { /A }\nusing { Features }\n\ncode()\nusing { Economy.Shop }; X := 1");
         });
 
         it("takes the floor over a pinned consumer sitting above it", async () => {
@@ -2528,7 +2530,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             // Grounding is keyed on the path: hoisting the copy above the
             // pinned line while the block declines to re-emit the path would
             // delete the one line that had to keep it.
-            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Economy.Shop }\nusing { Features }; X := 1\nusing { Economy.Shop }\ncode()");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\n\nusing { Economy.Shop }\nusing { Features }; X := 1\nusing { Economy.Shop }\ncode()");
         });
 
         it("splits the delete around a grounded import rather than taking its line with the block", async () => {
@@ -2540,7 +2542,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(success).toBe(true);
             // One block, two runs: deleting it whole would take the grounded
             // line with it while nothing re-emits that path, losing the import.
-            expect(appliedText(input)).toBe("using { /A }\nusing { /B }\nusing { /Fortnite.com/Devices }\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\ncode()");
+            expect(appliedText(input)).toBe("using { /A }\nusing { /B }\nusing { /Fortnite.com/Devices }\n\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\ncode()");
         });
 
         it("grounds against a provider pinned by the comment it anchors, past the comment body", async () => {
@@ -2550,7 +2552,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Features } <#> why this is here\n    it brings Economy into scope\nusing { Economy.Shop }\ncode()");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\n\nusing { Features } <#> why this is here\n    it brings Economy into scope\nusing { Economy.Shop }\ncode()");
         });
 
         it("consolidates a file with nothing pinned exactly as before", async () => {
@@ -2560,7 +2562,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /C }"]);
 
             expect(success).toBe(true);
-            expect(appliedText(input)).toBe("using { /A }\nusing { /B }\nusing { /C }\ncode()");
+            expect(appliedText(input)).toBe("using { /A }\nusing { /B }\nusing { /C }\n\ncode()");
         });
     });
 });
@@ -2612,16 +2614,11 @@ describe("ImportDocumentEditor rewrite verification", () => {
         expect(appliedText(input)).toBe("using { /A }\nusing { /B }\n\ncode()");
     });
 
-    // The off-by-one the ticket names, on the path that has no output text to
-    // read: a hoisted run reaching one line past its block deletes the code
-    // line below it.
-    it("refuses to add imports when a queued deletion reaches onto code", async () => {
-        const input = "using { /A }\ncode()";
-        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
-            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key === "behavior.preserveImportLocations" ? false : defaultValue)),
-            update: jest.fn().mockResolvedValue(undefined),
-        });
-        jest.spyOn(editor as unknown as { hoistedRuns: () => Array<{ start: number; end: number }> }, "hoistedRuns").mockReturnValue([{ start: 0, end: 1 }]);
+    // The add path reads its guard off the same rebuilt text as organize, so
+    // an injected composition bug in its builder must be refused the same way.
+    it("refuses to add imports when the rebuilt text loses a line of code", async () => {
+        const input = "using { /A }\ncode()\nmore()";
+        jest.spyOn(editor, "buildPreservedContent").mockReturnValue("using { /A }\nusing { /B }\ncode()");
 
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
@@ -2629,28 +2626,34 @@ describe("ImportDocumentEditor rewrite verification", () => {
         expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
-    it("adds imports as usual when the queued edits touch nothing but imports", async () => {
+    it("refuses to add imports when the rebuilt text drops an import", async () => {
+        const input = "using { /A }\ncode()";
+        jest.spyOn(editor, "buildPreservedContent").mockReturnValue("using { /B }\ncode()");
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
+
+        expect(success).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    // A null from the builder with paths still to add is its splices refusing
+    // to compose, and nothing may reach the document on it.
+    it("refuses to add imports when the rebuilt text could not be composed", async () => {
+        jest.spyOn(editor, "buildPreservedContent").mockReturnValue(null);
+
+        const success = await editor.addImportsToDocument(fakeDocument("code()"), ["using { /B }"]);
+
+        expect(success).toBe(false);
+        expect(applyEditMock()).not.toHaveBeenCalled();
+    });
+
+    it("adds imports as usual when the rebuilt text is sound", async () => {
         const input = "using { /A }\ncode()";
 
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
         expect(success).toBe(true);
         expect(appliedText(input)).toBe("using { /A }\nusing { /B }\ncode()");
-    });
-
-    // insertImportLines documents its past-the-end branch as the thing standing
-    // between the writer and "one unreadable line where two belong". An
-    // insertion carries no range, so nothing else here would notice.
-    it("refuses to add imports when an insertion splices onto a line of code", async () => {
-        type InsertImportLines = (edit: vscode.WorkspaceEdit, document: vscode.TextDocument, line: number, statements: string[], eol: string, blankLineAfter: boolean) => void;
-        jest.spyOn(editor as unknown as { insertImportLines: InsertImportLines }, "insertImportLines").mockImplementation((edit, document, _line, statements, eol) => {
-            edit.insert(document.uri, new vscode.Position(0, "code()".length), statements.join(eol) + eol);
-        });
-
-        const success = await editor.addImportsToDocument(fakeDocument("code()"), ["using { /B }"]);
-
-        expect(success).toBe(false);
-        expect(applyEditMock()).not.toHaveBeenCalled();
     });
 
     /**
@@ -2715,98 +2718,27 @@ describe("ImportDocumentEditor rewrite verification", () => {
     });
 });
 
-/**
- * Port-equivalence scaffold: buildPreservedContent against the live add-path
- * writer, line for line, across every document shape and preserve-mode setting
- * row. Deleted with the swap that routes the writer through the builder, at
- * which point it compares a function against itself.
- *
- * Line-based and ending-insensitive on purpose: the builder joins with one
- * detected ending where the old writer splices text into place, so endings may
- * differ while any placement drift still has to surface.
- */
-describe("buildPreservedContent matches the live add path", () => {
+describe("ImportDocumentEditor.buildPreservedContent", () => {
     let editor: ImportDocumentEditor;
 
-    const documents: Array<[string, string]> = [
-        ["an empty file", ""],
-        ["no trailing newline", "using { /A }\ncode()"],
-        ["a trailing newline", "using { /A }\ncode()\n"],
-        ["CRLF", "using { /A }\r\ncode()\r\n"],
-        ["only imports", "using { /A }\nusing { /B }"],
-        ["no imports at all", "code()\nmore()"],
-        ["a header comment", "# licence\n\nusing { /A }\n\ncode()"],
-        ["an annotated import", "# why /A is here\nusing { /A }\n\ncode()"],
-        ["an import pinned by a second statement", "X := 1; using { /A }\ncode()"],
-        ["a commented-out import", "<#\nusing { /Old }\n#>\nusing { /A }\n\ncode()"],
-        ["an indented using pair", "using{\n    /A\n}\ncode()"],
-        ["a using inside a module body", "using { /A }\n\nM := module:\n    using { /B }\n    F():void = {}"],
-        ["two gapped blocks", "using { /A }\n\nusing { Local.One }\n\ncode()"],
-        ["a relative import under an absolute one", "using { /A }\nusing { Local.One }\n\ncode()"],
-        ["a pinned import below a block", "using { /A }\ncode()\nX := 1; using { /Verse.org/Simulation }\nmore()"],
-    ];
-
-    const settings: Array<[string, Record<string, unknown>]> = [
-        ["defaults", {}],
-        ["unsorted", { "behavior.sortImportsAlphabetically": false }],
-        ["grouped local first", { "behavior.importGrouping": "localFirst" }],
-        ["grouped digest first", { "behavior.importGrouping": "digestFirst" }],
-        ["grouped digest first, unsorted", { "behavior.importGrouping": "digestFirst", "behavior.sortImportsAlphabetically": false }],
-        ["dot syntax", { "behavior.importSyntax": "dot" }],
-    ];
-
-    function useSettings(overrides: Record<string, unknown>): void {
-        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
-            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key in overrides ? overrides[key] : defaultValue)),
-            update: jest.fn().mockResolvedValue(undefined),
-        });
-    }
-
-    function optionsFrom(overrides: Record<string, unknown>) {
-        return {
-            preferDotSyntax: overrides["behavior.importSyntax"] === "dot",
-            sortAlphabetically: (overrides["behavior.sortImportsAlphabetically"] as boolean | undefined) ?? true,
-            importGrouping: (overrides["behavior.importGrouping"] as string | undefined) ?? "none",
-        };
-    }
+    const defaults = { preferDotSyntax: false, sortAlphabetically: true, importGrouping: "none" };
 
     beforeEach(() => {
         const outputChannel = vscode.window.createOutputChannel("test");
         editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
-        (vscode.workspace.applyEdit as unknown as jest.Mock).mockClear();
-    });
-
-    for (const [documentName, input] of documents) {
-        for (const [settingsName, overrides] of settings) {
-            it(`matches on ${documentName} with ${settingsName}`, async () => {
-                useSettings(overrides);
-                const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
-                expect(success).toBe(true);
-
-                const built = editor.buildPreservedContent(input, ["/Fortnite.com/Devices"], optionsFrom(overrides));
-                expect(built).not.toBeNull();
-                expect(built!.split(/\r?\n/)).toEqual(appliedText(input).split(/\r?\n/));
-            });
-        }
-    }
-
-    it("matches when diagnostic evidence raises a ceiling over a pinned consumer", async () => {
-        const input = "using { Economy.Shop } <#> note\n    body\ncode()";
-        useSettings({});
-        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy }"], new Map([["using { Economy }", [{ line: 0, character: 8 }]]]));
-        expect(success).toBe(true);
-
-        const built = editor.buildPreservedContent(input, ["Economy"], optionsFrom({}), new Map([["Economy", [{ line: 0, character: 8 }]]]));
-        expect(built).not.toBeNull();
-        expect(built!.split(/\r?\n/)).toEqual(appliedText(input).split(/\r?\n/));
     });
 
     it("returns null for a path the document already imports", () => {
-        expect(editor.buildPreservedContent("using { /A }\ncode()", ["/A"], optionsFrom({}))).toBeNull();
+        expect(editor.buildPreservedContent("using { /A }\ncode()", ["/A"], defaults)).toBeNull();
     });
 
     it("returns null for blank paths", () => {
-        expect(editor.buildPreservedContent("code()", ["  ", ""], optionsFrom({}))).toBeNull();
+        expect(editor.buildPreservedContent("code()", ["  ", ""], defaults)).toBeNull();
+    });
+
+    it("leaves every line it does not rewrite untouched", () => {
+        const input = "# note\nusing { /A }\n\ncode()\nmore()";
+        expect(editor.buildPreservedContent(input, ["/B"], defaults)).toBe("# note\nusing { /A }\nusing { /B }\n\ncode()\nmore()");
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -2564,6 +2564,76 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             expect(success).toBe(true);
             expect(appliedText(input)).toBe("using { /A }\nusing { /B }\nusing { /C }\n\ncode()");
         });
+
+        it("carries an import's annotation with it into the block", async () => {
+            mockConfig(consolidating);
+            const input = ["using { /A }", "# why /B is here", "using { /B }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /C }"]);
+
+            expect(success).toBe(true);
+            expect(appliedText(input)).toBe("using { /A }\n# why /B is here\nusing { /B }\nusing { /C }\n\ncode()");
+        });
+
+        it("withholds a movable duplicate of a pinned path when every using is absolute", async () => {
+            mockConfig(consolidating);
+            const input = ["using { /B }; X := 1", "using { /B }", "code()"].join("\n");
+
+            const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /C }"]);
+
+            expect(success).toBe(true);
+            expect(appliedText(input)).toBe("using { /C }\n\nusing { /B }; X := 1\ncode()");
+        });
+    });
+});
+
+/**
+ * The one conflict rule. A diagnostic inside a pinned dotted import's own
+ * statement licenses reading the added path as its provider, which must then
+ * precede it (the ceiling); another pinned import the added path could resolve
+ * through asks it to stay below (the floor). Where the two collide the ceiling
+ * wins on every route: a `using` resolves through the `using` set above it in
+ * document order, so a provider written below its evidenced consumer can never
+ * fix the diagnostic that asked for it, while the floor is form-based
+ * suspicion with no evidence behind it. See placementLine.
+ */
+describe("one conflict rule across both entry points", () => {
+    let editor: ImportDocumentEditor;
+
+    const input = ["using { Economy.Shop } <#> note", "    the marker body", "using { Features2 }; X := 1", "code()"].join("\n");
+    const resolved = "using { Features }\nusing { Economy.Shop } <#> note\n    the marker body\nusing { Features2 }; X := 1\ncode()";
+
+    beforeEach(() => {
+        const outputChannel = vscode.window.createOutputChannel("test");
+        editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
+        (vscode.workspace.applyEdit as unknown as jest.Mock).mockClear();
+    });
+
+    it("organize writes the evidenced provider above its consumer past a floor below", async () => {
+        const success = await editor.organizeImports(fakeDocument(input), ["Features"], new Map([["Features", [{ line: 0, character: 8 }]]]));
+
+        expect(success).toBe(true);
+        expect(appliedText(input)).toBe(resolved);
+    });
+
+    it("a consolidating add produces the same document", async () => {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key === "behavior.preserveImportLocations" ? false : defaultValue)),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], new Map([["using { Features }", [{ line: 0, character: 8 }]]]));
+
+        expect(success).toBe(true);
+        expect(appliedText(input)).toBe(resolved);
+    });
+
+    it("a preserving add picks the same line", async () => {
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], new Map([["using { Features }", [{ line: 0, character: 8 }]]]));
+
+        expect(success).toBe(true);
+        // The same placement; only the blank line after a fresh run differs.
+        expect(appliedText(input)).toBe("using { Features }\n\nusing { Economy.Shop } <#> note\n    the marker body\nusing { Features2 }; X := 1\ncode()");
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1201,6 +1201,39 @@ function appliedOperations(call: number): RecordedOperation[] {
     return edit.operations;
 }
 
+/**
+ * The document text the recorded edit produces: every operation of one
+ * applyEdit call replayed onto `input`. Ranges are coordinates in `input`, as
+ * a WorkspaceEdit's are, so ops apply back-to-front; ties keep recorded order,
+ * with an insertion at the start of a replaced range landing first, as VS Code
+ * applies them.
+ */
+const appliedText = (input: string, call = 0): string => {
+    const lineStarts = [0];
+    for (let i = 0; i < input.length; i++) {
+        if (input[i] === "\n") {
+            lineStarts.push(i + 1);
+        }
+    }
+    const offsetAt = (position: { line: number; character: number }): number => {
+        const lineStart = lineStarts[Math.min(position.line, lineStarts.length - 1)];
+        return Math.min(lineStart + position.character, input.length);
+    };
+    const spans = appliedOperations(call).map((op, index) => {
+        if (op.kind === "insert") {
+            const offset = offsetAt(op.position!);
+            return { start: offset, end: offset, text: op.text ?? "", index };
+        }
+        return { start: offsetAt(op.range!.start), end: offsetAt(op.range!.end), text: op.kind === "replace" ? (op.text ?? "") : "", index };
+    });
+    spans.sort((a, b) => a.start - b.start || a.end - b.end || a.index - b.index);
+    let result = input;
+    for (let i = spans.length - 1; i >= 0; i--) {
+        result = result.slice(0, spans[i].start) + spans[i].text + result.slice(spans[i].end);
+    }
+    return result;
+};
+
 describe("ImportDocumentEditor.addImportsToDocument", () => {
     let editor: ImportDocumentEditor;
     const applyEditMock = () => vscode.workspace.applyEdit as unknown as jest.Mock;
@@ -1239,17 +1272,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const insert = operations.find((op) => op.kind === "insert");
-        expect(insert).toBeDefined();
-        expect(insert!.text).toContain("/Verse.org/Simulation");
-        expect(insert!.text).toContain("/Fortnite.com/Devices");
-
-        const deletes = operations.filter((op) => op.kind === "delete");
-        expect(deletes).toHaveLength(1);
-        expect(deletes[0].range!.start.line).toBe(0);
-        expect(deletes[0].range!.end.line).toBe(2);
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n\nhello := 1");
     });
 
     it("recognizes an import that already exists as an indented pair and makes no edit", async () => {
@@ -1314,11 +1337,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
-        expect(operations[0].position).toEqual({ line: 4, character: 0 });
-        expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n\n");
+        expect(appliedText(input)).toBe(
+            "<#\nusing { /Fortnite.com/Devices }\n#>\n\nusing { /Fortnite.com/Devices }\n\nmy_device := class(creative_device):\n    Button : button_device = button_device{}",
+        );
     });
 
     it("adds a new import without rebuilding an import line that opens a block comment", async () => {
@@ -1329,11 +1350,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
-        expect(operations[0].position).toEqual({ line: 0, character: 0 });
-        expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n\n");
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\n\nusing { /A } <# disabled below\nusing { /Old/Path }\n#>\n\ncode()");
     });
 
     it("still counts an import whose line opens a block comment as already present", async () => {
@@ -1391,15 +1408,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const insert = operations.find((op) => op.kind === "insert");
-        expect(insert!.text).not.toContain("/Verse.org/Random");
-
-        const deletes = operations.filter((op) => op.kind === "delete");
-        expect(deletes).toHaveLength(1);
-        expect(deletes[0].range!.start.line).toBe(0);
-        expect(deletes[0].range!.end.line).toBe(1);
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { /Top }\n\nUtilities := module:\n    using { /Verse.org/Random }\n\n    GenerateId<public>():int = 1");
     });
 
     // The auto-import path, which users reach without invoking a command. It
@@ -1411,8 +1420,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Apple }"]);
 
         expect(success).toBe(true);
-        const replace = appliedOperations(0).find((op) => op.kind === "replace");
-        expect(replace!.text).toBe("using { /Apple }\nusing { /Zebra } # network only\n");
+        expect(appliedText(input)).toBe("using { /Apple }\nusing { /Zebra } # network only\n\nhello := 1");
     });
 
     it("keeps that comment when consolidating every import at the top", async () => {
@@ -1430,8 +1438,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Apple }"]);
 
         expect(success).toBe(true);
-        const insert = appliedOperations(0).find((op) => op.kind === "insert");
-        expect(insert!.text).toContain("using { /Zebra } # network only");
+        expect(appliedText(input)).toBe("using { /Apple }\nusing { /Zebra } # network only\n\nhello := 1");
     });
 
     it("does not add an import under an unclosed opener that ends the buffer", async () => {
@@ -1442,14 +1449,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
         expect(success).toBe(true);
-        // Pinned to the exact edit rather than to "no `<#` anywhere": a delete
-        // operation carries no text, so an assertion over every operation's
-        // text passes vacuously and would hold for an edit that writes nothing.
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
-        expect(operations[0].text).toBe("using { /B }\n\n");
-        expect(operations[0].position!.line).toBe(0);
+        // Pinned to the whole document rather than to "no `<#` above the new
+        // import": that reading holds vacuously of an edit writing nothing.
+        expect(appliedText(input)).toBe("using { /B }\n\nhello := 1\nusing { /A } <#");
     });
 
     // The same two shapes through the auto-import path, which reaches the floor
@@ -1461,11 +1463,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Gadgets.Tools }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
-        expect(operations[0].text).toBe("using { Gadgets.Tools }\n\n");
-        expect(operations[0].position!.line).toBe(2);
+        expect(appliedText(input)).toBe("using { /A }; M := module:\n    Body<public>():int = 1\nusing { Gadgets.Tools }\n\ncode()");
     });
 
     it("does not add a relative import under an unclosed opener that ends the buffer", async () => {
@@ -1474,11 +1472,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Gadgets.Tools }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
-        expect(operations[0].text).toBe("using { Gadgets.Tools }\n\n");
-        expect(operations[0].position!.line).toBe(0);
+        expect(appliedText(input)).toBe("using { Gadgets.Tools }\n\nhello := 1\nusing { /A } <#");
     });
 
     it("adds it below a comment trailing the body a blank line separates from it", async () => {
@@ -1487,10 +1481,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Gadgets.Tools }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
-        expect(operations[0].position!.line).toBe(4);
+        expect(appliedText(input)).toBe("using { /A }; M := module:\n    Body<public>():int = 1\n\n    # what the module is for\nusing { Gadgets.Tools }\n\ncode()");
     });
 
     it("keeps the floor a pinned import above an unclosed opener raises", async () => {
@@ -1499,13 +1490,10 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features.Shop }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
         // Below the provider that could be bringing `Features` into scope, not
         // at the top of the file: the unwritable span above the comment is
         // skipped on its own, and takes no other pinned import's floor with it.
-        expect(operations[0].position!.line).toBe(1);
+        expect(appliedText(input)).toBe("using { Features }; X := 1\nusing { Features.Shop }\n\ncode()\nusing { /B } <# note");
     });
 
     function mockConfig(overrides: Record<string, unknown>): void {
@@ -1531,18 +1519,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const replace = operations.find((op) => op.kind === "replace");
-        expect(replace).toBeDefined();
-        expect(replace!.range!.start.line).toBe(3);
-        expect(replace!.text).toContain("/Fortnite.com/Random");
-        expect(replace!.text).toContain("/Verse.org/Simulation");
-        expect(replace!.text).toContain("/Fortnite.com/Devices");
-
-        // Nothing is inserted above the header comment.
-        const insertsAtTop = operations.filter((op) => op.kind === "insert" && op.position!.line === 0);
-        expect(insertsAtTop).toHaveLength(0);
+        expect(appliedText(input)).toBe(
+            "# Header comment line 1\n# Header comment line 2\n\nusing { /Fortnite.com/Devices }\nusing { /Fortnite.com/Random }\nusing { /Verse.org/Simulation }\n\nhello := 1",
+        );
     });
 
     it("preserve + localFirst: replaces a single import block below a header in place, not at the top", async () => {
@@ -1556,16 +1535,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const replace = operations.find((op) => op.kind === "replace");
-        expect(replace).toBeDefined();
-        expect(replace!.range!.start.line).toBe(3);
-        expect(replace!.text).toContain("/Fortnite.com/Random");
-        expect(replace!.text).toContain("/Verse.org/Simulation");
-
-        const insertsAtTop = operations.filter((op) => op.kind === "insert" && op.position!.line === 0);
-        expect(insertsAtTop).toHaveLength(0);
+        expect(appliedText(input)).toBe(
+            "# Header comment line 1\n# Header comment line 2\n\nusing { /Fortnite.com/Devices }\nusing { /Fortnite.com/Random }\nusing { /Verse.org/Simulation }\n\nhello := 1",
+        );
     });
 
     // Regrouping an ungrouped block writes the whole block, so localFirst gets
@@ -1582,12 +1554,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const replace = operations.find((op) => op.kind === "replace");
-        expect(replace).toBeDefined();
-        expect(replace!.text.indexOf("/Verse.org/Simulation")).toBeLessThan(replace!.text.indexOf("Economy.Shop"));
-        expect(replace!.text.indexOf("/Verse.org/Simulation")).toBeLessThan(replace!.text.indexOf("Features"));
+        expect(appliedText(input)).toBe("# Header comment line 1\n# Header comment line 2\n\nusing { /Verse.org/Simulation }\n\nusing { Economy.Shop }\nusing { Features }\n\nhello := 1");
     });
 
     // A file localFirst organized has two local blocks, one either side of the
@@ -1604,16 +1571,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /mygame@fortnite.com/mygame/Combat }", "using { Features }"]);
 
         expect(success).toBe(true);
-        const replaces = appliedOperations(0).filter((op) => op.kind === "replace");
-
-        const upper = replaces.find((op) => op.range!.start.line === 0);
-        expect(upper).toBeDefined();
-        expect(upper!.text).toContain("/mygame@fortnite.com/mygame/Combat");
-
-        const lower = replaces.find((op) => op.range!.start.line === 4);
-        expect(lower).toBeDefined();
-        expect(lower!.text).toContain("Features");
-        expect(lower!.text).not.toContain("Combat");
+        expect(appliedText(input)).toBe(
+            "using { /mygame@fortnite.com/mygame/Combat }\nusing { /mygame@fortnite.com/mygame/Utils }\n\nusing { /Verse.org/Simulation }\n\nusing { Economy.Shop }\nusing { Features }\n\nhello := 1",
+        );
     });
 
     it("preserve + digestFirst: a new bare local import lands after the dotted local import already in its block", async () => {
@@ -1627,11 +1587,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const replace = operations.find((op) => op.kind === "replace");
-        expect(replace).toBeDefined();
-        expect(replace!.text).toBe("using { Economy.Shop }\nusing { Features }\n");
+        expect(appliedText(input)).toBe("# Header comment line 1\n# Header comment line 2\n\nusing { /Verse.org/Simulation }\n\nusing { Economy.Shop }\nusing { Features }\n\nhello := 1");
     });
 
     it("preserve + grouping none + sort on (default config): merges a new bare import into the existing block, below the import already there", async () => {
@@ -1645,16 +1601,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const replace = operations.find((op) => op.kind === "replace");
-        expect(replace).toBeDefined();
-        expect(replace!.range!.start.line).toBe(0);
-        expect(replace!.text).toBe("using { Economy.Shop }\nusing { Features }\n");
-
-        // The new import is not appended after the block.
-        const insertsAfterBlock = operations.filter((op) => op.kind === "insert" && op.position!.line === 1);
-        expect(insertsAfterBlock).toHaveLength(0);
+        expect(appliedText(input)).toBe("using { Economy.Shop }\nusing { Features }\n\nhello := 1");
     });
 
     it("preserve + grouping none + sort OFF: keeps the original append-after-block behavior and leaves existing lines untouched", async () => {
@@ -1668,15 +1615,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        // No block is rewritten; the existing import line stays as-is.
-        expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-        const insert = operations.find((op) => op.kind === "insert");
-        expect(insert).toBeDefined();
-        expect(insert!.position!.line).toBe(1);
-        expect(insert!.text).toBe("using { Features }\n");
+        // Appending after the block and merging into it write the same text
+        // here, and the text is the observable contract.
+        expect(appliedText(input)).toBe("using { Economy.Shop }\nusing { Features }\n\nhello := 1");
     });
 
     // A blank line between imports starts a second block, and rank-sorting only
@@ -1693,10 +1634,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
         expect(success).toBe(true);
-        const replaces = appliedOperations(0).filter((op) => op.kind === "replace");
-        expect(replaces).toHaveLength(1);
-        expect(replaces[0].range!.start.line).toBe(2);
-        expect(replaces[0].text).toBe("using { Features }\nusing { Economy.Shop }\n");
+        expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\n\nusing { Features }\nusing { Economy.Shop }\n\nhello := 1");
     });
 
     // The dotted import in the earlier block can be what brings the new import's
@@ -1713,10 +1651,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
         expect(success).toBe(true);
-        const replaces = appliedOperations(0).filter((op) => op.kind === "replace");
-        expect(replaces).toHaveLength(1);
-        expect(replaces[0].range!.start.line).toBe(2);
-        expect(replaces[0].text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+        expect(appliedText(input)).toBe("using { Economy.Shop }\n\nusing { /Verse.org/Simulation }\nusing { Features }\n\nhello := 1");
     });
 
     it("preserve + grouping none + sort on: a new absolute import still joins the first block", async () => {
@@ -1730,10 +1665,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }"]);
 
         expect(success).toBe(true);
-        const replaces = appliedOperations(0).filter((op) => op.kind === "replace");
-        expect(replaces).toHaveLength(1);
-        expect(replaces[0].range!.start.line).toBe(0);
-        expect(replaces[0].text).toBe("using { /Fortnite.com/Random }\nusing { /Verse.org/Simulation }\n");
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Random }\nusing { /Verse.org/Simulation }\n\nusing { /Fortnite.com/Devices }\n\nhello := 1");
     });
 
     it("preserve + grouping none + sort on: imports whose ranks want different blocks are merged into each block separately", async () => {
@@ -1747,18 +1679,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }", "using { Economy.Shop }"]);
 
         expect(success).toBe(true);
-        const replaces = appliedOperations(0).filter((op) => op.kind === "replace");
-        expect(replaces).toHaveLength(2);
-
         // The absolute path joins the block of absolute paths, the dotted
         // reference the block holding its provider.
-        expect(replaces[0].range!.start.line).toBe(0);
-        expect(replaces[0].text).toBe("using { /Fortnite.com/Random }\nusing { /Verse.org/Simulation }\n");
-        expect(replaces[1].range!.start.line).toBe(2);
-        expect(replaces[1].text).toBe("using { Features }\nusing { Economy.Shop }\n");
-
-        // Blocks are disjoint, so the two replacements cannot overlap.
-        expect(replaces[0].range!.end.line).toBeLessThanOrEqual(replaces[1].range!.start.line);
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Random }\nusing { /Verse.org/Simulation }\n\nusing { Features }\nusing { Economy.Shop }\n\nhello := 1");
     });
 
     it("preserve + grouping none + sort OFF: appends after the last import block, not the first", async () => {
@@ -1772,13 +1695,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-        const insert = operations.find((op) => op.kind === "insert");
-        expect(insert).toBeDefined();
-        expect(insert!.position!.line).toBe(3);
-        expect(insert!.text).toBe("using { Economy.Shop }\n");
+        expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\n\nusing { Features }\nusing { Economy.Shop }\n\nhello := 1");
     });
 
     // Line 0 is the top of the file, not the top of the import block. Inserting
@@ -1795,15 +1712,12 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
         expect(success).toBe(true);
-        const insert = appliedOperations(0).find((op) => op.kind === "insert");
-        expect(insert).toBeDefined();
-        expect(insert!.position!.line).toBe(3);
-        expect(insert!.text).toBe("using { Economy.Shop }\n");
+        expect(appliedText(input)).toBe("# Copyright 2026 MyGame\n\nusing { /Verse.org/Simulation }\nusing { Economy.Shop }\n\nhello := 1");
     });
 
-    // The line after the last import does not exist in a document with no
-    // trailing newline, and VS Code clamps a position past the end onto the end
-    // of the last line - splicing the two statements into one unreadable line.
+    // A document with no trailing newline has no line below its last import for
+    // the new one to occupy, so the new statement has to arrive carrying its own
+    // line break - or the two of them end up spliced onto one unreadable line.
     it("preserve + grouping none + sort OFF: appends onto a block that ends the document", async () => {
         mockConfig({
             "behavior.preserveImportLocations": true,
@@ -1815,11 +1729,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
         expect(success).toBe(true);
-        const insert = appliedOperations(0).find((op) => op.kind === "insert");
-        expect(insert).toBeDefined();
-        expect(insert!.position!.line).toBe(1);
-        expect(insert!.position!.character).toBe("using { /A }".length);
-        expect(insert!.text).toBe("\nusing { /B }");
+        expect(appliedText(input)).toBe("code()\nusing { /A }\nusing { /B }");
     });
 
     it("writes CRLF endings into a CRLF document when merging into an existing block", async () => {
@@ -1833,8 +1743,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input, vscode.EndOfLine.CRLF), ["using { Features }"]);
 
         expect(success).toBe(true);
-        const replace = appliedOperations(0).find((op) => op.kind === "replace");
-        expect(replace!.text).toBe("using { Economy.Shop }\r\nusing { Features }\r\n");
+        expect(appliedText(input)).toBe("using { Economy.Shop }\r\nusing { Features }\r\n\r\nhello := 1\r\n");
     });
 
     it("writes CRLF endings into a CRLF document when inserting a new block at the top", async () => {
@@ -1847,8 +1756,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input, vscode.EndOfLine.CRLF), ["using { /Fortnite.com/Random }"]);
 
         expect(success).toBe(true);
-        const insert = appliedOperations(0).find((op) => op.kind === "insert");
-        expect(insert!.text).toBe("using { /Fortnite.com/Random }\r\n\r\n");
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Random }\r\n\r\nhello := 1\r\nworld := 2\r\n");
     });
 
     it("writes CRLF endings into a CRLF document when consolidating at the top", async () => {
@@ -1858,8 +1766,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input, vscode.EndOfLine.CRLF), ["using { /Fortnite.com/Devices }"]);
 
         expect(success).toBe(true);
-        const insert = appliedOperations(0).find((op) => op.kind === "insert");
-        expect(insert!.text).toBe("using { /Fortnite.com/Devices }\r\nusing { /Verse.org/Simulation }\r\n");
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\r\nusing { /Verse.org/Simulation }\r\n\r\nhello := 1\r\n");
     });
 
     it("preserve + digestFirst: inserts at the top when the file has no existing imports", async () => {
@@ -1872,15 +1779,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Random }"]);
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-
-        const insert = operations.find((op) => op.kind === "insert");
-        expect(insert).toBeDefined();
-        expect(insert!.position!.line).toBe(0);
-        expect(insert!.text).toContain("/Fortnite.com/Random");
-
-        expect(operations.some((op) => op.kind === "replace")).toBe(false);
-        expect(operations.some((op) => op.kind === "delete")).toBe(false);
+        expect(appliedText(input)).toBe("using { /Fortnite.com/Random }\n\nhello := 1\nworld := 2");
     });
 
     // The rule that a header stays above the block was held by the organize
@@ -1900,10 +1799,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(2);
-            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\n\n");
+            expect(appliedText(input)).toBe("# Copyright 2026 MyGame\n\nusing { /Fortnite.com/Devices }\n\nhello := 1");
         });
 
         // Grouping with no block of its own to regroup: the file's only import
@@ -1919,10 +1815,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(2);
-            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\n\n");
+            expect(appliedText(input)).toBe("# Copyright 2026 MyGame\n\nusing { /Fortnite.com/Devices }\n\nusing { Economy.Shop } <#> note\n    body\nhello := 1");
         });
 
         it("consolidating: writes the consolidated block below the header", async () => {
@@ -1932,10 +1825,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(2);
-            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n");
+            expect(appliedText(input)).toBe("# Copyright 2026 MyGame\n\nusing { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n\nhello := 1");
         });
 
         // Every case above has code below the header. Where the header is an
@@ -1949,9 +1839,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
+            expect(appliedText(input)).toBe("using { /B }\n\n<# note\nstill note");
         });
 
         it("writes between a closed header and the unclosed opener below it", async () => {
@@ -1961,9 +1849,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(1);
+            expect(appliedText(input)).toBe("# Copyright 2026 MyGame\nusing { /B }\n\n<# unclosed\nmore");
         });
     });
 
@@ -1984,14 +1870,10 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations).toHaveLength(1);
-            expect(operations[0].kind).toBe("insert");
-            // Line 2, not line 1: the line below the marker is the comment's
-            // own body, and an import at column 0 there both lands inside the
-            // comment and truncates the rest of what the author wrote.
-            expect(operations[0].position).toEqual({ line: 2, character: 0 });
-            expect(operations[0].text).toBe("using { Economy.Shop }\n\n");
+            // Below the comment body, not between the marker and it: an import
+            // at column 0 there both lands inside the comment and truncates the
+            // rest of what the author wrote.
+            expect(appliedText(input)).toBe("using { Features } <#> why this is here\n    it brings Economy into scope\nusing { Economy.Shop }\n\ncode()");
         });
 
         it("writes a new consumer below an anchored provider, past the block comment it leaves open", async () => {
@@ -2005,11 +1887,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations).toHaveLength(1);
-            expect(operations[0].kind).toBe("insert");
-            expect(operations[0].position).toEqual({ line: 3, character: 0 });
-            expect(operations[0].text).toBe("using { Economy.Shop }\n\n");
+            expect(appliedText(input)).toBe("using { Features } <# why this is here\nit brings Economy into scope\n#>\nusing { Economy.Shop }\n\ncode()");
         });
 
         it("keeps a new consumer out of a block that sits above the anchored provider it needs", async () => {
@@ -2023,14 +1901,8 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // The block at line 0 would have taken it, above the provider.
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(4);
-            expect(insert!.text).toBe("using { Economy.Shop }\n\n");
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\n\nusing { Features } <#> note\n    body\nusing { Economy.Shop }\n\ncode()");
         });
 
         it("still merges a new consumer into a block that sits below the anchored provider", async () => {
@@ -2044,15 +1916,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // Nothing forbids that block, so the ordinary merge still happens
             // rather than a standalone line.
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(3);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Economy.Shop }\n");
+            expect(appliedText(input)).toBe("using { Features } <#> note\n    body\n\nusing { /Verse.org/Simulation }\nusing { Economy.Shop }\ncode()");
         });
 
         it("writes a new provider above the anchored consumer that depends on it", async () => {
@@ -2066,15 +1932,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // Merging into the block below would put the provider under the
             // anchored consumer, which is the same breakage the other way up.
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("using { Features }\n\nusing { Economy.Shop } <#> note\n    body\n\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         // The anchored consumer names the line the new import must stay above,
@@ -2093,13 +1953,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(0);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\nusing { Features }\n\nusing { Economy.Shop } <#> note\n    body\ncode()");
         });
 
         it("sort OFF: appends below the anchored provider rather than after the last block", async () => {
@@ -2113,10 +1967,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(4);
-            expect(insert!.text).toBe("using { Economy.Shop }\n");
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\n\nusing { Features } <#> note\n    body\nusing { Economy.Shop }\ncode()");
         });
 
         // The provider has to clear the anchored consumer, and an anchored
@@ -2134,10 +1985,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("using { Features }\n\nusing { Economy.Shop } <#> note\n    body\nusing { /A } <#> note\n    body\ncode()");
         });
 
         // Directly above the statement that needs it, which is not the same
@@ -2156,10 +2004,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(2);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("# Copyright 2026 MyGame\n\nusing { Features }\n\nusing { Economy.Shop } <#> note\n    body\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         // An anchored bare import does not constrain a new absolute one: an
@@ -2178,13 +2023,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(2);
-            expect(replace!.text).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n");
+            expect(appliedText(input)).toBe("using { Features } <#> why\n    body\nusing { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         it("digestFirst with two existing groups: keeps a new consumer out of the group above the anchored provider", async () => {
@@ -2197,14 +2036,8 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // The local group at line 2 would have taken it, above the provider.
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(6);
-            expect(insert!.text).toBe("using { Economy.Shop }\n");
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\n\nusing { Other }\n\nusing { Features } <#> note\n    body\nusing { Economy.Shop }\ncode()");
         });
 
         // Two new paths of different ranks take their bounds from different
@@ -2221,16 +2054,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }", "using { Zone.Area }"]);
 
             expect(success).toBe(true);
-            const inserts = appliedOperations(0).filter((op) => op.kind === "insert");
-            expect(inserts).toHaveLength(2);
-
-            // The absolute path is only needed above the anchored consumer.
-            expect(inserts[0].position!.line).toBe(0);
-            expect(inserts[0].text).toBe("using { /Fortnite.com/Devices }\n\n");
-
-            // The dotted one needs `Features` above it, so it goes below.
-            expect(inserts[1].position!.line).toBe(4);
-            expect(inserts[1].text).toBe("using { Zone.Area }\n\n");
+            // The absolute path is only needed above the anchored consumer; the
+            // dotted one needs `Features` above it, so it goes below.
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\n\nusing { Economy.Shop } <#> note\n    body\nusing { Features } <#> why\n    body\nusing { Zone.Area }\n\ncode()");
         });
 
         // The one branch that rewrites a block in place and inserts on its own
@@ -2246,20 +2072,10 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-
             // The existing block is rebuilt where it stands, without the
-            // displaced path in it.
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(2);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\n");
-
-            // The provider goes above the anchored consumer that needs it.
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n");
+            // displaced path in it, and the provider goes above the anchored
+            // consumer that needs it.
+            expect(appliedText(input)).toBe("using { Features }\nusing { Economy.Shop } <#> note\n    body\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         it("digestFirst: writes the new group below the anchored provider, not at the top", async () => {
@@ -2272,10 +2088,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(2);
-            expect(insert!.text).toBe("using { Economy.Shop }\n\n");
+            expect(appliedText(input)).toBe("using { Features } <#> note\n    body\nusing { Economy.Shop }\n\ncode()");
         });
     });
 
@@ -2294,14 +2107,8 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Delta }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // The local group at line 0 would have taken it, above Beta.Gamma.
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(4);
-            expect(insert!.text).toBe("using { Delta }\n");
+            expect(appliedText(input)).toBe("using { Alpha }\n\nusing { /Verse.org/Simulation }\nusing { Beta.Gamma }\nusing { Delta }\n\ncode()");
         });
 
         it("localFirst: keeps a new relative import out of the local group above a later relative import", async () => {
@@ -2314,13 +2121,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Delta }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(4);
-            expect(insert!.text).toBe("using { Delta }\n");
+            expect(appliedText(input)).toBe("using { Alpha }\n\nusing { /Verse.org/Simulation }\nusing { Beta.Gamma }\nusing { Delta }\n\ncode()");
         });
 
         it("still merges a new relative import into its group when every block below holds only absolute imports", async () => {
@@ -2333,15 +2134,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Delta }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // Nothing below can be providing for it, so the group still takes
             // it rather than falling back to a standalone line.
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(0);
-            expect(replace!.text).toBe("using { Alpha }\nusing { Delta }\n");
+            expect(appliedText(input)).toBe("using { Alpha }\nusing { Delta }\n\nusing { /Verse.org/Simulation }\n\ncode()");
         });
 
         it("still merges a new absolute import into the digest group above a later relative import", async () => {
@@ -2354,15 +2149,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // An absolute path needs nothing in scope above it, so a relative
             // import below is not a provider it has to stay under.
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(0);
-            expect(replace!.text).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { /Verse.org/Simulation }\n\nusing { Alpha }\nusing { Beta.Gamma }\n\ncode()");
         });
     });
 
@@ -2385,14 +2174,8 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // The block at line 0 would have taken it, above the provider.
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(3);
-            expect(insert!.text).toBe("using { Economy.Shop }\n\n");
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\nX := 1\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\n\ncode()");
         });
 
         it("still merges a new consumer into a block that sits below the pinned provider", async () => {
@@ -2406,15 +2189,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // Nothing forbids that block, so the ordinary merge still happens
             // rather than a standalone line.
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(1);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Economy.Shop }\n");
+            expect(appliedText(input)).toBe("using { Features }; MyVal := 5\nusing { /Verse.org/Simulation }\nusing { Economy.Shop }\ncode()");
         });
 
         it("writes a new provider above the pinned consumer that depends on it", async () => {
@@ -2428,15 +2205,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // Merging into the block below would put the provider under the
             // pinned consumer, which is the same breakage the other way up.
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("using { Features }\n\nusing { Economy.Shop }; MyVal := 5\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         // The same file and the same new import as the test above, differing
@@ -2457,13 +2228,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(1);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+            expect(appliedText(input)).toBe("using { Economy.Shop }; MyVal := 5\nusing { /Verse.org/Simulation }\nusing { Features }\ncode()");
         });
 
         // Regression for the diagnostic landing on the pinned line but inside
@@ -2484,13 +2249,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 24));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(1);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+            expect(appliedText(input)).toBe("using { Economy.Shop }; MyVal := 5\nusing { /Verse.org/Simulation }\nusing { Features }\ncode()");
         });
 
         // The same line, the diagnostic now inside the clause itself - column 8
@@ -2508,13 +2267,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 8));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("using { Features }\n\nusing { Economy.Shop }; MyVal := 5\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         // A clause written after a definition starts at column 8, so the head
@@ -2532,13 +2285,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 16));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("using { Features }\n\nX := 1; using { Economy.Shop }\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         it("takes no override from a diagnostic on the definition preceding a clause", async () => {
@@ -2552,13 +2299,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 0));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(1);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+            expect(appliedText(input)).toBe("X := 1; using { Economy.Shop }\nusing { /Verse.org/Simulation }\nusing { Features }\ncode()");
         });
 
         // The span is two lines and the compiler reports an unresolved path on
@@ -2576,10 +2317,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 1));
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("using { Features }\n\nusing { Other }; using:\n    Economy.Shop\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         // Regression for the diagnostic landing on the opener line of a pinned
@@ -2600,13 +2338,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 0));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(2);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+            expect(appliedText(input)).toBe("X := 1; using:\n    Economy.Shop\nusing { /Verse.org/Simulation }\nusing { Features }\ncode()");
         });
 
         // The same file with the diagnostic inside the `using:` opener itself -
@@ -2623,13 +2355,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 0, 8));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "replace")).toBe(false);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(0);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("using { Features }\n\nX := 1; using:\n    Economy.Shop\nusing { /Verse.org/Simulation }\ncode()");
         });
 
         // The path text ends at column 16 and column 17 is inside the trailing
@@ -2647,13 +2373,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 1, 17));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(2);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+            expect(appliedText(input)).toBe("X := 1; using:\n    Economy.Shop # note\nusing { /Verse.org/Simulation }\nusing { Features }\ncode()");
         });
 
         // The floor reaches past the pinned statement, because the `using:` at
@@ -2672,10 +2392,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(2);
-            expect(insert!.text).toBe("using { Features }\n\n");
+            expect(appliedText(input)).toBe("X := 1; using { /A }; using:\n    Foo'Loc'\nusing { Features }\n\ncode()");
         });
 
         // A caller that names no diagnostic has to be read as evidence of
@@ -2692,13 +2409,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations.some((op) => op.kind === "insert")).toBe(false);
-
-            const replace = operations.find((op) => op.kind === "replace");
-            expect(replace).toBeDefined();
-            expect(replace!.range!.start.line).toBe(1);
-            expect(replace!.text).toBe("using { /Verse.org/Simulation }\nusing { Features }\n");
+            expect(appliedText(input)).toBe("using { Economy.Shop }; MyVal := 5\nusing { /Verse.org/Simulation }\nusing { Features }\ncode()");
         });
 
         it("sort OFF: appends below the pinned provider rather than after the last block", async () => {
@@ -2712,10 +2423,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const insert = appliedOperations(0).find((op) => op.kind === "insert");
-            expect(insert).toBeDefined();
-            expect(insert!.position!.line).toBe(3);
-            expect(insert!.text).toBe("using { Economy.Shop }\n");
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\nX := 1\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\ncode()");
         });
     });
 
@@ -2737,11 +2445,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations).toHaveLength(1);
-            expect(operations[0].kind).toBe("insert");
-            expect(operations[0].position).toEqual({ line: 0, character: 0 });
-            expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Features }; X := 1\nusing { Economy.Shop }\ncode()");
         });
 
         it("still hoists a consumer written above the pinned line", async () => {
@@ -2751,16 +2455,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // Position is the question, not presence: hoisting this one lands
             // it above the pinned line, which is where it already was.
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert!.text).toBe("using { /Fortnite.com/Devices }\nusing { Economy.Shop }\n");
-
-            const deletes = operations.filter((op) => op.kind === "delete");
-            expect(deletes).toHaveLength(1);
-            expect(deletes[0].range!.start.line).toBe(0);
-            expect(deletes[0].range!.end.line).toBe(1);
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Economy.Shop }\nusing { Features }; MyVal := 5\ncode()");
         });
 
         it("writes a new consumer below the pinned provider instead of into the block", async () => {
@@ -2770,20 +2467,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy.Shop }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-
-            const inserts = operations.filter((op) => op.kind === "insert");
-            expect(inserts).toHaveLength(2);
-            expect(inserts[0].position).toEqual({ line: 0, character: 0 });
-            expect(inserts[0].text).toBe("using { /Verse.org/Simulation }\n");
-            expect(inserts[1].position!.line).toBe(1);
-            expect(inserts[1].text).toBe("using { Economy.Shop }\n");
-
-            // The hoisted import still leaves its line, or the file imports it
-            // twice.
-            const deletes = operations.filter((op) => op.kind === "delete");
-            expect(deletes).toHaveLength(1);
-            expect(deletes[0].range).toEqual({ start: { line: 1, character: 0 }, end: { line: 2, character: 0 } });
+            // The hoisted import leaves the line it was written on, or the
+            // file imports it twice.
+            expect(appliedText(input)).toBe("using { /Verse.org/Simulation }\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\ncode()");
         });
 
         // The same shape as the test below, with no diagnostic naming the
@@ -2798,15 +2484,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-
-            const top = operations.find((op) => op.kind === "insert" && op.position!.line === 0);
-            expect(top).toBeDefined();
-            expect(top!.text).toBe("using { /A }\n");
-
-            const below = operations.find((op) => op.kind === "insert" && op.text.includes("using { Features }"));
-            expect(below).toBeDefined();
-            expect(below!.position!.line).toBe(3);
+            expect(appliedText(input)).toBe("using { /A }\ncode()\nusing { Economy.Shop }; X := 1\nusing { Features }\nmore()");
         });
 
         it("still consolidates a new provider the pinned consumer below it may need", async () => {
@@ -2816,14 +2494,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Features }"], reportedOn("using { Features }", 2));
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
             // The block itself sits above the pinned consumer, so nothing is
             // gained by writing the provider on a line of its own further down.
-            expect(operations).toHaveLength(2);
-            expect(operations[0].kind).toBe("insert");
-            expect(operations[0].position).toEqual({ line: 0, character: 0 });
-            expect(operations[0].text).toBe("using { /A }\nusing { Features }\n");
-            expect(operations[1].range).toEqual({ start: { line: 0, character: 0 }, end: { line: 1, character: 0 } });
+            expect(appliedText(input)).toBe("using { /A }\nusing { Features }\ncode()\nusing { Economy.Shop }; X := 1");
         });
 
         it("takes the floor over a pinned consumer sitting above it", async () => {
@@ -2837,11 +2510,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             // for, and it is left unfixed: the line above it is also above the
             // pinned import that may bring this path's own first segment into
             // scope. A compiling file outranks a fixed diagnostic.
-            const operations = appliedOperations(0);
-            expect(operations).toHaveLength(1);
-            expect(operations[0].kind).toBe("insert");
-            expect(operations[0].position!.line).toBe(3);
-            expect(operations[0].text).toBe("using { Economy }\n");
+            expect(appliedText(input)).toBe("using { Economy.Shop }; X := 1\ncode()\nusing { Features }; Y := 2\nusing { Economy }\nmore()");
         });
 
         it("keeps both copies of a path written on either side of the pinned line", async () => {
@@ -2854,10 +2523,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             // Grounding is keyed on the path: hoisting the copy above the
             // pinned line while the block declines to re-emit the path would
             // delete the one line that had to keep it.
-            const operations = appliedOperations(0);
-            expect(operations).toHaveLength(1);
-            expect(operations[0].kind).toBe("insert");
-            expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Economy.Shop }\nusing { Features }; X := 1\nusing { Economy.Shop }\ncode()");
         });
 
         it("splits the delete around a grounded import rather than taking its line with the block", async () => {
@@ -2867,17 +2533,9 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-
-            const insert = operations.find((op) => op.kind === "insert");
-            expect(insert!.text).toBe("using { /A }\nusing { /B }\nusing { /Fortnite.com/Devices }\n");
-
             // One block, two runs: deleting it whole would take the grounded
             // line with it while nothing re-emits that path, losing the import.
-            const deletes = operations.filter((op) => op.kind === "delete").sort((a, b) => a.range!.start.line - b.range!.start.line);
-            expect(deletes).toHaveLength(2);
-            expect(deletes[0].range).toEqual({ start: { line: 1, character: 0 }, end: { line: 2, character: 0 } });
-            expect(deletes[1].range).toEqual({ start: { line: 3, character: 0 }, end: { line: 4, character: 0 } });
+            expect(appliedText(input)).toBe("using { /A }\nusing { /B }\nusing { /Fortnite.com/Devices }\nusing { Features }; MyVal := 5\nusing { Economy.Shop }\ncode()");
         });
 
         it("grounds against a provider pinned by the comment it anchors, past the comment body", async () => {
@@ -2887,10 +2545,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations).toHaveLength(1);
-            expect(operations[0].kind).toBe("insert");
-            expect(operations[0].text).toBe("using { /Fortnite.com/Devices }\n");
+            expect(appliedText(input)).toBe("using { /Fortnite.com/Devices }\nusing { Features } <#> why this is here\n    it brings Economy into scope\nusing { Economy.Shop }\ncode()");
         });
 
         it("consolidates a file with nothing pinned exactly as before", async () => {
@@ -2900,13 +2555,7 @@ describe("ImportDocumentEditor.addImportsToDocument", () => {
             const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /C }"]);
 
             expect(success).toBe(true);
-            const operations = appliedOperations(0);
-            expect(operations).toHaveLength(2);
-            expect(operations[0].kind).toBe("insert");
-            expect(operations[0].position).toEqual({ line: 0, character: 0 });
-            expect(operations[0].text).toBe("using { /A }\nusing { /B }\nusing { /C }\n");
-            expect(operations[1].kind).toBe("delete");
-            expect(operations[1].range).toEqual({ start: { line: 0, character: 0 }, end: { line: 2, character: 0 } });
+            expect(appliedText(input)).toBe("using { /A }\nusing { /B }\nusing { /C }\ncode()");
         });
     });
 });
@@ -2955,7 +2604,7 @@ describe("ImportDocumentEditor rewrite verification", () => {
         const success = await editor.organizeImports(fakeDocument(input), []);
 
         expect(success).toBe(true);
-        expect(appliedOperations(0)[0].text).toBe("using { /A }\nusing { /B }\n\ncode()");
+        expect(appliedText(input)).toBe("using { /A }\nusing { /B }\n\ncode()");
     });
 
     // The off-by-one the ticket names, on the path that has no output text to
@@ -2981,7 +2630,7 @@ describe("ImportDocumentEditor rewrite verification", () => {
         const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /B }"]);
 
         expect(success).toBe(true);
-        expect(appliedOperations(0)[0].text).toContain("using { /B }");
+        expect(appliedText(input)).toBe("using { /A }\nusing { /B }\ncode()");
     });
 
     // insertImportLines documents its past-the-end branch as the thing standing
@@ -3082,7 +2731,7 @@ describe("ImportDocumentEditor.organizeImports carries the diagnostic evidence",
         const success = await editor.organizeImports(fakeDocument(input), ["Features"], new Map([["Features", [{ line: 0, character: 0 }]]]));
 
         expect(success).toBe(true);
-        expect(appliedOperations(0)[0].text).toBe(["using { Features }", "", "using { Economy.Shop } <#> note", "    body", "code()"].join("\n"));
+        expect(appliedText(input)).toBe("using { Features }\n\nusing { Economy.Shop } <#> note\n    body\ncode()");
     });
 
     it("leaves the written order alone when the evidence names a line elsewhere", async () => {
@@ -3091,7 +2740,7 @@ describe("ImportDocumentEditor.organizeImports carries the diagnostic evidence",
         const success = await editor.organizeImports(fakeDocument(input), ["Features"], new Map([["Features", [{ line: 2, character: 0 }]]]));
 
         expect(success).toBe(true);
-        expect(appliedOperations(0)[0].text).toBe(["using { Economy.Shop } <#> note", "    body", "using { Features }", "code()"].join("\n"));
+        expect(appliedText(input)).toBe("using { Economy.Shop } <#> note\n    body\nusing { Features }\ncode()");
     });
 
     it("leaves the written order alone when the caller has no evidence at all", async () => {
@@ -3100,7 +2749,7 @@ describe("ImportDocumentEditor.organizeImports carries the diagnostic evidence",
         const success = await editor.organizeImports(fakeDocument(input), ["Features"]);
 
         expect(success).toBe(true);
-        expect(appliedOperations(0)[0].text).toBe(["using { Economy.Shop } <#> note", "    body", "using { Features }", "code()"].join("\n"));
+        expect(appliedText(input)).toBe("using { Economy.Shop } <#> note\n    body\nusing { Features }\ncode()");
     });
 });
 
@@ -3138,10 +2787,7 @@ describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {
         const success = await editor.ensureEmptyLinesAfterImports(fakeDocument(input));
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations).toHaveLength(1);
-        expect(operations[0].kind).toBe("insert");
-        expect(operations[0].position!.line).toBe(1);
+        expect(appliedText(input)).toBe("using { /Top }\n\ncode()");
     });
 
     // This runs right after both writers, so an LF blank line here would put
@@ -3152,8 +2798,7 @@ describe("ImportDocumentEditor.ensureEmptyLinesAfterImports", () => {
         const success = await editor.ensureEmptyLinesAfterImports(fakeDocument(input, vscode.EndOfLine.CRLF));
 
         expect(success).toBe(true);
-        const operations = appliedOperations(0);
-        expect(operations[0].text).toBe("\r\n");
+        expect(appliedText(input)).toBe("using { /Top }\r\n\r\ncode()\r\n");
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1216,8 +1216,13 @@ const appliedText = (input: string, call = 0): string => {
         }
     }
     const offsetAt = (position: { line: number; character: number }): number => {
-        const lineStart = lineStarts[Math.min(position.line, lineStarts.length - 1)];
-        return Math.min(lineStart + position.character, input.length);
+        // A line past the last clamps to the end of the document, as VS Code's
+        // validatePosition clamps it - not to the last line's start, which
+        // would leave that line's text out of a range meant to cover it.
+        if (position.line >= lineStarts.length) {
+            return input.length;
+        }
+        return Math.min(lineStarts[position.line] + position.character, input.length);
     };
     const spans = appliedOperations(call).map((op, index) => {
         if (op.kind === "insert") {
@@ -2707,6 +2712,101 @@ describe("ImportDocumentEditor rewrite verification", () => {
                 });
             }
         }
+    });
+});
+
+/**
+ * Port-equivalence scaffold: buildPreservedContent against the live add-path
+ * writer, line for line, across every document shape and preserve-mode setting
+ * row. Deleted with the swap that routes the writer through the builder, at
+ * which point it compares a function against itself.
+ *
+ * Line-based and ending-insensitive on purpose: the builder joins with one
+ * detected ending where the old writer splices text into place, so endings may
+ * differ while any placement drift still has to surface.
+ */
+describe("buildPreservedContent matches the live add path", () => {
+    let editor: ImportDocumentEditor;
+
+    const documents: Array<[string, string]> = [
+        ["an empty file", ""],
+        ["no trailing newline", "using { /A }\ncode()"],
+        ["a trailing newline", "using { /A }\ncode()\n"],
+        ["CRLF", "using { /A }\r\ncode()\r\n"],
+        ["only imports", "using { /A }\nusing { /B }"],
+        ["no imports at all", "code()\nmore()"],
+        ["a header comment", "# licence\n\nusing { /A }\n\ncode()"],
+        ["an annotated import", "# why /A is here\nusing { /A }\n\ncode()"],
+        ["an import pinned by a second statement", "X := 1; using { /A }\ncode()"],
+        ["a commented-out import", "<#\nusing { /Old }\n#>\nusing { /A }\n\ncode()"],
+        ["an indented using pair", "using{\n    /A\n}\ncode()"],
+        ["a using inside a module body", "using { /A }\n\nM := module:\n    using { /B }\n    F():void = {}"],
+        ["two gapped blocks", "using { /A }\n\nusing { Local.One }\n\ncode()"],
+        ["a relative import under an absolute one", "using { /A }\nusing { Local.One }\n\ncode()"],
+        ["a pinned import below a block", "using { /A }\ncode()\nX := 1; using { /Verse.org/Simulation }\nmore()"],
+    ];
+
+    const settings: Array<[string, Record<string, unknown>]> = [
+        ["defaults", {}],
+        ["unsorted", { "behavior.sortImportsAlphabetically": false }],
+        ["grouped local first", { "behavior.importGrouping": "localFirst" }],
+        ["grouped digest first", { "behavior.importGrouping": "digestFirst" }],
+        ["grouped digest first, unsorted", { "behavior.importGrouping": "digestFirst", "behavior.sortImportsAlphabetically": false }],
+        ["dot syntax", { "behavior.importSyntax": "dot" }],
+    ];
+
+    function useSettings(overrides: Record<string, unknown>): void {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => (key in overrides ? overrides[key] : defaultValue)),
+            update: jest.fn().mockResolvedValue(undefined),
+        });
+    }
+
+    function optionsFrom(overrides: Record<string, unknown>) {
+        return {
+            preferDotSyntax: overrides["behavior.importSyntax"] === "dot",
+            sortAlphabetically: (overrides["behavior.sortImportsAlphabetically"] as boolean | undefined) ?? true,
+            importGrouping: (overrides["behavior.importGrouping"] as string | undefined) ?? "none",
+        };
+    }
+
+    beforeEach(() => {
+        const outputChannel = vscode.window.createOutputChannel("test");
+        editor = new ImportDocumentEditor(outputChannel, new ImportFormatter());
+        (vscode.workspace.applyEdit as unknown as jest.Mock).mockClear();
+    });
+
+    for (const [documentName, input] of documents) {
+        for (const [settingsName, overrides] of settings) {
+            it(`matches on ${documentName} with ${settingsName}`, async () => {
+                useSettings(overrides);
+                const success = await editor.addImportsToDocument(fakeDocument(input), ["using { /Fortnite.com/Devices }"]);
+                expect(success).toBe(true);
+
+                const built = editor.buildPreservedContent(input, ["/Fortnite.com/Devices"], optionsFrom(overrides));
+                expect(built).not.toBeNull();
+                expect(built!.split(/\r?\n/)).toEqual(appliedText(input).split(/\r?\n/));
+            });
+        }
+    }
+
+    it("matches when diagnostic evidence raises a ceiling over a pinned consumer", async () => {
+        const input = "using { Economy.Shop } <#> note\n    body\ncode()";
+        useSettings({});
+        const success = await editor.addImportsToDocument(fakeDocument(input), ["using { Economy }"], new Map([["using { Economy }", [{ line: 0, character: 8 }]]]));
+        expect(success).toBe(true);
+
+        const built = editor.buildPreservedContent(input, ["Economy"], optionsFrom({}), new Map([["Economy", [{ line: 0, character: 8 }]]]));
+        expect(built).not.toBeNull();
+        expect(built!.split(/\r?\n/)).toEqual(appliedText(input).split(/\r?\n/));
+    });
+
+    it("returns null for a path the document already imports", () => {
+        expect(editor.buildPreservedContent("using { /A }\ncode()", ["/A"], optionsFrom({}))).toBeNull();
+    });
+
+    it("returns null for blank paths", () => {
+        expect(editor.buildPreservedContent("code()", ["  ", ""], optionsFrom({}))).toBeNull();
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { detectEol, ImportDocumentEditor } from "../ImportDocumentEditor";
+import { applyLineSplices, detectEol, ImportDocumentEditor, minimalSplice } from "../ImportDocumentEditor";
 import { ImportFormatter } from "../ImportFormatter";
 import * as vscode from "vscode";
 
@@ -24,6 +24,138 @@ describe("detectEol", () => {
 
     it("prefers LF on a tie", () => {
         expect(detectEol("a\r\nb\n")).toBe("\n");
+    });
+});
+
+describe("applyLineSplices", () => {
+    const lines = ["a", "b", "c", "d"];
+
+    it("returns the lines unchanged with no splices", () => {
+        expect(applyLineSplices(lines, [])).toEqual(["a", "b", "c", "d"]);
+    });
+
+    it("replaces a range", () => {
+        expect(applyLineSplices(lines, [{ start: 1, endExclusive: 3, newLines: ["B"] }])).toEqual(["a", "B", "d"]);
+    });
+
+    it("inserts above the line equal bounds name", () => {
+        expect(applyLineSplices(lines, [{ start: 2, endExclusive: 2, newLines: ["X"] }])).toEqual(["a", "b", "X", "c", "d"]);
+    });
+
+    it("appends with equal bounds at the array's length", () => {
+        expect(applyLineSplices(lines, [{ start: 4, endExclusive: 4, newLines: ["X"] }])).toEqual(["a", "b", "c", "d", "X"]);
+    });
+
+    it("applies splices by position whatever order they arrive in", () => {
+        const splices = [
+            { start: 3, endExclusive: 4, newLines: ["D"] },
+            { start: 0, endExclusive: 1, newLines: ["A"] },
+        ];
+        expect(applyLineSplices(lines, splices)).toEqual(["A", "b", "c", "D"]);
+    });
+
+    it("puts an insertion at the start of a replaced range first", () => {
+        const splices = [
+            { start: 1, endExclusive: 3, newLines: ["B"] },
+            { start: 1, endExclusive: 1, newLines: ["X"] },
+        ];
+        expect(applyLineSplices(lines, splices)).toEqual(["a", "X", "B", "d"]);
+    });
+
+    it("keeps two insertions at one line in their given order", () => {
+        const splices = [
+            { start: 2, endExclusive: 2, newLines: ["X"] },
+            { start: 2, endExclusive: 2, newLines: ["Y"] },
+        ];
+        expect(applyLineSplices(lines, splices)).toEqual(["a", "b", "X", "Y", "c", "d"]);
+    });
+
+    it("refuses overlapping splices", () => {
+        const splices = [
+            { start: 0, endExclusive: 2, newLines: ["A"] },
+            { start: 1, endExclusive: 3, newLines: ["B"] },
+        ];
+        expect(applyLineSplices(lines, splices)).toBeNull();
+    });
+
+    it("refuses a splice reaching past the array", () => {
+        expect(applyLineSplices(lines, [{ start: 3, endExclusive: 5, newLines: [] }])).toBeNull();
+    });
+
+    it("refuses inverted bounds", () => {
+        expect(applyLineSplices(lines, [{ start: 2, endExclusive: 1, newLines: [] }])).toBeNull();
+    });
+});
+
+describe("minimalSplice", () => {
+    const apply = (before: string, after: string): string => {
+        const splice = minimalSplice(before, after);
+        if (splice === null) {
+            return before;
+        }
+        return before.slice(0, splice.start) + splice.newText + before.slice(splice.end);
+    };
+
+    it("returns null for identical texts", () => {
+        expect(minimalSplice("a\nb\n", "a\nb\n")).toBeNull();
+    });
+
+    it("replaces one changed line on line boundaries", () => {
+        const splice = minimalSplice("a\nold\nc\n", "a\nnew\nc\n")!;
+        expect(splice).toEqual({ start: 2, end: 6, newText: "new\n" });
+    });
+
+    it("inserts a line without touching its neighbours", () => {
+        const splice = minimalSplice("a\nc\n", "a\nb\nc\n")!;
+        expect(splice).toEqual({ start: 2, end: 2, newText: "b\n" });
+    });
+
+    it("inserts at the top of a file sharing no prefix", () => {
+        const splice = minimalSplice("code()", "using { /A }\ncode()")!;
+        expect(splice).toEqual({ start: 0, end: 0, newText: "using { /A }\n" });
+    });
+
+    it("appends to a document with no trailing newline without inventing one", () => {
+        expect(apply("using { /A }\ncode()", "using { /A }\nusing { /B }\ncode()")).toBe("using { /A }\nusing { /B }\ncode()");
+    });
+
+    it("replaces to the end when the last line changes and has no newline", () => {
+        const splice = minimalSplice("a\ncode(1)", "a\ncode(2)")!;
+        expect(splice).toEqual({ start: 2, end: 9, newText: "code(2)" });
+    });
+
+    it("deletes a run of lines", () => {
+        const splice = minimalSplice("a\nx\ny\nb\n", "a\nb\n")!;
+        expect(splice).toEqual({ start: 2, end: 6, newText: "" });
+    });
+
+    it("covers the whole text when nothing is shared", () => {
+        const splice = minimalSplice("x\ny\n", "p\nq\n")!;
+        expect(splice.start).toBe(0);
+        expect(splice.end).toBe(4);
+        expect(splice.newText).toBe("p\nq\n");
+    });
+
+    it("never splits a CRLF pair", () => {
+        const splice = minimalSplice("a\r\nold\r\nc\r\n", "a\r\nnew\r\nc\r\n")!;
+        expect(splice).toEqual({ start: 3, end: 8, newText: "new\r\n" });
+    });
+
+    it("produces an edit for an ending-only normalization", () => {
+        expect(apply("a\r\nb\n", "a\nb\n")).toBe("a\nb\n");
+    });
+
+    it("inserts into an empty text", () => {
+        const splice = minimalSplice("", "using { /A }\n")!;
+        expect(splice).toEqual({ start: 0, end: 0, newText: "using { /A }\n" });
+    });
+
+    it("round-trips a scattered multi-hunk change as one line-aligned range", () => {
+        const before = "h\nusing { /A }\nbody\nusing { /B }\ntail\n";
+        const after = "h\nusing { /A }\nusing { /B }\nbody\ntail\n";
+        expect(apply(before, after)).toBe(after);
+        const splice = minimalSplice(before, after)!;
+        expect(before.slice(0, splice.start).endsWith("\n") || splice.start === 0).toBe(true);
     });
 });
 

--- a/src/imports/__tests__/ImportDocumentEditor.test.ts
+++ b/src/imports/__tests__/ImportDocumentEditor.test.ts
@@ -197,6 +197,18 @@ describe("ImportDocumentEditor.buildOrganizedContent", () => {
         expect(editor.buildOrganizedContent(input, ["/A"], curlySorted)).toBe("using { /A }\nusing { /M }\nusing { /Z }\n\ncode()\r\nmore()\nlast()\n");
     });
 
+    it("keeps the final break of a comment-only file the block appends past", () => {
+        const input = "# note\n# more\n";
+        expect(editor.buildOrganizedContent(input, ["/New"], curlySorted)).toBe("# note\n# more\n\nusing { /New }\n");
+    });
+
+    // The last line's own break survives the hoist that removes the line, so
+    // a file that ended on its import ends on a break once the import moves.
+    it("keeps the break a hoisted last line carried into it", () => {
+        const input = "code()\nusing { /A }";
+        expect(editor.buildOrganizedContent(input, [], curlySorted)).toBe("using { /A }\n\ncode()\n");
+    });
+
     it("consolidates existing imports at the top with one blank line before code", () => {
         const input = "using { /A }\nusing { /B }\ncode()";
         expect(editor.buildOrganizedContent(input, [], curlyNoSort)).toBe("using { /A }\nusing { /B }\n\ncode()");

--- a/src/imports/__tests__/ImportRewriteGuard.test.ts
+++ b/src/imports/__tests__/ImportRewriteGuard.test.ts
@@ -1,13 +1,4 @@
-import { QueuedEdit, verifyImportEdits, verifyOrganizedRewrite } from "../ImportRewriteGuard";
-
-/** A whole-line removal, the only shape the writers produce. */
-function removal(startLine: number, endLineExclusive: number, newText = ""): QueuedEdit {
-    return { startLine, startCharacter: 0, endLine: endLineExclusive, endCharacter: 0, newText };
-}
-
-function insertion(line: number, newText: string): QueuedEdit {
-    return { startLine: line, startCharacter: 0, endLine: line, endCharacter: 0, newText };
-}
+import { verifyOrganizedRewrite } from "../ImportRewriteGuard";
 
 describe("verifyOrganizedRewrite", () => {
     it("passes a consolidation that keeps every path and every body line", () => {
@@ -88,94 +79,5 @@ describe("verifyOrganizedRewrite", () => {
         const after = "using { /A }\n\ncode()";
 
         expect(verifyOrganizedRewrite(before, after, [])).toBe("the rebuilt document no longer imports /B");
-    });
-});
-
-describe("verifyImportEdits", () => {
-    it("passes an edit that only inserts", () => {
-        const lines = ["code()"];
-
-        expect(verifyImportEdits(lines, [insertion(0, "using { /A }\n")], ["/A"])).toBeNull();
-    });
-
-    it("passes a block replacement that writes its paths back", () => {
-        const lines = ["using { /B }", "using { /A }", "code()"];
-
-        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\nusing { /B }\n")], [])).toBeNull();
-    });
-
-    it("passes a consolidation that deletes a block and rewrites it at the top", () => {
-        const lines = ["code()", "using { /A }", "using { /B }"];
-        const edits = [insertion(0, "using { /A }\nusing { /B }\n"), removal(1, 3)];
-
-        expect(verifyImportEdits(lines, edits, [])).toBeNull();
-    });
-
-    // The off-by-one the ticket names: a run reaching one line past the block
-    // takes a line of the user's code with it.
-    it("refuses a range that reaches past the imports onto code", () => {
-        const lines = ["using { /A }", "code()"];
-
-        expect(verifyImportEdits(lines, [removal(0, 2, "using { /A }\n")], [])).toBe('the queued edits remove line 2, which is code rather than an import: "code()"');
-    });
-
-    it("refuses a deletion that never writes the path back", () => {
-        const lines = ["using { /A }", "using { /B }", "code()"];
-
-        expect(verifyImportEdits(lines, [removal(0, 2)], [])).toBe("the queued edits remove /A, /B without writing it back");
-    });
-
-    // A path written twice is still imported while either line is left alone,
-    // so removing one copy is a deduplication rather than a loss.
-    it("passes a deletion that leaves another statement for the same path", () => {
-        const lines = ["using { /A }", "using { /A }", "code()"];
-
-        expect(verifyImportEdits(lines, [removal(1, 2)], [])).toBeNull();
-    });
-
-    it("treats a range ending at character 0 as stopping above that line", () => {
-        const lines = ["using { /A }", "code()"];
-
-        expect(verifyImportEdits(lines, [removal(0, 1, "using { /A }\n")], [])).toBeNull();
-    });
-
-    it("counts a line a range only partly covers as removed", () => {
-        const lines = ["using { /A }", "code()"];
-
-        expect(verifyImportEdits(lines, [{ startLine: 0, startCharacter: 0, endLine: 1, endCharacter: 3, newText: "using { /A }\n" }], [])).toContain("line 2, which is code");
-    });
-
-    // VS Code clamps a range past the end onto the document, so there is no
-    // line under those indices to classify.
-    it("ignores the part of a range that reaches past the last line", () => {
-        const lines = ["using { /A }"];
-
-        expect(verifyImportEdits(lines, [removal(0, 5, "using { /A }\n")], [])).toBeNull();
-    });
-
-    // insertImportLines writes past the last line from the end of that line
-    // rather than from column 0, which is still an insertion and removes
-    // nothing. Its text opens with the break that keeps it off that line.
-    it("passes an insertion anchored at the end of the last line", () => {
-        const lines = ["using { /A }", "code()"];
-        const endOfLastLine: QueuedEdit = { startLine: 1, startCharacter: 6, endLine: 1, endCharacter: 6, newText: "\nusing { /B }" };
-
-        expect(verifyImportEdits(lines, [endOfLastLine], ["/B"])).toBeNull();
-    });
-
-    // The hazard insertImportLines documents its past-the-end branch to avoid:
-    // the same position with the break missing splices the statement onto the
-    // code already there and leaves one unreadable line where two belong.
-    it("refuses an insertion that splices into the middle of a line", () => {
-        const lines = ["code()"];
-        const spliced: QueuedEdit = { startLine: 0, startCharacter: 6, endLine: 0, endCharacter: 6, newText: "using { /B }\n" };
-
-        expect(verifyImportEdits(lines, [spliced], ["/B"])).toBe('the queued edits splice "using { /B }\\n" into the middle of line 1');
-    });
-
-    it("refuses an import no caller asked for", () => {
-        const lines = ["using { /A }", "code()"];
-
-        expect(verifyImportEdits(lines, [insertion(0, "using { /EVIL }\n")], [])).toBe("the queued edits import /EVIL, which nothing asked for");
     });
 });


### PR DESCRIPTION
Closes #384

Both entry points now produce their document through one pure rebuilder and apply it as a single minimal, line-aligned replace. `addImportsToDocument` builds through `buildPreservedContent` (the four preserve-locations branches, ported verbatim to text space) or, when consolidating, the same `buildOrganizedContent` that Optimize Imports runs; `organizeImports` is unchanged in policy and now applies a narrowed replace instead of a whole-document one. Every write passes through the text-level `verifyOrganizedRewrite` before anything reaches the buffer, so the range-level `verifyImportEdits`, `QueuedEdit`, and their suite are gone — the replacement PR #406 recorded as this ticket's landing shape.

### The one conflict rule

The live divergence the ticket cites is fixed: where an added path has both an evidenced ceiling (a diagnostic inside a pinned dotted import's own statement names it the consumer) and a speculative floor (a pinned import the path could resolve through), the ceiling now wins on every route, as the preserve path already decided. Authority: ordinary identifier resolution consults a scope's `using` set position-free (`SemanticScope.cpp:523-543`); only a `using` resolving through another `using`'s module is document-order-dependent, and that dependency is FIFO (`SemanticAnalyzer.cpp:6528-6592`). A provider written below its evidenced consumer therefore can never fix the diagnostic that asked for it, so `hoistFloor`'s "a compiling file outranks a fixed diagnostic" rested on a false premise — the diagnostic is live. The paired regression test drives the same conflict fixture through all three routes; its organize and consolidate legs fail against the pre-swap writer (the preserve leg pins the behavior that was already correct).

### Deliberate behavior changes

- Consolidating on the add path now carries an import's annotation comments with it, withholds a movable duplicate of a pinned path when every `using` in the file is absolute, and writes the rebuild's blank separator after the block — the same document Optimize Imports produces. Each is pinned by a new test that fails against the pre-swap writer.
- A grounded extra whose floor sits above its ceiling lands directly above its evidenced consumer (`placementLine`'s "beside its consumer" rule) rather than at floor + 1. Same rule as the paired test; not double-pinned.
- The per-block debug log lines went with the branch matrix; `applyImports`' own logs remain.
- Review-driven, both builders: untouched lines now come back byte for byte, endings included. Rounds 1 and 2 each found one half of the same root cause (rejoining the whole document with one ending), so the rule was restated once — a rebuild returns the original bytes for every line it does not rewrite — and both builders compose through the same `spliceLines`. Consequences, each pinned: an already-organized mixed-ending file now produces no edit at all where it previously produced a whole-file replace; a comment-only file keeps (and never invents) its final break through a past-end append; and a file that ended on a hoisted import ends on that line's own break once the import moves. The residual convergence (a comment-only file with no final break gains one on the rebuild after the appended import gives it a code line) is named in `buildOrganizedContent`'s doc.

A side effect the round-1 review's fuzzing surfaced: in 17 of 8,500 fuzzed scenarios, the old consolidate path silently commented out a line of user code (hoisting an import above a `<#>` marker so an indented body line fell into the comment). The rebuilt text now trips the guard and the edit is refused instead.

### Validation (`validation.change`)

- **Verse rule the approach relies on** — settled from the compiler source before implementation: the position-free/FIFO resolution facts above (rule 7 pin), path forms (rules 5-6), comment forms (rules 13/14/23), file scope of module imports (rule 9). The scanner, formatter and classifier stay the single implementations of those rules; none was re-derived from this codebase's own model.
- **Extractor order and facade boundary** — `ImportSuggestionExtractor` untouched, so pattern order does not apply. `npx jest src/imports/__tests__` run in full and read whole after every stage; production callers still reach the editor only through `ImportHandler`, and nothing new is exported from the facade.

### Deferred, deliberately

- The preserve path still rebuilds a block without carrying annotation comments through an in-block re-sort, so a comment can end up labelling a neighbouring import. Pre-existing on main and untouched here; the ticket's "one comment-carry rule" is delivered where imports actually move (consolidate/organize). Worth its own ticket.
- A guard refusal surfaces as "the document may have changed or be read-only", which under-describes the third cause this PR makes reachable. Already recorded by #406 as worth its own ticket.
- `blockKeepsRelativeOrder` remains the preserve-mode block-eligibility residual, now the only extra rule beside `pinnedBounds`/`placementLine`; folding it in was out of scope for the verbatim port.

### Verification

`npm run compile`

```
> verse-auto-imports@0.11.3 compile
> tsc -p ./
```

`npm test`

```
Test Suites: 63 passed, 63 total
Tests:       1751 passed, 1751 total
```

`npm run format:check`

```
Checking formatting...
All matched files use Prettier code style!
```

### Review

Round 1 (fresh context, opus, full diff): PASS_WITH_SUGGESTIONS — 0 Critical, 2 Important, 7 suggestions, ~60 probes including a 1,242-scenario branch-vs-main differ (every difference one of the declared changes; zero drift in preserve or organize mode) and 8,500 fuzz cases (zero lost imports, zero new duplicates, zero preserve-mode drift). Important 1 (mixed-EOL normalization) fixed in `b8cdd20`; Important 2 (preserve-path comment carry) deferred above. Suggestions applied: stale doc and test comments, the mislabelled matrix fixture (a real indented pair row added), the unreachable header clamp's comment. Skipped: merging `applyRebuiltText`'s five message strings (the two callers' messages share no format) and splitting `buildPreservedContent` (verbatim port by design; decomposition is follow-up work).

Round 2 (fresh context, opus, the fix commit): PASS_WITH_SUGGESTIONS — 0 Critical, 1 Important, 3 suggestions. Verified the round-1 fix byte-identical to its parent on single-ending files (46,960 differential builder calls, zero reachable divergence; 16,899 mixed-ending rebuilds with zero bytes changed outside the minimal splice). Its Important — the same rejoin-normalization still live in `buildOrganizedContent` — is the "two rounds, one root cause" trigger, answered by re-deriving the byte-fidelity rule into the one shared primitive (`fad1ee7`) rather than patching the second site; its three suggestions (two understating docstrings, the empty-past-end splice shape) are folded into the same commit.

Round 3 (fresh context, opus, the recomposition commit): PASS_WITH_SUGGESTIONS — 0 Critical, 2 Important, 2 suggestions, ~467,000 differential comparisons against the parent (content-identical everywhere outside the declared classes; no constructible splice overlap; grounded extras, comment carry and withholding byte-identical across an adversarial corpus). Its Importants — the past-end append dropping an existing final break, and the idempotence doc missing the comment-only convergence — are fixed in `a5dc537` with the exact patch that round pre-verified over 29,484 cases; its suggestions (pin the hoisted-last-line break, name the edit-region shrink in the changelog) are in the same commit and the fragment.
